### PR TITLE
Add authority-provider adapter layer and version-dispatch factory

### DIFF
--- a/src/main/java/com/otilm/core/client/ConnectorApiFactory.java
+++ b/src/main/java/com/otilm/core/client/ConnectorApiFactory.java
@@ -35,6 +35,7 @@ import com.otilm.api.interfaces.client.v1.KeyManagementSyncApiClient;
 import com.otilm.api.interfaces.client.v1.LocationSyncApiClient;
 import com.otilm.api.interfaces.client.v1.NotificationInstanceSyncApiClient;
 import com.otilm.api.interfaces.client.v1.TokenInstanceSyncApiClient;
+import com.otilm.api.interfaces.client.v3.AuthoritySyncApiClient;
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.core.proxy.ProxyDto;
 import com.otilm.core.service.v2.ConnectorService;
@@ -90,6 +91,8 @@ public class ConnectorApiFactory {
     private final com.otilm.api.clients.v2.HealthApiClient restHealthApiClientV2;
     private final com.otilm.api.clients.v2.InfoApiClient restInfoApiClientV2;
     private final com.otilm.api.clients.v2.MetricsApiClient restMetricsApiClientV2;
+    private final com.otilm.api.clients.v3.CertificateApiClient restCertificateApiClientV3;
+    private final com.otilm.api.clients.v3.AuthorityApiClient restAuthorityApiClientV3;
 
     // MQ clients (optional - Spring injects Optional.empty() if bean is missing)
     private final Optional<com.otilm.api.clients.mq.AttributeApiClient> mqAttributeApiClient;
@@ -112,6 +115,8 @@ public class ConnectorApiFactory {
     private final Optional<com.otilm.api.clients.mq.v2.HealthApiClient> mqHealthApiClientV2;
     private final Optional<com.otilm.api.clients.mq.v2.InfoApiClient> mqInfoApiClientV2;
     private final Optional<com.otilm.api.clients.mq.v2.MetricsApiClient> mqMetricsApiClientV2;
+    private final Optional<com.otilm.api.clients.mq.v3.CertificateApiClient> mqCertificateApiClientV3;
+    private final Optional<com.otilm.api.clients.mq.v3.AuthorityApiClient> mqAuthorityApiClientV3;
 
     // Signing clients
     private final SignatureFormatterApiClient restSignatureFormatterApiClient;
@@ -131,8 +136,8 @@ public class ConnectorApiFactory {
 
     @PostConstruct
     void logInitialization() {
-        log.info("ConnectorApiFactory initialized. MQ clients available: attribute={}, authorityInstance={}, certificate={}, certificateV2={}, compliance={}, complianceV2={}, connector={}, discovery={}, endEntity={}, endEntityProfile={}, entityInstance={}, health={}, healthV2={}, infoV2={}, location={}, metricsV2={}, notificationInstance={}, tokenInstance={}, keyManagement={}, cryptographicOperations={}, signatureFormatter={}, vault={}, secret(REST-only)={}",
-                mqAttributeApiClient.isPresent(), mqAuthorityInstanceApiClient.isPresent(), mqCertificateApiClient.isPresent(), mqCertificateApiClientV2.isPresent(), mqComplianceApiClient.isPresent(), mqComplianceApiClientV2.isPresent(), mqConnectorApiClient.isPresent(), mqDiscoveryApiClient.isPresent(), mqEndEntityApiClient.isPresent(), mqEndEntityProfileApiClient.isPresent(), mqEntityInstanceApiClient.isPresent(), mqHealthApiClient.isPresent(), mqHealthApiClientV2.isPresent(), mqInfoApiClientV2.isPresent(), mqLocationApiClient.isPresent(), mqMetricsApiClientV2.isPresent(), mqNotificationInstanceApiClient.isPresent(), mqTokenInstanceApiClient.isPresent(), mqKeyManagementApiClient.isPresent(), mqCryptographicOperationsApiClient.isPresent(), mqSignatureFormatterApiClient.isPresent(), mqVaultApiClient.isPresent(), true);
+        log.info("ConnectorApiFactory initialized. MQ clients available: attribute={}, authorityInstance={}, certificate={}, certificateV2={}, certificateV3={}, authorityV3={}, compliance={}, complianceV2={}, connector={}, discovery={}, endEntity={}, endEntityProfile={}, entityInstance={}, health={}, healthV2={}, infoV2={}, location={}, metricsV2={}, notificationInstance={}, tokenInstance={}, keyManagement={}, cryptographicOperations={}, signatureFormatter={}, vault={}, secret(REST-only)={}",
+                mqAttributeApiClient.isPresent(), mqAuthorityInstanceApiClient.isPresent(), mqCertificateApiClient.isPresent(), mqCertificateApiClientV2.isPresent(), mqCertificateApiClientV3.isPresent(), mqAuthorityApiClientV3.isPresent(), mqComplianceApiClient.isPresent(), mqComplianceApiClientV2.isPresent(), mqConnectorApiClient.isPresent(), mqDiscoveryApiClient.isPresent(), mqEndEntityApiClient.isPresent(), mqEndEntityProfileApiClient.isPresent(), mqEntityInstanceApiClient.isPresent(), mqHealthApiClient.isPresent(), mqHealthApiClientV2.isPresent(), mqInfoApiClientV2.isPresent(), mqLocationApiClient.isPresent(), mqMetricsApiClientV2.isPresent(), mqNotificationInstanceApiClient.isPresent(), mqTokenInstanceApiClient.isPresent(), mqKeyManagementApiClient.isPresent(), mqCryptographicOperationsApiClient.isPresent(), mqSignatureFormatterApiClient.isPresent(), mqVaultApiClient.isPresent(), true);
     }
 
     /**
@@ -250,6 +255,14 @@ public class ConnectorApiFactory {
         // REST-only — no MQ implementation exists yet
         Objects.requireNonNull(connector, "connector must not be null");
         return restSecretApiClient;
+    }
+
+    public com.otilm.api.interfaces.client.v3.CertificateSyncApiClient getCertificateApiClientV3(ApiClientConnectorInfo connector) {
+        return getClient(connector, restCertificateApiClientV3, mqCertificateApiClientV3);
+    }
+
+    public AuthoritySyncApiClient getAuthorityInstanceApiClientV3(ApiClientConnectorInfo connector) {
+        return getClient(connector, restAuthorityApiClientV3, mqAuthorityApiClientV3);
     }
 
     /**

--- a/src/main/java/com/otilm/core/config/ApplicationConfig.java
+++ b/src/main/java/com/otilm/core/config/ApplicationConfig.java
@@ -201,6 +201,18 @@ public class ApplicationConfig {
         return new SchedulerApiClient();
     }
 
+    // Connectors v3 API Clients
+
+    @Bean
+    public com.otilm.api.clients.v3.CertificateApiClient certificateApiClientV3(WebClient webClient, TrustManager[] defaultTrustManagers) {
+        return new com.otilm.api.clients.v3.CertificateApiClient(webClient, defaultTrustManagers);
+    }
+
+    @Bean
+    public com.otilm.api.clients.v3.AuthorityApiClient authorityApiClientV3(WebClient webClient, TrustManager[] defaultTrustManagers) {
+        return new com.otilm.api.clients.v3.AuthorityApiClient(webClient, defaultTrustManagers);
+    }
+
     @Bean
     public SignatureFormatterApiClient signatureFormatterApiClient(WebClient webClient, TrustManager[] defaultTrustManagers) {
         return new SignatureFormatterApiClient(webClient, defaultTrustManagers);

--- a/src/main/java/com/otilm/core/dao/entity/AuthorityInstanceReference.java
+++ b/src/main/java/com/otilm/core/dao/entity/AuthorityInstanceReference.java
@@ -50,6 +50,14 @@ public class AuthorityInstanceReference extends UniquelyIdentifiedAndAudited imp
     @Column(name="connector_name")
     private String connectorName;
 
+    @Column(name = "connector_interface_uuid")
+    private UUID connectorInterfaceUuid;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "connector_interface_uuid", insertable = false, updatable = false)
+    @ToString.Exclude
+    private ConnectorInterfaceEntity connectorInterface;
+
     @OneToMany(mappedBy = "authorityInstanceReference", fetch = FetchType.LAZY)
     @JsonIgnore
     @ToString.Exclude
@@ -59,6 +67,11 @@ public class AuthorityInstanceReference extends UniquelyIdentifiedAndAudited imp
         this.connector = connector;
         if(connector != null) this.connectorUuid = connector.getUuid();
         else this.connectorUuid = null;
+    }
+
+    public void setConnectorInterface(ConnectorInterfaceEntity connectorInterface) {
+        this.connectorInterface = connectorInterface;
+        this.connectorInterfaceUuid = connectorInterface == null ? null : connectorInterface.getUuid();
     }
 
     @Override

--- a/src/main/java/com/otilm/core/exception/ConnectorAcceptedButLocalFailureException.java
+++ b/src/main/java/com/otilm/core/exception/ConnectorAcceptedButLocalFailureException.java
@@ -1,0 +1,15 @@
+package com.otilm.core.exception;
+
+import com.otilm.api.exception.ConnectorException;
+
+/**
+ * Thrown by the v3 authority adapter when the connector has accepted the operation (200/202)
+ * but a subsequent local processing step failed. Per the state-divergence pattern documented
+ * in the core CLAUDE.md, callers MUST NOT roll back certificate state on this exception —
+ * the external commitment must be preserved.
+ */
+public class ConnectorAcceptedButLocalFailureException extends ConnectorException {
+    public ConnectorAcceptedButLocalFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/otilm/core/exception/UnsupportedAuthorityVersionException.java
+++ b/src/main/java/com/otilm/core/exception/UnsupportedAuthorityVersionException.java
@@ -1,0 +1,13 @@
+package com.otilm.core.exception;
+
+import com.otilm.api.exception.PlatformException;
+
+/**
+ * Thrown by AuthorityProviderAdapterFactory when no adapter is registered for the
+ * authority's connector interface version. Defensive — v1 authorities should never
+ * reach the factory per the structural separation between legacy v1 service and the
+ * v2/v3 adapter-based service.
+ */
+public class UnsupportedAuthorityVersionException extends RuntimeException implements PlatformException {
+    public UnsupportedAuthorityVersionException(String message) { super(message); }
+}

--- a/src/main/java/com/otilm/core/messaging/proxy/ProxyClientConfig.java
+++ b/src/main/java/com/otilm/core/messaging/proxy/ProxyClientConfig.java
@@ -181,4 +181,22 @@ public class ProxyClientConfig {
     public NotificationInstanceApiClient mqNotificationInstanceApiClient(ProxyClient proxyClient) {
         return new NotificationInstanceApiClient(proxyClient);
     }
+
+    /**
+     * Create MQ-based v3 CertificateApiClient bean.
+     * This bean is used when connector has proxyId set for v3 certificate operations.
+     */
+    @Bean
+    public com.otilm.api.clients.mq.v3.CertificateApiClient mqCertificateApiClientV3(ProxyClient proxyClient) {
+        return new com.otilm.api.clients.mq.v3.CertificateApiClient(proxyClient);
+    }
+
+    /**
+     * Create MQ-based v3 AuthorityApiClient bean.
+     * This bean is used when connector has proxyId set for v3 authority operations.
+     */
+    @Bean
+    public com.otilm.api.clients.mq.v3.AuthorityApiClient mqAuthorityApiClientV3(ProxyClient proxyClient) {
+        return new com.otilm.api.clients.mq.v3.AuthorityApiClient(proxyClient);
+    }
 }

--- a/src/main/java/com/otilm/core/service/handler/authority/AbstractAuthorityProviderAdapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AbstractAuthorityProviderAdapter.java
@@ -1,0 +1,69 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.model.client.attribute.RequestAttribute;
+import com.otilm.api.model.common.attribute.common.MetadataAttribute;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
+import com.otilm.core.client.ConnectorApiFactory;
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.service.v2.ConnectorService;
+
+import java.util.List;
+
+/**
+ * Shared base for the version-specific authority provider adapters. Holds the collaborators
+ * and the version-agnostic helpers that were previously copy-pasted between
+ * {@link AuthorityProviderV2Adapter} and {@link AuthorityProviderV3Adapter}: connector
+ * resolution, RA-profile attribute loading, and metadata-bag loading.
+ *
+ * <p>Version-specific behavior (request building, the per-version HTTP-status response
+ * matrices, issue-attribute operation tagging) stays in the concrete subclasses — those
+ * genuinely differ per wire contract and must not be merged.</p>
+ */
+public abstract class AbstractAuthorityProviderAdapter implements AuthorityProviderAdapter {
+
+    protected final ConnectorService connectorService;
+    protected final ConnectorApiFactory connectorApiFactory;
+    protected final AttributeEngine attributeEngine;
+
+    protected AbstractAuthorityProviderAdapter(ConnectorService connectorService,
+                                               ConnectorApiFactory connectorApiFactory,
+                                               AttributeEngine attributeEngine) {
+        this.connectorService = connectorService;
+        this.connectorApiFactory = connectorApiFactory;
+        this.attributeEngine = attributeEngine;
+    }
+
+    protected ApiClientConnectorInfo connectorForApiClient(AuthorityInstanceReference authority) throws ConnectorException {
+        try {
+            return connectorService.getConnectorForApiClient(authority.getConnectorUuid());
+        } catch (NotFoundException e) {
+            throw new ConnectorException("Connector not found for authority instance: " + authority.getAuthorityInstanceUuid(), e);
+        }
+    }
+
+    protected List<RequestAttribute> raProfileAttributesFor(RaProfile raProfile, AuthorityInstanceReference authority) {
+        return attributeEngine.getRequestObjectDataAttributesContent(
+                ObjectAttributeContentInfo.builder(Resource.RA_PROFILE, raProfile.getUuid())
+                        .connector(authority.getConnectorUuid())
+                        .build());
+    }
+
+    /**
+     * Loads the stored metadata bag for a certificate — the connector-owned opaque attributes
+     * captured on a prior issue/renew/register and replayed verbatim on subsequent operations
+     * (the unified meta model). Empty when the certificate has no stored meta.
+     */
+    protected List<MetadataAttribute> loadMeta(Certificate cert, AuthorityInstanceReference authority) {
+        return attributeEngine.getMetadataAttributesDefinitionContent(
+                ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, cert.getUuid())
+                        .connector(authority.getConnectorUuid())
+                        .build());
+    }
+}

--- a/src/main/java/com/otilm/core/service/handler/authority/AdapterOperationOutcome.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AdapterOperationOutcome.java
@@ -1,0 +1,7 @@
+package com.otilm.core.service.handler.authority;
+
+public enum AdapterOperationOutcome {
+    SYNC_OK,
+    SYNC_NO_CONTENT,
+    ASYNC_ACCEPTED
+}

--- a/src/main/java/com/otilm/core/service/handler/authority/AdapterOperationResult.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AdapterOperationResult.java
@@ -1,0 +1,35 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.model.common.attribute.common.MetadataAttribute;
+import com.otilm.api.model.core.certificate.CertificateType;
+import org.springframework.lang.Nullable;
+
+import java.util.List;
+
+/**
+ * Unified return type for adapter operation methods (issue, renew, revoke, register).
+ * Outcome discriminates sync 200 / sync 204 / async 202.
+ *
+ * <p>Known constraint: closed record shape. If a future v4 introduces partial-progress
+ * or intermediate-certificate semantics, refactor to a sealed interface.</p>
+ */
+public record AdapterOperationResult(
+    AdapterOperationOutcome outcome,
+    @Nullable String certificateData,
+    @Nullable List<MetadataAttribute> meta,
+    @Nullable CertificateType certificateType
+) {
+    public boolean isAsync() { return outcome == AdapterOperationOutcome.ASYNC_ACCEPTED; }
+
+    public static AdapterOperationResult syncOk(String data, List<MetadataAttribute> meta, CertificateType type) {
+        return new AdapterOperationResult(AdapterOperationOutcome.SYNC_OK, data, meta, type);
+    }
+
+    public static AdapterOperationResult syncNoContent() {
+        return new AdapterOperationResult(AdapterOperationOutcome.SYNC_NO_CONTENT, null, null, null);
+    }
+
+    public static AdapterOperationResult asyncAccepted(List<MetadataAttribute> meta) {
+        return new AdapterOperationResult(AdapterOperationOutcome.ASYNC_ACCEPTED, null, meta, null);
+    }
+}

--- a/src/main/java/com/otilm/core/service/handler/authority/AsyncOperationCapability.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AsyncOperationCapability.java
@@ -1,0 +1,14 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.core.dao.entity.Certificate;
+
+/**
+ * v3-only capability: poll status and cancel in-flight async operations.
+ */
+public interface AsyncOperationCapability {
+
+    StatusPollResult pollStatus(Certificate cert, CertificateOperation op) throws ConnectorException;
+
+    CancelResult cancel(Certificate cert, CertificateOperation op) throws ConnectorException;
+}

--- a/src/main/java/com/otilm/core/service/handler/authority/AsyncOperationCapability.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AsyncOperationCapability.java
@@ -8,7 +8,19 @@ import com.otilm.core.dao.entity.Certificate;
  */
 public interface AsyncOperationCapability {
 
+    /**
+     * Polls the connector for the status of an async operation. The {@link StatusPollResult} carries
+     * the operation status (in-progress / completed / failed); the caller maps it onto the certificate
+     * state per the operation's transition matrix.
+     */
     StatusPollResult pollStatus(Certificate cert, CertificateOperation op) throws ConnectorException;
 
+    /**
+     * Requests cancellation of an in-flight async operation. The {@link CancelResult}'s
+     * {@link CancelOutcome} drives the caller's rollback decision: {@code CANCELLED} and
+     * {@code NOT_TRACKED} are both soft successes — the operation is no longer running, so the caller
+     * rolls local state back — while {@code REFUSED_PAST_POINT_OF_NO_RETURN} means the connector could
+     * not cancel and local state must be left unchanged.
+     */
     CancelResult cancel(Certificate cert, CertificateOperation op) throws ConnectorException;
 }

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
@@ -19,6 +19,17 @@ import java.util.List;
  */
 public interface AuthorityProviderAdapter {
 
+    /**
+     * Issues a certificate through the authority provider.
+     *
+     * @param cert the certificate to issue — provides the CSR ({@code getCertificateRequest()}) and
+     *             the RA-profile association used to resolve connector attributes.
+     * @param req  the operator-level sign request DTO. Currently informational at the adapter layer:
+     *             the wire body is reconstructed from the persisted certificate plus the attribute
+     *             engine (Core persists the operator's CSR + request attributes before the adapter
+     *             runs, then the adapter re-reads them). Kept for contract symmetry with
+     *             {@code renew}/{@code revoke}/{@code register}, which do consume their DTOs.
+     */
     AdapterOperationResult issue(Certificate cert, ClientCertificateSignRequestDto req) throws ConnectorException;
 
     /**
@@ -29,8 +40,10 @@ public interface AuthorityProviderAdapter {
      * @param newCert the successor certificate — provides the new CSR
      *                ({@code getCertificateRequest().getContent()} / {@code .getCertificateRequestFormat()})
      *                and the RA profile association used to look up connector attributes.
-     * @param req     the operator-level renew request DTO (carries client-visible fields such as
-     *                {@code replaceInLocations}; wire-level fields are derived from oldCert/newCert).
+     * @param req     the operator-level renew request DTO. Not consumed by the adapter: client-visible
+     *                fields (e.g. {@code replaceInLocations}) are handled by the service layer and the
+     *                wire body is derived from oldCert/newCert. Kept for contract symmetry with the
+     *                other operations.
      */
     AdapterOperationResult renew(Certificate oldCert, Certificate newCert, ClientCertificateRenewRequestDto req) throws ConnectorException;
 

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
@@ -1,0 +1,70 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.client.attribute.RequestAttribute;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
+import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.RaProfile;
+
+import java.util.List;
+
+/**
+ * Common authority-provider operations supported by every interface version (v1 not implemented).
+ * Methods take Core's operator DTOs; adapter translates to version-specific wire DTOs internally.
+ */
+public interface AuthorityProviderAdapter {
+
+    AdapterOperationResult issue(Certificate cert, ClientCertificateSignRequestDto req) throws ConnectorException;
+
+    /**
+     * Renews (or rekeys) a certificate through the authority provider.
+     *
+     * @param oldCert the predecessor certificate — provides the old cert content
+     *                ({@code getCertificateContent().getContent()}) and its connector-issued metadata.
+     * @param newCert the successor certificate — provides the new CSR
+     *                ({@code getCertificateRequest().getContent()} / {@code .getCertificateRequestFormat()})
+     *                and the RA profile association used to look up connector attributes.
+     * @param req     the operator-level renew request DTO (carries client-visible fields such as
+     *                {@code replaceInLocations}; wire-level fields are derived from oldCert/newCert).
+     */
+    AdapterOperationResult renew(Certificate oldCert, Certificate newCert, ClientCertificateRenewRequestDto req) throws ConnectorException;
+
+    AdapterOperationResult revoke(Certificate cert, ClientCertificateRevocationDto req) throws ConnectorException;
+
+    /**
+     * Authority-instance attribute definitions. v2 lists via the function-group attribute endpoint
+     * (`/v1/authorityProvider/{kind}/attributes`); v3 via the stateless
+     * `/v3/authorityProvider/authorities/attributes`. Used by authority create/edit so the operator
+     * input is validated against the version-correct schema (legacy connectors do NOT use this —
+     * they stay on the function-group path in ConnectorService).
+     */
+    List<BaseAttribute> listAuthorityInstanceAttributes(AuthorityInstanceReference authority) throws ConnectorException;
+
+    /**
+     * Dynamic issue-attribute schema scoped to a specific RA profile. v3 carries both
+     * {@code authorityAttributes} (auth/identity to the upstream CA) and {@code raProfileAttributes}
+     * (which profile/template determines the schema). v2 ignores {@code raProfile} — its endpoint
+     * is keyed by {@code authorityInstanceUuid} alone and returns a single per-authority schema.
+     */
+    List<BaseAttribute> listIssueAttributes(AuthorityInstanceReference authority, RaProfile raProfile) throws ConnectorException;
+
+    /** See {@link #listIssueAttributes} — identical semantics for revoke. */
+    List<BaseAttribute> listRevokeAttributes(AuthorityInstanceReference authority, RaProfile raProfile) throws ConnectorException;
+
+    /**
+     * Connector-side validation of operator-supplied issue attributes. v2 calls the connector's
+     * {@code /validate} endpoint; v3 is a no-op (the v3 contract dropped {@code /validate} — Core
+     * validates structurally against the listed definitions instead).
+     */
+    void validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+
+    /** Connector-side validation of operator-supplied revoke attributes. See {@link #validateIssueAttributes}. */
+    void validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+
+    void checkAuthorityConnection(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+}

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
@@ -1,0 +1,61 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.ConnectorInterfaceEntity;
+import com.otilm.core.exception.UnsupportedAuthorityVersionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Dispatches authority operations to the adapter matching the authority's connector interface
+ * version. v2 → {@link AuthorityProviderV2Adapter}, v3 → {@link AuthorityProviderV3Adapter}.
+ *
+ * <p>Defensive — legacy v1-authority connectors ({@code FunctionGroupCode.LEGACY_AUTHORITY_PROVIDER})
+ * flow through the separate legacy service path and never reach this factory.</p>
+ *
+ * <p>{@link ConnectorInterfaceEntity#getVersion()} returns the version string as reported by the
+ * connector's info endpoint (e.g. {@code "v2"}, {@code "v3"}). A {@code null} interface is treated
+ * as v2: framework-v1 connectors that speak the v2 authority wire protocol (e.g. ejbca-ng) declare
+ * no interface row, so they route to {@link AuthorityProviderV2Adapter} (see {@link #forAuthority}).
+ * Any other non-null value (an unrecognized or bare-decimal version such as {@code "2"}) results in
+ * an {@link UnsupportedAuthorityVersionException}.</p>
+ */
+@Component
+public class AuthorityProviderAdapterFactory {
+
+    private final AuthorityProviderV2Adapter v2Adapter;
+    private final AuthorityProviderV3Adapter v3Adapter;
+
+    @Autowired
+    public AuthorityProviderAdapterFactory(AuthorityProviderV2Adapter v2Adapter,
+                                           AuthorityProviderV3Adapter v3Adapter) {
+        this.v2Adapter = v2Adapter;
+        this.v3Adapter = v3Adapter;
+    }
+
+    public AuthorityProviderAdapter forAuthority(AuthorityInstanceReference authority) {
+        ConnectorInterfaceEntity iface = authority.getConnectorInterface();
+        if (iface == null) {
+            // Connector declared no AUTHORITY interface row in connector_interface. This is
+            // expected for framework-v1 connectors that implement the v2 authority wire
+            // protocol (e.g. ejbca-ng) — their /v1/info endpoint predates the v2 interface
+            // descriptor and the M0 backfill cannot create a row for them. Route to v2
+            // since that is the wire protocol they speak. Legacy v1-authority connectors
+            // (FunctionGroupCode.LEGACY_AUTHORITY_PROVIDER) never reach this factory; they
+            // route through the separate legacy service path by design.
+            return v2Adapter;
+        }
+        String version = iface.getVersion();
+        if (version == null) {
+            throw new UnsupportedAuthorityVersionException(
+                    "Authority connector interface has no version (authority " + authority.getUuid() + ")");
+        }
+        return switch (version) {
+            case "v2" -> v2Adapter;
+            case "v3" -> v3Adapter;
+            default -> throw new UnsupportedAuthorityVersionException(
+                    "Unsupported authority connector interface version: " + version
+                            + " (authority " + authority.getUuid() + ")");
+        };
+    }
+}

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
@@ -36,13 +36,7 @@ public class AuthorityProviderAdapterFactory {
     public AuthorityProviderAdapter forAuthority(AuthorityInstanceReference authority) {
         ConnectorInterfaceEntity iface = authority.getConnectorInterface();
         if (iface == null) {
-            // Connector declared no AUTHORITY interface row in connector_interface. This is
-            // expected for framework-v1 connectors that implement the v2 authority wire
-            // protocol (e.g. ejbca-ng) — their /v1/info endpoint predates the v2 interface
-            // descriptor and the M0 backfill cannot create a row for them. Route to v2
-            // since that is the wire protocol they speak. Legacy v1-authority connectors
-            // (FunctionGroupCode.LEGACY_AUTHORITY_PROVIDER) never reach this factory; they
-            // route through the separate legacy service path by design.
+            // No interface row → a framework-v1 connector speaking the v2 authority protocol (see class Javadoc).
             return v2Adapter;
         }
         String version = iface.getVersion();

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV2Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV2Adapter.java
@@ -1,0 +1,196 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.interfaces.client.v2.CertificateSyncApiClient;
+import com.otilm.api.model.client.attribute.RequestAttribute;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.connector.v2.CertRevocationDto;
+import com.otilm.api.model.connector.v2.CertificateDataResponseDto;
+import com.otilm.api.model.connector.v2.CertificateRenewRequestDto;
+import com.otilm.api.model.connector.v2.CertificateSignRequestDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.authority.CertificateRevocationReason;
+import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
+import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.AttributeOperation;
+import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
+import com.otilm.core.client.ConnectorApiFactory;
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.service.v2.ConnectorService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Adapts the legacy v2 connector clients ({@link CertificateSyncApiClient} and
+ * {@link com.otilm.api.interfaces.client.v1.AuthorityInstanceSyncApiClient}) to the
+ * {@link AuthorityProviderAdapter} interface shape.
+ *
+ * <p>Does not alter any v2 wire behavior — it is a pure call-site shape adaptation.
+ * v2 connectors MAY return HTTP 202 (async accepted) from issue, renew, or revoke.
+ * {@link #mapV2Response(ResponseEntity)} surfaces 202 from issue/renew as
+ * {@link AdapterOperationResult#asyncAccepted}; revoke applies equivalent logic inline.</p>
+ */
+@Component
+public class AuthorityProviderV2Adapter extends AbstractAuthorityProviderAdapter {
+
+    @Autowired
+    public AuthorityProviderV2Adapter(ConnectorService connectorService,
+                                      ConnectorApiFactory connectorApiFactory,
+                                      AttributeEngine attributeEngine) {
+        super(connectorService, connectorApiFactory, attributeEngine);
+    }
+
+    @Override
+    public AdapterOperationResult issue(Certificate cert, ClientCertificateSignRequestDto req) throws ConnectorException {
+        RaProfile raProfile = cert.getRaProfile();
+        AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
+
+        CertificateSignRequestDto wire = new CertificateSignRequestDto();
+        wire.setRequest(cert.getCertificateRequest().getContent());
+        wire.setFormat(cert.getCertificateRequest().getCertificateRequestFormat());
+        wire.setAttributes(issueAttributesFor(cert, authority));
+        wire.setRaProfileAttributes(raProfileAttributesFor(raProfile, authority));
+
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        ResponseEntity<CertificateDataResponseDto> response =
+                connectorApiFactory.getCertificateApiClientV2(connectorDto)
+                        .issueCertificate(connectorDto, authority.getAuthorityInstanceUuid(), wire);
+
+        return mapV2Response(response);
+    }
+
+    @Override
+    public AdapterOperationResult renew(Certificate oldCert, Certificate newCert, ClientCertificateRenewRequestDto req) throws ConnectorException {
+        RaProfile raProfile = newCert.getRaProfile();
+        AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
+
+        CertificateRenewRequestDto wire = new CertificateRenewRequestDto();
+        // CSR is optional (e.g. reuse-key renewal); omit it when absent rather than NPE — matches V3.
+        if (newCert.getCertificateRequest() != null) {
+            wire.setRequest(newCert.getCertificateRequest().getContent());
+            wire.setFormat(newCert.getCertificateRequest().getCertificateRequestFormat());
+        }
+        wire.setRaProfileAttributes(raProfileAttributesFor(raProfile, authority));
+        wire.setCertificate(oldCert.getCertificateContent().getContent());
+        wire.setMeta(loadMeta(oldCert, authority));
+
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        ResponseEntity<CertificateDataResponseDto> response =
+                connectorApiFactory.getCertificateApiClientV2(connectorDto)
+                        .renewCertificate(connectorDto, authority.getAuthorityInstanceUuid(), wire);
+
+        return mapV2Response(response);
+    }
+
+    @Override
+    public AdapterOperationResult revoke(Certificate cert, ClientCertificateRevocationDto req) throws ConnectorException {
+        RaProfile raProfile = cert.getRaProfile();
+        AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
+
+        CertRevocationDto wire = new CertRevocationDto();
+        wire.setReason(req.getReason() != null ? req.getReason() : CertificateRevocationReason.UNSPECIFIED);
+        wire.setAttributes(req.getAttributes());
+        wire.setRaProfileAttributes(raProfileAttributesFor(raProfile, authority));
+        wire.setCertificate(cert.getCertificateContent().getContent());
+
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        ResponseEntity<Void> response = connectorApiFactory.getCertificateApiClientV2(connectorDto)
+                .revokeCertificate(connectorDto, authority.getAuthorityInstanceUuid(), wire);
+
+        if (response.getStatusCode().value() == 202) {
+            return AdapterOperationResult.asyncAccepted(null);
+        }
+        return AdapterOperationResult.syncNoContent();
+    }
+
+    @Override
+    public List<BaseAttribute> listAuthorityInstanceAttributes(AuthorityInstanceReference authority) throws ConnectorException {
+        // v2 authority-instance attributes come from the function-group attribute endpoint
+        // (/v1/authorityProvider/{kind}/attributes). Legacy (LEGACY_AUTHORITY_PROVIDER) connectors
+        // never reach this adapter — they stay on ConnectorService's function-group path.
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        return connectorApiFactory.getAttributeApiClient(connectorDto)
+                .listAttributeDefinitions(connectorDto,
+                        com.otilm.api.model.core.connector.FunctionGroupCode.AUTHORITY_PROVIDER,
+                        authority.getKind());
+    }
+
+    @Override
+    public List<BaseAttribute> listIssueAttributes(AuthorityInstanceReference authority, RaProfile raProfile) throws ConnectorException {
+        // v2 endpoint is keyed by authorityInstanceUuid alone — raProfile is unused (single per-authority schema).
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        return connectorApiFactory.getCertificateApiClientV2(connectorDto)
+                .listIssueCertificateAttributes(connectorDto, authority.getAuthorityInstanceUuid());
+    }
+
+    @Override
+    public List<BaseAttribute> listRevokeAttributes(AuthorityInstanceReference authority, RaProfile raProfile) throws ConnectorException {
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        return connectorApiFactory.getCertificateApiClientV2(connectorDto)
+                .listRevokeCertificateAttributes(connectorDto, authority.getAuthorityInstanceUuid());
+    }
+
+    @Override
+    public void validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes)
+            throws ValidationException, ConnectorException {
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        connectorApiFactory.getCertificateApiClientV2(connectorDto)
+                .validateIssueCertificateAttributes(connectorDto, authority.getAuthorityInstanceUuid(), attributes);
+    }
+
+    @Override
+    public void validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes)
+            throws ValidationException, ConnectorException {
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        connectorApiFactory.getCertificateApiClientV2(connectorDto)
+                .validateRevokeCertificateAttributes(connectorDto, authority.getAuthorityInstanceUuid(), attributes);
+    }
+
+    /**
+     * Validates the authority instance's RA profile configuration against the connector.
+     * Uses {@code validateRAProfileAttributes} as the v2 wire equivalent of "check connection"
+     * for an authority: it probes the connector with the given attributes and throws on failure.
+     */
+    @Override
+    public void checkAuthorityConnection(AuthorityInstanceReference authority, List<RequestAttribute> attributes)
+            throws ValidationException, ConnectorException {
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        connectorApiFactory.getAuthorityInstanceApiClient(connectorDto)
+                .validateRAProfileAttributes(connectorDto, authority.getAuthorityInstanceUuid(), attributes);
+    }
+
+    // --- private helpers ---
+
+    private List<RequestAttribute> issueAttributesFor(Certificate cert, AuthorityInstanceReference authority) {
+        return attributeEngine.getRequestObjectDataAttributesContent(
+                ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, cert.getUuid())
+                        .connector(authority.getConnectorUuid())
+                        .operation(AttributeOperation.CERTIFICATE_ISSUE)
+                        .build());
+    }
+
+    /**
+     * Maps a v2 connector response to an {@link AdapterOperationResult}.
+     * HTTP 202 is surfaced as {@link AdapterOperationOutcome#ASYNC_ACCEPTED}; all other 2xx
+     * responses (including 200) are treated as synchronous success ({@link AdapterOperationOutcome#SYNC_OK}).
+     */
+    private AdapterOperationResult mapV2Response(ResponseEntity<CertificateDataResponseDto> response) {
+        CertificateDataResponseDto body = response.getBody();
+        if (response.getStatusCode().value() == 202) {
+            return AdapterOperationResult.asyncAccepted(body != null ? body.getMeta() : null);
+        }
+        return AdapterOperationResult.syncOk(
+                body != null ? body.getCertificateData() : null,
+                body != null ? body.getMeta() : null,
+                null);
+    }
+}

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -24,6 +24,7 @@ import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
 import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.AttributeOperation;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
@@ -294,6 +295,7 @@ public class AuthorityProviderV3Adapter
         return attributeEngine.getRequestObjectDataAttributesContent(
                 ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, cert.getUuid())
                         .connector(authority.getConnectorUuid())
+                        .operation(AttributeOperation.CERTIFICATE_ISSUE)
                         .build());
     }
 

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -1,0 +1,353 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.ConnectorProblemException;
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.interfaces.client.v3.AuthoritySyncApiClient;
+import com.otilm.api.interfaces.client.v3.CertificateSyncApiClient;
+import com.otilm.api.model.client.attribute.RequestAttribute;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.error.ErrorCode;
+import com.otilm.api.model.connector.v3.certificate.CertificateAttributeListRequestDtoV3;
+import com.otilm.api.model.connector.v3.certificate.CertificateDataResponseDto;
+import com.otilm.api.model.connector.v3.certificate.CertificateOperationCancelRequestDtoV3;
+import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatusRequestDtoV3;
+import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatusResponseDto;
+import com.otilm.api.model.connector.v3.certificate.CertificateRegistrationRequestDtoV3;
+import com.otilm.api.model.connector.v3.certificate.CertificateRenewRequestDtoV3;
+import com.otilm.api.model.connector.v3.certificate.CertificateRevocationRequestDtoV3;
+import com.otilm.api.model.connector.v3.certificate.CertificateSignRequestDtoV3;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
+import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
+import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
+import com.otilm.core.client.ConnectorApiFactory;
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.exception.ConnectorAcceptedButLocalFailureException;
+import com.otilm.core.service.v2.ConnectorService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Adapter for v3 authority provider connectors. Wraps {@link CertificateSyncApiClient} (v3)
+ * and {@link AuthoritySyncApiClient} (v3) via {@link ConnectorApiFactory}.
+ *
+ * <p>Issue/renew/register: 200 = SYNC_OK, 202 = ASYNC_ACCEPTED.
+ * Revoke: 204 = SYNC_NO_CONTENT, 202 = ASYNC_ACCEPTED, 200 = SYNC_OK (meta only).
+ * Cancel: 204 = CANCELLED; 422 with OPERATION_PAST_POINT_OF_NO_RETURN = refused;
+ * 422 with REGISTRATION_NOT_FOUND or OPERATION_NOT_TRACKED = not tracked.</p>
+ *
+ * <p>Post-acceptance failures (local mapping after 200/202) are wrapped in
+ * {@link ConnectorAcceptedButLocalFailureException} — callers must NOT roll back
+ * certificate state on this exception.</p>
+ */
+@Component
+public class AuthorityProviderV3Adapter
+        extends AbstractAuthorityProviderAdapter
+        implements RegisterCapability, AsyncOperationCapability {
+
+    @Autowired
+    public AuthorityProviderV3Adapter(ConnectorService connectorService,
+                                      ConnectorApiFactory connectorApiFactory,
+                                      AttributeEngine attributeEngine) {
+        super(connectorService, connectorApiFactory, attributeEngine);
+    }
+
+    // ---- AuthorityProviderAdapter ----
+
+    @Override
+    public AdapterOperationResult issue(Certificate cert, ClientCertificateSignRequestDto req) throws ConnectorException {
+        RaProfile raProfile = cert.getRaProfile();
+        AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+
+        CertificateSignRequestDtoV3 wire = new CertificateSignRequestDtoV3();
+        wire.setRequest(cert.getCertificateRequest().getContent());
+        wire.setFormat(cert.getCertificateRequest().getCertificateRequestFormat());
+        wire.setAttributes(issueAttributesFor(cert, authority));
+        wire.setAuthorityAttributes(authorityAttributesFor(authority));
+        wire.setRaProfileAttributes(raProfileAttributesFor(raProfile, authority));
+        // Replay any meta the connector emitted on a prior register/renew/issue for this cert.
+        // Unified meta semantic — connector owns the bag; we forward verbatim. Empty when fresh issuance.
+        wire.setMeta(loadMeta(cert, authority));
+
+        return executeWithAcceptanceGuard(CertificateOperation.ISSUE,
+                () -> connectorApiFactory.getCertificateApiClientV3(connectorDto).issue(connectorDto, wire),
+                this::mapIssueRenewRegisterResponse);
+    }
+
+    @Override
+    public AdapterOperationResult renew(Certificate oldCert, Certificate newCert, ClientCertificateRenewRequestDto req) throws ConnectorException {
+        RaProfile raProfile = newCert.getRaProfile();
+        AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+
+        CertificateRenewRequestDtoV3 wire = new CertificateRenewRequestDtoV3();
+        if (newCert.getCertificateRequest() != null) {
+            wire.setRequest(newCert.getCertificateRequest().getContent());
+            wire.setFormat(newCert.getCertificateRequest().getCertificateRequestFormat());
+        }
+        wire.setExistingCertificate(oldCert.getCertificateContent().getContent());
+        wire.setMeta(loadMeta(oldCert, authority));
+        wire.setAuthorityAttributes(authorityAttributesFor(authority));
+        wire.setRaProfileAttributes(raProfileAttributesFor(raProfile, authority));
+
+        return executeWithAcceptanceGuard(CertificateOperation.RENEW,
+                () -> connectorApiFactory.getCertificateApiClientV3(connectorDto).renew(connectorDto, wire),
+                this::mapIssueRenewRegisterResponse);
+    }
+
+    @Override
+    public AdapterOperationResult revoke(Certificate cert, ClientCertificateRevocationDto req) throws ConnectorException {
+        RaProfile raProfile = cert.getRaProfile();
+        AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+
+        CertificateRevocationRequestDtoV3 wire = new CertificateRevocationRequestDtoV3();
+        wire.setCertificate(cert.getCertificateContent().getContent());
+        wire.setReason(req.getReason());
+        wire.setAttributes(req.getAttributes());
+        wire.setMeta(loadMeta(cert, authority));
+        wire.setAuthorityAttributes(authorityAttributesFor(authority));
+        wire.setRaProfileAttributes(raProfileAttributesFor(raProfile, authority));
+
+        return executeWithAcceptanceGuard(CertificateOperation.REVOKE,
+                () -> connectorApiFactory.getCertificateApiClientV3(connectorDto).revoke(connectorDto, wire),
+                this::mapRevokeResponse);
+    }
+
+    @Override
+    public List<BaseAttribute> listAuthorityInstanceAttributes(AuthorityInstanceReference authority) throws ConnectorException {
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        return connectorApiFactory.getAuthorityInstanceApiClientV3(connectorDto)
+                .listAuthorityAttributes(connectorDto);
+    }
+
+    @Override
+    public List<BaseAttribute> listIssueAttributes(AuthorityInstanceReference authority, RaProfile raProfile) throws ConnectorException {
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        return connectorApiFactory.getCertificateApiClientV3(connectorDto)
+                .listIssueAttributes(connectorDto, attributeListRequest(authority, raProfile));
+    }
+
+    @Override
+    public List<BaseAttribute> listRevokeAttributes(AuthorityInstanceReference authority, RaProfile raProfile) throws ConnectorException {
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        return connectorApiFactory.getCertificateApiClientV3(connectorDto)
+                .listRevokeAttributes(connectorDto, attributeListRequest(authority, raProfile));
+    }
+
+    @Override
+    public void validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) {
+        // v3 dropped the connector-side /validate endpoint (interfaces #560). Structural
+        // validation against the listed definitions is done locally by the caller via
+        // AttributeEngine.validateUpdateDataAttributes — no connector round-trip needed.
+    }
+
+    @Override
+    public void validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) {
+        // v3 has no connector-side /validate — see validateIssueAttributes.
+    }
+
+    @Override
+    public void checkAuthorityConnection(AuthorityInstanceReference authority, List<RequestAttribute> attributes)
+            throws ValidationException, ConnectorException {
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        connectorApiFactory.getAuthorityInstanceApiClientV3(connectorDto)
+                .checkAuthorityConnection(connectorDto, attributes);
+    }
+
+    // ---- RegisterCapability ----
+
+    @Override
+    public List<BaseAttribute> listRegisterAttributes(AuthorityInstanceReference authority, RaProfile raProfile) throws ConnectorException {
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        return connectorApiFactory.getCertificateApiClientV3(connectorDto)
+                .listRegisterAttributes(connectorDto, attributeListRequest(authority, raProfile));
+    }
+
+    @Override
+    public AdapterOperationResult register(Certificate cert, ClientCertificateRegistrationDto req) throws ConnectorException {
+        RaProfile raProfile = cert.getRaProfile();
+        AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+
+        CertificateRegistrationRequestDtoV3 wire = new CertificateRegistrationRequestDtoV3();
+        if (req != null) {
+            wire.setSubjectDn(req.getSubjectDn());
+            wire.setSubjectAltName(req.getSubjectAltName());
+            wire.setExtensions(req.getExtensions());
+            wire.setAttributes(req.getAttributes());
+        }
+        wire.setAuthorityAttributes(authorityAttributesFor(authority));
+        wire.setRaProfileAttributes(raProfileAttributesFor(raProfile, authority));
+
+        return executeWithAcceptanceGuard(CertificateOperation.REGISTER,
+                () -> connectorApiFactory.getCertificateApiClientV3(connectorDto).register(connectorDto, wire),
+                this::mapIssueRenewRegisterResponse);
+    }
+
+    // ---- AsyncOperationCapability ----
+
+    /**
+     * Issues 3 separate {@code attribute_content_2_object} reads (cert meta + authority
+     * attrs + RA profile attrs) plus the connector HTTP call per poll message. Bounded
+     * constant per message (not per cert), so the absolute round-trip cost is small —
+     * but in high-throughput async pipelines (thousands of in-flight cert ops) a single
+     * batched lookup would halve the DB load from this listener. Tracked as M4-M9
+     * follow-up; the API surface change in AttributeEngine is out of scope for this batch.
+     */
+    @Override
+    public StatusPollResult pollStatus(Certificate cert, CertificateOperation op) throws ConnectorException {
+        RaProfile raProfile = cert.getRaProfile();
+        AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+
+        CertificateOperationStatusRequestDtoV3 wire = new CertificateOperationStatusRequestDtoV3();
+        wire.setMeta(loadMeta(cert, authority));
+        wire.setAuthorityAttributes(authorityAttributesFor(authority));
+        wire.setRaProfileAttributes(raProfileAttributesFor(raProfile, authority));
+
+        CertificateSyncApiClient v3Client = connectorApiFactory.getCertificateApiClientV3(connectorDto);
+        CertificateOperationStatusResponseDto resp = switch (op) {
+            case ISSUE, RENEW -> v3Client.getIssueStatus(connectorDto, wire);
+            case REVOKE       -> v3Client.getRevokeStatus(connectorDto, wire);
+            case REGISTER     -> v3Client.getRegisterStatus(connectorDto, wire);
+        };
+        return new StatusPollResult(resp.getStatus(), resp.getCertificateData(), resp.getMeta(), resp.getReason());
+    }
+
+    @Override
+    public CancelResult cancel(Certificate cert, CertificateOperation op) throws ConnectorException {
+        RaProfile raProfile = cert.getRaProfile();
+        AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+
+        CertificateOperationCancelRequestDtoV3 wire = new CertificateOperationCancelRequestDtoV3();
+        wire.setMeta(loadMeta(cert, authority));
+        wire.setAuthorityAttributes(authorityAttributesFor(authority));
+        wire.setRaProfileAttributes(raProfileAttributesFor(raProfile, authority));
+
+        CertificateSyncApiClient v3Client = connectorApiFactory.getCertificateApiClientV3(connectorDto);
+        try {
+            switch (op) {
+                case ISSUE, RENEW -> v3Client.cancelIssue(connectorDto, wire);
+                case REVOKE       -> v3Client.cancelRevoke(connectorDto, wire);
+                case REGISTER     -> v3Client.cancelRegister(connectorDto, wire);
+            }
+            return new CancelResult(CancelOutcome.CANCELLED);
+        } catch (ConnectorProblemException e) {
+            ErrorCode code = e.getProblemDetail() != null ? e.getProblemDetail().getErrorCode() : null;
+            if (code == ErrorCode.OPERATION_PAST_POINT_OF_NO_RETURN) {
+                return new CancelResult(CancelOutcome.REFUSED_PAST_POINT_OF_NO_RETURN);
+            }
+            if (ConnectorOperationErrorCodes.isOperationNotTracked(code)) {
+                return new CancelResult(CancelOutcome.NOT_TRACKED);
+            }
+            throw e;
+        }
+    }
+
+    // ---- private helpers ----
+
+    @FunctionalInterface
+    private interface ConnectorCall {
+        ResponseEntity<CertificateDataResponseDto> call() throws ConnectorException;
+    }
+
+    /**
+     * Runs a v3 connector call and maps the response, applying the post-acceptance failure rule:
+     * once the connector returns 2xx, a failure in the local mapping is surfaced as
+     * {@link ConnectorAcceptedButLocalFailureException} (callers must NOT roll back state).
+     * Connector-side failures (the call itself throwing) propagate unchanged.
+     */
+    private AdapterOperationResult executeWithAcceptanceGuard(
+            CertificateOperation op, ConnectorCall call,
+            java.util.function.Function<ResponseEntity<CertificateDataResponseDto>, AdapterOperationResult> mapper)
+            throws ConnectorException {
+        boolean connectorAccepted = false;
+        try {
+            ResponseEntity<CertificateDataResponseDto> response = call.call();
+            connectorAccepted = response.getStatusCode().is2xxSuccessful();
+            return mapper.apply(response);
+        } catch (ConnectorException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            if (connectorAccepted) {
+                throw new ConnectorAcceptedButLocalFailureException(
+                        "Connector accepted " + op.name().toLowerCase() + " but local mapping failed", e);
+            }
+            throw e;
+        }
+    }
+
+    private List<RequestAttribute> issueAttributesFor(Certificate cert, AuthorityInstanceReference authority) {
+        return attributeEngine.getRequestObjectDataAttributesContent(
+                ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, cert.getUuid())
+                        .connector(authority.getConnectorUuid())
+                        .build());
+    }
+
+    private List<RequestAttribute> authorityAttributesFor(AuthorityInstanceReference authority) {
+        return attributeEngine.getRequestObjectDataAttributesContent(
+                ObjectAttributeContentInfo.builder(Resource.AUTHORITY, authority.getUuid())
+                        .connector(authority.getConnectorUuid())
+                        .build());
+    }
+
+    /**
+     * Builds the body for the three v3 attribute-list endpoints (issue/revoke/register). Both
+     * attribute blobs are required so the stateless connector can identify the upstream CA AND
+     * scope the returned schema to a specific RA profile. {@code raProfile} may be null only for
+     * authority-wide listing flows that don't exist today — callers go through the operator
+     * controller which always carries a profile.
+     */
+    private CertificateAttributeListRequestDtoV3 attributeListRequest(AuthorityInstanceReference authority, RaProfile raProfile) {
+        CertificateAttributeListRequestDtoV3 dto = new CertificateAttributeListRequestDtoV3();
+        dto.setAuthorityAttributes(authorityAttributesFor(authority));
+        dto.setRaProfileAttributes(raProfile != null ? raProfileAttributesFor(raProfile, authority) : List.of());
+        return dto;
+    }
+
+    private AdapterOperationResult mapIssueRenewRegisterResponse(ResponseEntity<CertificateDataResponseDto> response) {
+        CertificateDataResponseDto body = response.getBody();
+        int status = response.getStatusCode().value();
+        if (status == 202) {
+            return AdapterOperationResult.asyncAccepted(body != null ? body.getMeta() : null);
+        }
+        if (status == 200) {
+            return AdapterOperationResult.syncOk(
+                    body != null ? body.getCertificateData() : null,
+                    body != null ? body.getMeta() : null,
+                    body != null ? body.getCertificateType() : null);
+        }
+        throw new IllegalStateException("Unexpected v3 status: " + status);
+    }
+
+    private AdapterOperationResult mapRevokeResponse(ResponseEntity<CertificateDataResponseDto> response) {
+        CertificateDataResponseDto body = response.getBody();
+        int status = response.getStatusCode().value();
+        if (status == 204) {
+            return AdapterOperationResult.syncNoContent();
+        }
+        if (status == 202) {
+            return AdapterOperationResult.asyncAccepted(body != null ? body.getMeta() : null);
+        }
+        if (status == 200) {
+            return AdapterOperationResult.syncOk(
+                    body != null ? body.getCertificateData() : null,
+                    body != null ? body.getMeta() : null,
+                    body != null ? body.getCertificateType() : null);
+        }
+        throw new IllegalStateException("Unexpected v3 revoke status: " + status);
+    }
+}

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -19,6 +19,7 @@ import com.otilm.api.model.connector.v3.certificate.CertificateRenewRequestDtoV3
 import com.otilm.api.model.connector.v3.certificate.CertificateRevocationRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateSignRequestDtoV3;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
@@ -115,7 +116,7 @@ public class AuthorityProviderV3Adapter
 
         CertificateRevocationRequestDtoV3 wire = new CertificateRevocationRequestDtoV3();
         wire.setCertificate(cert.getCertificateContent().getContent());
-        wire.setReason(req.getReason());
+        wire.setReason(req.getReason() != null ? req.getReason() : CertificateRevocationReason.UNSPECIFIED);
         wire.setAttributes(req.getAttributes());
         wire.setMeta(loadMeta(cert, authority));
         wire.setAuthorityAttributes(authorityAttributesFor(authority));

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -38,6 +38,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Adapter for v3 authority provider connectors. Wraps {@link CertificateSyncApiClient} (v3)
@@ -150,9 +151,8 @@ public class AuthorityProviderV3Adapter
 
     @Override
     public void validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) {
-        // v3 dropped the connector-side /validate endpoint (interfaces #560). Structural
-        // validation against the listed definitions is done locally by the caller via
-        // AttributeEngine.validateUpdateDataAttributes — no connector round-trip needed.
+        // v3 has no connector-side /validate; the caller validates structurally against the listed
+        // definitions (AttributeEngine.validateUpdateDataAttributes) — no connector round-trip.
     }
 
     @Override
@@ -200,14 +200,6 @@ public class AuthorityProviderV3Adapter
 
     // ---- AsyncOperationCapability ----
 
-    /**
-     * Issues 3 separate {@code attribute_content_2_object} reads (cert meta + authority
-     * attrs + RA profile attrs) plus the connector HTTP call per poll message. Bounded
-     * constant per message (not per cert), so the absolute round-trip cost is small —
-     * but in high-throughput async pipelines (thousands of in-flight cert ops) a single
-     * batched lookup would halve the DB load from this listener. Tracked as M4-M9
-     * follow-up; the API surface change in AttributeEngine is out of scope for this batch.
-     */
     @Override
     public StatusPollResult pollStatus(Certificate cert, CertificateOperation op) throws ConnectorException {
         RaProfile raProfile = cert.getRaProfile();
@@ -274,7 +266,7 @@ public class AuthorityProviderV3Adapter
      */
     private AdapterOperationResult executeWithAcceptanceGuard(
             CertificateOperation op, ConnectorCall call,
-            java.util.function.Function<ResponseEntity<CertificateDataResponseDto>, AdapterOperationResult> mapper)
+            Function<ResponseEntity<CertificateDataResponseDto>, AdapterOperationResult> mapper)
             throws ConnectorException {
         boolean connectorAccepted = false;
         try {

--- a/src/main/java/com/otilm/core/service/handler/authority/CancelOutcome.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/CancelOutcome.java
@@ -1,0 +1,7 @@
+package com.otilm.core.service.handler.authority;
+
+public enum CancelOutcome {
+    CANCELLED,
+    NOT_TRACKED,
+    REFUSED_PAST_POINT_OF_NO_RETURN
+}

--- a/src/main/java/com/otilm/core/service/handler/authority/CancelResult.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/CancelResult.java
@@ -1,0 +1,3 @@
+package com.otilm.core.service.handler.authority;
+
+public record CancelResult(CancelOutcome outcome) {}

--- a/src/main/java/com/otilm/core/service/handler/authority/CertificateOperation.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/CertificateOperation.java
@@ -1,0 +1,39 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.model.core.certificate.CertificateState;
+
+public enum CertificateOperation {
+    ISSUE,
+    RENEW,
+    REVOKE,
+    REGISTER;
+
+    /** The PENDING state a certificate sits in while this operation is async-in-flight. */
+    public CertificateState pendingState() {
+        return switch (this) {
+            case ISSUE, RENEW -> CertificateState.PENDING_ISSUE;
+            case REVOKE       -> CertificateState.PENDING_REVOKE;
+            case REGISTER     -> CertificateState.PENDING_REGISTRATION;
+        };
+    }
+
+    /** Terminal state when this operation completes successfully. */
+    public CertificateState terminalSuccessState() {
+        return switch (this) {
+            case ISSUE, RENEW -> CertificateState.ISSUED;
+            case REGISTER     -> CertificateState.REGISTERED;
+            case REVOKE       -> CertificateState.REVOKED;
+        };
+    }
+
+    /**
+     * Terminal state when this operation fails or is cancelled. Note REVOKE failure returns the
+     * certificate to ISSUED — a failed/cancelled revocation leaves the cert valid, not FAILED.
+     */
+    public CertificateState terminalFailureState() {
+        return switch (this) {
+            case ISSUE, RENEW, REGISTER -> CertificateState.FAILED;
+            case REVOKE                 -> CertificateState.ISSUED;
+        };
+    }
+}

--- a/src/main/java/com/otilm/core/service/handler/authority/ConnectorOperationErrorCodes.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/ConnectorOperationErrorCodes.java
@@ -1,0 +1,24 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.model.common.error.ErrorCode;
+
+/**
+ * Shared classification of connector error codes that recur across the adapter and the async
+ * poll listener. Centralized so the two consumers don't drift when a new "not tracked" code is
+ * introduced.
+ */
+public final class ConnectorOperationErrorCodes {
+
+    private ConnectorOperationErrorCodes() {
+    }
+
+    /**
+     * True when the connector reports that it no longer tracks (or never tracked) the operation —
+     * the upstream identity/handle is gone. Cancel treats this as a soft success (NOT_TRACKED);
+     * the poll listener treats it as a terminal poll error (no point retrying).
+     */
+    public static boolean isOperationNotTracked(ErrorCode code) {
+        return code == ErrorCode.OPERATION_NOT_TRACKED
+                || code == ErrorCode.REGISTRATION_NOT_FOUND;
+    }
+}

--- a/src/main/java/com/otilm/core/service/handler/authority/RegisterCapability.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/RegisterCapability.java
@@ -1,0 +1,30 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.RaProfile;
+
+import java.util.List;
+
+/**
+ * v3-only capability: pre-register a certificate identity at the upstream CA before a CSR exists.
+ */
+public interface RegisterCapability {
+
+    /**
+     * Dynamic register-attribute schema scoped to an RA profile (v3 stateless model: connector
+     * needs both authorityAttributes for upstream auth and raProfileAttributes for profile scope).
+     */
+    List<BaseAttribute> listRegisterAttributes(AuthorityInstanceReference authority, RaProfile raProfile) throws ConnectorException;
+
+    /**
+     * Sends a pre-registration request to the upstream CA for the given certificate placeholder.
+     * The CA reserves a slot/identity and returns a tracking handle in the response metadata.
+     *
+     * @return SYNC_OK when the CA confirmed registration immediately, ASYNC_ACCEPTED when polling is needed.
+     */
+    AdapterOperationResult register(Certificate cert, ClientCertificateRegistrationDto req) throws ConnectorException;
+}

--- a/src/main/java/com/otilm/core/service/handler/authority/StatusPollResult.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/StatusPollResult.java
@@ -1,0 +1,14 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.model.common.attribute.common.MetadataAttribute;
+import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatus;
+import org.springframework.lang.Nullable;
+
+import java.util.List;
+
+public record StatusPollResult(
+    CertificateOperationStatus status,
+    @Nullable String certificateData,
+    @Nullable List<MetadataAttribute> meta,
+    @Nullable String reason
+) {}

--- a/src/main/resources/db/migration/V202605251200__add_connector_interface_uuid_to_authority_instance_reference.sql
+++ b/src/main/resources/db/migration/V202605251200__add_connector_interface_uuid_to_authority_instance_reference.sql
@@ -2,13 +2,14 @@ ALTER TABLE authority_instance_reference
     ADD COLUMN connector_interface_uuid UUID
     REFERENCES connector_interface(uuid) ON UPDATE CASCADE ON DELETE RESTRICT;
 
--- Backfill: link each authority instance to its connector's AUTHORITY interface row.
+-- Backfill: link each existing authority instance to its connector's AUTHORITY interface row.
 --
--- A connector may expose multiple AUTHORITY interface rows when it advertises both v2
--- and v3 side-by-side during migration. Pick the highest version deterministically so
--- the UPDATE never aborts with "more than one row returned by a subquery". Existing
--- authorities are pre-v3 so this resolves to v2 on coexisting connectors. v3 authorities
--- created via the service from M2 onward set the FK explicitly and bypass this backfill.
+-- Every authority touched by this backfill predates v3 (v3 authorities created via the service
+-- set the FK explicitly and are excluded by the WHERE clause below). They must therefore resolve
+-- to the v2 AUTHORITY interface. A connector may expose multiple AUTHORITY rows when it advertises
+-- v2 and v3 side-by-side, so the subquery prefers v2 explicitly (then orders by version for
+-- determinism) — this both avoids "more than one row returned by a subquery" and guarantees the
+-- v2 resolution regardless of which connector versions happen to be registered at migration time.
 --
 -- The FK stays NULL for authorities whose connector declares no connector_interface row.
 -- That happens in two unrelated cases:
@@ -24,7 +25,7 @@ SET connector_interface_uuid = (
     FROM connector_interface ci
     WHERE ci.connector_uuid = air.connector_uuid
       AND ci.interface = 'AUTHORITY'
-    ORDER BY ci.version DESC
+    ORDER BY CASE WHEN ci.version = 'v2' THEN 0 ELSE 1 END, ci.version
     LIMIT 1
 )
 WHERE connector_interface_uuid IS NULL;

--- a/src/main/resources/db/migration/V202605251200__add_connector_interface_uuid_to_authority_instance_reference.sql
+++ b/src/main/resources/db/migration/V202605251200__add_connector_interface_uuid_to_authority_instance_reference.sql
@@ -1,0 +1,30 @@
+ALTER TABLE authority_instance_reference
+    ADD COLUMN connector_interface_uuid UUID
+    REFERENCES connector_interface(uuid) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+-- Backfill: link each authority instance to its connector's AUTHORITY interface row.
+--
+-- A connector may expose multiple AUTHORITY interface rows when it advertises both v2
+-- and v3 side-by-side during migration. Pick the highest version deterministically so
+-- the UPDATE never aborts with "more than one row returned by a subquery". Existing
+-- authorities are pre-v3 so this resolves to v2 on coexisting connectors. v3 authorities
+-- created via the service from M2 onward set the FK explicitly and bypass this backfill.
+--
+-- The FK stays NULL for authorities whose connector declares no connector_interface row.
+-- That happens in two unrelated cases:
+--   * connector framework v1 implementing the v2 authority wire protocol (e.g. ejbca-ng)
+--   * legacy v1-authority connectors (AUTHORITY function group = LEGACY_AUTHORITY_PROVIDER)
+-- Disambiguating these at the DB level is not possible from the schema; the factory
+-- (AuthorityProviderAdapterFactory) handles NULL by routing to the v2 adapter, which is
+-- correct for the framework-v1 + authority-v2 case. Legacy v1-authority connectors flow
+-- through a separate service path that never consults this column.
+UPDATE authority_instance_reference air
+SET connector_interface_uuid = (
+    SELECT ci.uuid
+    FROM connector_interface ci
+    WHERE ci.connector_uuid = air.connector_uuid
+      AND ci.interface = 'AUTHORITY'
+    ORDER BY ci.version DESC
+    LIMIT 1
+)
+WHERE connector_interface_uuid IS NULL;

--- a/src/test/java/com/otilm/core/service/handler/authority/AdapterOperationResultTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AdapterOperationResultTest.java
@@ -33,21 +33,6 @@ class AdapterOperationResultTest {
     }
 
     @Test
-    void cancelOutcomeAllValues() {
-        assertNotNull(CancelOutcome.CANCELLED);
-        assertNotNull(CancelOutcome.NOT_TRACKED);
-        assertNotNull(CancelOutcome.REFUSED_PAST_POINT_OF_NO_RETURN);
-    }
-
-    @Test
-    void certificateOperationAllValues() {
-        assertNotNull(CertificateOperation.ISSUE);
-        assertNotNull(CertificateOperation.RENEW);
-        assertNotNull(CertificateOperation.REVOKE);
-        assertNotNull(CertificateOperation.REGISTER);
-    }
-
-    @Test
     void statusPollResultRecord() {
         StatusPollResult r = new StatusPollResult(CertificateOperationStatus.COMPLETED, "data", List.of(), null);
         assertEquals(CertificateOperationStatus.COMPLETED, r.status());

--- a/src/test/java/com/otilm/core/service/handler/authority/AdapterOperationResultTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AdapterOperationResultTest.java
@@ -1,0 +1,62 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdapterOperationResultTest {
+
+    @Test
+    void syncOkFactory() {
+        AdapterOperationResult r = AdapterOperationResult.syncOk("data", List.of(), null);
+        assertEquals(AdapterOperationOutcome.SYNC_OK, r.outcome());
+        assertEquals("data", r.certificateData());
+        assertFalse(r.isAsync());
+    }
+
+    @Test
+    void asyncAcceptedFactory() {
+        AdapterOperationResult r = AdapterOperationResult.asyncAccepted(List.of());
+        assertEquals(AdapterOperationOutcome.ASYNC_ACCEPTED, r.outcome());
+        assertNull(r.certificateData());
+        assertTrue(r.isAsync());
+    }
+
+    @Test
+    void syncNoContentFactory() {
+        AdapterOperationResult r = AdapterOperationResult.syncNoContent();
+        assertEquals(AdapterOperationOutcome.SYNC_NO_CONTENT, r.outcome());
+        assertFalse(r.isAsync());
+    }
+
+    @Test
+    void cancelOutcomeAllValues() {
+        assertNotNull(CancelOutcome.CANCELLED);
+        assertNotNull(CancelOutcome.NOT_TRACKED);
+        assertNotNull(CancelOutcome.REFUSED_PAST_POINT_OF_NO_RETURN);
+    }
+
+    @Test
+    void certificateOperationAllValues() {
+        assertNotNull(CertificateOperation.ISSUE);
+        assertNotNull(CertificateOperation.RENEW);
+        assertNotNull(CertificateOperation.REVOKE);
+        assertNotNull(CertificateOperation.REGISTER);
+    }
+
+    @Test
+    void statusPollResultRecord() {
+        StatusPollResult r = new StatusPollResult(CertificateOperationStatus.COMPLETED, "data", List.of(), null);
+        assertEquals(CertificateOperationStatus.COMPLETED, r.status());
+        assertEquals("data", r.certificateData());
+    }
+
+    @Test
+    void cancelResultRecord() {
+        CancelResult r = new CancelResult(CancelOutcome.CANCELLED);
+        assertEquals(CancelOutcome.CANCELLED, r.outcome());
+    }
+}

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactoryTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactoryTest.java
@@ -1,0 +1,64 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.ConnectorInterfaceEntity;
+import com.otilm.core.exception.UnsupportedAuthorityVersionException;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuthorityProviderAdapterFactoryTest {
+
+    private final AuthorityProviderV2Adapter v2 = mock(AuthorityProviderV2Adapter.class);
+    private final AuthorityProviderV3Adapter v3 = mock(AuthorityProviderV3Adapter.class);
+    private final AuthorityProviderAdapterFactory factory = new AuthorityProviderAdapterFactory(v2, v3);
+
+    @Test
+    void dispatchesV2() {
+        assertSame(v2, factory.forAuthority(authorityWithVersion("v2")));
+    }
+
+    @Test
+    void dispatchesV3() {
+        assertSame(v3, factory.forAuthority(authorityWithVersion("v3")));
+    }
+
+    @Test
+    void rejectsV1() {
+        AuthorityInstanceReference auth = authorityWithVersion("v1");
+        UnsupportedAuthorityVersionException ex = assertThrows(
+                UnsupportedAuthorityVersionException.class,
+                () -> factory.forAuthority(auth));
+        assertTrue(ex.getMessage().contains("v1"));
+    }
+
+    @Test
+    void missingInterfaceFallsBackToV2() {
+        // A null connector interface is expected for framework-v1 connectors that implement the
+        // v2 authority wire protocol (e.g. ejbca-ng) — they declare no connector_interface row,
+        // so the M0 backfill leaves the FK null. The factory routes these to the v2 adapter
+        // (the protocol they speak). Legacy v1-authority connectors never reach this factory.
+        AuthorityInstanceReference auth = new AuthorityInstanceReference();
+        auth.setUuid(UUID.randomUUID());
+        // connector interface left null
+        assertSame(v2, factory.forAuthority(auth));
+    }
+
+    /**
+     * @param version connector-format version string, e.g. {@code "v2"}, {@code "v3"}, {@code "v1"}.
+     *                Must include the {@code v} prefix — that is the format stored by
+     *                {@link com.otilm.core.service.handler.ConnectorV2Adapter} from the
+     *                connector's info endpoint.
+     */
+    private AuthorityInstanceReference authorityWithVersion(String version) {
+        AuthorityInstanceReference auth = new AuthorityInstanceReference();
+        auth.setUuid(UUID.randomUUID());
+        ConnectorInterfaceEntity iface = new ConnectorInterfaceEntity();
+        iface.setVersion(version);
+        auth.setConnectorInterface(iface);
+        return auth;
+    }
+}

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactoryTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactoryTest.java
@@ -45,10 +45,8 @@ class AuthorityProviderAdapterFactoryTest {
 
     @Test
     void missingInterfaceFallsBackToV2() {
-        // A null connector interface is expected for framework-v1 connectors that implement the
-        // v2 authority wire protocol (e.g. ejbca-ng) — they declare no connector_interface row,
-        // so the M0 backfill leaves the FK null. The factory routes these to the v2 adapter
-        // (the protocol they speak). Legacy v1-authority connectors never reach this factory.
+        // A null connector interface = a framework-v1 connector speaking the v2 authority protocol
+        // (e.g. ejbca-ng), which declares no connector_interface row → routes to the v2 adapter.
         AuthorityInstanceReference auth = new AuthorityInstanceReference();
         auth.setUuid(UUID.randomUUID());
         // connector interface left null

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactoryTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactoryTest.java
@@ -36,6 +36,14 @@ class AuthorityProviderAdapterFactoryTest {
     }
 
     @Test
+    void rejectsNullVersion() {
+        // A non-null connector interface carrying a null version is malformed; the factory throws
+        // (rather than NPE on the switch). Distinct from the null-interface fallback below.
+        AuthorityInstanceReference auth = authorityWithVersion(null);
+        assertThrows(UnsupportedAuthorityVersionException.class, () -> factory.forAuthority(auth));
+    }
+
+    @Test
     void missingInterfaceFallsBackToV2() {
         // A null connector interface is expected for framework-v1 connectors that implement the
         // v2 authority wire protocol (e.g. ejbca-ng) — they declare no connector_interface row,

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV2AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV2AdapterTest.java
@@ -297,6 +297,22 @@ class AuthorityProviderV2AdapterTest {
         verify(authorityClient).validateRAProfileAttributes(connectorInfo, "auth-instance-uuid", attrs);
     }
 
+    // --- validate attributes (v2 delegates to the connector /validate endpoints) ---
+
+    @Test
+    void validateIssueAttributes_delegatesToCertClient() throws Exception {
+        List<RequestAttribute> attrs = List.of(mock(RequestAttribute.class));
+        adapter.validateIssueAttributes(authority, attrs);
+        verify(certClient).validateIssueCertificateAttributes(connectorInfo, "auth-instance-uuid", attrs);
+    }
+
+    @Test
+    void validateRevokeAttributes_delegatesToCertClient() throws Exception {
+        List<RequestAttribute> attrs = List.of(mock(RequestAttribute.class));
+        adapter.validateRevokeAttributes(authority, attrs);
+        verify(certClient).validateRevokeCertificateAttributes(connectorInfo, "auth-instance-uuid", attrs);
+    }
+
     // --- error handling ---
 
     @Test

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV2AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV2AdapterTest.java
@@ -1,0 +1,310 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.interfaces.client.v1.AuthorityInstanceSyncApiClient;
+import com.otilm.api.interfaces.client.v2.CertificateSyncApiClient;
+import com.otilm.api.model.client.attribute.RequestAttribute;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.connector.v2.CertRevocationDto;
+import com.otilm.api.model.connector.v2.CertificateDataResponseDto;
+import com.otilm.api.model.connector.v2.CertificateRenewRequestDto;
+import com.otilm.api.model.connector.v2.CertificateSignRequestDto;
+import com.otilm.api.model.core.authority.CertificateRevocationReason;
+import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
+import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.client.ConnectorApiFactory;
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.CertificateContent;
+import com.otilm.core.dao.entity.CertificateRequestEntity;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.service.v2.ConnectorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorityProviderV2AdapterTest {
+
+    @Mock
+    ConnectorService connectorService;
+    @Mock
+    ConnectorApiFactory connectorApiFactory;
+    @Mock
+    AttributeEngine attributeEngine;
+
+    @InjectMocks
+    AuthorityProviderV2Adapter adapter;
+
+    @Mock
+    CertificateSyncApiClient certClient;
+    @Mock
+    AuthorityInstanceSyncApiClient authorityClient;
+
+    private ApiClientConnectorInfo connectorInfo;
+    private AuthorityInstanceReference authority;
+    private RaProfile raProfile;
+    /** Certificate used for issue tests and as the successor (new) cert in renew tests. */
+    private Certificate cert;
+    /** Predecessor (old) certificate used in renew tests — carries the old cert content and UUID. */
+    private Certificate oldCert;
+
+    @BeforeEach
+    void setUp() throws NotFoundException, java.security.NoSuchAlgorithmException {
+        UUID connectorUuid = UUID.randomUUID();
+
+        connectorInfo = mock(ApiClientConnectorInfo.class);
+        authority = new AuthorityInstanceReference();
+        authority.setConnectorUuid(connectorUuid);
+        authority.setAuthorityInstanceUuid("auth-instance-uuid");
+
+        raProfile = new RaProfile();
+        raProfile.setUuid(UUID.randomUUID());
+        raProfile.setAuthorityInstanceReference(authority);
+
+        // CertificateRequestEntity.setContent() decodes via Base64 and hashes; any valid Base64 works.
+        CertificateRequestEntity certRequest = new CertificateRequestEntity();
+        certRequest.setContent("dGVzdGNzcg=="); // "testcsr" in Base64
+
+        CertificateContent certContent = new CertificateContent();
+        certContent.setContent("dGVzdGNlcnQ="); // "testcert" in Base64
+
+        cert = new Certificate();
+        cert.setUuid(UUID.randomUUID());
+        cert.setRaProfile(raProfile);
+        cert.setCertificateRequest(certRequest);
+        cert.setCertificateContent(certContent);
+
+        // oldCert carries the predecessor cert content (wire field "certificate") and the UUID
+        // used for metadata lookup. Its CSR is irrelevant for renew — the adapter reads CSR from newCert.
+        CertificateContent oldCertContent = new CertificateContent();
+        oldCertContent.setContent("dGVzdGNlcnQ="); // same value for assertions; distinct object
+
+        oldCert = new Certificate();
+        oldCert.setUuid(UUID.randomUUID());
+        oldCert.setRaProfile(raProfile);
+        oldCert.setCertificateContent(oldCertContent);
+
+        // Lenient: not every test goes through the cert-client or authority-client path.
+        lenient().when(connectorService.getConnectorForApiClient(connectorUuid)).thenReturn(connectorInfo);
+        lenient().when(connectorApiFactory.getCertificateApiClientV2(connectorInfo)).thenReturn(certClient);
+        lenient().when(connectorApiFactory.getAuthorityInstanceApiClient(connectorInfo)).thenReturn(authorityClient);
+        lenient().when(attributeEngine.getRequestObjectDataAttributesContent(any())).thenReturn(List.of());
+    }
+
+    // --- issue ---
+
+    @Test
+    void issue_wrapsV2ResponseAsSyncOk() throws ConnectorException {
+        CertificateDataResponseDto responseBody = new CertificateDataResponseDto();
+        responseBody.setCertificateData("issuedCertData==");
+        when(certClient.issueCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateSignRequestDto.class)))
+                .thenReturn(ResponseEntity.ok(responseBody));
+
+        AdapterOperationResult result = adapter.issue(cert, new ClientCertificateSignRequestDto());
+
+        assertEquals(AdapterOperationOutcome.SYNC_OK, result.outcome());
+        assertEquals("issuedCertData==", result.certificateData());
+        assertFalse(result.isAsync());
+    }
+
+    @Test
+    void issue_buildsWireDtoFromCertEntity() throws ConnectorException {
+        CertificateDataResponseDto responseBody = new CertificateDataResponseDto();
+        responseBody.setCertificateData("cert==");
+        when(certClient.issueCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateSignRequestDto.class)))
+                .thenReturn(ResponseEntity.ok(responseBody));
+
+        adapter.issue(cert, new ClientCertificateSignRequestDto());
+
+        ArgumentCaptor<CertificateSignRequestDto> captor = ArgumentCaptor.forClass(CertificateSignRequestDto.class);
+        verify(certClient).issueCertificate(eq(connectorInfo), eq("auth-instance-uuid"), captor.capture());
+        assertEquals("dGVzdGNzcg==", captor.getValue().getRequest());
+    }
+
+    // --- renew ---
+
+    @Test
+    void renew_wrapsV2ResponseAsSyncOk() throws ConnectorException {
+        CertificateDataResponseDto responseBody = new CertificateDataResponseDto();
+        responseBody.setCertificateData("renewedCertData==");
+        when(attributeEngine.getMetadataAttributesDefinitionContent(any())).thenReturn(List.of());
+        when(certClient.renewCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateRenewRequestDto.class)))
+                .thenReturn(ResponseEntity.ok(responseBody));
+
+        AdapterOperationResult result = adapter.renew(oldCert, cert, new ClientCertificateRenewRequestDto());
+
+        assertEquals(AdapterOperationOutcome.SYNC_OK, result.outcome());
+        assertEquals("renewedCertData==", result.certificateData());
+    }
+
+    @Test
+    void renew_buildsWireDtoWithOldCertContent() throws ConnectorException {
+        CertificateDataResponseDto responseBody = new CertificateDataResponseDto();
+        responseBody.setCertificateData("cert==");
+        when(attributeEngine.getMetadataAttributesDefinitionContent(any())).thenReturn(List.of());
+        when(certClient.renewCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateRenewRequestDto.class)))
+                .thenReturn(ResponseEntity.ok(responseBody));
+
+        // newCert (cert) provides the CSR; oldCert provides the predecessor cert content.
+        adapter.renew(oldCert, cert, new ClientCertificateRenewRequestDto());
+
+        ArgumentCaptor<CertificateRenewRequestDto> captor = ArgumentCaptor.forClass(CertificateRenewRequestDto.class);
+        verify(certClient).renewCertificate(eq(connectorInfo), eq("auth-instance-uuid"), captor.capture());
+        assertEquals("dGVzdGNzcg==", captor.getValue().getRequest());   // from newCert (cert)
+        assertEquals("dGVzdGNlcnQ=", captor.getValue().getCertificate()); // from oldCert
+    }
+
+    @Test
+    void renew_withoutCsr_omitsRequestInsteadOfNpe() throws ConnectorException {
+        // Reuse-key renewal: the successor cert may carry no CSR. The adapter must omit the
+        // request/format fields rather than NPE on newCert.getCertificateRequest() (matches V3).
+        cert.setCertificateRequest(null);
+        CertificateDataResponseDto responseBody = new CertificateDataResponseDto();
+        responseBody.setCertificateData("renewedNoCsr==");
+        when(attributeEngine.getMetadataAttributesDefinitionContent(any())).thenReturn(List.of());
+        when(certClient.renewCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateRenewRequestDto.class)))
+                .thenReturn(ResponseEntity.ok(responseBody));
+
+        AdapterOperationResult result = adapter.renew(oldCert, cert, new ClientCertificateRenewRequestDto());
+
+        ArgumentCaptor<CertificateRenewRequestDto> captor = ArgumentCaptor.forClass(CertificateRenewRequestDto.class);
+        verify(certClient).renewCertificate(eq(connectorInfo), eq("auth-instance-uuid"), captor.capture());
+        assertNull(captor.getValue().getRequest());
+        assertNull(captor.getValue().getFormat());
+        assertEquals(AdapterOperationOutcome.SYNC_OK, result.outcome());
+    }
+
+    @Test
+    void issue_status202ReturnsAsyncAccepted() throws ConnectorException {
+        CertificateDataResponseDto responseBody = new CertificateDataResponseDto();
+        responseBody.setCertificateData(null); // 202 body may omit cert data
+        when(certClient.issueCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateSignRequestDto.class)))
+                .thenReturn(ResponseEntity.status(202).body(responseBody));
+
+        AdapterOperationResult result = adapter.issue(cert, new ClientCertificateSignRequestDto());
+
+        assertEquals(AdapterOperationOutcome.ASYNC_ACCEPTED, result.outcome());
+        assertTrue(result.isAsync());
+        assertNull(result.certificateData());
+    }
+
+    @Test
+    void renew_status202ReturnsAsyncAccepted() throws ConnectorException {
+        when(attributeEngine.getMetadataAttributesDefinitionContent(any())).thenReturn(List.of());
+        when(certClient.renewCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateRenewRequestDto.class)))
+                .thenReturn(ResponseEntity.status(202).build());
+
+        AdapterOperationResult result = adapter.renew(oldCert, cert, new ClientCertificateRenewRequestDto());
+
+        assertEquals(AdapterOperationOutcome.ASYNC_ACCEPTED, result.outcome());
+        assertTrue(result.isAsync());
+    }
+
+    // --- revoke ---
+
+    @Test
+    void revoke_returnsSyncNoContent() throws ConnectorException {
+        when(certClient.revokeCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertRevocationDto.class)))
+                .thenReturn(ResponseEntity.noContent().build());
+
+        ClientCertificateRevocationDto req = new ClientCertificateRevocationDto();
+        req.setReason(CertificateRevocationReason.KEY_COMPROMISE);
+
+        AdapterOperationResult result = adapter.revoke(cert, req);
+
+        assertEquals(AdapterOperationOutcome.SYNC_NO_CONTENT, result.outcome());
+        assertNull(result.certificateData());
+    }
+
+    @Test
+    void revoke_status202ReturnsAsyncAccepted() throws ConnectorException {
+        when(certClient.revokeCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertRevocationDto.class)))
+                .thenReturn(ResponseEntity.status(202).build());
+
+        ClientCertificateRevocationDto req = new ClientCertificateRevocationDto();
+        req.setReason(CertificateRevocationReason.UNSPECIFIED);
+
+        AdapterOperationResult result = adapter.revoke(cert, req);
+
+        assertEquals(AdapterOperationOutcome.ASYNC_ACCEPTED, result.outcome());
+        assertTrue(result.isAsync());
+    }
+
+    @Test
+    void revoke_defaultsNullReasonToUnspecified() throws ConnectorException {
+        when(certClient.revokeCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertRevocationDto.class)))
+                .thenReturn(ResponseEntity.status(HttpStatus.OK).build());
+
+        ClientCertificateRevocationDto req = new ClientCertificateRevocationDto();
+        req.setReason(null);
+
+        adapter.revoke(cert, req);
+
+        ArgumentCaptor<CertRevocationDto> captor = ArgumentCaptor.forClass(CertRevocationDto.class);
+        verify(certClient).revokeCertificate(eq(connectorInfo), eq("auth-instance-uuid"), captor.capture());
+        assertEquals(CertificateRevocationReason.UNSPECIFIED, captor.getValue().getReason());
+    }
+
+    // --- listIssueAttributes / listRevokeAttributes ---
+
+    @Test
+    void listIssueAttributes_delegatesToCertClient() throws ConnectorException {
+        List<BaseAttribute> expected = List.of(mock(BaseAttribute.class));
+        when(certClient.listIssueCertificateAttributes(connectorInfo, "auth-instance-uuid")).thenReturn(expected);
+
+        List<BaseAttribute> result = adapter.listIssueAttributes(authority, null);
+
+        assertSame(expected, result);
+    }
+
+    @Test
+    void listRevokeAttributes_delegatesToCertClient() throws ConnectorException {
+        List<BaseAttribute> expected = List.of(mock(BaseAttribute.class));
+        when(certClient.listRevokeCertificateAttributes(connectorInfo, "auth-instance-uuid")).thenReturn(expected);
+
+        List<BaseAttribute> result = adapter.listRevokeAttributes(authority, null);
+
+        assertSame(expected, result);
+    }
+
+    // --- checkAuthorityConnection ---
+
+    @Test
+    void checkAuthorityConnection_delegatesToValidateRAProfileAttributes() throws Exception {
+        List<RequestAttribute> attrs = List.of(mock(RequestAttribute.class));
+        when(authorityClient.validateRAProfileAttributes(connectorInfo, "auth-instance-uuid", attrs)).thenReturn(true);
+
+        adapter.checkAuthorityConnection(authority, attrs);
+
+        verify(authorityClient).validateRAProfileAttributes(connectorInfo, "auth-instance-uuid", attrs);
+    }
+
+    // --- error handling ---
+
+    @Test
+    void connectorNotFound_wrappedAsConnectorException() throws NotFoundException {
+        UUID connectorUuid = authority.getConnectorUuid();
+        when(connectorService.getConnectorForApiClient(connectorUuid))
+                .thenThrow(new NotFoundException("Connector not found"));
+
+        assertThrows(ConnectorException.class, () -> adapter.listIssueAttributes(authority, null));
+    }
+}

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -18,8 +18,11 @@ import com.otilm.api.model.connector.v3.certificate.CertificateSignRequestDtoV3;
 import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
