### PR TITLE
Port certificate test coverage from feat/signing

### DIFF
--- a/src/test/java/com/otilm/core/service/CertificateChainParityTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateChainParityTest.java
@@ -4,8 +4,6 @@ import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.certificate.CertificateType;
 import com.otilm.api.model.core.certificate.CertificateValidationStatus;
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
-import com.otilm.api.model.core.certificate.CertificateChainResponseDto;
-import com.otilm.api.model.core.certificate.CertificateDetailDto;
 import com.otilm.core.config.cache.CacheConfig;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateContent;
@@ -27,8 +25,6 @@ import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Date;
@@ -88,25 +84,25 @@ class CertificateChainParityTest extends BaseSpringBootTest {
         }
 
         // Scenario: single self-signed root certificate.
-        KeyPair rootKp = rsaKeyPair();
+        KeyPair rootKp = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
         X509Certificate rootX509 = CertificateGeneratorHelper.generateCACertificate(rootKp, "CN=Parity-Root-1");
         selfSignedRoot = persistCertificate(rootX509, null);
 
         // Scenario: two-level linked chain (leaf → root).
-        KeyPair twoRootKp = rsaKeyPair();
+        KeyPair twoRootKp = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
         twoLevelRootX509 = CertificateGeneratorHelper.generateCACertificate(twoRootKp, "CN=Parity-Root-2");
-        KeyPair twoLeafKp = rsaKeyPair();
+        KeyPair twoLeafKp = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
         twoLevelLeafX509 = CertificateGeneratorHelper.generateEndEntityCertificate(
                 twoRootKp, twoLevelRootX509, twoLeafKp, "CN=Parity-Leaf-2", null);
         Certificate twoRoot = persistCertificate(twoLevelRootX509, null);
         twoLevelLeaf = persistCertificate(twoLevelLeafX509, twoRoot.getUuid());
 
         // Scenario: three-level linked chain (leaf → intermediate → root).
-        KeyPair threeRootKp = rsaKeyPair();
+        KeyPair threeRootKp = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
         threeLevelRootX509 = CertificateGeneratorHelper.generateCACertificate(threeRootKp, "CN=Parity-Root-3");
-        KeyPair threeInterKp = rsaKeyPair();
+        KeyPair threeInterKp = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
         threeLevelInterX509 = CertificateGeneratorHelper.generateCACertificate(threeInterKp, "CN=Parity-Inter-3");
-        KeyPair threeLeafKp = rsaKeyPair();
+        KeyPair threeLeafKp = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
         threeLevelLeafX509 = CertificateGeneratorHelper.generateEndEntityCertificate(
                 threeInterKp, threeLevelInterX509, threeLeafKp, "CN=Parity-Leaf-3", null);
         Certificate threeRoot = persistCertificate(threeLevelRootX509, null);
@@ -124,9 +120,16 @@ class CertificateChainParityTest extends BaseSpringBootTest {
         }
     }
 
