### PR TITLE
Pass null as additional info to event history when issuing certificate with not compliant request

### DIFF
--- a/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -333,7 +333,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
         ComplianceCheckResultDto complianceResult = complianceService.getComplianceCheckResult(Resource.CERTIFICATE_REQUEST, certificateRequestUuid);
         if (complianceResult.getStatus() == ComplianceStatus.NOK || complianceResult.getStatus() == ComplianceStatus.FAILED) {
             Certificate newCertificate = certificateRepository.findByUuid(certificateUuid).orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
-            handleFailedOrRejectedEvent(newCertificate, null, CertificateState.REJECTED, certificateEvent, new HashMap<>(), "Certificate request is not compliant");
+            handleFailedOrRejectedEvent(newCertificate, null, CertificateState.REJECTED, certificateEvent, null, "Certificate request is not compliant");
             return true;
         }
 


### PR DESCRIPTION
Replaces the empty HashMap argument with null in the handleFailedOrRejectedEvent call when a certificate request is not compliant. This may affect how event data is processed for rejected certificate requests.