+import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.AttributeOperation;
+import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.Certificate;
@@ -31,6 +34,7 @@ import com.otilm.core.service.v2.ConnectorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -136,6 +140,28 @@ class AuthorityProviderV3AdapterTest {
         assertEquals(AdapterOperationOutcome.SYNC_OK, result.outcome());
         assertEquals("issuedCert==", result.certificateData());
         assertFalse(result.isAsync());
+    }
+
+    // ---- issue: request attributes scoped to the ISSUE operation (parity with V2) ----
+
+    @Test
+    void issueLoadsCertificateRequestAttributesScopedToIssueOperation() throws ConnectorException {
+        CertificateDataResponseDto body = new CertificateDataResponseDto();
+        body.setCertificateData("issuedCert==");
+        when(certClientV3.issue(eq(connectorInfo), any(CertificateSignRequestDtoV3.class)))
+                .thenReturn(ResponseEntity.ok(body));
+
+        adapter.issue(cert, new ClientCertificateSignRequestDto());
+
+        // The certificate-scoped attribute load must carry operation=CERTIFICATE_ISSUE, otherwise the
+        // engine returns unscoped attributes. (Other captured calls are AUTHORITY/RA_PROFILE-scoped.)
+        ArgumentCaptor<ObjectAttributeContentInfo> captor = ArgumentCaptor.forClass(ObjectAttributeContentInfo.class);
+        verify(attributeEngine, atLeastOnce()).getRequestObjectDataAttributesContent(captor.capture());
+        ObjectAttributeContentInfo certScoped = captor.getAllValues().stream()
+                .filter(info -> info.objectType() == Resource.CERTIFICATE)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no CERTIFICATE-scoped attribute load during issue"));
+        assertEquals(AttributeOperation.CERTIFICATE_ISSUE, certScoped.operation());
     }
 
     // ---- issue: 202 -> ASYNC_ACCEPTED ----

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -7,6 +7,7 @@ import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.interfaces.client.v3.AuthoritySyncApiClient;
 import com.otilm.api.interfaces.client.v3.CertificateSyncApiClient;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.error.ErrorCode;
 import com.otilm.api.model.common.error.ProblemDetailExtended;
 import com.otilm.api.model.connector.v3.certificate.CertificateDataResponseDto;
