### PR TITLE
Rename RecipientType.MAPPED to OBJECT

### DIFF
--- a/src/main/java/com/czertainly/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/czertainly/core/messaging/jms/listeners/NotificationListener.java
@@ -206,8 +206,8 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
     }
 
     private List<NotificationRecipient> getRecipients(RecipientType recipientType, List<UUID> recipientUuids, ResourceEvent event, Object data, Resource resource, UUID objectUuid) {
-        if (recipientType == RecipientType.MAPPED) {
-            return List.of(new NotificationRecipient(RecipientType.MAPPED, objectUuid));
+        if (recipientType == RecipientType.OBJECT) {
+            return List.of(new NotificationRecipient(RecipientType.OBJECT, objectUuid));
         }
 
         if (recipientType != RecipientType.OWNER && recipientType != RecipientType.DEFAULT) {
@@ -295,15 +295,15 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
                     continue;
                 }
 
-                Resource customAttributeResource = recipient.getRecipientType() == RecipientType.MAPPED
+                Resource customAttributeResource = recipient.getRecipientType() == RecipientType.OBJECT
                         ? resource
                         : recipient.getRecipientType().getRecipientResource();
                 // Unauthenticated lookup is correct here, since the access to the custom attributes has been resolved when defining mapping attributes.
                 List<ResponseAttribute> recipientCustomAttributes = attributeEngine.getObjectCustomAttributesContentForSystemContext(customAttributeResource, recipient.getRecipientUuid());
                 // prepare mapped attributes
                 List<RequestAttribute> mappedAttributes = getMappedAttributes(notificationInstanceReference, mappingAttributes, recipientCustomAttributes);
-                if (recipient.getRecipientType() == RecipientType.MAPPED && mappedAttributes.isEmpty()) {
-                    logger.warn("Notification recipient with MAPPED type does not have any mapped attributes resolved, notification cannot be sent for recipient mapped to {} object with UUID {}.", customAttributeResource, recipient.getRecipientUuid());
+                if (recipient.getRecipientType() == RecipientType.OBJECT && mappedAttributes.isEmpty()) {
+                    logger.warn("Notification recipient with OBJECT type does not have any mapped attributes resolved, notification cannot be sent for recipient mapped to {} object with UUID {}.", customAttributeResource, recipient.getRecipientUuid());
                     continue;
                 }
                 recipientDto.setMappedAttributes(mappedAttributes);
@@ -367,10 +367,10 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
 
                 recipientDto = null;
             }
-            case MAPPED -> {
+            case OBJECT -> {
                 // The connector resolves contact details via mapped attributes — no email to set here
                 recipientDto = new NotificationRecipientDto();
-                recipientDto.setName("Mapped recipient for %s with object UUID %s".formatted(resource.getLabel(), recipient.getRecipientUuid()));
+                recipientDto.setName("Object recipient for %s with object UUID %s".formatted(resource.getLabel(), recipient.getRecipientUuid()));
             }
             default ->
                     throw new NotSupportedException("Notification recipient type %s is not supported".formatted(recipient.getRecipientType().getLabel()));

--- a/src/main/java/com/czertainly/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/czertainly/core/messaging/jms/listeners/NotificationListener.java
@@ -303,7 +303,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
                 // prepare mapped attributes
                 List<RequestAttribute> mappedAttributes = getMappedAttributes(notificationInstanceReference, mappingAttributes, recipientCustomAttributes);
                 if (recipient.getRecipientType() == RecipientType.OBJECT && mappedAttributes.isEmpty()) {
-                    logger.warn("Notification recipient with OBJECT type does not have any mapped attributes resolved, notification cannot be sent for recipient mapped to {} object with UUID {}.", customAttributeResource, recipient.getRecipientUuid());
+                    logger.warn("Notification recipient with OBJECT type does not have any mapped attributes resolved, notification cannot be sent for the OBJECT recipient ({} object with UUID {}).", customAttributeResource.getLabel(), recipient.getRecipientUuid());
                     continue;
                 }
                 recipientDto.setMappedAttributes(mappedAttributes);

--- a/src/test/java/com/czertainly/core/events/NotificationObjectRecipientIntegrationTest.java
+++ b/src/test/java/com/czertainly/core/events/NotificationObjectRecipientIntegrationTest.java
@@ -39,7 +39,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import java.util.List;
 import java.util.UUID;
 
-class NotificationMappedIntegrationTest extends BaseSpringBootTest {
+class NotificationObjectRecipientIntegrationTest extends BaseSpringBootTest {
 
     private static final String MAPPING_ATTRIBUTE_UUID = "1e5657af-423b-4b4b-a9f7-b1150c584a4a";
     private static final String CONTACT_VALUE = "alice@example.com";
@@ -110,7 +110,7 @@ class NotificationMappedIntegrationTest extends BaseSpringBootTest {
         // Notification profile with mapped_CONTACT
         NotificationProfileRequestDto profileRequest = new NotificationProfileRequestDto();
         profileRequest.setName("mappedContactProfile");
-        profileRequest.setRecipientType(RecipientType.MAPPED);
+        profileRequest.setRecipientType(RecipientType.OBJECT);
         profileRequest.setInternalNotification(false);
         profileRequest.setNotificationInstanceUuid(instance.getUuid());
         profile = notificationProfileService.createNotificationProfile(profileRequest);

--- a/src/test/java/com/czertainly/core/events/NotificationObjectRecipientIntegrationTest.java
+++ b/src/test/java/com/czertainly/core/events/NotificationObjectRecipientIntegrationTest.java
@@ -163,8 +163,7 @@ class NotificationObjectRecipientIntegrationTest extends BaseSpringBootTest {
         // Processing must not throw — missing attribute is handled gracefully
         Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(message));
 
-        // Connector is still called — the notification is not dropped, but the recipient
-        // carries no mapped attributes (required: false means the missing value is silently skipped)
+        // Connector is still called — the notification is not dropped, but the recipient carries no mapped attributes (required: false means the missing value is silently skipped)
         mockServer.verify(1, WireMock.postRequestedFor(
                 WireMock.urlPathMatching("/v1/notificationProvider/notifications/[^/]+/notify")));
     }

--- a/src/test/java/com/czertainly/core/events/NotificationObjectRecipientIntegrationTest.java
+++ b/src/test/java/com/czertainly/core/events/NotificationObjectRecipientIntegrationTest.java
@@ -95,14 +95,14 @@ class NotificationObjectRecipientIntegrationTest extends BaseSpringBootTest {
 
         // Connector and notification instance
         Connector connector = new Connector();
-        connector.setName("testMappedContactConnector");
+        connector.setName("testObjectRecipientConnector");
         connector.setUrl("http://localhost:" + mockServer.port());
         connector.setVersion(ConnectorVersion.V1);
         connector.setStatus(ConnectorStatus.CONNECTED);
         connector = connectorRepository.save(connector);
 
         NotificationInstanceReference instance = new NotificationInstanceReference();
-        instance.setName("testMappedContactInstance");
+        instance.setName("testObjectRecipientInstance");
         instance.setKind("EMAIL");
         instance.setConnectorUuid(connector.getUuid());
         instance.setNotificationInstanceUuid(UUID.randomUUID());
@@ -115,9 +115,9 @@ class NotificationObjectRecipientIntegrationTest extends BaseSpringBootTest {
         mapping.setNotificationInstanceRefUuid(instance.getUuid());
         notificationInstanceMappedAttributeRepository.save(mapping);
 
-        // Notification profile with mapped_CONTACT
+        // Notification profile with OBJECT recipient type
         NotificationProfileRequestDto profileRequest = new NotificationProfileRequestDto();
-        profileRequest.setName("mappedContactProfile");
+        profileRequest.setName("objectRecipientProfile");
         profileRequest.setRecipientType(RecipientType.OBJECT);
         profileRequest.setInternalNotification(false);
         profileRequest.setNotificationInstanceUuid(instance.getUuid());
@@ -130,7 +130,7 @@ class NotificationObjectRecipientIntegrationTest extends BaseSpringBootTest {
     }
 
     @Test
-    void testMappedContact_mappedAttributeFromCertificateSentToConnector() throws AttributeException, NotFoundException {
+    void testObjectRecipient_mappedAttributeFromCertificateSentToConnector() throws AttributeException, NotFoundException {
         UUID certificateUuid = UUID.randomUUID();
         attributeEngine.updateObjectCustomAttributeContent(
                 Resource.CERTIFICATE, certificateUuid,
@@ -150,7 +150,7 @@ class NotificationObjectRecipientIntegrationTest extends BaseSpringBootTest {
     }
 
     @Test
-    void testMappedContact_certificateWithoutCustomAttribute_connectorCalledWithoutMappedAttribute() {
+    void testObjectRecipient_certificateWithoutCustomAttribute_connectorCalledWithoutMappedAttribute() {
         // No updateObjectCustomAttributeContent call — this certificate has no attribute value set
         UUID certificateWithoutAttribute = UUID.randomUUID();
 
@@ -169,7 +169,7 @@ class NotificationObjectRecipientIntegrationTest extends BaseSpringBootTest {
     }
 
     @Test
-    void testMappedContact_requiredMappingAttributeMissingOnCertificate_connectorCalledWithEmptyRecipients() {
+    void testObjectRecipient_requiredMappingAttributeMissingOnCertificate_connectorCalledWithEmptyRecipients() {
         // Override the @BeforeEach stub: the connector now declares the attribute as required.
         // WireMock matches stubs in reverse registration order, so this takes precedence.
         mockServer.stubFor(WireMock.get(WireMock.urlPathMatching("/v1/notificationProvider/[^/]+/attributes/mapping"))

--- a/src/test/java/com/czertainly/core/events/NotificationObjectRecipientIntegrationTest.java
+++ b/src/test/java/com/czertainly/core/events/NotificationObjectRecipientIntegrationTest.java
@@ -180,8 +180,8 @@ class NotificationObjectRecipientIntegrationTest extends BaseSpringBootTest {
                 List.of(UUID.fromString(profile.getUuid())),
                 List.of(), null);
 
-        // Processing must not throw — the ValidationException from getMappedAttributes() is
-        // caught by the per-recipient catch (Exception e) block, the recipient is skipped
+        // Processing must not throw — the ValidationException raised while resolving mapped
+        // attributes is caught by the per-recipient exception handler, so the recipient is skipped
         Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(message));
 
         // Connector is still called with an empty recipients list — same observable result as


### PR DESCRIPTION
Follow the interfaces rename of the MAPPED recipient type to OBJECT. Updates the recipient resolution, custom-attribute lookup, empty-attrs guard, warn log, and recipient DTO construction in NotificationListener, and renames the integration test to NotificationObjectRecipientIntegrationTest.

The "mapped attributes" join mechanism (NotificationInstanceMappedAttributes, getMappedAttributes) keeps its name — it is the attribute join, not the recipient type.