### PR TITLE
Fix crash on optional attribute with null content

### DIFF
--- a/src/main/java/com/czertainly/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/czertainly/core/attribute/engine/AttributeEngine.java
@@ -1291,6 +1291,14 @@ public class AttributeEngine {
 
         validateAttributeContent(attributeDefinition, attributeContentItems);
 
+        // validateAttributeContent treats null and empty content equivalently for non-required
+        // attributes; mirror that contract here. Without this guard the iteration below NPEs on
+        // attributeContentItems.size() and surfaces as a 500 with framework-internal message,
+        // instead of a clean no-op for an optional attribute the connector left unset.
+        if (attributeContentItems == null || attributeContentItems.isEmpty()) {
+            return;
+        }
+
         for (int i = 0; i < attributeContentItems.size(); i++) {
             AttributeContent attributeContentItem = attributeContentItems.get(i);
             AttributeContentItem contentItemEntity = null;

--- a/src/test/java/com/czertainly/core/attribute/AttributeEngineTest.java
+++ b/src/test/java/com/czertainly/core/attribute/AttributeEngineTest.java
@@ -331,6 +331,35 @@ class AttributeEngineTest extends BaseSpringBootTest {
     }
 
     @Test
+    void updateObjectDataAttributesContentAcceptsNullContentForNonRequiredAttribute() throws AttributeException {
+        // Regression: a connector legitimately returning content=null for an optional attribute
+        // used to NPE deep in createObjectAttributeContent (attributeContentItems.size() on null),
+        // surfacing as HTTP 500 with a framework-internal message instead of a clean no-op.
+        // validateAttributeContent already accepts null/empty equivalently for non-required
+        // attributes; the iteration site must mirror that contract.
+        DataAttributeV3 optionalAttribute = new DataAttributeV3();
+        optionalAttribute.setUuid(UUID.randomUUID().toString());
+        optionalAttribute.setName("optionalNullContentAttribute");
+        optionalAttribute.setContentType(AttributeContentType.STRING);
+        DataAttributeProperties props = new DataAttributeProperties();
+        props.setLabel("Optional null-content attribute");
+        props.setRequired(false);
+        optionalAttribute.setProperties(props);
+        attributeEngine.updateDataAttributeDefinitions(null, null, List.of(optionalAttribute));
+
+        RequestAttributeV3 requestAttribute = new RequestAttributeV3();
+        requestAttribute.setUuid(UUID.fromString(optionalAttribute.getUuid()));
+        requestAttribute.setName(optionalAttribute.getName());
+        requestAttribute.setContent(null);
+
+        UUID certificateUuid = certificate.getUuid();
+        Assertions.assertDoesNotThrow(() -> attributeEngine.updateObjectDataAttributesContent(
+                        ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificateUuid).build(),
+                        List.of(requestAttribute)),
+                "null content for a non-required attribute must be a no-op, not an NPE");
+    }
+
+    @Test
     void testGetDataAttributesByContent() throws AttributeException {
         DataAttributeV2 dataAttributeV2 = new DataAttributeV2();
         dataAttributeV2.setUuid(UUID.randomUUID().toString());


### PR DESCRIPTION
## Summary

`AttributeEngine.createObjectAttributeContent` calls `attributeContentItems.size()` without a null guard, but the immediately-preceding `validateAttributeContent` accepts `null` and empty content equivalently for non-required attributes (`boolean noContent = attributeContent == null || attributeContent.isEmpty();`). A `RequestAttribute` with `content == null` for an optional attribute therefore passes validation and then triggers an NPE on the next line, which surfaces as HTTP 500 with the framework-internal message `Cannot invoke \"java.util.List.size()\" because \"attributeContentItems\" is null` via the global handler.

## What changed

After `validateAttributeContent` passes, return cleanly when the content is null or empty. The two halves of `createObjectAttributeContent` now agree on what null means for non-required attributes.

## Test plan

- [x] New regression test `updateObjectDataAttributesContentAcceptsNullContentForNonRequiredAttribute` in `AttributeEngineTest` — registers a non-required v3 data attribute, sends a `RequestAttribute` with `content=null`, asserts no exception.
- [x] Full `AttributeEngineTest` passes (27 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)