@@ -339,5 +340,111 @@ class AuthorityProviderV3AdapterTest {
                 .thenThrow(new NotFoundException("Connector not found"));
 
         assertThrows(ConnectorException.class, () -> adapter.listIssueAttributes(authority, null));
+    }
+
+    // ---- renew ----
+
+    @Test
+    void renewMaps200ToSyncOk() throws ConnectorException {
+        CertificateDataResponseDto body = new CertificateDataResponseDto();
+        body.setCertificateData("renewed==");
+        when(certClientV3.renew(eq(connectorInfo), any())).thenReturn(ResponseEntity.ok(body));
+
+        AdapterOperationResult result = adapter.renew(oldCert, cert, new ClientCertificateRenewRequestDto());
+
+        assertEquals(AdapterOperationOutcome.SYNC_OK, result.outcome());
+        assertEquals("renewed==", result.certificateData());
+    }
+
+    @Test
+    void renewMaps202ToAsyncAccepted() throws ConnectorException {
+        when(certClientV3.renew(eq(connectorInfo), any())).thenReturn(ResponseEntity.status(202).build());
+
+        AdapterOperationResult result = adapter.renew(oldCert, cert, new ClientCertificateRenewRequestDto());
+
+        assertEquals(AdapterOperationOutcome.ASYNC_ACCEPTED, result.outcome());
+    }
+
+    // ---- attribute listing / validation / connection check ----
+
+    @Test
+    void listAuthorityInstanceAttributesDelegates() throws ConnectorException {
+        List<BaseAttribute> expected = List.of(mock(BaseAttribute.class));
+        when(authorityClientV3.listAuthorityAttributes(connectorInfo)).thenReturn(expected);
+        assertEquals(expected, adapter.listAuthorityInstanceAttributes(authority));
+    }
+
+    @Test
+    void listIssueAttributesDelegates() throws ConnectorException {
+        List<BaseAttribute> expected = List.of(mock(BaseAttribute.class));
+        when(certClientV3.listIssueAttributes(eq(connectorInfo), any())).thenReturn(expected);
+        assertEquals(expected, adapter.listIssueAttributes(authority, raProfile));
+    }
+
+    @Test
+    void listRevokeAttributesDelegates() throws ConnectorException {
+        List<BaseAttribute> expected = List.of(mock(BaseAttribute.class));
+        when(certClientV3.listRevokeAttributes(eq(connectorInfo), any())).thenReturn(expected);
+        assertEquals(expected, adapter.listRevokeAttributes(authority, raProfile));
+    }
+
+    @Test
+    void listRegisterAttributesDelegates() throws ConnectorException {
+        List<BaseAttribute> expected = List.of(mock(BaseAttribute.class));
+        when(certClientV3.listRegisterAttributes(eq(connectorInfo), any())).thenReturn(expected);
+        assertEquals(expected, adapter.listRegisterAttributes(authority, raProfile));
+    }
+
+    @Test
+    void validateAttributesAreNoOpForV3() {
+        // v3 dropped the connector-side /validate; these must neither call the connector nor throw.
+        adapter.validateIssueAttributes(authority, List.of());
+        adapter.validateRevokeAttributes(authority, List.of());
+        verifyNoInteractions(certClientV3);
+    }
+
+    @Test
+    void checkAuthorityConnectionDelegates() throws ConnectorException {
+        adapter.checkAuthorityConnection(authority, List.of());
+        verify(authorityClientV3).checkAuthorityConnection(eq(connectorInfo), any());
+    }
+
+    // ---- pollStatus: revoke + register branches ----
+
+    @Test
+    void pollStatusUsesRevokeEndpointForRevoke() throws ConnectorException {
+        CertificateOperationStatusResponseDto resp = new CertificateOperationStatusResponseDto();
+        resp.setStatus(CertificateOperationStatus.IN_PROGRESS);
+        when(certClientV3.getRevokeStatus(eq(connectorInfo), any())).thenReturn(resp);
+
+        StatusPollResult result = adapter.pollStatus(cert, CertificateOperation.REVOKE);
+
+        assertEquals(CertificateOperationStatus.IN_PROGRESS, result.status());
+        verify(certClientV3).getRevokeStatus(eq(connectorInfo), any());
+    }
+
+    @Test
+    void pollStatusUsesRegisterEndpointForRegister() throws ConnectorException {
+        CertificateOperationStatusResponseDto resp = new CertificateOperationStatusResponseDto();
+        resp.setStatus(CertificateOperationStatus.FAILED);
+        resp.setReason("rejected upstream");
+        when(certClientV3.getRegisterStatus(eq(connectorInfo), any())).thenReturn(resp);
+
+        StatusPollResult result = adapter.pollStatus(cert, CertificateOperation.REGISTER);
+
+        assertEquals(CertificateOperationStatus.FAILED, result.status());
+        assertEquals("rejected upstream", result.reason());
+    }
+
+    // ---- cancel: revoke branch ----
+
+    @Test
+    void cancelUsesCancelRevokeForRevoke() throws ConnectorException {
+        when(certClientV3.cancelRevoke(eq(connectorInfo), any())).thenReturn(ResponseEntity.noContent().build());
+
+        CancelResult result = adapter.cancel(cert, CertificateOperation.REVOKE);
+
+        assertEquals(CancelOutcome.CANCELLED, result.outcome());
+        verify(certClientV3).cancelRevoke(eq(connectorInfo), any());
     }
 }

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -14,11 +14,13 @@ import com.otilm.api.model.connector.v3.certificate.CertificateOperationCancelRe
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatus;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatusRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatusResponseDto;
+import com.otilm.api.model.connector.v3.certificate.CertificateRevocationRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateSignRequestDtoV3;
 import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeOperation;