-    @FunctionalInterface
     interface ChainExtractor {
-        List<byte[]> extract(Certificate cert, boolean withEnd) throws Exception;
+        List<byte[]> extract(Certificate cert, boolean withEndCert) throws Exception;
+
+        default List<byte[]> extractWithEndCert(Certificate cert) throws Exception {
+            return extract(cert, true);
+        }
+
+        default List<byte[]> extractWithoutEndCert(Certificate cert) throws Exception {
+            return extract(cert, false);
+        }
     }
 
     private ChainExtractor resolveExtractor(String name) {
@@ -156,7 +159,7 @@ class CertificateChainParityTest extends BaseSpringBootTest {
     @ParameterizedTest(name = "{0}: self-signed root, withEnd=true → [root]")
     @MethodSource("extractorNames")
     void selfSignedRoot_withEnd(String name) throws Exception {
-        List<byte[]> chain = resolveExtractor(name).extract(selfSignedRoot, true);
+        List<byte[]> chain = resolveExtractor(name).extractWithEndCert(selfSignedRoot);
         assertEquals(1, chain.size());
         assertArrayEquals(decodeContent(selfSignedRoot), chain.get(0));
     }
@@ -164,14 +167,14 @@ class CertificateChainParityTest extends BaseSpringBootTest {
     @ParameterizedTest(name = "{0}: self-signed root, withEnd=false → []")
     @MethodSource("extractorNames")
     void selfSignedRoot_withoutEnd(String name) throws Exception {
-        List<byte[]> chain = resolveExtractor(name).extract(selfSignedRoot, false);
+        List<byte[]> chain = resolveExtractor(name).extractWithoutEndCert(selfSignedRoot);
         assertEquals(0, chain.size());
     }
 
     @ParameterizedTest(name = "{0}: 2-level chain, withEnd=true → [leaf, root]")
     @MethodSource("extractorNames")
     void twoLevelChain_withEnd(String name) throws Exception {
-        List<byte[]> chain = resolveExtractor(name).extract(twoLevelLeaf, true);
+        List<byte[]> chain = resolveExtractor(name).extractWithEndCert(twoLevelLeaf);
         assertEquals(2, chain.size());
         assertArrayEquals(twoLevelLeafX509.getEncoded(), chain.get(0));
         assertArrayEquals(twoLevelRootX509.getEncoded(), chain.get(1));
@@ -180,7 +183,7 @@ class CertificateChainParityTest extends BaseSpringBootTest {
     @ParameterizedTest(name = "{0}: 2-level chain, withEnd=false → [root]")
     @MethodSource("extractorNames")
     void twoLevelChain_withoutEnd(String name) throws Exception {
-        List<byte[]> chain = resolveExtractor(name).extract(twoLevelLeaf, false);
+        List<byte[]> chain = resolveExtractor(name).extractWithoutEndCert(twoLevelLeaf);
         assertEquals(1, chain.size());
         assertArrayEquals(twoLevelRootX509.getEncoded(), chain.get(0));
     }
@@ -188,7 +191,7 @@ class CertificateChainParityTest extends BaseSpringBootTest {
     @ParameterizedTest(name = "{0}: 3-level chain, withEnd=true → [leaf, inter, root]")
     @MethodSource("extractorNames")
     void threeLevelChain_withEnd(String name) throws Exception {
-        List<byte[]> chain = resolveExtractor(name).extract(threeLevelLeaf, true);
+        List<byte[]> chain = resolveExtractor(name).extractWithEndCert(threeLevelLeaf);
         assertEquals(3, chain.size());
         assertArrayEquals(threeLevelLeafX509.getEncoded(), chain.get(0));
         assertArrayEquals(threeLevelInterX509.getEncoded(), chain.get(1));
@@ -198,7 +201,7 @@ class CertificateChainParityTest extends BaseSpringBootTest {
     @ParameterizedTest(name = "{0}: 3-level chain, withEnd=false → [inter, root]")
     @MethodSource("extractorNames")
     void threeLevelChain_withoutEnd(String name) throws Exception {
-        List<byte[]> chain = resolveExtractor(name).extract(threeLevelLeaf, false);
+        List<byte[]> chain = resolveExtractor(name).extractWithoutEndCert(threeLevelLeaf);
         assertEquals(2, chain.size());
         assertArrayEquals(threeLevelInterX509.getEncoded(), chain.get(0));
         assertArrayEquals(threeLevelRootX509.getEncoded(), chain.get(1));
@@ -207,7 +210,7 @@ class CertificateChainParityTest extends BaseSpringBootTest {
     @ParameterizedTest(name = "{0}: leaf with no stored content → []")
     @MethodSource("extractorNames")
     void leafWithoutStoredContent(String name) throws Exception {
-        List<byte[]> chain = resolveExtractor(name).extract(leafWithoutContent, true);
+        List<byte[]> chain = resolveExtractor(name).extractWithEndCert(leafWithoutContent);
         assertEquals(0, chain.size());
     }
 
@@ -219,12 +222,6 @@ class CertificateChainParityTest extends BaseSpringBootTest {
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────
-
-    private static KeyPair rsaKeyPair() throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(2048, new SecureRandom());
-        return kpg.generateKeyPair();
-    }
 
     private Certificate persistCertificate(X509Certificate x509, UUID issuerUuid) throws Exception {
         CertificateContent content = new CertificateContent();

--- a/src/test/java/com/otilm/core/service/CertificateChainParityTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateChainParityTest.java
@@ -1,29 +1,60 @@
 package com.otilm.core.service;
 
+import com.otilm.api.model.core.certificate.CertificateState;
+import com.otilm.api.model.core.certificate.CertificateType;
+import com.otilm.api.model.core.certificate.CertificateValidationStatus;
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
 import com.otilm.api.model.core.certificate.CertificateChainResponseDto;
 import com.otilm.api.model.core.certificate.CertificateDetailDto;
 import com.otilm.core.config.cache.CacheConfig;
 import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.CertificateContent;
+import com.otilm.core.dao.repository.CertificateContentRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.helpers.CertificateGeneratorHelper;
+import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
+import java.util.Date;
 import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
 
-@SpringBootTest
-public class CertificateChainParityTest extends BaseSpringBootTest {
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Parity tests ensuring that {@link CertificateService#getCertificateChain(SecuredUUID, boolean)}
+ * (DTO path) and {@link CertificateService#getCertificateChainForSigning(UUID, boolean)}
+ * (signing hot path) return the same certificate bytes in the same order for every scenario
+ * where parity is expected.
+ *
+ * <p>The DTO path can mutate state (issuer-DN lookup, AIA fetch, FK updates) via
+ * {@code completeCertificateChain} when the chain is incomplete. Parity only holds when there
+ * is nothing to repair, so these fixtures link {@code issuerCertificateUuid} explicitly and do
+ * not embed AIA URLs. Divergent cases (incomplete chain, unknown UUID) are covered separately.</p>
+ */
+@Transactional
+@Rollback
+class CertificateChainParityTest extends BaseSpringBootTest {
 
     @Autowired
     private CertificateService certificateService;
@@ -32,16 +63,58 @@ public class CertificateChainParityTest extends BaseSpringBootTest {
     private CertificateRepository certificateRepository;
 
     @Autowired
+    private CertificateContentRepository certificateContentRepository;
+
+    @Autowired
     private CacheManager cacheManager;
 
     private Cache certChainCache;
 
+    private Certificate selfSignedRoot;
+    private Certificate twoLevelLeaf;
+    private X509Certificate twoLevelRootX509;
+    private X509Certificate twoLevelLeafX509;
+    private Certificate threeLevelLeaf;
+    private X509Certificate threeLevelRootX509;
+    private X509Certificate threeLevelInterX509;
+    private X509Certificate threeLevelLeafX509;
+    private Certificate leafWithoutContent;
+
     @BeforeEach
-    void clearCertChainCache() {
+    void setUp() throws Exception {
         certChainCache = cacheManager.getCache(CacheConfig.CERTIFICATE_CHAIN_CACHE);
         if (certChainCache != null) {
             certChainCache.clear();
         }
+
+        // Scenario: single self-signed root certificate.
+        KeyPair rootKp = rsaKeyPair();
+        X509Certificate rootX509 = CertificateGeneratorHelper.generateCACertificate(rootKp, "CN=Parity-Root-1");
+        selfSignedRoot = persistCertificate(rootX509, null);
+
+        // Scenario: two-level linked chain (leaf → root).
+        KeyPair twoRootKp = rsaKeyPair();
+        twoLevelRootX509 = CertificateGeneratorHelper.generateCACertificate(twoRootKp, "CN=Parity-Root-2");
+        KeyPair twoLeafKp = rsaKeyPair();
+        twoLevelLeafX509 = CertificateGeneratorHelper.generateEndEntityCertificate(
+                twoRootKp, twoLevelRootX509, twoLeafKp, "CN=Parity-Leaf-2", null);
+        Certificate twoRoot = persistCertificate(twoLevelRootX509, null);
+        twoLevelLeaf = persistCertificate(twoLevelLeafX509, twoRoot.getUuid());
+
+        // Scenario: three-level linked chain (leaf → intermediate → root).
+        KeyPair threeRootKp = rsaKeyPair();
+        threeLevelRootX509 = CertificateGeneratorHelper.generateCACertificate(threeRootKp, "CN=Parity-Root-3");
+        KeyPair threeInterKp = rsaKeyPair();
+        threeLevelInterX509 = CertificateGeneratorHelper.generateCACertificate(threeInterKp, "CN=Parity-Inter-3");
+        KeyPair threeLeafKp = rsaKeyPair();
+        threeLevelLeafX509 = CertificateGeneratorHelper.generateEndEntityCertificate(
+                threeInterKp, threeLevelInterX509, threeLeafKp, "CN=Parity-Leaf-3", null);
+        Certificate threeRoot = persistCertificate(threeLevelRootX509, null);
+        Certificate threeInter = persistCertificate(threeLevelInterX509, threeRoot.getUuid());
+        threeLevelLeaf = persistCertificate(threeLevelLeafX509, threeInter.getUuid());
+
+        // Scenario: certificate row exists but has no stored content.
+        leafWithoutContent = persistCertificateWithoutContent();
     }
 
     @AfterEach
@@ -51,137 +124,152 @@ public class CertificateChainParityTest extends BaseSpringBootTest {
         }
     }
 
-    /**
-     * Self-signed root with withEndCertificate=true should return exactly 1 cert,
-     * and its DER bytes should match.
-     */
+    @FunctionalInterface
+    interface ChainExtractor {
+        List<byte[]> extract(Certificate cert, boolean withEnd) throws Exception;
+    }
+
+    private ChainExtractor resolveExtractor(String name) {
+        return switch (name) {
+            case "dto-path" -> (cert, withEnd) -> {
+                var dtos = certificateService.getCertificateChain(cert.getSecuredUuid(), withEnd).getCertificates();
+                if (dtos == null) return List.of();
+                return dtos.stream()
+                        .map(dto -> Base64.getDecoder().decode(dto.getCertificateContent()))
+                        .toList();
+            };
+            case "signing-path" -> (cert, withEnd) -> certificateService
+                    .getCertificateChainForSigning(cert.getUuid(), withEnd)
+                    .stream()
+                    .map(this::encoded)
+                    .toList();
+            default -> throw new IllegalArgumentException(name);
+        };
+    }
+
+    static Stream<Arguments> extractorNames() {
+        return Stream.of(Arguments.of("dto-path"), Arguments.of("signing-path"));
+    }
+
+    // ── parity scenarios ────────────────────────────────────────────────────────
+
+    @ParameterizedTest(name = "{0}: self-signed root, withEnd=true → [root]")
+    @MethodSource("extractorNames")
+    void selfSignedRoot_withEnd(String name) throws Exception {
+        List<byte[]> chain = resolveExtractor(name).extract(selfSignedRoot, true);
+        assertEquals(1, chain.size());
+        assertArrayEquals(decodeContent(selfSignedRoot), chain.get(0));
+    }
+
+    @ParameterizedTest(name = "{0}: self-signed root, withEnd=false → []")
+    @MethodSource("extractorNames")
+    void selfSignedRoot_withoutEnd(String name) throws Exception {
+        List<byte[]> chain = resolveExtractor(name).extract(selfSignedRoot, false);
+        assertEquals(0, chain.size());
+    }
+
+    @ParameterizedTest(name = "{0}: 2-level chain, withEnd=true → [leaf, root]")
+    @MethodSource("extractorNames")
+    void twoLevelChain_withEnd(String name) throws Exception {
+        List<byte[]> chain = resolveExtractor(name).extract(twoLevelLeaf, true);
+        assertEquals(2, chain.size());
+        assertArrayEquals(twoLevelLeafX509.getEncoded(), chain.get(0));
+        assertArrayEquals(twoLevelRootX509.getEncoded(), chain.get(1));
+    }
+
+    @ParameterizedTest(name = "{0}: 2-level chain, withEnd=false → [root]")
+    @MethodSource("extractorNames")
+    void twoLevelChain_withoutEnd(String name) throws Exception {
+        List<byte[]> chain = resolveExtractor(name).extract(twoLevelLeaf, false);
+        assertEquals(1, chain.size());
+        assertArrayEquals(twoLevelRootX509.getEncoded(), chain.get(0));
+    }
+
+    @ParameterizedTest(name = "{0}: 3-level chain, withEnd=true → [leaf, inter, root]")
+    @MethodSource("extractorNames")
+    void threeLevelChain_withEnd(String name) throws Exception {
+        List<byte[]> chain = resolveExtractor(name).extract(threeLevelLeaf, true);
+        assertEquals(3, chain.size());
+        assertArrayEquals(threeLevelLeafX509.getEncoded(), chain.get(0));
+        assertArrayEquals(threeLevelInterX509.getEncoded(), chain.get(1));
+        assertArrayEquals(threeLevelRootX509.getEncoded(), chain.get(2));
+    }
+
+    @ParameterizedTest(name = "{0}: 3-level chain, withEnd=false → [inter, root]")
+    @MethodSource("extractorNames")
+    void threeLevelChain_withoutEnd(String name) throws Exception {
+        List<byte[]> chain = resolveExtractor(name).extract(threeLevelLeaf, false);
+        assertEquals(2, chain.size());
+        assertArrayEquals(threeLevelInterX509.getEncoded(), chain.get(0));
+        assertArrayEquals(threeLevelRootX509.getEncoded(), chain.get(1));
+    }
+
+    @ParameterizedTest(name = "{0}: leaf with no stored content → []")
+    @MethodSource("extractorNames")
+    void leafWithoutStoredContent(String name) throws Exception {
+        List<byte[]> chain = resolveExtractor(name).extract(leafWithoutContent, true);
+        assertEquals(0, chain.size());
+    }
+
+    // ── signing-path-specific behaviour (no parity expected) ─────────────────
+
     @Test
-    void selfSignedChain_withEndCertificate_true() throws Exception {
-        KeyPair rootKeyPair = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
-        X509Certificate rootX509 = CertificateGeneratorHelper.generateCACertificate(rootKeyPair, "CN=Root");
-        Certificate root = persistCert(rootX509, null);
-
-        CertificateChainResponseDto dtoResponse = certificateService.getCertificateChain(root.getSecuredUuid(), true);
-        List<CertificateDetailDto> dtoChain = dtoResponse.getCertificates();
-
-        List<X509Certificate> forSigning = certificateService.getCertificateChainForSigning(root.getUuid(), true);
-
-        Assertions.assertEquals(1, dtoChain.size(), "Expected 1 cert for self-signed with withEndCertificate=true");
-        assertParityByDer(dtoChain, forSigning);
+    void signingPath_returnsEmptyForUnknownUuid() throws Exception {
+        assertTrue(certificateService.getCertificateChainForSigning(UUID.randomUUID(), true).isEmpty());
     }
 
-    @Test
-    void selfSignedChain_withEndCertificate_false_returnsNoAncestors() throws Exception {
-        KeyPair rootKeyPair = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
-        X509Certificate rootX509 = CertificateGeneratorHelper.generateCACertificate(rootKeyPair, "CN=Root-False");
-        Certificate root = persistCert(rootX509, null);
+    // ── helpers ──────────────────────────────────────────────────────────────
 
-        CertificateChainResponseDto dtoResponse = certificateService.getCertificateChain(root.getSecuredUuid(), false);
-        List<CertificateDetailDto> dtoChain = dtoResponse.getCertificates();
-
-        List<X509Certificate> forSigning = certificateService.getCertificateChainForSigning(root.getUuid(), false);
-
-        Assertions.assertEquals(0, dtoChain.size(), "Expected 0 certs for self-signed with withEndCertificate=false");
-        Assertions.assertEquals(0, forSigning.size(), "Expected 0 certs from getCertificateChainForSigning with withEndCertificate=false");
+    private static KeyPair rsaKeyPair() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048, new SecureRandom());
+        return kpg.generateKeyPair();
     }
 
-    /**
-     * Two-level chain (leaf → root) with withEndCertificate=true should return [leaf, root],
-     * and DER bytes should match at each position.
-     */
-    @Test
-    void twoLevelChain_withEndCertificate_true() throws Exception {
-        KeyPair rootKeyPair = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
-        X509Certificate rootX509 = CertificateGeneratorHelper.generateCACertificate(rootKeyPair, "CN=Root-2L");
-        Certificate root = persistCert(rootX509, null);
+    private Certificate persistCertificate(X509Certificate x509, UUID issuerUuid) throws Exception {
+        CertificateContent content = new CertificateContent();
+        content.setContent(Base64.getEncoder().encodeToString(x509.getEncoded()));
+        content = certificateContentRepository.save(content);
 
-        KeyPair leafKeyPair = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
-        X509Certificate leafX509 = CertificateGeneratorHelper.generateEndEntityCertificate(rootKeyPair, rootX509, leafKeyPair, "CN=Leaf-2L", null);
-        Certificate leaf = persistCert(leafX509, root);
-
-        CertificateChainResponseDto dtoResponse = certificateService.getCertificateChain(leaf.getSecuredUuid(), true);
-        List<CertificateDetailDto> dtoChain = dtoResponse.getCertificates();
-
-        List<X509Certificate> forSigning = certificateService.getCertificateChainForSigning(leaf.getUuid(), true);
-
-        Assertions.assertEquals(2, dtoChain.size(), "Expected 2 certs: [leaf, root]");
-        assertParityByDer(dtoChain, forSigning);
+        Certificate cert = new Certificate();
+        cert.setCommonName(x509.getSubjectX500Principal().getName());
+        cert.setSubjectDn(x509.getSubjectX500Principal().getName());
+        cert.setIssuerDn(x509.getIssuerX500Principal().getName());
+        cert.setSerialNumber(x509.getSerialNumber().toString(16));
+        cert.setCertificateType(CertificateType.X509);
+        cert.setState(CertificateState.ISSUED);
+        cert.setValidationStatus(CertificateValidationStatus.VALID);
+        cert.setNotBefore(new Date(x509.getNotBefore().getTime()));
+        cert.setNotAfter(new Date(x509.getNotAfter().getTime()));
+        cert.setCertificateContent(content);
+        cert.setIssuerCertificateUuid(issuerUuid);
+        return certificateRepository.save(cert);
     }
 
-    /**
-     * Two-level chain (leaf → root) with withEndCertificate=false should return only [root],
-     * and DER bytes should match.
-     */
-    @Test
-    void twoLevelChain_withEndCertificate_false() throws Exception {
-        KeyPair rootKeyPair = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
-        X509Certificate rootX509 = CertificateGeneratorHelper.generateCACertificate(rootKeyPair, "CN=Root-2LF");
-        Certificate root = persistCert(rootX509, null);
-
-        KeyPair leafKeyPair = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
-        X509Certificate leafX509 = CertificateGeneratorHelper.generateEndEntityCertificate(rootKeyPair, rootX509, leafKeyPair, "CN=Leaf-2LF", null);
-        Certificate leaf = persistCert(leafX509, root);
-
-        CertificateChainResponseDto dtoResponse = certificateService.getCertificateChain(leaf.getSecuredUuid(), false);
-        List<CertificateDetailDto> dtoChain = dtoResponse.getCertificates();
-
-        List<X509Certificate> forSigning = certificateService.getCertificateChainForSigning(leaf.getUuid(), false);
-
-        Assertions.assertEquals(1, dtoChain.size(), "Expected 1 cert: [root] with withEndCertificate=false");
-        assertParityByDer(dtoChain, forSigning);
+    private Certificate persistCertificateWithoutContent() {
+        Certificate cert = new Certificate();
+        cert.setCommonName("CN=No-Content");
+        cert.setSubjectDn("CN=No-Content");
+        cert.setIssuerDn("CN=No-Content");
+        cert.setSerialNumber("deadbeef");
+        cert.setCertificateType(CertificateType.X509);
+        cert.setState(CertificateState.REQUESTED);
+        cert.setValidationStatus(CertificateValidationStatus.NOT_CHECKED);
+        cert.setNotBefore(new Date());
+        cert.setNotAfter(new Date());
+        return certificateRepository.save(cert);
     }
 
-    /**
-     * Three-hop chain (leaf → intermediate → root) with withEndCertificate=true should return
-     * [leaf, intermediate, root] in that order, with matching DER bytes.
-     */
-    @Test
-    void threeHopChain_withEndCertificate_true() throws Exception {
-        KeyPair rootKeyPair = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
-        X509Certificate rootX509 = CertificateGeneratorHelper.generateCACertificate(rootKeyPair, "CN=Root-3H");
-        Certificate root = persistCert(rootX509, null);
-
-        KeyPair intKeyPair = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
-        X509Certificate intX509 = CertificateGeneratorHelper.generateEndEntityCertificate(rootKeyPair, rootX509, intKeyPair, "CN=Intermediate-3H", null);
-        Certificate intermediate = persistCert(intX509, root);
-
-        KeyPair leafKeyPair = CertificateGeneratorHelper.generateKeyPair(KeyAlgorithm.RSA, null);
-        X509Certificate leafX509 = CertificateGeneratorHelper.generateEndEntityCertificate(intKeyPair, intX509, leafKeyPair, "CN=Leaf-3H", null);
-        Certificate leaf = persistCert(leafX509, intermediate);
-
-        CertificateChainResponseDto dtoResponse = certificateService.getCertificateChain(leaf.getSecuredUuid(), true);
-        List<CertificateDetailDto> dtoChain = dtoResponse.getCertificates();
-
-        List<X509Certificate> forSigning = certificateService.getCertificateChainForSigning(leaf.getUuid(), true);
-
-        Assertions.assertEquals(3, dtoChain.size(), "Expected 3 certs: [leaf, intermediate, root]");
-        assertParityByDer(dtoChain, forSigning);
+    private byte[] decodeContent(Certificate cert) {
+        assertNotNull(cert.getCertificateContent(), "fixture must have content");
+        return Base64.getDecoder().decode(cert.getCertificateContent().getContent());
     }
 
-    /**
-     * Persists an X509Certificate as a Certificate entity, optionally linking to an issuer.
-     * Uses createCertificateEntity to build the entity (bypasses AIA fetch and FK-update triggers),
-     * then sets issuerCertificateUuid manually before saving.
-     */
-    private Certificate persistCert(X509Certificate x509, Certificate issuer) {
-        Certificate cert = certificateService.createCertificateEntity(x509);
-        if (issuer != null) {
-            cert.setIssuerCertificateUuid(issuer.getUuid());
-        }
-        return certificateRepository.saveAndFlush(cert);
-    }
-
-    /**
-     * Asserts that the DTO chain and the signing chain have the same length and identical DER bytes at each index.
-     */
-    private void assertParityByDer(List<CertificateDetailDto> dtoChain, List<X509Certificate> forSigning) throws Exception {
-        Assertions.assertEquals(dtoChain.size(), forSigning.size(), "Chain length mismatch");
-        for (int i = 0; i < dtoChain.size(); i++) {
-            Assertions.assertArrayEquals(
-                    Base64.getDecoder().decode(dtoChain.get(i).getCertificateContent()),
-                    forSigning.get(i).getEncoded(),
-                    "DER mismatch at index " + i
-            );
+    private byte[] encoded(X509Certificate x509) {
+        try {
+            return x509.getEncoded();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/java/com/otilm/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateServiceTest.java
@@ -89,7 +89,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CertificateServiceTest extends BaseSpringBootTest {
 
@@ -666,8 +666,8 @@ class CertificateServiceTest extends BaseSpringBootTest {
         CertificateDetailDto dto = certificateService.getCertificate(SecuredUUID.fromString(uuidDto.getUuid()));
         CertificateQcStatementsDto qc = dto.getQcStatements();
         Assertions.assertNotNull(qc, "qcStatements should be present in the DTO");
-        Assertions.assertTrue(Boolean.TRUE.equals(qc.getQcCompliance()), "qcCompliance should be true");
-        Assertions.assertTrue(Boolean.TRUE.equals(qc.getQcSscd()), "qcSscd should be true");
+        Assertions.assertEquals(Boolean.TRUE, qc.getQcCompliance(), "qcCompliance should be true");
+        Assertions.assertEquals(Boolean.TRUE, qc.getQcSscd(), "qcSscd should be true");
         Assertions.assertNotNull(qc.getQcType(), "qcType list should not be null");
         Assertions.assertTrue(qc.getQcType().contains(QcType.ESIGN), "ESIGN should be in qcType");
         Assertions.assertTrue(qc.getQcType().contains(QcType.ESEAL), "ESEAL should be in qcType");
@@ -1571,8 +1571,12 @@ class CertificateServiceTest extends BaseSpringBootTest {
         createCertificateEntity(commonName, key, certificateState, validationStatus, archived);
 
         List<CertificateDto> certificates = certificateService.listScepCaCertificates(SecurityFilter.create(), intuneEnabled);
-        boolean isPresent = certificates.stream().anyMatch(c -> c.getCommonName().equals(commonName));
-        Assertions.assertEquals(shouldBeAccepted, isPresent, "Certificate '" + commonName + "' acceptance mismatch");
+        var presentCommonNames = certificates.stream().map(CertificateDto::getCommonName).toList();
+        if (shouldBeAccepted) {
+            assertThat(presentCommonNames).as("listed certificates").contains(commonName);
+        } else {
+            assertThat(presentCommonNames).as("listed certificates").doesNotContain(commonName);
+        }
     }
 
     @ParameterizedTest
@@ -1592,8 +1596,12 @@ class CertificateServiceTest extends BaseSpringBootTest {
                 extendedKeyUsages, extendedKeyUsageCritical, qcCompliance);
 
         List<CertificateDto> certificates = certificateService.listDigitalSigningCertificates(SecurityFilter.create(), workflowType, qualifiedTimestamp);
-        boolean isPresent = certificates.stream().anyMatch(c -> c.getCommonName().equals(testCaseName));
-        Assertions.assertEquals(shouldBeAccepted, isPresent, "Certificate '" + testCaseName + "' acceptance mismatch");
+        var presentCommonNames = certificates.stream().map(CertificateDto::getCommonName).toList();
+        if (shouldBeAccepted) {
+            assertThat(presentCommonNames).as("listed certificates").contains(testCaseName);
+        } else {
+            assertThat(presentCommonNames).as("listed certificates").doesNotContain(testCaseName);
+        }
     }
 
     private CryptographicKey prepareKeyWithItems(String name,

--- a/src/test/java/com/otilm/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateServiceTest.java
@@ -9,7 +9,6 @@ import com.otilm.api.model.core.search.FilterConditionOperator;
 import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.workflows.*;
 import com.otilm.core.dao.entity.Certificate;
-import com.otilm.core.dao.repository.*;
 import com.otilm.core.enums.FilterField;
 import com.otilm.api.model.client.attribute.custom.CustomAttributeCreateRequestDto;
 import com.otilm.api.model.client.certificate.*;
@@ -1516,16 +1515,7 @@ class CertificateServiceTest extends BaseSpringBootTest {
             CertificateState certificateState, CertificateValidationStatus validationStatus, boolean archived,
             boolean shouldBeAccepted
     ) {
-        CryptographicKey key = null;
-        if (!publicKeys.isEmpty() || !privateKeys.isEmpty()) {
-            key = createCryptographicKey(commonName + " Key");
-            for (CertificateTestData.KeyItemData keyItemData : publicKeys) {
-                createCryptographicKeyItem(key, keyItemData.type(), keyItemData.algorithm(), keyItemData.usage(), keyItemData.state());
-            }
-            for (CertificateTestData.KeyItemData keyItemData : privateKeys) {
-                createCryptographicKeyItem(key, keyItemData.type(), keyItemData.algorithm(), keyItemData.usage(), keyItemData.state());
-            }
-        }
+        CryptographicKey key = prepareKeyWithItems(commonName, publicKeys, privateKeys);
 
         createCertificateEntity(commonName, key, certificateState, validationStatus, archived);
 
@@ -1576,16 +1566,7 @@ class CertificateServiceTest extends BaseSpringBootTest {
             CertificateState certificateState, CertificateValidationStatus validationStatus, boolean archived,
             boolean intuneEnabled, boolean shouldBeAccepted
     ) {
-        CryptographicKey key = null;
-        if (!publicKeys.isEmpty() || !privateKeys.isEmpty()) {
-            key = createCryptographicKey(commonName + " Key");
-            for (CertificateTestData.KeyItemData keyItemData : publicKeys) {
-                createCryptographicKeyItem(key, keyItemData.type(), keyItemData.algorithm(), keyItemData.usage(), keyItemData.state());
-            }
-            for (CertificateTestData.KeyItemData keyItemData : privateKeys) {
-                createCryptographicKeyItem(key, keyItemData.type(), keyItemData.algorithm(), keyItemData.usage(), keyItemData.state());
-            }
-        }
+        CryptographicKey key = prepareKeyWithItems(commonName, publicKeys, privateKeys);
 
         createCertificateEntity(commonName, key, certificateState, validationStatus, archived);
 
@@ -1605,33 +1586,59 @@ class CertificateServiceTest extends BaseSpringBootTest {
             SigningWorkflowType workflowType, boolean qualifiedTimestamp, Boolean qcCompliance,
             boolean shouldBeAccepted
     ) {
-        CryptographicKey key = null;
-        if (!publicKeys.isEmpty() || !privateKeys.isEmpty()) {
-            key = createCryptographicKey(testCaseName + " Key");
-            for (CertificateTestData.KeyItemData keyItemData : publicKeys) {
-                createCryptographicKeyItem(key, keyItemData.type(), keyItemData.algorithm(), keyItemData.usage(), keyItemData.state());
-            }
-            for (CertificateTestData.KeyItemData keyItemData : privateKeys) {
-                createCryptographicKeyItem(key, keyItemData.type(), keyItemData.algorithm(), keyItemData.usage(), keyItemData.state());
-            }
-            if (withTokenProfile) {
-                TokenProfile tokenProfile = new TokenProfile();
-                tokenProfile.setName(testCaseName + " Token Profile");
-                tokenProfile.setEnabled(true);
-                tokenProfile = tokenProfileRepository.save(tokenProfile);
-                key.setTokenProfile(tokenProfile);
-                cryptographicKeyRepository.save(key);
-            }
-            if (withTokenInstanceReference) {
-                TokenInstanceReference tokenInstanceReference = new TokenInstanceReference();
-                tokenInstanceReference.setName(testCaseName + " Token Instance");
-                tokenInstanceReference.setTokenInstanceUuid(UUID.randomUUID().toString());
-                tokenInstanceReference = tokenInstanceReferenceRepository.save(tokenInstanceReference);
-                key.setTokenInstanceReference(tokenInstanceReference);
-                cryptographicKeyRepository.save(key);
-            }
-        }
+        CryptographicKey key = prepareKeyWithItems(testCaseName, publicKeys, privateKeys);
+        attachTokenAssociations(key, testCaseName, withTokenProfile, withTokenInstanceReference);
+        prepareDigitalSigningCertificate(testCaseName, key, certificateState, validationStatus, archived,
+                extendedKeyUsages, extendedKeyUsageCritical, qcCompliance);
 
+        List<CertificateDto> certificates = certificateService.listDigitalSigningCertificates(SecurityFilter.create(), workflowType, qualifiedTimestamp);
+        boolean isPresent = certificates.stream().anyMatch(c -> c.getCommonName().equals(testCaseName));
+        Assertions.assertEquals(shouldBeAccepted, isPresent, "Certificate '" + testCaseName + "' acceptance mismatch");
+    }
+
+    private CryptographicKey prepareKeyWithItems(String name,
+                                                 List<CertificateTestData.KeyItemData> publicKeys,
+                                                 List<CertificateTestData.KeyItemData> privateKeys) {
+        if (publicKeys.isEmpty() && privateKeys.isEmpty()) {
+            return null;
+        }
+        CryptographicKey key = createCryptographicKey(name + " Key");
+        for (CertificateTestData.KeyItemData keyItemData : publicKeys) {
+            createCryptographicKeyItem(key, keyItemData.type(), keyItemData.algorithm(), keyItemData.usage(), keyItemData.state());
+        }
+        for (CertificateTestData.KeyItemData keyItemData : privateKeys) {
+            createCryptographicKeyItem(key, keyItemData.type(), keyItemData.algorithm(), keyItemData.usage(), keyItemData.state());
+        }
+        return key;
+    }
+
+    private void attachTokenAssociations(CryptographicKey key, String testCaseName,
+                                         boolean withTokenProfile, boolean withTokenInstanceReference) {
+        if (key == null) {
+            return;
+        }
+        if (withTokenProfile) {
+            TokenProfile tokenProfile = new TokenProfile();
+            tokenProfile.setName(testCaseName + " Token Profile");
+            tokenProfile.setEnabled(true);
+            tokenProfile = tokenProfileRepository.save(tokenProfile);
+            key.setTokenProfile(tokenProfile);
+            cryptographicKeyRepository.save(key);
+        }
+        if (withTokenInstanceReference) {
+            TokenInstanceReference tokenInstanceReference = new TokenInstanceReference();
+            tokenInstanceReference.setName(testCaseName + " Token Instance");
+            tokenInstanceReference.setTokenInstanceUuid(UUID.randomUUID().toString());
+            tokenInstanceReference = tokenInstanceReferenceRepository.save(tokenInstanceReference);
+            key.setTokenInstanceReference(tokenInstanceReference);
+            cryptographicKeyRepository.save(key);
+        }
+    }
+
+    private void prepareDigitalSigningCertificate(String testCaseName, CryptographicKey key,
+                                                  CertificateState certificateState, CertificateValidationStatus validationStatus,
+                                                  boolean archived, List<String> extendedKeyUsages,
+                                                  boolean extendedKeyUsageCritical, Boolean qcCompliance) {
         Certificate cert = createCertificateEntity(testCaseName, key, certificateState, validationStatus, archived);
         if (!extendedKeyUsages.isEmpty()) {
             cert.setExtendedKeyUsage(MetaDefinitions.serializeArrayString(extendedKeyUsages));
@@ -1641,10 +1648,6 @@ class CertificateServiceTest extends BaseSpringBootTest {
             cert.setQcCompliance(qcCompliance);
         }
         certificateRepository.save(cert);
-
-        List<CertificateDto> certificates = certificateService.listDigitalSigningCertificates(SecurityFilter.create(), workflowType, qualifiedTimestamp);
-        boolean isPresent = certificates.stream().anyMatch(c -> c.getCommonName().equals(testCaseName));
-        Assertions.assertEquals(shouldBeAccepted, isPresent, "Certificate '" + testCaseName + "' acceptance mismatch");
     }
 
     private CryptographicKey createCryptographicKey(String name) {

--- a/src/test/java/com/otilm/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateServiceTest.java
@@ -8,13 +8,13 @@ import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.api.model.core.search.FilterConditionOperator;
 import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.api.model.core.workflows.*;
-import com.otilm.core.dao.entity.*;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.repository.*;
 import com.otilm.core.enums.FilterField;
 import com.otilm.api.model.client.attribute.custom.CustomAttributeCreateRequestDto;
 import com.otilm.api.model.client.certificate.*;
 import com.otilm.api.model.client.connector.v2.ConnectorVersion;
+import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
 import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.common.UuidDto;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
@@ -38,7 +38,9 @@ import com.otilm.api.model.core.enums.CertificateProtocol;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
+import com.otilm.core.dao.entity.*;
 import com.otilm.core.dao.entity.acme.AcmeProfile;
+import com.otilm.core.dao.repository.*;
 import com.otilm.core.messaging.jms.producers.NotificationProducer;
 import com.otilm.core.model.auth.CertificateProtocolInfo;
 import com.otilm.core.model.auth.ResourceAction;
@@ -135,6 +137,10 @@ class CertificateServiceTest extends BaseSpringBootTest {
     private CryptographicKeyRepository cryptographicKeyRepository;
     @Autowired
     private CryptographicKeyItemRepository cryptographicKeyItemRepository;
+    @Autowired
+    private TokenProfileRepository tokenProfileRepository;
+    @Autowired
+    private TokenInstanceReferenceRepository tokenInstanceReferenceRepository;
     @Autowired
     private AttributeService attributeService;
     @Autowired
@@ -645,6 +651,44 @@ class CertificateServiceTest extends BaseSpringBootTest {
 
     private @NonNull RequestAttributeV3 getAttribute() throws AlreadyExistException, AttributeException {
         return getRequestAttribute();
+    }
+
+    @Test
+    void testUploadCertificate_withQcStatements() throws Exception {
+        X509Certificate qcX509 = CertificateTestUtil.createCertificateWithQcStatements(
+                true, true, List.of(QcType.ESIGN, QcType.ESEAL), List.of("DE", "AT"));
+
+        UploadCertificateRequestDto request = new UploadCertificateRequestDto();
+        request.setCertificate(Base64.getEncoder().encodeToString(qcX509.getEncoded()));
+
+        UuidDto uuidDto = certificateService.uploadSync(request);
+        Assertions.assertNotNull(uuidDto);
+
+        CertificateDetailDto dto = certificateService.getCertificate(SecuredUUID.fromString(uuidDto.getUuid()));
+        CertificateQcStatementsDto qc = dto.getQcStatements();
+        Assertions.assertNotNull(qc, "qcStatements should be present in the DTO");
+        Assertions.assertTrue(Boolean.TRUE.equals(qc.getQcCompliance()), "qcCompliance should be true");
+        Assertions.assertTrue(Boolean.TRUE.equals(qc.getQcSscd()), "qcSscd should be true");
+        Assertions.assertNotNull(qc.getQcType(), "qcType list should not be null");
+        Assertions.assertTrue(qc.getQcType().contains(QcType.ESIGN), "ESIGN should be in qcType");
+        Assertions.assertTrue(qc.getQcType().contains(QcType.ESEAL), "ESEAL should be in qcType");
+        Assertions.assertNotNull(qc.getQcCcLegislation(), "qcCcLegislation should not be null");
+        Assertions.assertTrue(qc.getQcCcLegislation().contains("DE"), "DE should be in qcCcLegislation");
+        Assertions.assertTrue(qc.getQcCcLegislation().contains("AT"), "AT should be in qcCcLegislation");
+    }
+
+    @Test
+    void testUploadCertificate_withoutQcStatements() throws Exception {
+        X509Certificate plainX509 = CertificateTestUtil.createCertificateWithoutEku();
+
+        UploadCertificateRequestDto request = new UploadCertificateRequestDto();
+        request.setCertificate(Base64.getEncoder().encodeToString(plainX509.getEncoded()));
+
+        UuidDto uuidDto = certificateService.uploadSync(request);
+        Assertions.assertNotNull(uuidDto);
+
+        CertificateDetailDto dto = certificateService.getCertificate(SecuredUUID.fromString(uuidDto.getUuid()));
+        Assertions.assertNull(dto.getQcStatements(), "qcStatements should be null for a plain certificate");
     }
 
     @Test
@@ -1550,6 +1594,58 @@ class CertificateServiceTest extends BaseSpringBootTest {
         Assertions.assertEquals(shouldBeAccepted, isPresent, "Certificate '" + commonName + "' acceptance mismatch");
     }
 
+    @ParameterizedTest
+    @MethodSource("com.otilm.core.util.CertificateTestData#provideDigitalSigningAcceptableTestData")
+    public void testListDigitalSigningCertificates(
+            String testCaseName,
+            List<CertificateTestData.KeyItemData> publicKeys,
+            List<CertificateTestData.KeyItemData> privateKeys,
+            CertificateState certificateState, CertificateValidationStatus validationStatus, boolean archived,
+            boolean withTokenProfile, boolean withTokenInstanceReference, List<String> extendedKeyUsages, boolean extendedKeyUsageCritical,
+            SigningWorkflowType workflowType, boolean qualifiedTimestamp, Boolean qcCompliance,
+            boolean shouldBeAccepted
+    ) {
+        CryptographicKey key = null;
+        if (!publicKeys.isEmpty() || !privateKeys.isEmpty()) {
+            key = createCryptographicKey(testCaseName + " Key");
+            for (CertificateTestData.KeyItemData keyItemData : publicKeys) {
+                createCryptographicKeyItem(key, keyItemData.type(), keyItemData.algorithm(), keyItemData.usage(), keyItemData.state());
+            }
+            for (CertificateTestData.KeyItemData keyItemData : privateKeys) {
+                createCryptographicKeyItem(key, keyItemData.type(), keyItemData.algorithm(), keyItemData.usage(), keyItemData.state());
+            }
+            if (withTokenProfile) {
+                TokenProfile tokenProfile = new TokenProfile();
+                tokenProfile.setName(testCaseName + " Token Profile");
+                tokenProfile.setEnabled(true);
+                tokenProfile = tokenProfileRepository.save(tokenProfile);
+                key.setTokenProfile(tokenProfile);
+                cryptographicKeyRepository.save(key);
+            }
+            if (withTokenInstanceReference) {
+                TokenInstanceReference tokenInstanceReference = new TokenInstanceReference();
+                tokenInstanceReference.setName(testCaseName + " Token Instance");
+                tokenInstanceReference.setTokenInstanceUuid(UUID.randomUUID().toString());
+                tokenInstanceReference = tokenInstanceReferenceRepository.save(tokenInstanceReference);
+                key.setTokenInstanceReference(tokenInstanceReference);
+                cryptographicKeyRepository.save(key);
+            }
+        }
+
+        Certificate cert = createCertificateEntity(testCaseName, key, certificateState, validationStatus, archived);
+        if (!extendedKeyUsages.isEmpty()) {
+            cert.setExtendedKeyUsage(MetaDefinitions.serializeArrayString(extendedKeyUsages));
+        }
+        cert.setExtendedKeyUsageCritical(extendedKeyUsageCritical);
+        if (qcCompliance != null) {
+            cert.setQcCompliance(qcCompliance);
+        }
+        certificateRepository.save(cert);
+
+        List<CertificateDto> certificates = certificateService.listDigitalSigningCertificates(SecurityFilter.create(), workflowType, qualifiedTimestamp);
+        boolean isPresent = certificates.stream().anyMatch(c -> c.getCommonName().equals(testCaseName));
+        Assertions.assertEquals(shouldBeAccepted, isPresent, "Certificate '" + testCaseName + "' acceptance mismatch");
+    }
 
     private CryptographicKey createCryptographicKey(String name) {
         CryptographicKey key = new CryptographicKey();


### PR DESCRIPTION
## Summary

Ports two certificate test files that had diverged on the `feat/signing` branch back to `main` as a standalone, **test-only** change. None of the signing-auth feature is included — this is purely the certificate-test drift, split out so it can land independently of the larger signing PR.

- **`CertificateServiceTest`** (+99) — adds:
  - `testUploadCertificate_withQcStatements` / `testUploadCertificate_withoutQcStatements` (QC-statements parsing on upload)
  - `testListDigitalSigningCertificates` — parameterized eligibility matrix over `listDigitalSigningCertificates(...)`
- **`CertificateChainParityTest`** (+202/−114) — rewritten as a `@ParameterizedTest` asserting the DTO path (`getCertificateChain`) and the signing hot path (`getCertificateChainForSigning`) return identical chain bytes and ordering, plus signing-path-specific behavior.

## No production changes
All production code under test (`CertificateQcStatementsDto`, `QcType`, `listDigitalSigningCertificates`, `getCertificateChainForSigning`, `CertificateTestUtil.createCertificateWithQcStatements`, `CertificateGeneratorHelper`, `CacheConfig.CERTIFICATE_CHAIN_CACHE`) already exists on `main`.

## Verification
```
mvn test -Dmaven.compiler.proc=full -Dtest=CertificateChainParityTest,CertificateServiceTest
Tests run: 139, Failures: 0, Errors: 0, Skipped: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)