### PR TITLE
Override Spring Security BOM to version 6.4.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,16 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- temporary override security package to solve critical vulnerability CVE-2025-41232
+                 Remove when spring boot version in parent dependencies is upgraded to 3.4.6 or later
+            -->
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-bom</artifactId>
+                <version>6.4.6</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -94,7 +104,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
-
 
         <!-- OpenTelemetry -->
         <dependency>


### PR DESCRIPTION
Temporarily imports spring-security-bom version 6.4.6 to resolve a critical vulnerability (CVE-2025-41232). This override should be removed once the parent Spring Boot dependency is upgraded to 3.4.6 or later.