### PR TITLE
Update default value for client certificate header name variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Operations can be automated by the `Core`, but also can be performed manually by
 | `JDBC_PASSWORD`                   | Password to access the database                                     | ![](https://img.shields.io/badge/-YES-success.svg) | `N/A`               |
 | `DB_SCHEMA`                       | Database schema to use                                              | ![](https://img.shields.io/badge/-NO-red.svg)      | `core`              |
 | `PORT`                            | Port where the service is exposed                                   | ![](https://img.shields.io/badge/-NO-red.svg)      | `8080`              |
-| `HEADER_NAME`                     | Name of the header where the certificate of the client can be found | ![](https://img.shields.io/badge/-NO-red.svg)      | `X-APP-CERTIFICATE` |
+| `HEADER_NAME`                     | Name of the header where the certificate of the client can be found | ![](https://img.shields.io/badge/-NO-red.svg)      | `ssl-client-cert` |
 | `HEADER_ENABLED`                  | True if the certificate should be get from the header               | ![](https://img.shields.io/badge/-YES-success.svg) | `N/A`               |
 | `TS_PASSWORD`                     | Password for the trusted certificate store                          | ![](https://img.shields.io/badge/-YES-success.svg) | `N/A`               |
 | `OPA_BASE_URL`                    | Base URL of the Open Policy Agent                                   | ![](https://img.shields.io/badge/-YES-success.svg) | `N/A`               |

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,7 +89,7 @@ server:
   ssl:
     # Client certificate HTTP header name
     certificate-header-enabled: ${HEADER_ENABLED}
-    certificate-header-name: ${HEADER_NAME:X-APP-CERTIFICATE}
+    certificate-header-name: ${HEADER_NAME:ssl-client-cert}
     client-auth: want
     enabled: ${SSL_ENABLE:false}
     trust-store: ${TS_PATH}


### PR DESCRIPTION
Changed the default value for the client certificate HTTP header from 'X-APP-CERTIFICATE' to 'ssl-client-cert' in both the README and application.yml for consistency and clarity to be corresponding to default value used in Dockerfile