### PR TITLE
Map proxy connectors to connector summaries

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/Proxy.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Proxy.java
@@ -1,6 +1,7 @@
 package com.czertainly.core.dao.entity;
 
 import com.czertainly.api.model.common.NameAndUuidDto;
+import com.czertainly.api.model.core.connector.ConnectorSummaryDto;
 import com.czertainly.api.model.core.proxy.ProxyDto;
 import com.czertainly.api.model.core.proxy.ProxyListDto;
 import com.czertainly.api.model.core.proxy.ProxyStatus;
@@ -64,7 +65,7 @@ public class Proxy extends UniquelyIdentifiedAndAudited implements Serializable,
         dto.setStatus(this.status);
         dto.setLastActivity(this.lastActivity);
         dto.setConnectors(this.connectors.stream()
-            .map(Connector::mapToDto)
+            .map(c -> new ConnectorSummaryDto(c.getUuid().toString(), c.getName(), c.getUrl(), c.getStatus()))
             .collect(Collectors.toList()));
         return dto;
     }
@@ -77,7 +78,6 @@ public class Proxy extends UniquelyIdentifiedAndAudited implements Serializable,
         dto.setCode(this.code);
         dto.setStatus(this.status);
         dto.setLastActivity(this.lastActivity);
-        // Don't set connectors to avoid circular reference
         return dto;
     }
 


### PR DESCRIPTION
## Summary

Follows the type narrowing in [interfaces#669](https://github.com/OmniTrustILM/interfaces/pull/669) (merged): `ProxyDto.connectors` is now `List<ConnectorSummaryDto>`, so `Proxy.mapToDto()` constructs summary items directly instead of mapping each `Connector` to a full `ConnectorDto`.

The `mapToDtoSimple()` workaround comment (\"*Don't set connectors to avoid circular reference*\") is dropped — the reverse-collection no longer pulls in full `ConnectorDto`, so there is no cycle to avoid. `mapToDtoSimple()` itself is kept; callers in `Connector.java` still use it to skip the connectors list in responses where the data isn't needed.

## Test plan

- [x] \`mvn -Dmaven.compiler.proc=full compile\` succeeds against the interfaces snapshot containing the type change.
- [x] \`mvn test -Dtest=ProxyControllerTest,ProxyProvisioningServiceTest,ConnectorRepositoryTest\` — 16 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)