### PR TITLE
Bump Testcontainers and import BOM entry to fix Docker engine issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <nimbus-jose-jwt.version>10.5</nimbus-jose-jwt.version>
         <mockwebserver.version>5.2.1</mockwebserver.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
-        <testcontainers-postgresql.version>1.21.3</testcontainers-postgresql.version>
+        <testcontainers-postgresql.version>1.21.4</testcontainers-postgresql.version>
         <git-commit-id-maven.version>9.0.2</git-commit-id-maven.version>
         <java.version>21</java.version>
 
@@ -45,6 +45,14 @@
                 <groupId>io.opentelemetry.instrumentation</groupId>
                 <artifactId>opentelemetry-instrumentation-bom</artifactId>
                 <version>2.21.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Remove after upgrading parent spring boot dependency to 3.5.9+ -->
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers-postgresql.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
- add an imported testcontainers-bom dependencyManagement entry
- The BOM import is a temporary workaround (note: remove after upgrading parent Spring Boot to 3.5.9+) to align Testcontainers artifact versions.