### PR TITLE
Bump build image and update dependency versions

### DIFF
--- a/Dockerfile-pre
+++ b/Dockerfile-pre
@@ -1,5 +1,5 @@
 # Build stage
-FROM maven:3.9.12-eclipse-temurin-21 AS build
+FROM maven:3.9.14-eclipse-temurin-21 AS build
 
 COPY src /home/app/src
 COPY pom.xml /home/app

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.czertainly</groupId>
         <artifactId>dependencies</artifactId>
-        <version>1.3.1</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>
@@ -17,8 +17,8 @@
         <log-schema.version>1.1</log-schema.version>
         <querydsl.version>5.1.0</querydsl.version>
         <hsqldb.version>2.7.3</hsqldb.version>
-        <nimbus-jose-jwt.version>10.5</nimbus-jose-jwt.version>
-        <mockwebserver.version>5.2.1</mockwebserver.version>
+        <nimbus-jose-jwt.version>10.8</nimbus-jose-jwt.version>
+        <mockwebserver.version>5.3.2</mockwebserver.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <testcontainers-postgresql.version>1.21.4</testcontainers-postgresql.version>
         <git-commit-id-maven.version>9.0.2</git-commit-id-maven.version>
@@ -37,14 +37,14 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>1.55.0</version>
+                <version>1.60.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry.instrumentation</groupId>
                 <artifactId>opentelemetry-instrumentation-bom</artifactId>
-                <version>2.21.0</version>
+                <version>2.26.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -192,7 +192,7 @@
         <dependency>
             <groupId>com.pivovarit</groupId>
             <artifactId>parallel-collectors</artifactId>
-            <version>3.3.0</version>
+            <version>3.4.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Update build base image and bump several dependency versions for compatibility and maintenance.

- Dockerfile-pre: use maven:3.9.14-eclipse-temurin-21 instead of 3.9.12.
- pom.xml: update parent to 1.4.0-SNAPSHOT and upgrade key dependencies/properties:
  - nimbus-jose-jwt: 10.5 -> 10.8
  - mockwebserver: 5.2.1 -> 5.3.2
  - io.opentelemetry/opentelemetry-bom: 1.55.0 -> 1.60.1
  - opentelemetry-instrumentation-bom: 2.21.0 -> 2.26.1
  - parallel-collectors: 3.3.0 -> 3.4.0