### PR TITLE
Allow Dashboard and Approval listings by default

### DIFF
--- a/src/main/java/com/czertainly/core/api/web/ApprovalControllerImpl.java
+++ b/src/main/java/com/czertainly/core/api/web/ApprovalControllerImpl.java
@@ -31,7 +31,7 @@ public class ApprovalControllerImpl implements ApprovalController {
     @Override
     @AuditLogged(module = Module.APPROVALS, resource = Resource.APPROVAL, operation = Operation.LIST)
     public ApprovalResponseDto listUserApprovals(PaginationRequestDto paginationRequestDto, ApprovalUserDto approvalUserDto) {
-        return approvalService.listUserApprovals(SecurityFilter.create(), approvalUserDto.isHistory(), paginationRequestDto);
+        return approvalService.listUserApprovals(approvalUserDto.isHistory(), paginationRequestDto);
     }
 
     @Override

--- a/src/main/java/com/czertainly/core/service/ApprovalExternalService.java
+++ b/src/main/java/com/czertainly/core/service/ApprovalExternalService.java
@@ -16,7 +16,7 @@ public interface ApprovalExternalService {
 
     ApprovalResponseDto listApprovalsByObject(final SecurityFilter securityFilter, final Resource resource, final UUID objectUuid, final PaginationRequestDto paginationRequestDto);
 
-    ApprovalResponseDto listUserApprovals(final SecurityFilter securityFilter, final boolean withHistory, final PaginationRequestDto paginationRequestDto);
+    ApprovalResponseDto listUserApprovals(final boolean withHistory, final PaginationRequestDto paginationRequestDto);
 
     ApprovalDetailDto getApprovalDetail(final String uuid) throws NotFoundException;
 

--- a/src/main/java/com/czertainly/core/service/impl/ApprovalServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/ApprovalServiceImpl.java
@@ -88,7 +88,7 @@ public class ApprovalServiceImpl implements ApprovalExternalService, ApprovalInt
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.APPROVAL, action = ResourceAction.LIST)
+    @SelfPrincipalEndpoint
     public ApprovalResponseDto listUserApprovals(final SecurityFilter securityFilter, final boolean withHistory, final PaginationRequestDto paginationRequestDto) {
         final UserProfileDto userProfileDto = AuthHelper.getUserProfile();
         final TriFunction<Root<Approval>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause = (root, cb, cr) -> {

--- a/src/main/java/com/czertainly/core/service/impl/ApprovalServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/ApprovalServiceImpl.java
@@ -89,7 +89,7 @@ public class ApprovalServiceImpl implements ApprovalExternalService, ApprovalInt
 
     @Override
     @SelfPrincipalEndpoint
-    public ApprovalResponseDto listUserApprovals(final SecurityFilter securityFilter, final boolean withHistory, final PaginationRequestDto paginationRequestDto) {
+    public ApprovalResponseDto listUserApprovals(final boolean withHistory, final PaginationRequestDto paginationRequestDto) {
         final UserProfileDto userProfileDto = AuthHelper.getUserProfile();
         final TriFunction<Root<Approval>, CriteriaBuilder, CriteriaQuery<?>, Predicate> additionalWhereClause = (root, cb, cr) -> {
             final Join joinApprovalRecipient = root.join("approvalRecipients", JoinType.LEFT);
@@ -99,7 +99,8 @@ public class ApprovalServiceImpl implements ApprovalExternalService, ApprovalInt
             final Predicate groupUuidPredicate = joinApprovalRecipient.get("approvalStep").get("groupUuid").in(userProfileDto.getUser().getGroups().stream().map(dto -> UUID.fromString(dto.getUuid())).toList());
             return cb.and(statusPredicate, cb.or(userUuidPredicate, roleUuidPredicate, groupUuidPredicate));
         };
-        return listOfApprovals(securityFilter, additionalWhereClause, paginationRequestDto);
+        // @SelfPrincipalEndpoint populates no object filter; scoping is via the predicate above.
+        return listOfApprovals(SecurityFilter.create(), additionalWhereClause, paginationRequestDto);
     }
 
     private List<ApprovalStatusEnum> prepareApprovalRecipientStatuses(final boolean withHistory) {

--- a/src/main/java/com/czertainly/core/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AuthServiceImpl.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
 @Transactional
 public class AuthServiceImpl implements AuthExternalService {
 
+    private static final List<Resource> DEFAULT_ALLOWED_LISTINGS = List.of(Resource.DASHBOARD, Resource.APPROVAL);
+
     private UserManagementApiClient userManagementApiClient;
     private ResourceApiClient resourceApiClient;
     private UserManagementService userManagementService;
@@ -84,8 +86,6 @@ public class AuthServiceImpl implements AuthExternalService {
         return userManagementService.updateUserInternal(userProfileDto.getUser().getUuid(), request, certificateUuid, certificateFingerprint);
     }
 
-    private static final List<Resource> DEFAULT_ALLOWED_LISTINGS = List.of(Resource.DASHBOARD, Resource.APPROVAL);
-
     private List<Resource> getAllowedResourceListings(UserProfileDto userProfileDto) {
         List<Resource> allowedListings;
         List<Resource> allListings = contextRefreshListener.getResources().stream()
@@ -128,6 +128,8 @@ public class AuthServiceImpl implements AuthExternalService {
                 result.add(defaultListing);
             }
         }
+        // keep deterministic by-code order after merging defaults
+        result.sort(Comparator.comparing(Resource::getCode));
         return result;
     }
 

--- a/src/main/java/com/czertainly/core/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AuthServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @Transactional
@@ -122,15 +123,12 @@ public class AuthServiceImpl implements AuthExternalService {
     }
 
     private List<Resource> withDefaultListings(List<Resource> listings) {
-        List<Resource> result = new ArrayList<>(listings);
-        for (Resource defaultListing : DEFAULT_ALLOWED_LISTINGS) {
-            if (!result.contains(defaultListing)) {
-                result.add(defaultListing);
-            }
-        }
-        // keep deterministic by-code order after merging defaults
-        result.sort(Comparator.comparing(Resource::getCode));
-        return result;
+        // append the missing defaults, then keep deterministic by-code order
+        return Stream.concat(
+                        listings.stream(),
+                        DEFAULT_ALLOWED_LISTINGS.stream().filter(defaultListing -> !listings.contains(defaultListing)))
+                .sorted(Comparator.comparing(Resource::getCode))
+                .toList();
     }
 
 }

--- a/src/main/java/com/czertainly/core/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/AuthServiceImpl.java
@@ -84,6 +84,8 @@ public class AuthServiceImpl implements AuthExternalService {
         return userManagementService.updateUserInternal(userProfileDto.getUser().getUuid(), request, certificateUuid, certificateFingerprint);
     }
 
+    private static final List<Resource> DEFAULT_ALLOWED_LISTINGS = List.of(Resource.DASHBOARD, Resource.APPROVAL);
+
     private List<Resource> getAllowedResourceListings(UserProfileDto userProfileDto) {
         List<Resource> allowedListings;
         List<Resource> allListings = contextRefreshListener.getResources().stream()
@@ -91,7 +93,7 @@ public class AuthServiceImpl implements AuthExternalService {
                 .map(syncResource -> Resource.findByCode(syncResource.getName().getCode())).sorted(Comparator.comparing(Resource::getCode)).toList();
 
         if (Boolean.TRUE.equals(userProfileDto.getPermissions().getAllowAllResources())) {
-            return allListings;
+            return withDefaultListings(allListings);
         }
 
         Map<Resource, ResourcePermissionsDto> mappedUserPermissions = userProfileDto.getPermissions().getResources().stream().collect(Collectors.toMap(resource -> Resource.findByCode(resource.getName()), resource -> resource));
@@ -116,7 +118,17 @@ public class AuthServiceImpl implements AuthExternalService {
                 allowedListings.add(resource);
             }
         }
-        return allowedListings;
+        return withDefaultListings(allowedListings);
+    }
+
+    private List<Resource> withDefaultListings(List<Resource> listings) {
+        List<Resource> result = new ArrayList<>(listings);
+        for (Resource defaultListing : DEFAULT_ALLOWED_LISTINGS) {
+            if (!result.contains(defaultListing)) {
+                result.add(defaultListing);
+            }
+        }
+        return result;
     }
 
 }

--- a/src/test/java/com/czertainly/core/service/ApprovalServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/ApprovalServiceTest.java
@@ -16,14 +16,18 @@ import com.czertainly.core.dao.entity.Approval;
 import com.czertainly.core.dao.entity.ApprovalProfile;
 import com.czertainly.core.dao.repository.ApprovalRepository;
 import com.czertainly.core.model.auth.ResourceAction;
+import com.czertainly.core.security.authz.ExternalAuthorization;
 import com.czertainly.core.security.authz.SecuredUUID;
 import com.czertainly.core.security.authz.SecurityFilter;
+import com.czertainly.core.security.authz.SelfPrincipalEndpoint;
+import com.czertainly.core.service.impl.ApprovalServiceImpl;
 import com.czertainly.core.util.AuthHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -70,9 +74,51 @@ class ApprovalServiceTest extends ApprovalProfileData {
         ApprovalProfile approvalProfile1 = approvalProfileService.createApprovalProfile(approvalProfileUpdateRequestDto);
 
         approvalInternalService.createApproval(approvalProfile1.getTheLatestApprovalProfileVersion(), Resource.CERTIFICATE, ResourceAction.CREATE, UUID.randomUUID(), UUID.fromString(userProfileDto.getUser().getUuid()), null);
-        ApprovalResponseDto responseDto = approvalService.listUserApprovals(SecurityFilter.create(), true, new PaginationRequestDto());
+        ApprovalResponseDto responseDto = approvalService.listUserApprovals(true, new PaginationRequestDto());
         Assertions.assertEquals(1, responseDto.getApprovals().size());
 
+    }
+
+    @Test
+    void testListUserApprovalsReturnsOnlyOwnApprovals() throws NotFoundException, AlreadyExistException {
+        final UserProfileDto userProfileDto = AuthHelper.getUserProfile();
+
+        ApprovalProfileRequestDto ownProfileRequest = new ApprovalProfileRequestDto();
+        ownProfileRequest.setName("own-approval-profile");
+        ApprovalStepDto ownStep = new ApprovalStepDto();
+        ownStep.setOrder(1);
+        ownStep.setUserUuid(UUID.fromString(userProfileDto.getUser().getUuid()));
+        ownStep.setRequiredApprovals(1);
+        ownProfileRequest.getApprovalSteps().add(ownStep);
+        ApprovalProfile ownProfile = approvalProfileService.createApprovalProfile(ownProfileRequest);
+
+        ApprovalProfileRequestDto otherProfileRequest = new ApprovalProfileRequestDto();
+        otherProfileRequest.setName("other-approval-profile");
+        ApprovalStepDto otherStep = new ApprovalStepDto();
+        otherStep.setOrder(1);
+        otherStep.setUserUuid(UUID.randomUUID());
+        otherStep.setRequiredApprovals(1);
+        otherProfileRequest.getApprovalSteps().add(otherStep);
+        ApprovalProfile otherProfile = approvalProfileService.createApprovalProfile(otherProfileRequest);
+
+        Approval ownApproval = approvalInternalService.createApproval(ownProfile.getTheLatestApprovalProfileVersion(), Resource.CERTIFICATE, ResourceAction.CREATE, UUID.randomUUID(), UUID.fromString(userProfileDto.getUser().getUuid()), null);
+        approvalInternalService.createApproval(otherProfile.getTheLatestApprovalProfileVersion(), Resource.CERTIFICATE, ResourceAction.CREATE, UUID.randomUUID(), UUID.randomUUID(), null);
+
+        ApprovalResponseDto responseDto = approvalService.listUserApprovals(true, new PaginationRequestDto());
+
+        Assertions.assertEquals(1, responseDto.getApprovals().size(),
+                "listUserApprovals must not leak approvals whose steps target another principal");
+        Assertions.assertEquals(ownApproval.getUuid().toString(), responseDto.getApprovals().getFirst().getApprovalUuid());
+    }
+
+    @Test
+    void testListUserApprovalsIsSelfPrincipalEndpoint() throws NoSuchMethodException {
+        Method method = ApprovalServiceImpl.class.getMethod("listUserApprovals", boolean.class, PaginationRequestDto.class);
+
+        Assertions.assertTrue(method.isAnnotationPresent(SelfPrincipalEndpoint.class),
+                "listUserApprovals must stay a @SelfPrincipalEndpoint so users can list their own approvals without an APPROVAL/LIST grant");
+        Assertions.assertFalse(method.isAnnotationPresent(ExternalAuthorization.class),
+                "listUserApprovals must not be gated by @ExternalAuthorization again");
     }
 
     @Test

--- a/src/test/java/com/czertainly/core/service/AuthServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.model.client.auth.UpdateUserRequestDto;
 import com.czertainly.api.model.common.NameAndUuidDto;
 import com.czertainly.api.model.core.auth.AuthResourceDto;
+import com.czertainly.api.model.core.auth.Resource;
 import com.czertainly.api.model.core.auth.UserDetailDto;
 import com.czertainly.api.model.core.auth.UserProfileDetailDto;
 import com.czertainly.api.model.core.logging.enums.AuthMethod;
@@ -78,13 +79,34 @@ class AuthServiceTest extends BaseSpringBootTest {
         injectLocalhostUserProfileToContext();
 
         UserProfileDetailDto userProfileDto = authService.getAuthProfile();
-        Assertions.assertEquals(4, userProfileDto.getPermissions().getAllowedListings().size());
+        List<Resource> allowedListings = userProfileDto.getPermissions().getAllowedListings();
+        // 4 permission-derived listings + DASHBOARD and APPROVAL added by default
+        Assertions.assertEquals(6, allowedListings.size());
+        Assertions.assertTrue(allowedListings.contains(Resource.DASHBOARD), "DASHBOARD must be allowed by default");
+        Assertions.assertTrue(allowedListings.contains(Resource.APPROVAL), "APPROVAL must be allowed by default");
 
         // allow also users through group object member permissions
         injectLocalhostUserProfileChangedToContext();
-        userProfileDto = authService.getAuthProfile();
-        Assertions.assertEquals(6, userProfileDto.getPermissions().getAllowedListings().size());
+        allowedListings = authService.getAuthProfile().getPermissions().getAllowedListings();
+        // 6 permission-derived listings + DASHBOARD and APPROVAL added by default
+        Assertions.assertEquals(8, allowedListings.size());
+        Assertions.assertTrue(allowedListings.contains(Resource.DASHBOARD), "DASHBOARD must be allowed by default");
+        Assertions.assertTrue(allowedListings.contains(Resource.APPROVAL), "APPROVAL must be allowed by default");
+    }
 
+    @Test
+    void testAuthProfileAllowAllResourcesDefaultListings() {
+        injectAllowAllResourcesUserProfileToContext();
+
+        List<Resource> allowedListings = authService.getAuthProfile().getPermissions().getAllowedListings();
+
+        Assertions.assertTrue(allowedListings.contains(Resource.DASHBOARD), "DASHBOARD must be allowed by default");
+        Assertions.assertTrue(allowedListings.contains(Resource.APPROVAL), "APPROVAL must be allowed by default");
+        // APPROVAL already has a list action in the synced resources — it must not be duplicated
+        Assertions.assertEquals(1, allowedListings.stream().filter(r -> r == Resource.APPROVAL).count(),
+                "APPROVAL must appear exactly once");
+        Assertions.assertEquals(1, allowedListings.stream().filter(r -> r == Resource.DASHBOARD).count(),
+                "DASHBOARD must appear exactly once");
     }
 
     @Test
@@ -211,6 +233,35 @@ class AuthServiceTest extends BaseSpringBootTest {
                 """;
 
         // inject other user profile
+        AuthenticationInfo info = new AuthenticationInfo(AuthMethod.USER_PROXY, "616be97b-0bd0-434c-a582-2d4dee5d0b41", "localhost", List.of(), userProfileData);
+        SecurityContextHolder.getContext().setAuthentication(new CzertainlyAuthenticationToken(new CzertainlyUserDetails(info)));
+    }
+
+    private void injectAllowAllResourcesUserProfileToContext() {
+        String userProfileData = """
+                {
+                    "user": {
+                        "uuid": "616be97b-0bd0-434c-a582-2d4dee5d0b41",
+                        "username": "localhost",
+                        "description": "System user for localhost operations",
+                        "groups": [],
+                        "enabled": true,
+                        "systemUser": true,
+                        "createdAt": "2024-12-02T10:52:54.36424+00:00",
+                        "updatedAt": "2024-12-02T10:52:54.364241+00:00"
+                    },
+                    "roles": [{
+                            "uuid": "9db01d1f-fb62-4be8-b344-a852e82edf80",
+                            "name": "localhost"
+                        }
+                    ],
+                    "permissions": {
+                        "allowAllResources": true,
+                        "resources": []
+                    }
+                }
+                """;
+
         AuthenticationInfo info = new AuthenticationInfo(AuthMethod.USER_PROXY, "616be97b-0bd0-434c-a582-2d4dee5d0b41", "localhost", List.of(), userProfileData);
         SecurityContextHolder.getContext().setAuthentication(new CzertainlyAuthenticationToken(new CzertainlyUserDetails(info)));
     }


### PR DESCRIPTION
closes #1555 

In addition, switch listUserApprovals to `@SelfPrincipalEndpoint` so users can list their own approvals without an explicit APPROVAL/LIST grant.