### PR TITLE
Support LIST search filter on native array columns

### DIFF
--- a/src/main/java/com/czertainly/core/enums/FilterField.java
+++ b/src/main/java/com/czertainly/core/enums/FilterField.java
@@ -176,6 +176,7 @@ public enum FilterField {
     OID_ENTRY_DISPLAY_NAME(Resource.OID, null, null, CustomOidEntry_.displayName, "Display Name", SearchFieldTypeEnum.STRING),
     OID_ENTRY_CATEGORY(Resource.OID, null, null, CustomOidEntry_.category, "Category", SearchFieldTypeEnum.LIST, OidCategory.class),
     OID_ENTRY_CODE(Resource.OID, null, null, RdnAttributeTypeCustomOidEntry_.code, "Code", SearchFieldTypeEnum.STRING),
+    OID_ENTRY_ALT_CODES(Resource.OID, null, null, RdnAttributeTypeCustomOidEntry_.altCodes, "Alt Codes", SearchFieldTypeEnum.NATIVE_ARRAY),
 
     // Vault Instance
     VAULT_INSTANCE_NAME(Resource.VAULT, null, null, VaultInstance_.name, "Name", SearchFieldTypeEnum.STRING),

--- a/src/main/java/com/czertainly/core/enums/SearchFieldTypeEnum.java
+++ b/src/main/java/com/czertainly/core/enums/SearchFieldTypeEnum.java
@@ -27,6 +27,11 @@ public enum SearchFieldTypeEnum {
     LIST(FilterFieldType.LIST,
             List.of(FilterConditionOperator.EQUALS, FilterConditionOperator.NOT_EQUALS, FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY)
             , true, null),
+    // Like LIST but the underlying column is a native PostgreSQL array (text[]).
+    // EQUALS/NOT_EQUALS use = ANY(column) instead of column = value.
+    NATIVE_ARRAY(FilterFieldType.LIST,
+            List.of(FilterConditionOperator.EQUALS, FilterConditionOperator.NOT_EQUALS, FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY)
+            , true, null),
     BOOLEAN(FilterFieldType.BOOLEAN,
          List.of(FilterConditionOperator.EQUALS, FilterConditionOperator.NOT_EQUALS, FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY), false, Boolean.class)
     ;

--- a/src/main/java/com/czertainly/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/czertainly/core/util/FilterPredicatesBuilder.java
@@ -206,7 +206,7 @@ public class FilterPredicatesBuilder {
         try {
             preparedValue = DatatypeFactory.newInstance().newDuration(stringValue);
         } catch (DatatypeConfigurationException e) {
-            throw new ValidationException("Cannot parse value " + stringValue + "to a Duration: " + e.getMessage());
+            throw new ValidationException("Cannot parse value " + stringValue + " to a Duration: " + e.getMessage());
         }
         return preparedValue;
     }
@@ -244,6 +244,8 @@ public class FilterPredicatesBuilder {
                 };
             }
         } else if (filterField.getType().getExpressionClass() != null && filterField.getExpectedValue() == null) {
+            if (expression == null)
+                throw new ValidationException("Invalid filter configuration: no expression for field " + filterField);
             expression = ((JpaExpression) expression).cast(filterField.getType().getExpressionClass());
         }
 