@@ -242,6 +244,19 @@ class AuthorityProviderV3AdapterTest {
 
         assertEquals(AdapterOperationOutcome.SYNC_NO_CONTENT, result.outcome());
         assertNull(result.certificateData());
+    }
+
+    @Test
+    void revokeDefaultsNullReasonToUnspecified() throws ConnectorException {
+        when(certClientV3.revoke(eq(connectorInfo), any()))
+                .thenReturn(ResponseEntity.noContent().build());
+
+        adapter.revoke(cert, new ClientCertificateRevocationDto());   // reason omitted (null)
+
+        ArgumentCaptor<CertificateRevocationRequestDtoV3> captor =
+                ArgumentCaptor.forClass(CertificateRevocationRequestDtoV3.class);
+        verify(certClientV3).revoke(eq(connectorInfo), captor.capture());
+        assertEquals(CertificateRevocationReason.UNSPECIFIED, captor.getValue().getReason());
     }
 
     // ---- register: delegates to v3 /register ----

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -1,0 +1,307 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.ConnectorProblemException;
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.interfaces.client.v3.AuthoritySyncApiClient;
+import com.otilm.api.interfaces.client.v3.CertificateSyncApiClient;
+import com.otilm.api.model.common.attribute.common.MetadataAttribute;
+import com.otilm.api.model.common.error.ErrorCode;
+import com.otilm.api.model.common.error.ProblemDetailExtended;
+import com.otilm.api.model.connector.v3.certificate.CertificateDataResponseDto;
+import com.otilm.api.model.connector.v3.certificate.CertificateOperationCancelRequestDtoV3;
+import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatus;
+import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatusRequestDtoV3;
+import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatusResponseDto;
+import com.otilm.api.model.connector.v3.certificate.CertificateSignRequestDtoV3;
+import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
+import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
+import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.client.ConnectorApiFactory;
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.CertificateContent;
+import com.otilm.core.dao.entity.CertificateRequestEntity;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.exception.ConnectorAcceptedButLocalFailureException;
+import com.otilm.core.service.v2.ConnectorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorityProviderV3AdapterTest {
+
+    @Mock
+    ConnectorService connectorService;
+    @Mock
+    ConnectorApiFactory connectorApiFactory;
+    @Mock
+    AttributeEngine attributeEngine;
+
+    @InjectMocks
+    AuthorityProviderV3Adapter adapter;
+
+    @Mock
+    CertificateSyncApiClient certClientV3;
+    @Mock
+    AuthoritySyncApiClient authorityClientV3;
+
+    private ApiClientConnectorInfo connectorInfo;
+    private AuthorityInstanceReference authority;
+    private RaProfile raProfile;
+    private Certificate cert;
+    private Certificate oldCert;
+
+    @BeforeEach
+    void setUp() throws NotFoundException, java.security.NoSuchAlgorithmException {
+        UUID connectorUuid = UUID.randomUUID();
+
+        connectorInfo = mock(ApiClientConnectorInfo.class);
+        authority = new AuthorityInstanceReference();
+        authority.setUuid(UUID.randomUUID());
+        authority.setConnectorUuid(connectorUuid);
+        authority.setAuthorityInstanceUuid("auth-instance-uuid");
+
+        raProfile = new RaProfile();
+        raProfile.setUuid(UUID.randomUUID());
+        raProfile.setAuthorityInstanceReference(authority);
+
+        CertificateRequestEntity certRequest = new CertificateRequestEntity();
+        certRequest.setContent("dGVzdGNzcg=="); // "testcsr" Base64
+
+        CertificateContent certContent = new CertificateContent();
+        certContent.setContent("dGVzdGNlcnQ="); // "testcert" Base64
+
+        cert = new Certificate();
+        cert.setUuid(UUID.randomUUID());
+        cert.setRaProfile(raProfile);
+        cert.setCertificateRequest(certRequest);
+        cert.setCertificateContent(certContent);
+
+        CertificateContent oldCertContent = new CertificateContent();
+        oldCertContent.setContent("b2xkY2VydA=="); // "oldcert" Base64
+
+        oldCert = new Certificate();
+        oldCert.setUuid(UUID.randomUUID());
+        oldCert.setRaProfile(raProfile);
+        oldCert.setCertificateContent(oldCertContent);
+
+        lenient().when(connectorService.getConnectorForApiClient(connectorUuid)).thenReturn(connectorInfo);
+        lenient().when(connectorApiFactory.getCertificateApiClientV3(connectorInfo)).thenReturn(certClientV3);
+        lenient().when(connectorApiFactory.getAuthorityInstanceApiClientV3(connectorInfo)).thenReturn(authorityClientV3);
+        lenient().when(attributeEngine.getRequestObjectDataAttributesContent(any())).thenReturn(List.of());
+        lenient().when(attributeEngine.getMetadataAttributesDefinitionContent(any())).thenReturn(List.of());
+    }
+
+    // ---- capability markers ----
+
+    @Test
+    void implementsRegisterCapability() {
+        assertInstanceOf(RegisterCapability.class, adapter);
+    }
+
+    @Test
+    void implementsAsyncOperationCapability() {
+        assertInstanceOf(AsyncOperationCapability.class, adapter);
+    }
+
+    // ---- issue: 200 -> SYNC_OK ----
+
+    @Test
+    void issueMaps200ToSyncOk() throws ConnectorException {
+        CertificateDataResponseDto body = new CertificateDataResponseDto();
+        body.setCertificateData("issuedCert==");
+        when(certClientV3.issue(eq(connectorInfo), any(CertificateSignRequestDtoV3.class)))
+                .thenReturn(ResponseEntity.ok(body));
+
+        AdapterOperationResult result = adapter.issue(cert, new ClientCertificateSignRequestDto());
+
+        assertEquals(AdapterOperationOutcome.SYNC_OK, result.outcome());
+        assertEquals("issuedCert==", result.certificateData());
+        assertFalse(result.isAsync());
+    }
+
+    // ---- issue: 202 -> ASYNC_ACCEPTED ----
+
+    @Test
+    void issueMaps202ToAsyncAccepted() throws ConnectorException {
+        CertificateDataResponseDto body = new CertificateDataResponseDto();
+        List<MetadataAttribute> trackingMeta = List.of();
+        body.setMeta(trackingMeta);
+        when(certClientV3.issue(eq(connectorInfo), any(CertificateSignRequestDtoV3.class)))
+                .thenReturn(ResponseEntity.status(202).body(body));
+
+        AdapterOperationResult result = adapter.issue(cert, new ClientCertificateSignRequestDto());
+
+        assertEquals(AdapterOperationOutcome.ASYNC_ACCEPTED, result.outcome());
+        assertTrue(result.isAsync());
+        assertNull(result.certificateData());
+    }
+
+    // ---- issue: post-acceptance local failure -> ConnectorAcceptedButLocalFailureException ----
+
+    @Test
+    void issueWrapsConnectorAcceptedLocalFailure() throws ConnectorException {
+        // Simulate connector returns 200 but body is null -> mapIssueRenewRegisterResponse throws NPE
+        // We can't make mapIssueRenewRegisterResponse throw internally easily without reflections,
+        // but we can verify the guard: if the client throws RuntimeException after 200 is observed,
+        // the adapter wraps it. Use a spy to inject the failure after acceptance.
+
+        // Direct test: issue throws RuntimeException from within try after connectorAccepted = true
+        // We simulate this by making the certClient return a response that causes a NPE in the map step.
+        // The simplest way: return a ResponseEntity whose getStatusCode() returns 200 but body.getMeta()
+        // throws — that happens in mapIssueRenewRegisterResponse after connectorAccepted = true.
+        @SuppressWarnings("unchecked")
+        ResponseEntity<CertificateDataResponseDto> faultyResponse = mock(ResponseEntity.class);
+        org.springframework.http.HttpStatus okStatus = org.springframework.http.HttpStatus.OK;
+        when(faultyResponse.getStatusCode()).thenReturn(okStatus);
+        // getBody() returning a body that throws on getCertificateData — use a spy
+        CertificateDataResponseDto faultyBody = spy(new CertificateDataResponseDto());
+        doThrow(new RuntimeException("synthetic local failure")).when(faultyBody).getCertificateData();
+        when(faultyResponse.getBody()).thenReturn(faultyBody);
+        when(certClientV3.issue(eq(connectorInfo), any(CertificateSignRequestDtoV3.class)))
+                .thenReturn(faultyResponse);
+
+        assertThrows(ConnectorAcceptedButLocalFailureException.class,
+                () -> adapter.issue(cert, new ClientCertificateSignRequestDto()));
+    }
+
+    // ---- revoke: 200 -> SYNC_OK ----
+
+    @Test
+    void revokeMaps200ToSyncOk() throws ConnectorException {
+        CertificateDataResponseDto body = new CertificateDataResponseDto();
+        body.setMeta(List.of());
+        when(certClientV3.revoke(eq(connectorInfo), any()))
+                .thenReturn(ResponseEntity.status(200).body(body));
+
+        AdapterOperationResult result = adapter.revoke(cert, new ClientCertificateRevocationDto());
+
+        assertEquals(AdapterOperationOutcome.SYNC_OK, result.outcome());
+    }
+
+    // ---- revoke: 202 -> ASYNC_ACCEPTED ----
+
+    @Test
+    void revokeMaps202ToAsyncAccepted() throws ConnectorException {
+        when(certClientV3.revoke(eq(connectorInfo), any()))
+                .thenReturn(ResponseEntity.status(202).build());
+
+        AdapterOperationResult result = adapter.revoke(cert, new ClientCertificateRevocationDto());
+
+        assertEquals(AdapterOperationOutcome.ASYNC_ACCEPTED, result.outcome());
+        assertTrue(result.isAsync());
+    }
+
+    // ---- revoke: 204 -> SYNC_NO_CONTENT ----
+
+    @Test
+    void revokeMaps204ToSyncNoContent() throws ConnectorException {
+        when(certClientV3.revoke(eq(connectorInfo), any()))
+                .thenReturn(ResponseEntity.noContent().build());
+
+        AdapterOperationResult result = adapter.revoke(cert, new ClientCertificateRevocationDto());
+
+        assertEquals(AdapterOperationOutcome.SYNC_NO_CONTENT, result.outcome());
+        assertNull(result.certificateData());
+    }
+
+    // ---- register: delegates to v3 /register ----
+
+    @Test
+    void registerCallsRegisterEndpoint() throws ConnectorException {
+        CertificateDataResponseDto body = new CertificateDataResponseDto();
+        body.setMeta(List.of());
+        when(certClientV3.register(eq(connectorInfo), any()))
+                .thenReturn(ResponseEntity.ok(body));
+
+        AdapterOperationResult result = adapter.register(cert, new ClientCertificateRegistrationDto());
+
+        assertEquals(AdapterOperationOutcome.SYNC_OK, result.outcome());
+        verify(certClientV3).register(eq(connectorInfo), any());
+    }
+
+    // ---- pollStatus: COMPLETED ----
+
+    @Test
+    void pollStatusReturnsCompletedOnHttpCompleted() throws ConnectorException {
+        CertificateOperationStatusResponseDto resp = new CertificateOperationStatusResponseDto();
+        resp.setStatus(CertificateOperationStatus.COMPLETED);
+        resp.setCertificateData("completedCert==");
+        when(certClientV3.getIssueStatus(eq(connectorInfo), any(CertificateOperationStatusRequestDtoV3.class)))
+                .thenReturn(resp);
+
+        StatusPollResult result = adapter.pollStatus(cert, CertificateOperation.ISSUE);
+
+        assertEquals(CertificateOperationStatus.COMPLETED, result.status());
+        assertEquals("completedCert==", result.certificateData());
+    }
+
+    // ---- cancel: 204 -> CANCELLED ----
+
+    @Test
+    void cancelMapsSuccessToCancelled() throws ConnectorException {
+        when(certClientV3.cancelIssue(eq(connectorInfo), any(CertificateOperationCancelRequestDtoV3.class)))
+                .thenReturn(ResponseEntity.noContent().build());
+
+        CancelResult result = adapter.cancel(cert, CertificateOperation.ISSUE);
+
+        assertEquals(CancelOutcome.CANCELLED, result.outcome());
+    }
+
+    // ---- cancel: 422 OPERATION_PAST_POINT_OF_NO_RETURN -> REFUSED ----
+
+    @Test
+    void cancelMaps422PastPonrToRefused() throws ConnectorException {
+        ProblemDetailExtended problem = ProblemDetailExtended.fromErrorCode(
+                ErrorCode.OPERATION_PAST_POINT_OF_NO_RETURN, "past ponr", URI.create("https://example.com"), null);
+        when(certClientV3.cancelIssue(eq(connectorInfo), any()))
+                .thenThrow(new ConnectorProblemException(problem));
+
+        CancelResult result = adapter.cancel(cert, CertificateOperation.ISSUE);
+
+        assertEquals(CancelOutcome.REFUSED_PAST_POINT_OF_NO_RETURN, result.outcome());
+    }
+
+    // ---- cancel: 422 REGISTRATION_NOT_FOUND -> NOT_TRACKED ----
+
+    @Test
+    void cancelMaps422RegistrationNotFoundToNotTracked() throws ConnectorException {
+        ProblemDetailExtended problem = ProblemDetailExtended.fromErrorCode(
+                ErrorCode.REGISTRATION_NOT_FOUND, "not found", URI.create("https://example.com"), null);
+        when(certClientV3.cancelRegister(eq(connectorInfo), any()))
+                .thenThrow(new ConnectorProblemException(problem));
+
+        CancelResult result = adapter.cancel(cert, CertificateOperation.REGISTER);
+
+        assertEquals(CancelOutcome.NOT_TRACKED, result.outcome());
+    }
+
+    // ---- connector not found -> ConnectorException ----
+
+    @Test
+    void connectorNotFound_wrappedAsConnectorException() throws NotFoundException {
+        UUID connectorUuid = authority.getConnectorUuid();
+        when(connectorService.getConnectorForApiClient(connectorUuid))
+                .thenThrow(new NotFoundException("Connector not found"));
+
+        assertThrows(ConnectorException.class, () -> adapter.listIssueAttributes(authority, null));
+    }
+}

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -185,15 +185,10 @@ class AuthorityProviderV3AdapterTest {
 
     @Test
     void issueWrapsConnectorAcceptedLocalFailure() throws ConnectorException {
-        // Simulate connector returns 200 but body is null -> mapIssueRenewRegisterResponse throws NPE
-        // We can't make mapIssueRenewRegisterResponse throw internally easily without reflections,
-        // but we can verify the guard: if the client throws RuntimeException after 200 is observed,
-        // the adapter wraps it. Use a spy to inject the failure after acceptance.
-
-        // Direct test: issue throws RuntimeException from within try after connectorAccepted = true
-        // We simulate this by making the certClient return a response that causes a NPE in the map step.
-        // The simplest way: return a ResponseEntity whose getStatusCode() returns 200 but body.getMeta()
-        // throws — that happens in mapIssueRenewRegisterResponse after connectorAccepted = true.
+        // Connector returns 200 (connectorAccepted = true), then the response-mapping step fails
+        // locally — here the body throws when its content is read. Because the connector already
+        // accepted, the adapter must wrap the failure in ConnectorAcceptedButLocalFailureException
+        // rather than let it propagate as a plain failure (no rollback of an accepted operation).
         @SuppressWarnings("unchecked")
         ResponseEntity<CertificateDataResponseDto> faultyResponse = mock(ResponseEntity.class);
         org.springframework.http.HttpStatus okStatus = org.springframework.http.HttpStatus.OK;

--- a/src/test/java/com/otilm/core/service/handler/authority/CertificateOperationTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/CertificateOperationTest.java
@@ -1,0 +1,34 @@
+package com.otilm.core.service.handler.authority;
+
+import com.otilm.api.model.core.certificate.CertificateState;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CertificateOperationTest {
+
+    @Test
+    void pendingStateMapsPerOperation() {
+        assertEquals(CertificateState.PENDING_ISSUE, CertificateOperation.ISSUE.pendingState());
+        assertEquals(CertificateState.PENDING_ISSUE, CertificateOperation.RENEW.pendingState());
+        assertEquals(CertificateState.PENDING_REVOKE, CertificateOperation.REVOKE.pendingState());
+        assertEquals(CertificateState.PENDING_REGISTRATION, CertificateOperation.REGISTER.pendingState());
+    }
+
+    @Test
+    void terminalSuccessStateMapsPerOperation() {
+        assertEquals(CertificateState.ISSUED, CertificateOperation.ISSUE.terminalSuccessState());
+        assertEquals(CertificateState.ISSUED, CertificateOperation.RENEW.terminalSuccessState());
+        assertEquals(CertificateState.REGISTERED, CertificateOperation.REGISTER.terminalSuccessState());
+        assertEquals(CertificateState.REVOKED, CertificateOperation.REVOKE.terminalSuccessState());
+    }
+
+    @Test
+    void terminalFailureStateMapsPerOperation() {
+        assertEquals(CertificateState.FAILED, CertificateOperation.ISSUE.terminalFailureState());
+        assertEquals(CertificateState.FAILED, CertificateOperation.RENEW.terminalFailureState());
+        assertEquals(CertificateState.FAILED, CertificateOperation.REGISTER.terminalFailureState());
+        // A failed/cancelled revoke leaves the certificate ISSUED, not FAILED.
+        assertEquals(CertificateState.ISSUED, CertificateOperation.REVOKE.terminalFailureState());
+    }
+}


### PR DESCRIPTION
Second slice of landing `feat/authority-v3` on `main` as a reviewable stacked-PR chain. Part of #1600 (epic #110). **Stacked on #1605 (S1)** — review that first; this PR's base retargets to `main` automatically once S1 merges.

## What

Introduces the version-dispatch adapter layer so the v2 client-operation service no longer calls the connector API client directly:

- `AuthorityProviderAdapter` + `AbstractAuthorityProviderAdapter` + `AuthorityProviderV2Adapter` / `AuthorityProviderV3Adapter` + `AuthorityProviderAdapterFactory`
- capability interfaces `RegisterCapability`, `AsyncOperationCapability`
- result types `AdapterOperationResult`/`AdapterOperationOutcome`, `CancelResult`/`CancelOutcome`, `StatusPollResult`, `CertificateOperation`, `ConnectorOperationErrorCodes`
- exceptions `UnsupportedAuthorityVersionException`, `ConnectorAcceptedButLocalFailureException`
- v3 connector client beans (`ApplicationConfig`, `ProxyClientConfig`, `ConnectorApiFactory`) — REST + MQ
- `AuthorityInstanceReference.connector_interface_uuid` FK + Flyway migration (deterministic, idempotent backfill)
- adapter unit tests

## Notes for review

- **Purely additive / dark merge.** Nothing calls the adapters yet — routing the v2 service through the factory lands in the activation slice (#1603). Compiles against `main` + the state-machine slice; the v3 client beans reference only the released interfaces lib. 39 adapter tests pass.
- Code originates from `feat/authority-v3` (already reviewed there); re-sliced for incremental review.

## Pre-review addressed (guided-pr-review + Copilot — both SHIP after fixes)

- **[MEDIUM] V2 `renew()` NPE on reuse-key (no-CSR) renewal** — `AuthorityProviderV2Adapter.renew` accessed `newCert.getCertificateRequest()` unconditionally where V3 guards it. Fixed (omit request/format when absent) + regression test `renew_withoutCsr_omitsRequestInsteadOfNpe`.
- **Factory null-version** — `forAuthority` now throws `UnsupportedAuthorityVersionException` for a null version instead of NPE, consistent with its Javadoc.
- **[LOW] "register() doesn't replay meta" — dismissed (false positive).** The v3 register DTO (`CertificateRegistrationRequestDtoV3`) has no `meta` field: register is the originating op that *produces* the tracking meta (returned in its 202), so there is nothing to replay on the request.

## Known items (intentional, not changed here)

- The migration FK uses `ON DELETE RESTRICT`; once backfilled it gates deletion of a referenced `connector_interface` row. Confirm connector-interface teardown paths before later slices rely on the FK.
- The migration version (`V202605251200…`) is back-dated relative to June migrations on the branch; safe because `spring.flyway.out-of-order` is enabled.

## Verification

`mvn test` across the adapter suite: **39 tests, 0 failures**.