### PR TITLE
Move to aquasecurity/trivy-action@v0.35.0 as 0.34.0 was compromised

### DIFF
--- a/.github/workflows/publish_docker_3key.yaml
+++ b/.github/workflows/publish_docker_3key.yaml
@@ -110,7 +110,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ env.CACHE_SCOPE }}-amd64
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_IMAGE_SRC: remote
           TRIVY_PLATFORM: linux/amd64
@@ -127,7 +127,7 @@ jobs:
           path: trivy-report-amd64.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_IMAGE_SRC: remote
           TRIVY_PLATFORM: linux/amd64
@@ -179,7 +179,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ env.CACHE_SCOPE }}-arm64
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_IMAGE_SRC: remote
           TRIVY_PLATFORM: linux/arm64
@@ -196,7 +196,7 @@ jobs:
           path: trivy-report-arm64.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_IMAGE_SRC: remote
           TRIVY_PLATFORM: linux/arm64

--- a/.github/workflows/publish_docker_czertainly.yaml
+++ b/.github/workflows/publish_docker_czertainly.yaml
@@ -110,7 +110,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ env.CACHE_SCOPE }}-amd64
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_IMAGE_SRC: remote
           TRIVY_PLATFORM: linux/amd64
@@ -127,7 +127,7 @@ jobs:
           path: trivy-report-amd64.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_IMAGE_SRC: remote
           TRIVY_PLATFORM: linux/amd64
@@ -179,7 +179,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ env.CACHE_SCOPE }}-arm64
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_IMAGE_SRC: remote
           TRIVY_PLATFORM: linux/arm64
@@ -196,7 +196,7 @@ jobs:
           path: trivy-report-arm64.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_IMAGE_SRC: remote
           TRIVY_PLATFORM: linux/arm64

--- a/.github/workflows/publish_harbor_3key.yaml
+++ b/.github/workflows/publish_harbor_3key.yaml
@@ -110,7 +110,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ env.CACHE_SCOPE }}-amd64
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_IMAGE_SRC: remote
           TRIVY_PLATFORM: linux/amd64
@@ -127,7 +127,7 @@ jobs:
           path: trivy-report-amd64.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_IMAGE_SRC: remote
           TRIVY_PLATFORM: linux/amd64
@@ -179,7 +179,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ env.CACHE_SCOPE }}-arm64
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_IMAGE_SRC: remote
           TRIVY_PLATFORM: linux/arm64
@@ -196,7 +196,7 @@ jobs:
           path: trivy-report-arm64.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_IMAGE_SRC: remote
           TRIVY_PLATFORM: linux/arm64

--- a/.github/workflows/test_docker_image.yaml
+++ b/.github/workflows/test_docker_image.yaml
@@ -91,7 +91,7 @@ jobs:
 
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.IMAGE }}:ci
           format: json
@@ -105,7 +105,7 @@ jobs:
           path: trivy-report-amd64.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.IMAGE }}:ci
           trivy-config: config/trivy.yaml
@@ -147,7 +147,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ env.CACHE_SCOPE }}-arm64
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.IMAGE }}:ci
           format: json
@@ -161,7 +161,7 @@ jobs:
           path: trivy-report-arm64.json
 
       - name: Fail build on vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.IMAGE }}:ci
           trivy-config: config/trivy.yaml


### PR DESCRIPTION
https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release

..and of course version 0.34.0 is no longer available so the build fails with an unknown action.