@@ -272,15 +274,28 @@ public class FilterPredicatesBuilder {
         final LocalDateTime now = LocalDateTime.now();
         boolean bitEnumProperty = filterField.getEnumClass() != null && BitMaskEnum.class.isAssignableFrom(filterField.getEnumClass());
         boolean isNativeArrayField = filterField.getType() == SearchFieldTypeEnum.NATIVE_ARRAY;
+        if (expression == null && !isCountOperator(conditionOperator))
+            throw new ValidationException("Invalid filter configuration: no expression for field " + filterField + " with operator " + conditionOperator);
+        final Expression finalExpression = expression;
         switch (conditionOperator) {
             case EQUALS -> {
                 if (bitEnumProperty)
                     predicate = criteriaBuilder.notEqual(getBitwiseEqualExpression(filterValues.getFirst(), expression, criteriaBuilder), 0);
                 else if (isJsonArray)
                     predicate = criteriaBuilder.isTrue(getJsonArrayEqualsExpression(criteriaBuilder, expression, filterValues.getFirst().toString()));
-                else if (isNativeArrayField)
-                    predicate = criteriaBuilder.isTrue(criteriaBuilder.function(ARRAY_CONTAINS_FUNCTION_NAME, Boolean.class, criteriaBuilder.literal(filterValues.getFirst().toString()), expression));
-                else
+                else if (isNativeArrayField) {
+                    List<Predicate> nativeArrayPredicates = filterValues.stream()
+                            .map(value -> criteriaBuilder.isTrue(criteriaBuilder.function(
+                                    ARRAY_CONTAINS_FUNCTION_NAME,
+                                    Boolean.class,
+                                    criteriaBuilder.literal(value.toString()),
+                                    finalExpression
+                            )))
+                            .toList();
+                    predicate = nativeArrayPredicates.size() == 1
+                            ? nativeArrayPredicates.getFirst()
+                            : criteriaBuilder.or(nativeArrayPredicates.toArray(new Predicate[0]));
+                } else
                     predicate = multipleValues ? expression.in(filterValues) : criteriaBuilder.equal(expression, filterValues.getFirst());
             }
             case NOT_EQUALS -> {
@@ -288,9 +303,20 @@ public class FilterPredicatesBuilder {
                     predicate = criteriaBuilder.equal(getBitwiseEqualExpression(filterValues.getFirst(), expression, criteriaBuilder), 0);
                 else if (isJsonArray)
                     predicate = criteriaBuilder.isFalse(getJsonArrayEqualsExpression(criteriaBuilder, expression, filterValues.getFirst().toString()));
-                else if (isNativeArrayField)
-                    predicate = criteriaBuilder.or(criteriaBuilder.isNull(expression),
-                            criteriaBuilder.isFalse(criteriaBuilder.function(ARRAY_CONTAINS_FUNCTION_NAME, Boolean.class, criteriaBuilder.literal(filterValues.getFirst().toString()), expression)));
+                else if (isNativeArrayField) {
+                    Predicate[] nativeArrayNotContainsPredicates = filterValues.stream()
+                            .map(value -> criteriaBuilder.isFalse(criteriaBuilder.function(
+                                    ARRAY_CONTAINS_FUNCTION_NAME,
+                                    Boolean.class,
+                                    criteriaBuilder.literal(value.toString()),
+                                    finalExpression
+                            )))
+                            .toArray(Predicate[]::new);
+                    predicate = criteriaBuilder.or(
+                            criteriaBuilder.isNull(expression),
+                            criteriaBuilder.and(nativeArrayNotContainsPredicates)
+                    );
+                }
                 else {
                     // hack how to filter out correctly Has private key property filter for certificate. Needs to find correct solution for SET attributes predicates!
                     if (filterField.getExpectedValue() != null && filterField == FilterField.PRIVATE_KEY) {

--- a/src/main/java/com/czertainly/core/util/FilterPredicatesBuilder.java
+++ b/src/main/java/com/czertainly/core/util/FilterPredicatesBuilder.java
@@ -43,6 +43,7 @@ public class FilterPredicatesBuilder {
     private static final List<AttributeContentType> castedAttributeContentData = List.of(AttributeContentType.INTEGER, AttributeContentType.FLOAT, AttributeContentType.DATE, AttributeContentType.TIME, AttributeContentType.DATETIME);
     private static final String JSONB_EXTRACT_PATH_TEXT_FUNCTION_NAME = "jsonb_extract_path_text";
     private static final String TEXTREGEXEQ_FUNCTION_NAME = "textregexeq";
+    private static final String ARRAY_CONTAINS_FUNCTION_NAME = PostgresFunctionContributor.ARRAY_CONTAINS;
 
     public static <T> Predicate getFiltersPredicate(final CriteriaBuilder criteriaBuilder, final CommonAbstractCriteria query, final Root<T> root, final List<SearchFilterRequestDto> filterDtos) {
         Map<String, From> joinedAssociations = new HashMap<>();
@@ -165,8 +166,20 @@ public class FilterPredicatesBuilder {
             } else {
                 preparedValue = switch (contentType) {
                     case BOOLEAN -> Boolean.parseBoolean(stringValue) ? "true" : "false";
-                    case INTEGER -> Integer.parseInt(stringValue);
-                    case FLOAT -> Float.parseFloat(stringValue);
+                    case INTEGER -> {
+                        try {
+                            yield Integer.parseInt(stringValue);
+                        } catch (NumberFormatException e) {
+                            throw new ValidationException("Filter field value " + stringValue + " cannot be parsed as an Integer.");
+                        }
+                    }
+                    case FLOAT -> {
+                        try {
+                            yield Float.parseFloat(stringValue);
+                        } catch (NumberFormatException e) {
+                            throw new ValidationException("Filter field value " + stringValue + " cannot be parsed as a Float.");
+                        }
+                    }
                     case DATE -> LocalDate.parse(stringValue);
                     case TIME -> LocalTime.parse(stringValue);
                     case DATETIME -> {
@@ -227,7 +240,7 @@ public class FilterPredicatesBuilder {
                     case 4 ->
                             criteriaBuilder.function(JSONB_EXTRACT_PATH_TEXT_FUNCTION_NAME, String.class, from.get(filterField.getFieldAttribute().getName()), criteriaBuilder.literal(filterField.getJsonPath()[0]), criteriaBuilder.literal(filterField.getJsonPath()[1]), criteriaBuilder.literal(filterField.getJsonPath()[2]), criteriaBuilder.literal(filterField.getJsonPath()[3]));
                     default ->
-                            throw new ValidationException("Unexpected size of JSON path `%s`: %d".formatted(filterField.getJsonPath(), filterField.getJsonPath().length));
+                            throw new ValidationException("Unexpected size of JSON path `%s`: %d".formatted(Arrays.toString(filterField.getJsonPath()), filterField.getJsonPath().length));
                 };
             }
         } else if (filterField.getType().getExpressionClass() != null && filterField.getExpectedValue() == null) {
@@ -258,12 +271,15 @@ public class FilterPredicatesBuilder {
         }
         final LocalDateTime now = LocalDateTime.now();
         boolean bitEnumProperty = filterField.getEnumClass() != null && BitMaskEnum.class.isAssignableFrom(filterField.getEnumClass());
+        boolean isNativeArrayField = filterField.getType() == SearchFieldTypeEnum.NATIVE_ARRAY;
         switch (conditionOperator) {
             case EQUALS -> {
                 if (bitEnumProperty)
                     predicate = criteriaBuilder.notEqual(getBitwiseEqualExpression(filterValues.getFirst(), expression, criteriaBuilder), 0);
                 else if (isJsonArray)
                     predicate = criteriaBuilder.isTrue(getJsonArrayEqualsExpression(criteriaBuilder, expression, filterValues.getFirst().toString()));
+                else if (isNativeArrayField)
+                    predicate = criteriaBuilder.isTrue(criteriaBuilder.function(ARRAY_CONTAINS_FUNCTION_NAME, Boolean.class, criteriaBuilder.literal(filterValues.getFirst().toString()), expression));
                 else
                     predicate = multipleValues ? expression.in(filterValues) : criteriaBuilder.equal(expression, filterValues.getFirst());
             }
@@ -272,6 +288,9 @@ public class FilterPredicatesBuilder {
                     predicate = criteriaBuilder.equal(getBitwiseEqualExpression(filterValues.getFirst(), expression, criteriaBuilder), 0);
                 else if (isJsonArray)
                     predicate = criteriaBuilder.isFalse(getJsonArrayEqualsExpression(criteriaBuilder, expression, filterValues.getFirst().toString()));
+                else if (isNativeArrayField)
+                    predicate = criteriaBuilder.or(criteriaBuilder.isNull(expression),
+                            criteriaBuilder.isFalse(criteriaBuilder.function(ARRAY_CONTAINS_FUNCTION_NAME, Boolean.class, criteriaBuilder.literal(filterValues.getFirst().toString()), expression)));
                 else {
                     // hack how to filter out correctly Has private key property filter for certificate. Needs to find correct solution for SET attributes predicates!
                     if (filterField.getExpectedValue() != null && filterField == FilterField.PRIVATE_KEY) {
@@ -289,10 +308,20 @@ public class FilterPredicatesBuilder {
             case NOT_CONTAINS ->
                     predicate = criteriaBuilder.or(getNotPresentPredicate(criteriaBuilder, from, expression, hasParent, isParentCollection, false, isJsonArray),
                             criteriaBuilder.notLike(expression, "%" + filterValues.getFirst() + "%"));
-            case EMPTY ->
+            case EMPTY -> {
+                if (isNativeArrayField)
+                    predicate = criteriaBuilder.or(criteriaBuilder.isNull(expression),
+                            criteriaBuilder.equal(criteriaBuilder.function("cardinality", Integer.class, expression), 0));
+                else
                     predicate = getNotPresentPredicate(criteriaBuilder, from, expression, hasParent, isParentCollection, bitEnumProperty, isJsonArray);
-            case NOT_EMPTY ->
+            }
+            case NOT_EMPTY -> {
+                if (isNativeArrayField)
+                    predicate = criteriaBuilder.and(criteriaBuilder.isNotNull(expression),
+                            criteriaBuilder.greaterThan(criteriaBuilder.function("cardinality", Integer.class, expression), 0));
+                else
                     predicate = criteriaBuilder.not(getNotPresentPredicate(criteriaBuilder, from, expression, hasParent, isParentCollection, bitEnumProperty, isJsonArray));
+            }
             case GREATER ->
                     predicate = criteriaBuilder.greaterThan(expression, (Expression) criteriaBuilder.literal(filterValues.getFirst()));
             case GREATER_OR_EQUAL ->
@@ -323,11 +352,20 @@ public class FilterPredicatesBuilder {
             case COUNT_EQUAL -> predicate = criteriaBuilder.equal(criteriaBuilder.size(from), filterValues.getFirst());
             case COUNT_NOT_EQUAL ->
                     predicate = criteriaBuilder.not(criteriaBuilder.equal(criteriaBuilder.size(from), filterValues.getFirst()));
-            case COUNT_GREATER_THAN ->
+            case COUNT_GREATER_THAN -> {
+                try {
                     predicate = criteriaBuilder.greaterThan(criteriaBuilder.size(from), (Expression) criteriaBuilder.literal(Integer.parseInt(filterValues.getFirst().toString())));
-            case COUNT_LESS_THAN ->
+                } catch (NumberFormatException e) {
+                    throw new ValidationException("Filter field value " + filterValues.getFirst() + " cannot be parsed as an Integer.");
+                }
+            }
+            case COUNT_LESS_THAN -> {
+                try {
                     predicate = criteriaBuilder.lessThan(criteriaBuilder.size(from), (Expression) criteriaBuilder.literal(Integer.parseInt(filterValues.getFirst().toString())));
-
+                } catch (NumberFormatException e) {
+                    throw new ValidationException("Filter field value " + filterValues.getFirst() + " cannot be parsed as an Integer.");
+                }
+            }
 
             default -> throw new ValidationException("Unexpected value: " + conditionOperator);
         }
@@ -466,7 +504,11 @@ public class FilterPredicatesBuilder {
                         preparedFilterValue = filterField.getExpectedValue();
                     }
                 } else if (filterField.getType() == SearchFieldTypeEnum.NUMBER) {
-                    preparedFilterValue = stringValue.contains(".") ? Float.parseFloat(stringValue) : Integer.parseInt(stringValue);
+                    try {
+                        preparedFilterValue = stringValue.contains(".") ? Float.parseFloat(stringValue) : Integer.parseInt(stringValue);
+                    } catch (NumberFormatException e) {
+                        throw new ValidationException("Filter field value " + stringValue + " cannot be parsed as a Number.");
+                    }
                 } else if (filterDto.getCondition() == FilterConditionOperator.IN_PAST || filterDto.getCondition() == FilterConditionOperator.IN_NEXT) {
                     try {
                         if (filterField.getType() == SearchFieldTypeEnum.DATE) {

--- a/src/main/java/com/czertainly/core/util/PostgresFunctionContributor.java
+++ b/src/main/java/com/czertainly/core/util/PostgresFunctionContributor.java
@@ -9,13 +9,16 @@ public class PostgresFunctionContributor implements FunctionContributor {
 
     public static final String BIT_AND_FUNCTION = "bitand";
     public static final String JSONB_CONTAINS = "jsonb_contains";
+    public static final String ARRAY_CONTAINS = "text_array_contains";
 
     @Override
     public void contributeFunctions(FunctionContributions functionContributions) {
         BasicType<Integer> resultType = functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve(StandardBasicTypes.INTEGER);
+        BasicType<Boolean> booleanType = functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve(StandardBasicTypes.BOOLEAN);
         functionContributions.getFunctionRegistry().registerPattern(BIT_AND_FUNCTION,
                 "?1 & ?2", resultType);
-        functionContributions.getFunctionRegistry().registerPattern(JSONB_CONTAINS, "?1 @> CAST(?2 AS jsonb)", functionContributions.getTypeConfiguration().getBasicTypeRegistry().resolve(StandardBasicTypes.BOOLEAN));
-
+        functionContributions.getFunctionRegistry().registerPattern(JSONB_CONTAINS, "?1 @> CAST(?2 AS jsonb)", booleanType);
+        // CAST(?1 AS TEXT) = ANY(?2)  —  check scalar membership in a native text[] column
+        functionContributions.getFunctionRegistry().registerPattern(ARRAY_CONTAINS, "CAST(?1 AS TEXT) = ANY(?2)", booleanType);
     }
 }

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+com.czertainly.core.util.PostgresFunctionContributor

--- a/src/test/java/com/czertainly/core/search/DiscoveryHistorySearchTest.java
+++ b/src/test/java/com/czertainly/core/search/DiscoveryHistorySearchTest.java
@@ -2,6 +2,7 @@ package com.czertainly.core.search;
 
 import com.czertainly.api.exception.AttributeException;
 import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.exception.ValidationException;
 import com.czertainly.api.model.client.attribute.RequestAttributeV3;
 import com.czertainly.api.model.client.certificate.DiscoveryResponseDto;
 import com.czertainly.api.model.client.certificate.SearchFilterRequestDto;
@@ -312,6 +313,32 @@ class DiscoveryHistorySearchTest extends BaseSpringBootTest {
         filters.add(new SearchFilterRequestDtoDummy(FilterFieldSource.CUSTOM, "attributeCustom1|TEXT", FilterConditionOperator.CONTAINS, "-custom-"));
         final DiscoveryResponseDto responseDto = retrieveTheDiscoveriesBySearch(filters);
         Assertions.assertEquals(1, responseDto.getDiscoveries().size());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // NumberFormatException → ValidationException on NUMBER property filters
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    void filterByTotalCertDiscovered_invalidStringValue_throwsValidationException() {
+        List<SearchFilterRequestDto> filters = List.of(
+                new SearchFilterRequestDtoDummy(FilterFieldSource.PROPERTY,
+                        FilterField.DISCOVERY_TOTAL_CERT_DISCOVERED.name(),
+                        FilterConditionOperator.EQUALS, "not-a-number"));
+        Assertions.assertThrows(ValidationException.class,
+                () -> retrieveTheDiscoveriesBySearch(filters),
+                "Non-numeric value for a NUMBER filter field must throw ValidationException, not NumberFormatException");
+    }
+
+    @Test
+    void filterByTotalCertDiscovered_invalidStringValue_forGreaterThanOperator_throwsValidationException() {
+        List<SearchFilterRequestDto> filters = List.of(
+                new SearchFilterRequestDtoDummy(FilterFieldSource.PROPERTY,
+                        FilterField.DISCOVERY_TOTAL_CERT_DISCOVERED.name(),
+                        FilterConditionOperator.GREATER, "xyz"));
+        Assertions.assertThrows(ValidationException.class,
+                () -> retrieveTheDiscoveriesBySearch(filters),
+                "Non-numeric value for GREATER on a NUMBER field must throw ValidationException");
     }
 
     private DiscoveryResponseDto retrieveTheDiscoveriesBySearch(final List<SearchFilterRequestDto> filters) {

--- a/src/test/java/com/czertainly/core/search/NativeArrayFilterSearchTest.java
+++ b/src/test/java/com/czertainly/core/search/NativeArrayFilterSearchTest.java
@@ -1,0 +1,179 @@
+package com.czertainly.core.search;
+
+import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.client.certificate.SearchFilterRequestDto;
+import com.czertainly.api.model.client.certificate.SearchRequestDto;
+import com.czertainly.api.model.core.oid.CustomOidEntryListResponseDto;
+import com.czertainly.api.model.core.oid.OidCategory;
+import com.czertainly.api.model.core.search.FilterConditionOperator;
+import com.czertainly.api.model.core.search.FilterFieldSource;
+import com.czertainly.core.dao.entity.oid.RdnAttributeTypeCustomOidEntry;
+import com.czertainly.core.dao.repository.CustomOidEntryRepository;
+import com.czertainly.core.enums.FilterField;
+import com.czertainly.core.service.CustomOidEntryService;
+import com.czertainly.core.util.BaseSpringBootTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Integration tests for NATIVE_ARRAY filter operators using OID_ENTRY_ALT_CODES.
+ *
+ * Covers: EQUALS, NOT_EQUALS, EMPTY, NOT_EMPTY — all operating on a native
+ * PostgreSQL text[] column (RdnAttributeTypeCustomOidEntry.altCodes).
+ */
+class NativeArrayFilterSearchTest extends BaseSpringBootTest {
+
+    @Autowired
+    private CustomOidEntryService customOidEntryService;
+
+    @Autowired
+    private CustomOidEntryRepository customOidEntryRepository;
+
+    // altCodes = ["OFI", "OFI2"]
+    private RdnAttributeTypeCustomOidEntry multiCode;
+    // altCodes = ["ALONE"]
+    private RdnAttributeTypeCustomOidEntry singleCode;
+    // altCodes = [] (empty array stored as {})
+    private RdnAttributeTypeCustomOidEntry noCode;
+
+    @BeforeEach
+    void setUp() {
+        multiCode = rdnEntry("2.5.4.100", "Multi", "MULTI", List.of("OFI", "OFI2"));
+        singleCode = rdnEntry("2.5.4.101", "Single", "SINGLE", List.of("ALONE"));
+        noCode = rdnEntry("2.5.4.102", "NoCode", "NOCODE", new ArrayList<>());
+    }
+
+    // ─────────────────────────────────────────────
+    // EQUALS
+    // ─────────────────────────────────────────────
+
+    @Test
+    void filterByAltCodes_equals_matchesSingleEntryContainingValue() {
+        List<String> oids = searchOids(FilterConditionOperator.EQUALS, "ALONE");
+
+        Assertions.assertEquals(1, oids.size());
+        Assertions.assertTrue(oids.contains(singleCode.getOid()));
+    }
+
+    @Test
+    void filterByAltCodes_equals_matchesOneOfMultipleAltCodes() {
+        List<String> oids = searchOids(FilterConditionOperator.EQUALS, "OFI2");
+
+        Assertions.assertEquals(1, oids.size());
+        Assertions.assertTrue(oids.contains(multiCode.getOid()));
+    }
+
+    @Test
+    void filterByAltCodes_equals_noMatchForAbsentValue() {
+        List<String> oids = searchOids(FilterConditionOperator.EQUALS, "NOSUCHCODE");
+
+        Assertions.assertEquals(0, oids.size());
+    }
+
+    @Test
+    void filterByAltCodes_equals_doesNotMatchEmptyArrayEntry() {
+        List<String> oids = searchOids(FilterConditionOperator.EQUALS, "OFI");
+
+        Assertions.assertFalse(oids.contains(noCode.getOid()),
+                "Entry with empty altCodes array must not match EQUALS filter");
+    }
+
+    // ─────────────────────────────────────────────
+    // NOT_EQUALS
+    // ─────────────────────────────────────────────
+
+    @Test
+    void filterByAltCodes_notEquals_excludesEntryContainingValue() {
+        List<String> oids = searchOids(FilterConditionOperator.NOT_EQUALS, "ALONE");
+
+        Assertions.assertFalse(oids.contains(singleCode.getOid()),
+                "Entry containing 'ALONE' must be excluded by NOT_EQUALS");
+        Assertions.assertTrue(oids.contains(multiCode.getOid()));
+        Assertions.assertTrue(oids.contains(noCode.getOid()));
+    }
+
+    @Test
+    void filterByAltCodes_notEquals_includesEntryWithEmptyArray() {
+        // An entry with {} does not contain "OFI", so NOT_EQUALS must include it.
+        List<String> oids = searchOids(FilterConditionOperator.NOT_EQUALS, "OFI");
+
+        Assertions.assertTrue(oids.contains(noCode.getOid()),
+                "Entry with empty altCodes array must be included by NOT_EQUALS");
+        Assertions.assertTrue(oids.contains(singleCode.getOid()));
+        Assertions.assertFalse(oids.contains(multiCode.getOid()));
+    }
+
+    // ─────────────────────────────────────────────
+    // EMPTY
+    // ─────────────────────────────────────────────
+
+    @Test
+    void filterByAltCodes_empty_matchesEntryWithEmptyArray() {
+        // This is the regression for the Copilot-reported bug:
+        // before the fix, IS NULL missed the non-null empty-array row.
+        List<String> oids = searchOids(FilterConditionOperator.EMPTY, null);
+
+        Assertions.assertEquals(1, oids.size(),
+                "EMPTY filter must match exactly the entry whose altCodes is an empty array {}");
+        Assertions.assertTrue(oids.contains(noCode.getOid()));
+    }
+
+    @Test
+    void filterByAltCodes_empty_doesNotMatchEntriesWithAltCodes() {
+        List<String> oids = searchOids(FilterConditionOperator.EMPTY, null);
+
+        Assertions.assertFalse(oids.contains(multiCode.getOid()));
+        Assertions.assertFalse(oids.contains(singleCode.getOid()));
+    }
+
+    // ─────────────────────────────────────────────
+    // NOT_EMPTY
+    // ─────────────────────────────────────────────
+
+    @Test
+    void filterByAltCodes_notEmpty_excludesEntryWithEmptyArray() {
+        List<String> oids = searchOids(FilterConditionOperator.NOT_EMPTY, null);
+
+        Assertions.assertFalse(oids.contains(noCode.getOid()),
+                "NOT_EMPTY filter must exclude the entry whose altCodes is an empty array {}");
+    }
+
+    @Test
+    void filterByAltCodes_notEmpty_includesEntriesWithAltCodes() {
+        List<String> oids = searchOids(FilterConditionOperator.NOT_EMPTY, null);
+
+        Assertions.assertTrue(oids.contains(multiCode.getOid()));
+        Assertions.assertTrue(oids.contains(singleCode.getOid()));
+    }
+
+    // ─────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────
+
+    private List<String> searchOids(FilterConditionOperator operator, String value) {
+        SearchRequestDto request = new SearchRequestDto();
+        request.setFilters(List.of(
+                new SearchFilterRequestDtoDummy(FilterFieldSource.PROPERTY,
+                        FilterField.OID_ENTRY_ALT_CODES.name(), operator, value)));
+        CustomOidEntryListResponseDto response = customOidEntryService.listCustomOidEntries(request);
+        return response.getOidEntries().stream()
+                .map(item -> item.getOid())
+                .toList();
+    }
+
+    private RdnAttributeTypeCustomOidEntry rdnEntry(String oid, String displayName, String code, List<String> altCodes) {
+        RdnAttributeTypeCustomOidEntry entry = new RdnAttributeTypeCustomOidEntry();
+        entry.setOid(oid);
+        entry.setCategory(OidCategory.RDN_ATTRIBUTE_TYPE);
+        entry.setDisplayName(displayName);
+        entry.setDescription("test entry");
+        entry.setCode(code);
+        entry.setAltCodes(altCodes);
+        return customOidEntryRepository.save(entry);
+    }
+}

--- a/src/test/java/com/czertainly/core/search/NativeArrayFilterSearchTest.java
+++ b/src/test/java/com/czertainly/core/search/NativeArrayFilterSearchTest.java
@@ -1,7 +1,5 @@
 package com.czertainly.core.search;
 
-import com.czertainly.api.exception.ValidationException;
-import com.czertainly.api.model.client.certificate.SearchFilterRequestDto;
 import com.czertainly.api.model.client.certificate.SearchRequestDto;
 import com.czertainly.api.model.core.oid.CustomOidEntryListResponseDto;
 import com.czertainly.api.model.core.oid.OidCategory;
@@ -109,6 +107,58 @@ class NativeArrayFilterSearchTest extends BaseSpringBootTest {
     }
 
     // ─────────────────────────────────────────────
+    // EQUALS — multi-value (OR semantics)
+    // ─────────────────────────────────────────────
+
+    @Test
+    void filterByAltCodes_equals_multiValue_matchesEntriesContainingAnyValue() {
+        // Provide two values: "ALONE" (in singleCode) and "OFI2" (in multiCode).
+        // EQUALS with multiple values = array contains any of them.
+        List<String> oids = searchOids(FilterConditionOperator.EQUALS, List.of("ALONE", "OFI2"));
+
+        Assertions.assertEquals(2, oids.size());
+        Assertions.assertTrue(oids.contains(singleCode.getOid()));
+        Assertions.assertTrue(oids.contains(multiCode.getOid()));
+        Assertions.assertFalse(oids.contains(noCode.getOid()));
+    }
+
+    @Test
+    void filterByAltCodes_equals_multiValue_noMatchWhenNonePresent() {
+        List<String> oids = searchOids(FilterConditionOperator.EQUALS, List.of("NOSUCH1", "NOSUCH2"));
+
+        Assertions.assertEquals(0, oids.size());
+    }
+
+    // ─────────────────────────────────────────────
+    // NOT_EQUALS — multi-value (AND semantics: contains none)
+    // ─────────────────────────────────────────────
+
+    @Test
+    void filterByAltCodes_notEquals_multiValue_excludesEntriesContainingAnyValue() {
+        // Provide "OFI" and "ALONE": entries containing either must be excluded.
+        // multiCode contains "OFI" → excluded; singleCode contains "ALONE" → excluded.
+        // noCode contains neither → included.
+        List<String> oids = searchOids(FilterConditionOperator.NOT_EQUALS, List.of("OFI", "ALONE"));
+
+        Assertions.assertFalse(oids.contains(multiCode.getOid()),
+                "multiCode contains 'OFI' and must be excluded");
+        Assertions.assertFalse(oids.contains(singleCode.getOid()),
+                "singleCode contains 'ALONE' and must be excluded");
+        Assertions.assertTrue(oids.contains(noCode.getOid()),
+                "noCode contains neither value and must be included");
+    }
+
+    @Test
+    void filterByAltCodes_notEquals_multiValue_includesEntryNotContainingAnyValue() {
+        // "OFI2" is only in multiCode; singleCode and noCode contain neither value.
+        List<String> oids = searchOids(FilterConditionOperator.NOT_EQUALS, List.of("OFI2", "NOSUCH"));
+
+        Assertions.assertFalse(oids.contains(multiCode.getOid()));
+        Assertions.assertTrue(oids.contains(singleCode.getOid()));
+        Assertions.assertTrue(oids.contains(noCode.getOid()));
+    }
+
+    // ─────────────────────────────────────────────
     // EMPTY
     // ─────────────────────────────────────────────
 
@@ -116,7 +166,7 @@ class NativeArrayFilterSearchTest extends BaseSpringBootTest {
     void filterByAltCodes_empty_matchesEntryWithEmptyArray() {
         // This is the regression for the Copilot-reported bug:
         // before the fix, IS NULL missed the non-null empty-array row.
-        List<String> oids = searchOids(FilterConditionOperator.EMPTY, null);
+        List<String> oids = searchOids(FilterConditionOperator.EMPTY, (String) null);
 
         Assertions.assertEquals(1, oids.size(),
                 "EMPTY filter must match exactly the entry whose altCodes is an empty array {}");
@@ -125,7 +175,7 @@ class NativeArrayFilterSearchTest extends BaseSpringBootTest {
 
     @Test
     void filterByAltCodes_empty_doesNotMatchEntriesWithAltCodes() {
-        List<String> oids = searchOids(FilterConditionOperator.EMPTY, null);
+        List<String> oids = searchOids(FilterConditionOperator.EMPTY, (String) null);
 
         Assertions.assertFalse(oids.contains(multiCode.getOid()));
         Assertions.assertFalse(oids.contains(singleCode.getOid()));
@@ -137,7 +187,7 @@ class NativeArrayFilterSearchTest extends BaseSpringBootTest {
 
     @Test
     void filterByAltCodes_notEmpty_excludesEntryWithEmptyArray() {
-        List<String> oids = searchOids(FilterConditionOperator.NOT_EMPTY, null);
+        List<String> oids = searchOids(FilterConditionOperator.NOT_EMPTY, (String) null);
 
         Assertions.assertFalse(oids.contains(noCode.getOid()),
                 "NOT_EMPTY filter must exclude the entry whose altCodes is an empty array {}");
@@ -145,7 +195,7 @@ class NativeArrayFilterSearchTest extends BaseSpringBootTest {
 
     @Test
     void filterByAltCodes_notEmpty_includesEntriesWithAltCodes() {
-        List<String> oids = searchOids(FilterConditionOperator.NOT_EMPTY, null);
+        List<String> oids = searchOids(FilterConditionOperator.NOT_EMPTY, (String) null);
 
         Assertions.assertTrue(oids.contains(multiCode.getOid()));
         Assertions.assertTrue(oids.contains(singleCode.getOid()));
@@ -160,6 +210,17 @@ class NativeArrayFilterSearchTest extends BaseSpringBootTest {
         request.setFilters(List.of(
                 new SearchFilterRequestDtoDummy(FilterFieldSource.PROPERTY,
                         FilterField.OID_ENTRY_ALT_CODES.name(), operator, value)));
+        CustomOidEntryListResponseDto response = customOidEntryService.listCustomOidEntries(request);
+        return response.getOidEntries().stream()
+                .map(item -> item.getOid())
+                .toList();
+    }
+
+    private List<String> searchOids(FilterConditionOperator operator, List<String> values) {
+        SearchRequestDto request = new SearchRequestDto();
+        request.setFilters(List.of(
+                new SearchFilterRequestDtoDummy(FilterFieldSource.PROPERTY,
+                        FilterField.OID_ENTRY_ALT_CODES.name(), operator, new ArrayList<>(values))));
         CustomOidEntryListResponseDto response = customOidEntryService.listCustomOidEntries(request);
         return response.getOidEntries().stream()
                 .map(item -> item.getOid())


### PR DESCRIPTION
For digital signing, we need to support search filter predicate of type LIST on the PostgreSQL column type NATIVE_ARRAY.