### PR TITLE
Surface connector reason when identification rejects RA-profile switch

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -2172,11 +2172,18 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
                 // anchor mismatch, validity, key usage, RA-profile attribute violation, etc.
                 // Forward the connector's own error descriptions so the operator sees the
                 // specific reason. The descriptions are domain-shaped and safe to expose.
-                String reason = e.getErrors() == null
-                        ? e.getMessage()
-                        : e.getErrors().stream()
-                                .map(ValidationError::getErrorDescription)
-                                .collect(Collectors.joining("; "));
+                String joinedDescriptions = e.getErrors() == null ? "" : e.getErrors().stream()
+                        .map(ValidationError::getErrorDescription)
+                        .filter(s -> s != null && !s.isBlank())
+                        .collect(Collectors.joining("; "));
+                String reason;
+                if (!joinedDescriptions.isBlank()) {
+                    reason = joinedDescriptions;
+                } else if (e.getMessage() != null && !e.getMessage().isBlank()) {
+                    reason = e.getMessage();
+                } else {
+                    reason = "no reason supplied by connector";
+                }
                 applicationEventPublisher.publishEvent(new UpdateCertificateHistoryEvent(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Identification by authority of new RA profile %s rejected the certificate: %s", newRaProfile.getName(), reason), null));
                 throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Identification by authority of new RA profile %s rejected the certificate: %s. Certificate: %s", newRaProfile.getName(), reason, certificate.toStringShort()));
             }

--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -2168,8 +2168,17 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
                 applicationEventPublisher.publishEvent(new UpdateCertificateHistoryEvent(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Certificate not identified by authority of new RA profile %s. Certificate needs to be reissued.", newRaProfile.getName()), null));
                 throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Certificate not identified by authority of new RA profile %s. Certificate: %s", newRaProfile.getName(), certificate.toStringShort()));
             } catch (ValidationException e) {
-                applicationEventPublisher.publishEvent(new UpdateCertificateHistoryEvent(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Certificate identified by authority of new RA profile %s but not valid according to RA profile attributes. Certificate needs to be reissued.", newRaProfile.getName()), null));
-                throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Certificate identified by authority of new RA profile %s but not valid according to RA profile attributes. Certificate: %s", newRaProfile.getName(), certificate.toStringShort()));
+                // A connector may reject identification for any policy it implements: trust
+                // anchor mismatch, validity, key usage, RA-profile attribute violation, etc.
+                // Forward the connector's own error descriptions so the operator sees the
+                // specific reason. The descriptions are domain-shaped and safe to expose.
+                String reason = e.getErrors() == null
+                        ? e.getMessage()
+                        : e.getErrors().stream()
+                                .map(ValidationError::getErrorDescription)
+                                .collect(Collectors.joining("; "));
+                applicationEventPublisher.publishEvent(new UpdateCertificateHistoryEvent(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Identification by authority of new RA profile %s rejected the certificate: %s", newRaProfile.getName(), reason), null));
+                throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Identification by authority of new RA profile %s rejected the certificate: %s. Certificate: %s", newRaProfile.getName(), reason, certificate.toStringShort()));
             }
         }
 

--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -2170,20 +2170,8 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
             } catch (ValidationException e) {
                 // A connector may reject identification for any policy it implements: trust
                 // anchor mismatch, validity, key usage, RA-profile attribute violation, etc.
-                // Forward the connector's own error descriptions so the operator sees the
-                // specific reason. The descriptions are domain-shaped and safe to expose.
-                String joinedDescriptions = e.getErrors() == null ? "" : e.getErrors().stream()
-                        .map(ValidationError::getErrorDescription)
-                        .filter(s -> s != null && !s.isBlank())
-                        .collect(Collectors.joining("; "));
-                String reason;
-                if (!joinedDescriptions.isBlank()) {
-                    reason = joinedDescriptions;
-                } else if (e.getMessage() != null && !e.getMessage().isBlank()) {
-                    reason = e.getMessage();
-                } else {
-                    reason = "no reason supplied by connector";
-                }
+                // Forward the connector's own reason so the operator sees the specific cause.
+                String reason = identifyRejectionReason(e);
                 applicationEventPublisher.publishEvent(new UpdateCertificateHistoryEvent(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Identification by authority of new RA profile %s rejected the certificate: %s", newRaProfile.getName(), reason), null));
                 throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Identification by authority of new RA profile %s rejected the certificate: %s. Certificate: %s", newRaProfile.getName(), reason, certificate.toStringShort()));
             }
@@ -2285,6 +2273,29 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
             throw new AttributeException("Certificate without content cannot be set as resource object in attribute.");
         contentData.setContent(certificate.getCertificateContent().getContent());
         return contentData;
+    }
+
+    /**
+     * Builds a human-readable rejection reason from a connector's {@link ValidationException}.
+     *
+     * <p>Joins all non-blank {@link ValidationError} descriptions with {@code "; "}. When no
+     * usable description is available, falls back to {@link Throwable#getMessage()}, then to a
+     * fixed placeholder so the surrounding operator-facing message never ends with an empty
+     * fragment. Filtering null / blank descriptions also avoids the {@code NullPointerException}
+     * {@code Collectors.joining} would otherwise throw.</p>
+     */
+    static String identifyRejectionReason(ValidationException e) {
+        String joined = e.getErrors() == null ? "" : e.getErrors().stream()
+                .map(ValidationError::getErrorDescription)
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.joining("; "));
+        if (!joined.isBlank()) {
+            return joined;
+        }
+        if (e.getMessage() != null && !e.getMessage().isBlank()) {
+            return e.getMessage();
+        }
+        return "no reason supplied by connector";
     }
 
 }

--- a/src/test/java/com/czertainly/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/CertificateServiceTest.java
@@ -589,6 +589,17 @@ class CertificateServiceTest extends BaseSpringBootTest {
                 () -> certificateService.updateCertificateObjects(certificate.getSecuredUuid(), uuidDto));
         Assertions.assertTrue(ex.getMessage().contains("Certificate is not issued by any of the configured CA certificates"),
                 "Expected connector's rejection reason to be surfaced, got: " + ex.getMessage());
+
+        // An empty error list from the connector must not produce a message ending with an
+        // empty placeholder; the reason should fall back to a useful string.
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/identify"))
+                .willReturn(WireMock.jsonResponse("[]", 422)));
+
+        CertificateOperationException emptyErrors = Assertions.assertThrows(CertificateOperationException.class,
+                () -> certificateService.updateCertificateObjects(certificate.getSecuredUuid(), uuidDto));
+        Assertions.assertFalse(emptyErrors.getMessage().contains("rejected the certificate: ."),
+                "Empty errors list must not surface as an empty reason; got: " + emptyErrors.getMessage());
     }
 
     @Test

--- a/src/test/java/com/czertainly/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/CertificateServiceTest.java
@@ -581,9 +581,14 @@ class CertificateServiceTest extends BaseSpringBootTest {
 
         mockServer.stubFor(WireMock
                 .post(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/identify"))
-                .willReturn(WireMock.jsonResponse("[\"Object of type 'Certificate' identified but not valid according RA profile attributes.\"]", 422)));
+                .willReturn(WireMock.jsonResponse("[\"Certificate is not issued by any of the configured CA certificates\"]", 422)));
 
-        Assertions.assertThrows(CertificateOperationException.class, () -> certificateService.updateCertificateObjects(certificate.getSecuredUuid(), uuidDto));
+        // The wrapped CertificateOperationException must include the connector's specific
+        // rejection reason so operators can see exactly why identification failed.
+        CertificateOperationException ex = Assertions.assertThrows(CertificateOperationException.class,
+                () -> certificateService.updateCertificateObjects(certificate.getSecuredUuid(), uuidDto));
+        Assertions.assertTrue(ex.getMessage().contains("Certificate is not issued by any of the configured CA certificates"),
+                "Expected connector's rejection reason to be surfaced, got: " + ex.getMessage());
     }
 
     @Test

--- a/src/test/java/com/czertainly/core/service/impl/CertificateServiceImplIdentifyRejectionReasonTest.java
+++ b/src/test/java/com/czertainly/core/service/impl/CertificateServiceImplIdentifyRejectionReasonTest.java
@@ -1,0 +1,75 @@
+package com.czertainly.core.service.impl;
+
+import com.czertainly.api.exception.ValidationError;
+import com.czertainly.api.exception.ValidationException;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link CertificateServiceImpl#identifyRejectionReason(ValidationException)}.
+ * Each branch is covered independently so the helper does not depend on Spring context wiring.
+ */
+class CertificateServiceImplIdentifyRejectionReasonTest {
+
+    @Test
+    void joinsNonBlankErrorDescriptions() {
+        ValidationException ex = new ValidationException(List.of(
+                ValidationError.create("first reason"),
+                ValidationError.create("second reason")
+        ));
+
+        String reason = CertificateServiceImpl.identifyRejectionReason(ex);
+
+        assertThat(reason).isEqualTo("first reason; second reason");
+    }
+
+    @Test
+    void filtersOutNullAndBlankDescriptions() {
+        // Mix of valid, null, blank, and whitespace-only descriptions — the joiner would NPE
+        // on a null element if not filtered, and blank entries would produce dangling separators.
+        List<ValidationError> errors = new ArrayList<>();
+        errors.add(ValidationError.create("real reason"));
+        errors.add(makeError(null));
+        errors.add(makeError(""));
+        errors.add(makeError("   "));
+        errors.add(ValidationError.create("another reason"));
+        ValidationException ex = new ValidationException(errors);
+
+        String reason = CertificateServiceImpl.identifyRejectionReason(ex);
+
+        assertThat(reason).isEqualTo("real reason; another reason");
+    }
+
+    @Test
+    void fallsBackToExceptionMessageWhenAllDescriptionsAreBlank() {
+        // No usable descriptions — the helper must still produce a non-empty reason so the
+        // operator-facing message never ends in an empty fragment.
+        List<ValidationError> errors = new ArrayList<>();
+        errors.add(makeError(null));
+        errors.add(makeError(""));
+        ValidationException ex = new ValidationException("some upstream message", errors);
+
+        String reason = CertificateServiceImpl.identifyRejectionReason(ex);
+
+        assertThat(reason).contains("some upstream message");
+    }
+
+    @Test
+    void fallsBackToPlaceholderWhenNothingUsable() {
+        // ValidationException constructed from an empty errors list — getMessage() is the
+        // empty string the joiner produces, getErrors() is non-null but empty.
+        ValidationException ex = new ValidationException(new ArrayList<>());
+
+        String reason = CertificateServiceImpl.identifyRejectionReason(ex);
+
+        assertThat(reason).isEqualTo("no reason supplied by connector");
+    }
+
+    private static ValidationError makeError(String description) {
+        return ValidationError.create(description);
+    }
+}


### PR DESCRIPTION
## Summary

`CertificateServiceImpl.switchRaProfile` invokes the connector's `identifyCertificate` to confirm the certificate belongs to the new RA profile's authority. When the connector rejects with `ValidationException`, the wrapping `CertificateOperationException` and the certificate-history event used a hardcoded message that presumed the rejection was an RA-profile-attribute violation — but that's only one of many reasons a connector can reject (trust-anchor mismatch, validity, key usage, ...). The presumption hid the actual failure cause from operators trying to diagnose why the switch was refused.

This change forwards the connector's own error descriptions in both the operator-facing exception and the history event.

**Before:**
```
Cannot switch RA profile for certificate. Certificate identified by authority of new RA profile X
but not valid according to RA profile attributes. Certificate: ...
```

**After (example, with the actual connector reason surfaced):**
```
Cannot switch RA profile for certificate. Identification by authority of new RA profile X rejected
the certificate: Certificate is not issued by any of the configured CA certificates. Certificate: ...
```

## Test plan

- [x] Existing `CertificateServiceTest#testUpdateRaProfileFails` extended to assert the connector's specific rejection reason is surfaced in the wrapped exception message.
- [x] Full `CertificateServiceTest` (90 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)