### PR TITLE
Performance improvement: RA profile names

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/Certificate.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Certificate.java
@@ -85,7 +85,7 @@ public class Certificate extends UniquelyIdentifiedAndAudited implements Complia
     @Column(name = "extended_key_usage")
     private String extendedKeyUsage;
 
-    @Column(name = "key_usage")
+    @Column(name = "key_usage", nullable = false)
     private int keyUsage;
 
     @Column(name = "subject_type", nullable = false)

--- a/src/main/java/com/czertainly/core/dao/repository/RaProfileRepository.java
+++ b/src/main/java/com/czertainly/core/dao/repository/RaProfileRepository.java
@@ -1,6 +1,7 @@
 package com.czertainly.core.dao.repository;
 
 import com.czertainly.core.dao.entity.RaProfile;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -25,4 +26,7 @@ public interface RaProfileRepository extends SecurityFilterRepository<RaProfile,
     List<RaProfile> findAllByCmpProfileUuid(UUID cmpProfileUuid);
 
     List<RaProfile> findAllByUuidIn(List<UUID>uuids);
+
+    @Query(value="SELECT name FROM core.ra_profile", nativeQuery = true)
+    List<String> findAllNames();
 }

--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -594,7 +594,7 @@ public class CertificateServiceImpl implements CertificateService {
                 SearchHelper.prepareSearch(FilterField.COMMON_NAME),
                 SearchHelper.prepareSearch(FilterField.SERIAL_NUMBER),
                 SearchHelper.prepareSearch(FilterField.ISSUER_SERIAL_NUMBER),
-                SearchHelper.prepareSearch(FilterField.RA_PROFILE_NAME, raProfileRepository.findAll().stream().map(RaProfile::getName).toList()),
+                SearchHelper.prepareSearch(FilterField.RA_PROFILE_NAME, raProfileRepository.findAllNames()),
                 SearchHelper.prepareSearch(FilterField.GROUP_NAME, groupRepository.findAll().stream().map(Group::getName).toList()),
                 SearchHelper.prepareSearch(FilterField.CERT_LOCATION_NAME, locationRepository.findAll().stream().map(Location::getName).toList()),
                 SearchHelper.prepareSearch(FilterField.OWNER, userManagementApiClient.getUsers().getData().stream().map(UserDto::getUsername).toList()),


### PR DESCRIPTION
With several hundreds of RA profiles, `/api/v1/certificates/search` API endpoint takes easily 10 seconds. With the proposed optimization, we are down to 200 ms total, with `RaProfileReposity.findAllNames()` taking just 10 ms.
The culprit is a costly SQL SELECT on the `core.ra_profile` table.

