### PR TITLE
Support running Core locally with properties from application.yml

### DIFF
--- a/src/main/java/com/czertainly/core/api/DatabaseInfoContributor.java
+++ b/src/main/java/com/czertainly/core/api/DatabaseInfoContributor.java
@@ -1,28 +1,24 @@
 package com.czertainly.core.api;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.info.Info;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 @Component
 @Profile("!test")
 public class DatabaseInfoContributor implements InfoContributor {
 
-    private final Map<String, Object> cachedDatabaseInfo = new HashMap<>();
+    private final Map<String, Object> cachedDatabaseInfo;
 
-    public DatabaseInfoContributor(@Value("${spring.datasource.url}") String jdbcUrl,
-                                   @Value("${spring.datasource.username}") String jdbcUsername,
-                                   @Value("${spring.datasource.password}") String jdbcPassword) {
-        precomputeDatabaseInfo(jdbcUrl, jdbcUsername, jdbcPassword);
+    public DatabaseInfoContributor(DataSource dataSource) {
+        this.cachedDatabaseInfo = precomputeDatabaseInfo(dataSource);
     }
 
     @Override
@@ -30,17 +26,17 @@ public class DatabaseInfoContributor implements InfoContributor {
         builder.withDetail("db", cachedDatabaseInfo);
     }
 
-    private void precomputeDatabaseInfo(String jdbcUrl, String jdbcUsername, String jdbcPassword) {
-        String url = Optional.ofNullable(System.getenv("JDBC_URL")).orElse(jdbcUrl);
-        String username = Optional.ofNullable(System.getenv("JDBC_USERNAME")).orElse(jdbcUsername);
-        String password = Optional.ofNullable(System.getenv("JDBC_PASSWORD")).orElse(jdbcPassword);
+    private Map<String, Object> precomputeDatabaseInfo(DataSource dataSource) {
+        Map<String, Object> dbInfo = new HashMap<>();
 
-        try (Connection connection = DriverManager.getConnection(url, username, password)) {
+        try (Connection connection = dataSource.getConnection()) {
             DatabaseMetaData metaData = connection.getMetaData();
-            cachedDatabaseInfo.put("system", metaData.getDatabaseProductName());
-            cachedDatabaseInfo.put("version", metaData.getDatabaseProductVersion());
+            dbInfo.put("system", metaData.getDatabaseProductName());
+            dbInfo.put("version", metaData.getDatabaseProductVersion());
         } catch (Exception e) {
             throw new RuntimeException("Unable to retrieve database information.", e);
         }
+
+        return dbInfo;
     }
 }


### PR DESCRIPTION
Supports starting Core in local development environment with all properties defined in `application.yml`.
Environment variables take precedence, so this is a backwards compatible change.