### PR TITLE
Add signing certificate cache

### DIFF
--- a/src/main/java/com/czertainly/core/aop/CertificateRepositoryCacheEvictionAspect.java
+++ b/src/main/java/com/czertainly/core/aop/CertificateRepositoryCacheEvictionAspect.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * Evicts certificate-dependent caches after any mutation on {@link CertificateRepository}.
+ * Evicts the certificate-chain and signing-certificate caches after any mutation on {@link CertificateRepository}.
  *
  * <p>Intercepts {@code save*}, {@code delete*}, {@code insert*}, {@code update*}, and {@code clear*} calls on
  * {@link CertificateRepository} — covering all Spring Data CRUD methods (save, saveAll, saveAndFlush, delete,
@@ -46,5 +46,6 @@ public class CertificateRepositoryCacheEvictionAspect {
     @AfterReturning("certificateMutation()")
     public void onMutation() {
         cacheEvictor.clear(CacheConfig.CERTIFICATE_CHAIN_CACHE);
+        cacheEvictor.clear(CacheConfig.SIGNING_CERTIFICATE_CACHE);
     }
 }

--- a/src/main/java/com/czertainly/core/aop/CertificateRepositoryCacheEvictionAspect.java
+++ b/src/main/java/com/czertainly/core/aop/CertificateRepositoryCacheEvictionAspect.java
@@ -11,12 +11,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * Evicts the certificate-chain and signing-certificate caches after any mutation on {@link CertificateRepository}.
- *
- * <p>Intercepts {@code save*}, {@code delete*}, {@code insert*}, {@code update*}, {@code clear*},
- * {@code archive*}, and {@code set*} calls on {@link CertificateRepository} — covering all Spring Data
- * CRUD methods (save, saveAll, saveAndFlush, delete, deleteAll, deleteAllInBatch, etc.), the custom native
- * upserts, the targeted {@code @Modifying} UPDATEs, bulk archive/unarchive operations, and the field-setting
- * helpers (e.g. {@code setKeyUuid}).
+ * The intercepted verb prefixes are declared in the {@link #certificateMutation()} pointcut below.
  *
  * <p><strong>Eviction strategy.</strong> Every matched mutation triggers a full {@code cache.clear()}
  * (deferred to {@code afterCommit} and deduped per transaction by {@link CacheEvictor}).
@@ -42,7 +37,7 @@ public class CertificateRepositoryCacheEvictionAspect {
     @Pointcut("target(com.czertainly.core.dao.repository.CertificateRepository+) "
             + "&& (execution(* save*(..)) || execution(* delete*(..)) || execution(* insert*(..)) "
             + "|| execution(* update*(..)) || execution(* clear*(..)) || execution(* archive*(..)) "
-            + "|| execution(* set*(..)))")
+            + "|| execution(* set*(..)) || execution(* transition*(..)))")
     private void certificateMutation() {}
 
     @AfterReturning("certificateMutation()")

--- a/src/main/java/com/czertainly/core/aop/CertificateRepositoryCacheEvictionAspect.java
+++ b/src/main/java/com/czertainly/core/aop/CertificateRepositoryCacheEvictionAspect.java
@@ -12,10 +12,11 @@ import org.springframework.stereotype.Component;
 /**
  * Evicts the certificate-chain and signing-certificate caches after any mutation on {@link CertificateRepository}.
  *
- * <p>Intercepts {@code save*}, {@code delete*}, {@code insert*}, {@code update*}, and {@code clear*} calls on
- * {@link CertificateRepository} — covering all Spring Data CRUD methods (save, saveAll, saveAndFlush, delete,
- * deleteAll, deleteAllInBatch, etc.), the custom native upserts, the targeted {@code @Modifying} UPDATEs and
- * the field-nulling helpers.
+ * <p>Intercepts {@code save*}, {@code delete*}, {@code insert*}, {@code update*}, {@code clear*},
+ * {@code archive*}, and {@code set*} calls on {@link CertificateRepository} — covering all Spring Data
+ * CRUD methods (save, saveAll, saveAndFlush, delete, deleteAll, deleteAllInBatch, etc.), the custom native
+ * upserts, the targeted {@code @Modifying} UPDATEs, bulk archive/unarchive operations, and the field-setting
+ * helpers (e.g. {@code setKeyUuid}).
  *
  * <p><strong>Eviction strategy.</strong> Every matched mutation triggers a full {@code cache.clear()}
  * (deferred to {@code afterCommit} and deduped per transaction by {@link CacheEvictor}).
@@ -40,7 +41,8 @@ public class CertificateRepositoryCacheEvictionAspect {
 
     @Pointcut("target(com.czertainly.core.dao.repository.CertificateRepository+) "
             + "&& (execution(* save*(..)) || execution(* delete*(..)) || execution(* insert*(..)) "
-            + "|| execution(* update*(..)) || execution(* clear*(..)))")
+            + "|| execution(* update*(..)) || execution(* clear*(..)) || execution(* archive*(..)) "
+            + "|| execution(* set*(..)))")
     private void certificateMutation() {}
 
     @AfterReturning("certificateMutation()")

--- a/src/main/java/com/czertainly/core/aop/CryptographicKeyRepositoryCacheEvictionAspect.java
+++ b/src/main/java/com/czertainly/core/aop/CryptographicKeyRepositoryCacheEvictionAspect.java
@@ -1,0 +1,48 @@
+package com.czertainly.core.aop;
+
+import com.czertainly.core.config.cache.CacheConfig;
+import com.czertainly.core.config.cache.CacheEvictor;
+import com.czertainly.core.dao.repository.CryptographicKeyItemRepository;
+import com.czertainly.core.dao.repository.CryptographicKeyRepository;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Evicts the signing-certificate cache after any mutation on {@link CryptographicKeyRepository}
+ * or {@link CryptographicKeyItemRepository}.
+ *
+ * <p>{@link com.czertainly.core.model.signing.SigningCertificate} caches key-level structural
+ * references ({@code tokenInstanceReferenceUuid}, {@code tokenProfileUuid}, {@code keyItemUuids})
+ * derived from the associated {@link com.czertainly.core.dao.entity.CryptographicKey}. When the
+ * key is mutated (e.g. token-profile reassignment via
+ * {@link com.czertainly.core.service.impl.CryptographicKeyServiceImpl#editKey}), those cached
+ * values become stale and must be cleared.
+ *
+ * <p>Only {@link CacheConfig#SIGNING_CERTIFICATE_CACHE} is cleared — key mutations do not
+ * affect the certificate chain.
+ */
+@Aspect
+@Component
+public class CryptographicKeyRepositoryCacheEvictionAspect {
+
+    private CacheEvictor cacheEvictor;
+
+    @Autowired
+    public void setCacheEvictor(CacheEvictor cacheEvictor) {
+        this.cacheEvictor = cacheEvictor;
+    }
+
+    @Pointcut("(target(com.czertainly.core.dao.repository.CryptographicKeyRepository+) "
+            + "|| target(com.czertainly.core.dao.repository.CryptographicKeyItemRepository+)) "
+            + "&& (execution(* save*(..)) || execution(* delete*(..)) || execution(* insert*(..)) "
+            + "|| execution(* update*(..)) || execution(* clear*(..)))")
+    private void cryptographicKeyMutation() {}
+
+    @AfterReturning("cryptographicKeyMutation()")
+    public void onMutation() {
+        cacheEvictor.clear(CacheConfig.SIGNING_CERTIFICATE_CACHE);
+    }
+}

--- a/src/main/java/com/czertainly/core/config/cache/CacheConfig.java
+++ b/src/main/java/com/czertainly/core/config/cache/CacheConfig.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
         ConnectorApiClientCacheProperties.class,
         CertificateChainCacheProperties.class,
         CryptographicKeyItemCacheProperties.class,
+        SigningCertificateCacheProperties.class,
         SigningProfileCacheProperties.class,
         TimeQualityConfigurationCacheProperties.class,
         TspProfileCacheProperties.class,
@@ -30,6 +31,7 @@ public class CacheConfig {
     public static final String CERTIFICATE_CHAIN_CACHE = "certificateChain";
     public static final String CONNECTOR_API_CLIENT_CACHE = "connectorApiClient";
     public static final String CRYPTOGRAPHIC_KEY_ITEM_CACHE = "cryptographicKeyItem";
+    public static final String SIGNING_CERTIFICATE_CACHE = "signingCertificate";
     public static final String SIGNING_PROFILE_CACHE = "signingProfile";
     public static final String SYSTEM_USER_AUTH_CACHE = "systemUserAuth";
     public static final String TIME_QUALITY_CONFIGURATION_CACHE = "timeQualityConfiguration";
@@ -42,6 +44,7 @@ public class CacheConfig {
                                      CertificateChainCacheProperties certChainProperties,
                                      ConnectorApiClientCacheProperties connectorCacheProperties,
                                      CryptographicKeyItemCacheProperties cryptographicKeyItemCacheProperties,
+                                     SigningCertificateCacheProperties signingCertificateCacheProperties,
                                      SigningProfileCacheProperties signingProfileCacheProperties,
                                      TimeQualityConfigurationCacheProperties tqcCacheProperties,
                                      TokenJtiIndex tokenJtiIndex,
@@ -80,6 +83,12 @@ public class CacheConfig {
         mgr.registerCustomCache(CRYPTOGRAPHIC_KEY_ITEM_CACHE, Caffeine.newBuilder()
                 .expireAfterWrite(cryptographicKeyItemCacheProperties.ttlMinutes(), TimeUnit.MINUTES)
                 .maximumSize(cryptographicKeyItemCacheProperties.maxSize())
+                .recordStats()
+                .build());
+
+        mgr.registerCustomCache(SIGNING_CERTIFICATE_CACHE, Caffeine.newBuilder()
+                .expireAfterWrite(signingCertificateCacheProperties.ttlMinutes(), TimeUnit.MINUTES)
+                .maximumSize(signingCertificateCacheProperties.maxSize())
                 .recordStats()
                 .build());
 

--- a/src/main/java/com/czertainly/core/config/cache/SigningCertificateCacheProperties.java
+++ b/src/main/java/com/czertainly/core/config/cache/SigningCertificateCacheProperties.java
@@ -1,0 +1,13 @@
+package com.czertainly.core.config.cache;
+
+import jakarta.validation.constraints.Min;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "caching.signing-certs")
+public record SigningCertificateCacheProperties(
+        @Min(1) int ttlMinutes,
+        @Min(1) int maxSize
+) {
+}

--- a/src/main/java/com/czertainly/core/dao/repository/CertificateRepository.java
+++ b/src/main/java/com/czertainly/core/dao/repository/CertificateRepository.java
@@ -79,6 +79,9 @@ public interface CertificateRepository extends SecurityFilterRepository<Certific
     @EntityGraph("Certificate.chainAssociations")
     List<Certificate> findChainWithAssociationsByUuidIn(List<UUID> uuids);
 
+    @EntityGraph(attributePaths = {"key", "key.items"})
+    Optional<Certificate> findForSigningByUuid(UUID uuid);
+
     Optional<Certificate> findBySerialNumberIgnoreCase(String serialNumber);
 
     Certificate findByCertificateContent(CertificateContent certificateContent);

--- a/src/main/java/com/czertainly/core/dao/repository/CertificateRepository.java
+++ b/src/main/java/com/czertainly/core/dao/repository/CertificateRepository.java
@@ -25,20 +25,13 @@ import java.util.UUID;
  * Spring Data repository for {@link Certificate} entities.
  *
  * <p><strong>Cache eviction:</strong>
- * {@link com.czertainly.core.aop.CertificateRepositoryCacheEvictionAspect} intercepts every
- * {@code save*}, {@code delete*} and {@code insert*} call on this bean and evicts the
- * certificate-chain cache automatically — callers do not need to evict manually after those
- * operations. This covers {@link #insertWithFingerprintConflictResolve}, which writes the
- * chain-defining {@code issuer_certificate_uuid} and {@code certificate_content_id} columns
- * via a native upsert.
+ * {@link com.czertainly.core.aop.CertificateRepositoryCacheEvictionAspect} intercepts mutations on this
+ * bean and evicts both the certificate-chain cache and the signing-certificate cache automatically —
+ * callers do not need to evict manually.
  *
- * <p>The remaining {@code @Modifying} bulk-update methods in this interface are <em>not</em>
- * matched by that aspect (the pointcut targets only the {@code save*}/{@code delete*}/{@code insert*}
- * naming convention), but they do not need manual cache eviction either: they only modify columns
- * that are not part of chain traversal ({@code keyUuid}/{@code altKeyUuid},
- * {@code hybridCertificate}, {@code archived}, {@code subjectDn}/{@code issuerDn} display strings).
- * The chain cache is built from {@code issuer_certificate_uuid} and {@code certificate_content_id}
- * — none of those columns are touched by these queries.
+ * <p>The naming convention is the contract: any new mutating method must begin with one of the verb
+ * prefixes matched by the aspect's pointcut. Over-matching a read-only method is harmless; under-matching
+ * a mutation leaves stale entries cached for up to the TTL.
  */
 @Repository
 public interface CertificateRepository extends SecurityFilterRepository<Certificate, UUID>, CustomCertificateRepository {

--- a/src/main/java/com/czertainly/core/mapper/certificate/SigningCertificateMapper.java
+++ b/src/main/java/com/czertainly/core/mapper/certificate/SigningCertificateMapper.java
@@ -28,7 +28,7 @@ public class SigningCertificateMapper {
                 cert.isArchived(),
                 cert.getState(),
                 cert.getValidationStatus(),
-                MetaDefinitions.deserializeArrayString(cert.getExtendedKeyUsage()),
+                List.copyOf(MetaDefinitions.deserializeArrayString(cert.getExtendedKeyUsage())),
                 cert.getExtendedKeyUsageCritical(),
                 cert.getQcCompliance(),
                 keyUuid,

--- a/src/main/java/com/czertainly/core/mapper/certificate/SigningCertificateMapper.java
+++ b/src/main/java/com/czertainly/core/mapper/certificate/SigningCertificateMapper.java
@@ -1,0 +1,40 @@
+package com.czertainly.core.mapper.certificate;
+
+import com.czertainly.core.dao.entity.Certificate;
+import com.czertainly.core.dao.entity.CryptographicKey;
+import com.czertainly.core.dao.entity.CryptographicKeyItem;
+import com.czertainly.core.model.signing.SigningCertificate;
+import com.czertainly.core.util.MetaDefinitions;
+
+import java.util.List;
+import java.util.UUID;
+
+public class SigningCertificateMapper {
+    private SigningCertificateMapper() {
+    }
+
+    public static SigningCertificate toSigningCertificate(Certificate cert) {
+        CryptographicKey key = cert.getKey();
+        UUID keyUuid = key != null ? key.getUuid() : null;
+        UUID tokenInstanceReferenceUuid = key != null ? key.getTokenInstanceReferenceUuid() : null;
+        UUID tokenProfileUuid = key != null ? key.getTokenProfileUuid() : null;
+        // Sort by UUID so the cached record has a stable, deterministic key-item ordering.
+        List<UUID> keyItemUuids = key != null
+                ? key.getItems().stream().map(CryptographicKeyItem::getUuid).sorted().toList()
+                : List.of();
+        return new SigningCertificate(
+                cert.getUuid(),
+                cert.getCommonName(),
+                cert.isArchived(),
+                cert.getState(),
+                cert.getValidationStatus(),
+                MetaDefinitions.deserializeArrayString(cert.getExtendedKeyUsage()),
+                cert.getExtendedKeyUsageCritical(),
+                cert.getQcCompliance(),
+                keyUuid,
+                tokenInstanceReferenceUuid,
+                tokenProfileUuid,
+                keyItemUuids
+        );
+    }
+}

--- a/src/main/java/com/czertainly/core/model/crypto/CryptographicKeyItemModel.java
+++ b/src/main/java/com/czertainly/core/model/crypto/CryptographicKeyItemModel.java
@@ -1,6 +1,7 @@
 package com.czertainly.core.model.crypto;
 
 import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.KeyType;
 import com.czertainly.api.model.core.cryptography.key.KeyState;
 import com.czertainly.api.model.core.cryptography.key.KeyUsage;
 
@@ -12,10 +13,12 @@ import java.util.UUID;
  */
 public record CryptographicKeyItemModel(
         UUID keyItemUuid,
-        KeyState state,
         boolean enabled,
-        List<KeyUsage> usage,
         KeyAlgorithm keyAlgorithm,
+        KeyState keyState,
+        KeyType keyType,
+        List<KeyUsage> keyUsage,
+        String pqcParameterSpecName,   // set only for PQC public keys
         UUID keyReferenceUuid,
         UUID connectorUuid,
         UUID tokenInstanceUuid

--- a/src/main/java/com/czertainly/core/model/signing/SigningCertificate.java
+++ b/src/main/java/com/czertainly/core/model/signing/SigningCertificate.java
@@ -12,14 +12,12 @@ import java.util.UUID;
 public record SigningCertificate(
         UUID uuid,
         String commonName,
-        // certificate-level acceptability inputs
         boolean archived,
         CertificateState state,
         CertificateValidationStatus validationStatus,
         List<String> extendedKeyUsageOids,
         Boolean extendedKeyUsageCritical,
         Boolean qcCompliance,
-        // structural references (key-level), not key-item material
         UUID keyUuid,
         UUID tokenInstanceReferenceUuid,
         UUID tokenProfileUuid,

--- a/src/main/java/com/czertainly/core/model/signing/SigningCertificate.java
+++ b/src/main/java/com/czertainly/core/model/signing/SigningCertificate.java
@@ -1,0 +1,27 @@
+package com.czertainly.core.model.signing;
+
+import com.czertainly.api.model.core.certificate.CertificateState;
+import com.czertainly.api.model.core.certificate.CertificateValidationStatus;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Immutable, internal-only snapshot of the certificate data the digital signing.
+ */
+public record SigningCertificate(
+        UUID uuid,
+        String commonName,
+        // certificate-level acceptability inputs
+        boolean archived,
+        CertificateState state,
+        CertificateValidationStatus validationStatus,
+        List<String> extendedKeyUsageOids,
+        Boolean extendedKeyUsageCritical,
+        Boolean qcCompliance,
+        // structural references (key-level), not key-item material
+        UUID keyUuid,
+        UUID tokenInstanceReferenceUuid,
+        UUID tokenProfileUuid,
+        List<UUID> keyItemUuids
+) {}

--- a/src/main/java/com/czertainly/core/model/signing/SigningCertificate.java
+++ b/src/main/java/com/czertainly/core/model/signing/SigningCertificate.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Immutable, internal-only snapshot of the certificate data the digital signing.
+ * Immutable, internal-only snapshot of the certificate data for digital signing.
  */
 public record SigningCertificate(
         UUID uuid,

--- a/src/main/java/com/czertainly/core/service/CertificateService.java
+++ b/src/main/java/com/czertainly/core/service/CertificateService.java
@@ -67,6 +67,8 @@ public interface CertificateService extends ResourceExtensionService {
      * Hot-path accessor for digital signing. Returns an immutable snapshot of the certificate's acceptability data and
      * structural key references, cached in {@link com.czertainly.core.config.cache.CacheConfig#SIGNING_CERTIFICATE_CACHE}.
      *
+     * <p>No authorization check — must not be called from REST controllers.
+     *
      * @throws NotFoundException if no certificate exists for the UUID
      */
     SigningCertificate getSigningCertificate(UUID certificateUuid) throws NotFoundException;

--- a/src/main/java/com/czertainly/core/service/CertificateService.java
+++ b/src/main/java/com/czertainly/core/service/CertificateService.java
@@ -16,6 +16,7 @@ import com.czertainly.core.dao.entity.Certificate;
 import com.czertainly.core.dao.entity.CertificateContent;
 import com.czertainly.core.dao.entity.RaProfile;
 import com.czertainly.core.model.auth.CertificateProtocolInfo;
+import com.czertainly.core.model.signing.SigningCertificate;
 import com.czertainly.core.security.authz.SecuredUUID;
 import com.czertainly.core.security.authz.SecurityFilter;
 
@@ -61,6 +62,14 @@ public interface CertificateService extends ResourceExtensionService {
      * @throws CertificateException if any chain entry cannot be parsed
      */
     List<X509Certificate> getCertificateChainForSigning(UUID certificateUuid, boolean withEndCertificate) throws CertificateException;
+
+    /**
+     * Hot-path accessor for digital signing. Returns an immutable snapshot of the certificate's acceptability data and
+     * structural key references, cached in {@link com.czertainly.core.config.cache.CacheConfig#SIGNING_CERTIFICATE_CACHE}.
+     *
+     * @throws NotFoundException if no certificate exists for the UUID
+     */
+    SigningCertificate getSigningCertificate(UUID certificateUuid) throws NotFoundException;
 
     CertificateChainDownloadResponseDto downloadCertificateChain(SecuredUUID uuid, CertificateFormat certificateFormat, boolean withEndCertificate, CertificateFormatEncoding encoding) throws NotFoundException, CertificateException;
 

--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -55,6 +55,7 @@ import com.czertainly.core.events.handlers.CertificateExpiringEventHandler;
 import com.czertainly.core.events.handlers.CertificateStatusChangedEventHandler;
 import com.czertainly.core.events.transaction.CertificateValidationEvent;
 import com.czertainly.core.events.transaction.UpdateCertificateHistoryEvent;
+import com.czertainly.core.mapper.certificate.SigningCertificateMapper;
 import com.czertainly.core.messaging.jms.producers.EventProducer;
 import com.czertainly.core.messaging.jms.producers.NotificationProducer;
 import com.czertainly.core.messaging.jms.producers.ValidationProducer;
@@ -63,6 +64,7 @@ import com.czertainly.core.messaging.model.ValidationMessage;
 import com.czertainly.core.model.auth.CertificateProtocolInfo;
 import com.czertainly.core.model.auth.ResourceAction;
 import com.czertainly.core.model.request.CertificateRequest;
+import com.czertainly.core.model.signing.SigningCertificate;
 import com.czertainly.core.oid.OidHandler;
 import com.czertainly.core.oid.OidRecord;
 import com.czertainly.core.security.authn.client.AuthenticationCache;
@@ -802,6 +804,14 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
             chain.add(CertificateUtil.parseCertificate(contents.get(i)));
         }
         return Collections.unmodifiableList(chain);
+    }
+
+    @Override
+    @Cacheable(value = CacheConfig.SIGNING_CERTIFICATE_CACHE, key = "#certificateUuid", sync = true)
+    public SigningCertificate getSigningCertificate(UUID certificateUuid) throws NotFoundException {
+        Certificate cert = certificateRepository.findForSigningByUuid(certificateUuid)
+                .orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
+        return SigningCertificateMapper.toSigningCertificate(cert);
     }
 
     @Override

--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -807,6 +807,7 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
     }
 
     @Override
+    @Transactional(readOnly = true)
     @Cacheable(value = CacheConfig.SIGNING_CERTIFICATE_CACHE, key = "#certificateUuid", sync = true)
     public SigningCertificate getSigningCertificate(UUID certificateUuid) throws NotFoundException {
         Certificate cert = certificateRepository.findForSigningByUuid(certificateUuid)

--- a/src/main/java/com/czertainly/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CryptographicKeyServiceImpl.java
@@ -943,12 +943,18 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyService {
         }
         UUID tokenInstanceUuid = UUID.fromString(tokenInstanceReference.getTokenInstanceUuid());
 
+        String pqcParameterSpecName = keyItem.getType() == KeyType.PUBLIC_KEY
+                ? CryptographyUtil.resolvePqcParameterSpecName(keyItem.getKeyAlgorithm(), keyItem.getKeyData())
+                : null;
+
         return new CryptographicKeyItemModel(
                 keyItem.getUuid(),
-                keyItem.getState(),
                 keyItem.isEnabled(),
-                keyItem.getUsage(),
                 keyItem.getKeyAlgorithm(),
+                keyItem.getState(),
+                keyItem.getType(),
+                keyItem.getUsage(),
+                pqcParameterSpecName,
                 keyItem.getKeyReferenceUuid(),
                 tokenInstanceReference.getConnectorUuid(),
                 tokenInstanceUuid

--- a/src/main/java/com/czertainly/core/service/impl/CryptographicOperationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CryptographicOperationServiceImpl.java
@@ -141,12 +141,12 @@ public class CryptographicOperationServiceImpl implements CryptographicOperation
         permissionEvaluator.tokenProfile(tokenProfileUuid);
         logger.info("Request to encrypt the data using the key: {} and data: {}", keyItemUuid, request);
         CryptographicKeyItemModel key = cryptographicKeyService.getKeyItemModel(keyItemUuid);
-        verifyActive(key.state(), key.enabled());
+        verifyActive(key.keyState(), key.enabled());
         logger.debug("Key details: {}", key);
         if (request.getCipherData() == null) {
             throw new ValidationException(ValidationError.create("Cannot encrypt null data"));
         }
-        if (!key.usage().contains(KeyUsage.ENCRYPT)) {
+        if (!key.keyUsage().contains(KeyUsage.ENCRYPT)) {
             throw new ValidationException(
                     ValidationError.create(
                             "Key Usage of the certificate does not support encryption"
@@ -198,12 +198,12 @@ public class CryptographicOperationServiceImpl implements CryptographicOperation
         permissionEvaluator.tokenProfile(tokenProfileUuid);
         logger.info("Decrypting using the key: {} and data: {}", keyItemUuid, request);
         CryptographicKeyItemModel key = cryptographicKeyService.getKeyItemModel(keyItemUuid);
-        verifyActive(key.state(), key.enabled());
+        verifyActive(key.keyState(), key.enabled());
         logger.debug("Key details: {}", key);
         if (request.getCipherData() == null) {
             throw new ValidationException(ValidationError.create("Cannot decrypt null data"));
         }
-        if (!key.usage().contains(KeyUsage.DECRYPT)) {
+        if (!key.keyUsage().contains(KeyUsage.DECRYPT)) {
             throw new ValidationException(
                     ValidationError.create(
                             "Key Usage of the certificate does not support decryption"
@@ -286,12 +286,12 @@ public class CryptographicOperationServiceImpl implements CryptographicOperation
     }
 
     private SignDataResponseDto executeSignData(CryptographicKeyItemModel key, SignDataRequestDto request) throws ConnectorException, NotFoundException {
-        verifyActive(key.state(), key.enabled());
+        verifyActive(key.keyState(), key.enabled());
         logger.debug("Key details: {}", key);
         if (request.getData() == null) {
             throw new ValidationException(ValidationError.create("Cannot sign empty data"));
         }
-        if (!key.usage().contains(KeyUsage.SIGN)) {
+        if (!key.keyUsage().contains(KeyUsage.SIGN)) {
             throw new ValidationException(ValidationError.create("Key Usage of the certificate does not support signing"));
         }
         validateSignatureAttributes(key.keyAlgorithm(), request.getSignatureAttributes());
@@ -331,13 +331,13 @@ public class CryptographicOperationServiceImpl implements CryptographicOperation
         permissionEvaluator.tokenProfile(tokenProfileUuid);
         logger.info("Request to verify data: {} for the key: {}", request, keyItemUuid);
         CryptographicKeyItemModel key = cryptographicKeyService.getKeyItemModel(keyItemUuid);
-        verifyActive(key.state(), key.enabled());
+        verifyActive(key.keyState(), key.enabled());
         logger.debug("Key details: {}", key);
         if (request.getSignatures() == null) {
             throw new ValidationException(ValidationError.create("Cannot verify empty data"));
         }
         validateSignatureAttributes(key.keyAlgorithm(), request.getSignatureAttributes());
-        if (!key.usage().contains(KeyUsage.VERIFY)) {
+        if (!key.keyUsage().contains(KeyUsage.VERIFY)) {
             throw new ValidationException(
                     ValidationError.create(
                             "Key Usage of the certificate does not support verification"

--- a/src/main/java/com/czertainly/core/util/CryptographyUtil.java
+++ b/src/main/java/com/czertainly/core/util/CryptographyUtil.java
@@ -55,46 +55,60 @@ public class CryptographyUtil {
                 );
                 return digest.getProviderName() + "WITHECDSA";
             }
-            // IOException is declared by each BC constructor but not triggered by any known input —
-            // caught defensively in case a future BC version starts throwing it for malformed payloads.
+            case FALCON, MLDSA, SLHDSA -> {
+                return resolvePqcParameterSpecName(keyAlgorithm, publicKey);
+            }
+            default -> throw new ValidationException(
+                    ValidationError.create("Cryptographic algorithm not supported"));
+        }
+    }
+
+    /**
+     * Resolves the post-quantum signature parameter-spec name for FALCON / ML-DSA / SLH-DSA public keys, and returns
+     * {@code null} for every other algorithm. The name is derived solely from the public key.
+     *
+     * @param keyAlgorithm the key algorithm
+     * @param publicKey    Base64-encoded {@code SubjectPublicKeyInfo}; read only for PQC algorithms
+     * @return the parameter-spec name for FALCON/ML-DSA/SLH-DSA, {@code null} otherwise
+     * @throws ValidationException if a PQC public key cannot be parsed
+     */
+    public static String resolvePqcParameterSpecName(KeyAlgorithm keyAlgorithm, String publicKey) {
+        if (publicKey == null) {
+            return null;
+        }
+        // IOException is declared by each BC constructor but not triggered by any known input —
+        // caught defensively in case a future BC version starts throwing it for malformed payloads.
+        switch (keyAlgorithm) {
             case FALCON -> {
                 try {
                     return new BCFalconPublicKey(
-                            SubjectPublicKeyInfo.getInstance(
-                                    Base64.getDecoder().decode(publicKey)))
-                            .getParameterSpec()
-                            .getName();
+                            SubjectPublicKeyInfo.getInstance(Base64.getDecoder().decode(publicKey)))
+                            .getParameterSpec().getName();
                 } catch (IOException | IllegalArgumentException | ClassCastException e) {
-                    throw new ValidationException(
-                            ValidationError.create("Failed obtaining signature algorithm"));
+                    throw new ValidationException(ValidationError.create("Failed obtaining signature algorithm"));
                 }
             }
             case MLDSA -> {
                 try {
                     return new BCMLDSAPublicKey(
-                            SubjectPublicKeyInfo.getInstance(
-                                    Base64.getDecoder().decode(publicKey)))
-                            .getParameterSpec()
-                            .getName();
+                            SubjectPublicKeyInfo.getInstance(Base64.getDecoder().decode(publicKey)))
+                            .getParameterSpec().getName();
                 } catch (IOException | IllegalArgumentException | ClassCastException e) {
-                    throw new ValidationException(
-                            ValidationError.create("Failed obtaining signature algorithm"));
+                    throw new ValidationException(ValidationError.create("Failed obtaining signature algorithm"));
                 }
             }
             case SLHDSA -> {
                 try {
                     return new BCSLHDSAPublicKey(
-                            SubjectPublicKeyInfo.getInstance(
-                                    Base64.getDecoder().decode(publicKey)))
-                            .getParameterSpec()
-                            .getName();
+                            SubjectPublicKeyInfo.getInstance(Base64.getDecoder().decode(publicKey)))
+                            .getParameterSpec().getName();
                 } catch (IOException | IllegalArgumentException | ClassCastException e) {
-                    throw new ValidationException(
-                            ValidationError.create("Failed obtaining signature algorithm"));
+                    throw new ValidationException(ValidationError.create("Failed obtaining signature algorithm"));
                 }
             }
-            default -> throw new ValidationException(
-                    ValidationError.create("Cryptographic algorithm not supported"));
+            default -> {
+                return null;
+            }
         }
     }
 

--- a/src/main/java/com/czertainly/core/util/CryptographyUtil.java
+++ b/src/main/java/com/czertainly/core/util/CryptographyUtil.java
@@ -74,7 +74,11 @@ public class CryptographyUtil {
      */
     public static String resolvePqcParameterSpecName(KeyAlgorithm keyAlgorithm, String publicKey) {
         if (publicKey == null) {
-            return null;
+            return switch (keyAlgorithm) {
+                case FALCON, MLDSA, SLHDSA -> throw new ValidationException(
+                        ValidationError.create("PQC algorithm requires a public key to derive the parameter-spec name"));
+                default -> null;
+            };
         }
         // IOException is declared by each BC constructor but not triggered by any known input —
         // caught defensively in case a future BC version starts throwing it for malformed payloads.
@@ -85,7 +89,7 @@ public class CryptographyUtil {
                             SubjectPublicKeyInfo.getInstance(Base64.getDecoder().decode(publicKey)))
                             .getParameterSpec().getName();
                 } catch (IOException | IllegalArgumentException | ClassCastException e) {
-                    throw new ValidationException(ValidationError.create("Failed obtaining signature algorithm"));
+                    throw new ValidationException(ValidationError.create("Failed parsing PQC public key to derive parameter-spec name"));
                 }
             }
             case MLDSA -> {
@@ -94,7 +98,7 @@ public class CryptographyUtil {
                             SubjectPublicKeyInfo.getInstance(Base64.getDecoder().decode(publicKey)))
                             .getParameterSpec().getName();
                 } catch (IOException | IllegalArgumentException | ClassCastException e) {
-                    throw new ValidationException(ValidationError.create("Failed obtaining signature algorithm"));
+                    throw new ValidationException(ValidationError.create("Failed parsing PQC public key to derive parameter-spec name"));
                 }
             }
             case SLHDSA -> {
@@ -103,7 +107,7 @@ public class CryptographyUtil {
                             SubjectPublicKeyInfo.getInstance(Base64.getDecoder().decode(publicKey)))
                             .getParameterSpec().getName();
                 } catch (IOException | IllegalArgumentException | ClassCastException e) {
-                    throw new ValidationException(ValidationError.create("Failed obtaining signature algorithm"));
+                    throw new ValidationException(ValidationError.create("Failed parsing PQC public key to derive parameter-spec name"));
                 }
             }
             default -> {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ caching:
   cert-chains:
     ttl-minutes: ${CERT_CHAINS_CACHE_TTL_MINUTES:5}
     max-size: ${CERT_CHAINS_CACHE_MAX_SIZE:1000}
+  # Signing-certificate cache holds certificate data + structural references for the signing hot path.
+  signing-certs:
+    ttl-minutes: ${SIGNING_CERTS_CACHE_TTL_MINUTES:5}
+    max-size: ${SIGNING_CERTS_CACHE_MAX_SIZE:1000}
   # Cryptographic Key Item cache caches keys and their associations to avoid repeated database lookups
   crypto-keys:
     ttl-minutes: ${CRYPTO_KEYS_CACHE_TTL_MINUTES:5}   # How long a cached key is considered valid
@@ -30,7 +34,7 @@ caching:
   # TQC cache caches TimeQualityConfigurationModel by UUID for the signing pipeline
   time-quality-configs:
     ttl-minutes: ${TQC_CACHE_TTL_MINUTES:5}   # How long a cached TQC model is considered valid
-    max-size: ${TQC_CACHE_MAX_SIZE:50}         # Maximum number of cached TQC models
+    max-size: ${TQC_CACHE_MAX_SIZE:50}        # Maximum number of cached TQC models
 
 certificate:
   chain:

--- a/src/test/java/com/czertainly/core/service/CryptographicKeyItemCacheTest.java
+++ b/src/test/java/com/czertainly/core/service/CryptographicKeyItemCacheTest.java
@@ -23,6 +23,8 @@ import com.czertainly.core.messaging.jms.producers.NotificationProducer;
 import com.czertainly.core.model.crypto.CryptographicKeyItemModel;
 import com.czertainly.core.security.authz.SecuredUUID;
 import com.czertainly.core.util.BaseSpringBootTest;
+import org.bouncycastle.jcajce.spec.MLDSAParameterSpec;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +32,9 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -242,6 +247,43 @@ class CryptographicKeyItemCacheTest extends BaseSpringBootTest {
                 NotFoundException.class,
                 () -> cryptographicKeyService.getKeyItemModel(unknownUuid)
         );
+    }
+
+    @Test
+    void modelCarriesTypeForPrivateKeyAndNullPqcSpec() throws NotFoundException {
+        CryptographicKeyItemModel model = cryptographicKeyService.getKeyItemModel(keyItem.getUuid());
+
+        assertThat(model.keyType()).isEqualTo(KeyType.PRIVATE_KEY);
+        assertThat(model.pqcParameterSpecName()).isNull(); // RSA private key → no PQC spec
+    }
+
+    @Test
+    void modelCarriesPqcSpecForMlDsaPublicKey() throws Exception {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-DSA", BouncyCastleProvider.PROVIDER_NAME);
+        kpg.initialize(MLDSAParameterSpec.ml_dsa_44);
+        String publicKeyB64 = Base64.getEncoder().encodeToString(kpg.generateKeyPair().getPublic().getEncoded());
+
+        CryptographicKeyItem pub = new CryptographicKeyItem();
+        pub.setName("mldsaPublic");
+        pub.setKey(key);
+        pub.setKeyUuid(key.getUuid());
+        pub.setType(KeyType.PUBLIC_KEY);
+        pub.setState(KeyState.ACTIVE);
+        pub.setEnabled(true);
+        pub.setKeyAlgorithm(KeyAlgorithm.MLDSA);
+        pub.setFormat(KeyFormat.SPKI);
+        pub.setKeyData(publicKeyB64);
+        pub = cryptographicKeyItemRepository.saveAndFlush(pub);
+        pub.setKeyReferenceUuid(pub.getUuid());
+        pub = cryptographicKeyItemRepository.saveAndFlush(pub);
+
+        CryptographicKeyItemModel model = cryptographicKeyService.getKeyItemModel(pub.getUuid());
+
+        assertThat(model.keyType()).isEqualTo(KeyType.PUBLIC_KEY);
+        assertThat(model.pqcParameterSpecName()).isEqualTo(MLDSAParameterSpec.ml_dsa_44.getName());
     }
 
     @Test

--- a/src/test/java/com/czertainly/core/service/SigningCertificateCacheTest.java
+++ b/src/test/java/com/czertainly/core/service/SigningCertificateCacheTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
@@ -195,7 +194,7 @@ class SigningCertificateCacheTest extends BaseSpringBootTest {
 
         Assertions.assertEquals(first, second);
         Mockito.verify(certificateRepository, Mockito.times(1))
-                .findForSigningByUuid(ArgumentMatchers.eq(uuid));
+                .findForSigningByUuid(uuid);
     }
 
     @Test

--- a/src/test/java/com/czertainly/core/service/SigningCertificateCacheTest.java
+++ b/src/test/java/com/czertainly/core/service/SigningCertificateCacheTest.java
@@ -1,0 +1,273 @@
+package com.czertainly.core.service;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.model.client.connector.v2.ConnectorVersion;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.KeyFormat;
+import com.czertainly.api.model.common.enums.cryptography.KeyType;
+import com.czertainly.api.model.connector.cryptography.enums.TokenInstanceStatus;
+import com.czertainly.api.model.core.certificate.CertificateValidationStatus;
+import com.czertainly.api.model.core.connector.ConnectorStatus;
+import com.czertainly.api.model.core.cryptography.key.KeyState;
+import com.czertainly.api.model.core.cryptography.key.KeyUsage;
+import com.czertainly.core.config.cache.CacheConfig;
+import com.czertainly.core.dao.entity.Certificate;
+import com.czertainly.core.dao.entity.Connector;
+import com.czertainly.core.dao.entity.CryptographicKey;
+import com.czertainly.core.dao.entity.CryptographicKeyItem;
+import com.czertainly.core.dao.entity.TokenInstanceReference;
+import com.czertainly.core.dao.entity.TokenProfile;
+import com.czertainly.core.dao.repository.CertificateRepository;
+import com.czertainly.core.dao.repository.ConnectorRepository;
+import com.czertainly.core.dao.repository.CryptographicKeyItemRepository;
+import com.czertainly.core.dao.repository.CryptographicKeyRepository;
+import com.czertainly.core.dao.repository.TokenInstanceReferenceRepository;
+import com.czertainly.core.dao.repository.TokenProfileRepository;
+import com.czertainly.core.helpers.CertificateGeneratorHelper;
+import com.czertainly.core.messaging.jms.producers.NotificationProducer;
+import com.czertainly.core.model.signing.SigningCertificate;
+import com.czertainly.core.util.BaseSpringBootTest;
+import com.czertainly.core.util.MetaDefinitions;
+import com.czertainly.api.model.core.oid.SystemOid;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Verifies that {@code getSigningCertificate} maps the entity graph correctly, is cached (second call
+ * is a hit), and is evicted by Certificate repository mutations.
+ * <p>
+ * Must NOT be {@code @Transactional} — afterCommit eviction callbacks need an actual commit to fire.
+ */
+class SigningCertificateCacheTest extends BaseSpringBootTest {
+
+    @Autowired
+    private CertificateService certificateService;
+
+    @MockitoSpyBean
+    private CertificateRepository certificateRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Autowired
+    private ConnectorRepository connectorRepository;
+    @Autowired
+    private TokenInstanceReferenceRepository tokenInstanceReferenceRepository;
+    @Autowired
+    private TokenProfileRepository tokenProfileRepository;
+    @Autowired
+    private CryptographicKeyRepository cryptographicKeyRepository;
+    @Autowired
+    private CryptographicKeyItemRepository cryptographicKeyItemRepository;
+
+    @MockitoBean
+    private NotificationProducer notificationProducer;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private Cache cache;
+    private CryptographicKey key;
+    private CryptographicKeyItem privateItem;
+
+    @BeforeEach
+    void prepare() {
+        cache = cacheManager.getCache(CacheConfig.SIGNING_CERTIFICATE_CACHE);
+        Assertions.assertNotNull(cache, "signingCertificate cache must be registered");
+        cache.clear();
+
+        Connector connector = new Connector();
+        connector.setUrl("http://localhost:18888");
+        connector.setVersion(ConnectorVersion.V1);
+        connector.setStatus(ConnectorStatus.CONNECTED);
+        connector = connectorRepository.saveAndFlush(connector);
+
+        TokenInstanceReference tokenInstanceRef = new TokenInstanceReference();
+        tokenInstanceRef.setName("testToken");
+        tokenInstanceRef.setTokenInstanceUuid(UUID.randomUUID().toString());
+        tokenInstanceRef.setConnector(connector);
+        tokenInstanceRef.setStatus(TokenInstanceStatus.CONNECTED);
+        tokenInstanceReferenceRepository.saveAndFlush(tokenInstanceRef);
+
+        TokenProfile tokenProfile = new TokenProfile();
+        tokenProfile.setName("testProfile");
+        tokenProfile.setTokenInstanceReference(tokenInstanceRef);
+        tokenProfile.setDescription("test");
+        tokenProfile.setEnabled(true);
+        tokenProfile.setTokenInstanceName("testInstance");
+        tokenProfileRepository.saveAndFlush(tokenProfile);
+
+        key = new CryptographicKey();
+        key.setName("testKey");
+        key.setTokenProfile(tokenProfile);
+        key.setTokenInstanceReference(tokenInstanceRef);
+        key = cryptographicKeyRepository.saveAndFlush(key);
+
+        privateItem = new CryptographicKeyItem();
+        privateItem.setName("priv");
+        privateItem.setKey(key);
+        privateItem.setKeyUuid(key.getUuid());
+        privateItem.setType(KeyType.PRIVATE_KEY);
+        privateItem.setState(KeyState.ACTIVE);
+        privateItem.setEnabled(true);
+        privateItem.setKeyAlgorithm(KeyAlgorithm.RSA);
+        privateItem.setLength(2048);
+        privateItem.setFormat(KeyFormat.PRKI);
+        privateItem.setKeyData("privKeyData");
+        privateItem.setUsage(List.of(KeyUsage.SIGN));
+        privateItem = cryptographicKeyItemRepository.saveAndFlush(privateItem);
+        privateItem.setKeyReferenceUuid(privateItem.getUuid());
+        privateItem = cryptographicKeyItemRepository.saveAndFlush(privateItem);
+
+        key.setItems(Set.of(privateItem));
+        key = cryptographicKeyRepository.saveAndFlush(key);
+    }
+
+    @AfterEach
+    void clearCache() {
+        if (cache != null) cache.clear();
+    }
+
+    private Certificate persistSigningCertificate() throws Exception {
+        KeyPair kp = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
+        X509Certificate x509 = CertificateGeneratorHelper.generateCACertificate(kp, "CN=SigningCacheTest");
+        Certificate cert = certificateService.createCertificateEntity(x509);
+        cert.setKey(key);
+        cert.setKeyUuid(key.getUuid());
+        cert.setValidationStatus(CertificateValidationStatus.VALID);
+        cert.setExtendedKeyUsage(MetaDefinitions.serializeArrayString(List.of(SystemOid.TIME_STAMPING.getOid())));
+        cert.setExtendedKeyUsageCritical(Boolean.TRUE);
+        cert.setQcCompliance(Boolean.TRUE);
+        return certificateRepository.saveAndFlush(cert);
+    }
+
+    @Test
+    void mapsEntityFieldsAndPopulatesCache() throws Exception {
+        Certificate cert = persistSigningCertificate();
+        UUID uuid = cert.getUuid();
+
+        Assertions.assertNull(cache.get(uuid), "cache should be cold before first call");
+
+        SigningCertificate sc = certificateService.getSigningCertificate(uuid);
+
+        Assertions.assertEquals(cert.getUuid(), sc.uuid());
+        Assertions.assertEquals(cert.getCommonName(), sc.commonName());
+        Assertions.assertEquals(cert.isArchived(), sc.archived());
+        Assertions.assertEquals(cert.getState(), sc.state());
+        Assertions.assertEquals(CertificateValidationStatus.VALID, sc.validationStatus());
+        Assertions.assertEquals(List.of(SystemOid.TIME_STAMPING.getOid()), sc.extendedKeyUsageOids());
+        Assertions.assertEquals(Boolean.TRUE, sc.extendedKeyUsageCritical());
+        Assertions.assertEquals(Boolean.TRUE, sc.qcCompliance());
+        Assertions.assertEquals(key.getUuid(), sc.keyUuid());
+        Assertions.assertEquals(key.getTokenInstanceReferenceUuid(), sc.tokenInstanceReferenceUuid());
+        Assertions.assertEquals(key.getTokenProfileUuid(), sc.tokenProfileUuid());
+        Assertions.assertEquals(List.of(privateItem.getUuid()), sc.keyItemUuids());
+
+        Assertions.assertNotNull(cache.get(uuid), "cache entry must be populated after first call");
+    }
+
+    @Test
+    void secondCallReturnsCachedInstance() throws Exception {
+        Certificate cert = persistSigningCertificate();
+        UUID uuid = cert.getUuid();
+
+        Mockito.clearInvocations(certificateRepository);
+
+        SigningCertificate first = certificateService.getSigningCertificate(uuid);
+        SigningCertificate second = certificateService.getSigningCertificate(uuid);
+
+        Assertions.assertEquals(first, second);
+        Mockito.verify(certificateRepository, Mockito.times(1))
+                .findForSigningByUuid(ArgumentMatchers.eq(uuid));
+    }
+
+    @Test
+    void unknownUuidThrowsNotFound() {
+        Assertions.assertThrows(NotFoundException.class,
+                () -> certificateService.getSigningCertificate(UUID.randomUUID()));
+    }
+
+    @Test
+    void cacheIsEvictedAfterDeleteCertificate() throws Exception {
+        Certificate cert = persistSigningCertificate();
+        UUID uuid = cert.getUuid();
+
+        certificateService.getSigningCertificate(uuid);
+        Assertions.assertNotNull(cache.get(uuid), "cache should be warm before delete");
+
+        certificateService.deleteCertificate(cert.getSecuredUuid());
+
+        Assertions.assertNull(cache.get(uuid), "deleteCertificate must evict the signingCertificate cache");
+    }
+
+    @Test
+    void multipleMutationsInOneTransactionClearAfterCommit() throws Exception {
+        Certificate cert = persistSigningCertificate();
+        UUID uuid = cert.getUuid();
+
+        certificateService.getSigningCertificate(uuid);
+        Assertions.assertNotNull(cache.get(uuid), "cache should be warm before transaction");
+
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            cert.setCommonName("renamed-1");
+            certificateRepository.save(cert);
+            cert.setCommonName("renamed-2");
+            certificateRepository.save(cert);
+            // Inside the transaction, before commit, eviction must NOT have happened yet.
+            Assertions.assertNotNull(cache.get(uuid), "cache must not be cleared before commit");
+        });
+
+        Assertions.assertNull(cache.get(uuid), "single afterCommit clear must have fired");
+    }
+
+    @Test
+    void rollbackLeavesCacheIntact() throws Exception {
+        Certificate cert = persistSigningCertificate();
+        UUID uuid = cert.getUuid();
+
+        certificateService.getSigningCertificate(uuid);
+        Assertions.assertNotNull(cache.get(uuid), "cache should be warm before transaction");
+
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            cert.setCommonName("renamed-rollback");
+            certificateRepository.save(cert);
+            status.setRollbackOnly();
+        });
+
+        Assertions.assertNotNull(cache.get(uuid), "rollback must leave the cache intact");
+    }
+
+    @Test
+    void keylessCertificateMapsNullKeyReferences() throws Exception {
+        KeyPair kp = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
+        X509Certificate x509 = CertificateGeneratorHelper.generateCACertificate(kp, "CN=SigningCacheTest-Keyless");
+        Certificate cert = certificateService.createCertificateEntity(x509);
+        // intentionally NO key association
+        cert = certificateRepository.saveAndFlush(cert);
+
+        SigningCertificate sc = certificateService.getSigningCertificate(cert.getUuid());
+
+        Assertions.assertEquals(cert.getUuid(), sc.uuid());
+        Assertions.assertNull(sc.keyUuid());
+        Assertions.assertNull(sc.tokenInstanceReferenceUuid());
+        Assertions.assertNull(sc.tokenProfileUuid());
+        Assertions.assertTrue(sc.keyItemUuids().isEmpty());
+    }
+}

--- a/src/test/java/com/czertainly/core/service/SigningCertificateCacheTest.java
+++ b/src/test/java/com/czertainly/core/service/SigningCertificateCacheTest.java
@@ -254,6 +254,38 @@ class SigningCertificateCacheTest extends BaseSpringBootTest {
     }
 
     @Test
+    void cacheIsEvictedAfterCryptographicKeyMutation() throws Exception {
+        Certificate cert = persistSigningCertificate();
+        UUID uuid = cert.getUuid();
+
+        certificateService.getSigningCertificate(uuid);
+        Assertions.assertNotNull(cache.get(uuid), "cache should be warm before key mutation");
+
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            key.setName("renamed-key");
+            cryptographicKeyRepository.save(key);
+        });
+
+        Assertions.assertNull(cache.get(uuid), "CryptographicKey mutation must evict the signingCertificate cache");
+    }
+
+    @Test
+    void cacheIsEvictedAfterCryptographicKeyItemMutation() throws Exception {
+        Certificate cert = persistSigningCertificate();
+        UUID uuid = cert.getUuid();
+
+        certificateService.getSigningCertificate(uuid);
+        Assertions.assertNotNull(cache.get(uuid), "cache should be warm before key-item mutation");
+
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            privateItem.setEnabled(false);
+            cryptographicKeyItemRepository.save(privateItem);
+        });
+
+        Assertions.assertNull(cache.get(uuid), "CryptographicKeyItem mutation must evict the signingCertificate cache");
+    }
+
+    @Test
     void keylessCertificateMapsNullKeyReferences() throws Exception {
         KeyPair kp = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
         X509Certificate x509 = CertificateGeneratorHelper.generateCACertificate(kp, "CN=SigningCacheTest-Keyless");

--- a/src/test/java/com/czertainly/core/service/SigningCertificateParityTest.java
+++ b/src/test/java/com/czertainly/core/service/SigningCertificateParityTest.java
@@ -1,0 +1,204 @@
+package com.czertainly.core.service;
+
+import com.czertainly.api.model.client.connector.v2.ConnectorVersion;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.KeyFormat;
+import com.czertainly.api.model.common.enums.cryptography.KeyType;
+import com.czertainly.api.model.connector.cryptography.enums.TokenInstanceStatus;
+import com.czertainly.api.model.core.certificate.CertificateValidationStatus;
+import com.czertainly.api.model.core.connector.ConnectorStatus;
+import com.czertainly.api.model.core.cryptography.key.KeyState;
+import com.czertainly.api.model.core.cryptography.key.KeyUsage;
+import com.czertainly.api.model.core.oid.SystemOid;
+import com.czertainly.core.dao.entity.Certificate;
+import com.czertainly.core.dao.entity.Connector;
+import com.czertainly.core.dao.entity.CryptographicKey;
+import com.czertainly.core.dao.entity.CryptographicKeyItem;
+import com.czertainly.core.dao.entity.TokenInstanceReference;
+import com.czertainly.core.dao.entity.TokenProfile;
+import com.czertainly.core.dao.repository.CertificateRepository;
+import com.czertainly.core.dao.repository.ConnectorRepository;
+import com.czertainly.core.dao.repository.CryptographicKeyItemRepository;
+import com.czertainly.core.dao.repository.CryptographicKeyRepository;
+import com.czertainly.core.dao.repository.TokenInstanceReferenceRepository;
+import com.czertainly.core.dao.repository.TokenProfileRepository;
+import com.czertainly.core.helpers.CertificateGeneratorHelper;
+import com.czertainly.core.messaging.jms.producers.NotificationProducer;
+import com.czertainly.core.model.crypto.CryptographicKeyItemModel;
+import com.czertainly.core.model.signing.SigningCertificate;
+import com.czertainly.core.util.BaseSpringBootTest;
+import com.czertainly.core.util.CryptographyUtil;
+import com.czertainly.core.util.MetaDefinitions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.bouncycastle.jcajce.spec.MLDSAParameterSpec;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+/**
+ * Parity: the cached {@link SigningCertificate} + per-item {@link CryptographicKeyItemModel} assembly
+ * reproduces the signer inputs available from the live {@code Certificate} entity graph.
+ */
+class SigningCertificateParityTest extends BaseSpringBootTest {
+
+    @Autowired
+    private CertificateService certificateService;
+    @Autowired
+    private CryptographicKeyService cryptographicKeyService;
+    @Autowired
+    private CertificateRepository certificateRepository;
+    @Autowired
+    private ConnectorRepository connectorRepository;
+    @Autowired
+    private TokenInstanceReferenceRepository tokenInstanceReferenceRepository;
+    @Autowired
+    private TokenProfileRepository tokenProfileRepository;
+    @Autowired
+    private CryptographicKeyRepository cryptographicKeyRepository;
+    @Autowired
+    private CryptographicKeyItemRepository cryptographicKeyItemRepository;
+
+    @MockitoBean
+    private NotificationProducer notificationProducer;
+
+    private CryptographicKey key;
+    private CryptographicKeyItem privateItem;
+    private CryptographicKeyItem publicItem;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+
+        Connector connector = new Connector();
+        connector.setUrl("http://localhost:18888");
+        connector.setVersion(ConnectorVersion.V1);
+        connector.setStatus(ConnectorStatus.CONNECTED);
+        connector = connectorRepository.saveAndFlush(connector);
+
+        TokenInstanceReference tokenInstanceRef = new TokenInstanceReference();
+        tokenInstanceRef.setName("testToken");
+        tokenInstanceRef.setTokenInstanceUuid(UUID.randomUUID().toString());
+        tokenInstanceRef.setConnector(connector);
+        tokenInstanceRef.setStatus(TokenInstanceStatus.CONNECTED);
+        tokenInstanceReferenceRepository.saveAndFlush(tokenInstanceRef);
+
+        TokenProfile tokenProfile = new TokenProfile();
+        tokenProfile.setName("testProfile");
+        tokenProfile.setTokenInstanceReference(tokenInstanceRef);
+        tokenProfile.setDescription("test");
+        tokenProfile.setEnabled(true);
+        tokenProfile.setTokenInstanceName("testInstance");
+        tokenProfileRepository.saveAndFlush(tokenProfile);
+
+        key = new CryptographicKey();
+        key.setName("testKey");
+        key.setTokenProfile(tokenProfile);
+        key.setTokenInstanceReference(tokenInstanceRef);
+        key = cryptographicKeyRepository.saveAndFlush(key);
+
+        privateItem = new CryptographicKeyItem();
+        privateItem.setName("priv");
+        privateItem.setKey(key);
+        privateItem.setKeyUuid(key.getUuid());
+        privateItem.setType(KeyType.PRIVATE_KEY);
+        privateItem.setState(KeyState.ACTIVE);
+        privateItem.setEnabled(true);
+        privateItem.setKeyAlgorithm(KeyAlgorithm.MLDSA);
+        privateItem.setFormat(KeyFormat.PRKI);
+        privateItem.setKeyData("privKeyData");
+        privateItem.setUsage(List.of(KeyUsage.SIGN));
+        privateItem = cryptographicKeyItemRepository.saveAndFlush(privateItem);
+        privateItem.setKeyReferenceUuid(privateItem.getUuid());
+        privateItem = cryptographicKeyItemRepository.saveAndFlush(privateItem);
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-DSA", "BC");
+        kpg.initialize(MLDSAParameterSpec.ml_dsa_44);
+        String publicKeyB64 = Base64.getEncoder().encodeToString(kpg.generateKeyPair().getPublic().getEncoded());
+
+        publicItem = new CryptographicKeyItem();
+        publicItem.setName("pub");
+        publicItem.setKey(key);
+        publicItem.setKeyUuid(key.getUuid());
+        publicItem.setType(KeyType.PUBLIC_KEY);
+        publicItem.setState(KeyState.ACTIVE);
+        publicItem.setEnabled(true);
+        publicItem.setKeyAlgorithm(KeyAlgorithm.MLDSA);
+        publicItem.setFormat(KeyFormat.SPKI);
+        publicItem.setKeyData(publicKeyB64);
+        publicItem.setUsage(List.of(KeyUsage.VERIFY));
+        publicItem = cryptographicKeyItemRepository.saveAndFlush(publicItem);
+        publicItem.setKeyReferenceUuid(publicItem.getUuid());
+        publicItem = cryptographicKeyItemRepository.saveAndFlush(publicItem);
+
+        key.setItems(new HashSet<>(Set.of(privateItem, publicItem)));
+        key = cryptographicKeyRepository.saveAndFlush(key);
+    }
+
+    @Test
+    void recordAndKeyItemModelsMatchLiveEntityGraph() throws Exception {
+        KeyPair kp = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
+        X509Certificate x509 = CertificateGeneratorHelper.generateCACertificate(kp, "CN=ParityTest");
+        Certificate cert = certificateService.createCertificateEntity(x509);
+        cert.setKey(key);
+        cert.setKeyUuid(key.getUuid());
+        cert.setValidationStatus(CertificateValidationStatus.VALID);
+        cert.setExtendedKeyUsage(MetaDefinitions.serializeArrayString(List.of(SystemOid.TIME_STAMPING.getOid())));
+        cert.setExtendedKeyUsageCritical(Boolean.TRUE);
+        cert.setQcCompliance(Boolean.TRUE);
+        cert = certificateRepository.saveAndFlush(cert);
+
+        Certificate live = certificateRepository.findForSigningByUuid(cert.getUuid()).orElseThrow();
+        SigningCertificate sc = certificateService.getSigningCertificate(cert.getUuid());
+
+        // certificate-level parity
+        Assertions.assertEquals(live.getUuid(), sc.uuid());
+        Assertions.assertEquals(live.getCommonName(), sc.commonName());
+        Assertions.assertEquals(live.isArchived(), sc.archived());
+        Assertions.assertEquals(live.getState(), sc.state());
+        Assertions.assertEquals(live.getValidationStatus(), sc.validationStatus());
+        Assertions.assertEquals(
+                MetaDefinitions.deserializeArrayString(live.getExtendedKeyUsage()), sc.extendedKeyUsageOids());
+        Assertions.assertEquals(live.getExtendedKeyUsageCritical(), sc.extendedKeyUsageCritical());
+        Assertions.assertEquals(live.getQcCompliance(), sc.qcCompliance());
+        Assertions.assertEquals(live.getKey().getUuid(), sc.keyUuid());
+        Assertions.assertEquals(live.getKey().getTokenInstanceReferenceUuid(), sc.tokenInstanceReferenceUuid());
+        Assertions.assertEquals(live.getKey().getTokenProfileUuid(), sc.tokenProfileUuid());
+
+        // structural references cover exactly the live key's items
+        Set<UUID> liveItemUuids = new HashSet<>();
+        live.getKey().getItems().forEach(i -> liveItemUuids.add(i.getUuid()));
+        Assertions.assertEquals(liveItemUuids, new HashSet<>(sc.keyItemUuids()));
+
+        // per-item key-item-model parity (assembled the way the resolver will assemble it)
+        for (UUID itemUuid : sc.keyItemUuids()) {
+            CryptographicKeyItem liveItem = live.getKey().getItems().stream()
+                    .filter(i -> i.getUuid().equals(itemUuid)).findFirst().orElseThrow();
+            CryptographicKeyItemModel model = cryptographicKeyService.getKeyItemModel(itemUuid);
+
+            Assertions.assertEquals(liveItem.getType(), model.keyType());
+            Assertions.assertEquals(liveItem.getState(), model.keyState());
+            Assertions.assertEquals(liveItem.getUsage(), model.keyUsage());
+            Assertions.assertEquals(liveItem.getKeyAlgorithm(), model.keyAlgorithm());
+
+            String expectedPqc = liveItem.getType() == KeyType.PUBLIC_KEY
+                    ? CryptographyUtil.resolvePqcParameterSpecName(liveItem.getKeyAlgorithm(), liveItem.getKeyData())
+                    : null;
+            Assertions.assertEquals(expectedPqc, model.pqcParameterSpecName());
+        }
+    }
+}

--- a/src/test/java/com/czertainly/core/util/CryptographyUtilTest.java
+++ b/src/test/java/com/czertainly/core/util/CryptographyUtilTest.java
@@ -333,6 +333,48 @@ class CryptographyUtilTest {
         assertNotNull(algId.getAlgorithm());
     }
 
+    // --- resolvePqcParameterSpecName ---
+
+    @Test
+    void resolvePqcSpecNameReturnsNullForRsa() {
+        assertNull(CryptographyUtil.resolvePqcParameterSpecName(KeyAlgorithm.RSA, null));
+    }
+
+    @Test
+    void resolvePqcSpecNameReturnsNullForEcdsa() {
+        assertNull(CryptographyUtil.resolvePqcParameterSpecName(KeyAlgorithm.ECDSA, null));
+    }
+
+    @Test
+    void resolvePqcSpecNameReturnsNullForMlkem() {
+        assertNull(CryptographyUtil.resolvePqcParameterSpecName(KeyAlgorithm.MLKEM, null));
+    }
+
+    @Test
+    void resolvePqcSpecNameFalcon1024() throws Exception {
+        String publicKey = generatePublicKeyBase64("Falcon", FalconParameterSpec.falcon_1024, BouncyCastlePQCProvider.PROVIDER_NAME);
+        assertEquals("FALCON-1024", CryptographyUtil.resolvePqcParameterSpecName(KeyAlgorithm.FALCON, publicKey));
+    }
+
+    @Test
+    void resolvePqcSpecNameMlDsa44() throws Exception {
+        String publicKey = generatePublicKeyBase64("ML-DSA", MLDSAParameterSpec.ml_dsa_44, BouncyCastleProvider.PROVIDER_NAME);
+        assertEquals(MLDSAParameterSpec.ml_dsa_44.getName(), CryptographyUtil.resolvePqcParameterSpecName(KeyAlgorithm.MLDSA, publicKey));
+    }
+
+    @Test
+    void resolvePqcSpecNameSlhDsa() throws Exception {
+        String publicKey = generatePublicKeyBase64("SLH-DSA", SLHDSAParameterSpec.slh_dsa_shake_128s, BouncyCastleProvider.PROVIDER_NAME);
+        assertEquals(SLHDSAParameterSpec.slh_dsa_shake_128s.getName(), CryptographyUtil.resolvePqcParameterSpecName(KeyAlgorithm.SLHDSA, publicKey));
+    }
+
+    @Test
+    void resolvePqcSpecNameThrowsOnInvalidPqcKey() {
+        String invalidKey = Base64.getEncoder().encodeToString(new byte[]{0x01, 0x02, 0x03});
+        assertThrows(ValidationException.class,
+                () -> CryptographyUtil.resolvePqcParameterSpecName(KeyAlgorithm.MLDSA, invalidKey));
+    }
+
     // --- helpers ---
 
     private static String generatePublicKeyBase64(String keyAlgorithm, AlgorithmParameterSpec spec, String provider)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,6 +11,9 @@ caching:
   cert-chains:
     ttl-minutes: 5
     max-size: 1000
+  signing-certs:
+    ttl-minutes: 5
+    max-size: 1000
   crypto-keys:
     ttl-minutes: 5
     max-size: 10000


### PR DESCRIPTION
Introduce a signing certificate cache on top of the unified cache infrastructure already present on main (#1534).

Adds SigningCertificate model, SigningCertificateMapper, SigningCertificateCacheProperties and the cache wiring in CacheConfig, with eviction via CertificateRepositoryCacheEvictionAspect.