### PR TITLE
Reduce certificate validation batch size to 200

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -116,9 +116,10 @@ import java.util.stream.Collectors;
 @Transactional
 public class CertificateServiceImpl implements CertificateService {
 
-    // calculated that batch processing will fit in one hour, based on average processing time of 3 seconds per certificate
+    // calculated that batch processing will take less than 30 minutes even under more load to prevent consumer timeout.
+    // Based on average processing time of 3 seconds per certificate with extensions and revocation check under common conditions.
     // batch size will prevent bloating size of enqueued message and better utilize parallel processing
-    private static final int VALIDATION_BATCH_SIZE = 1000;
+    private static final int VALIDATION_BATCH_SIZE = 200;
     private static final String UNDEFINED_CERTIFICATE_OBJECT_NAME = "undefined";
     private static final Logger logger = LoggerFactory.getLogger(CertificateServiceImpl.class);
 


### PR DESCRIPTION
Lowered VALIDATION_BATCH_SIZE from 1000 to 200 to ensure batch processing completes in less than 30 minutes under higher load, preventing consumer timeout.