### PR TITLE
Split InternalService and ExternalService - part 11

### DIFF
--- a/src/main/java/com/otilm/core/api/web/SigningRecordControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/SigningRecordControllerImpl.java
@@ -16,7 +16,7 @@ import com.otilm.core.auth.AuthEndpoint;
 import com.otilm.core.logging.LogResource;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.SigningRecordService;
+import com.otilm.core.service.SigningRecordExternalService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,10 +26,10 @@ import java.util.UUID;
 @RestController
 public class SigningRecordControllerImpl implements SigningRecordController {
 
-    private final SigningRecordService signingRecordService;
+    private final SigningRecordExternalService signingRecordService;
 
     @Autowired
-    public SigningRecordControllerImpl(SigningRecordService signingRecordService) {
+    public SigningRecordControllerImpl(SigningRecordExternalService signingRecordService) {
         this.signingRecordService = signingRecordService;
     }
 

--- a/src/main/java/com/otilm/core/api/web/StatisticsControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/StatisticsControllerImpl.java
@@ -9,7 +9,7 @@ import com.otilm.api.model.core.logging.enums.Module;
 import com.otilm.api.model.core.logging.enums.Operation;
 import com.otilm.core.aop.AuditLogged;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.SigningRecordService;
+import com.otilm.core.service.SigningRecordExternalService;
 import com.otilm.core.service.StatisticsExternalService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class StatisticsControllerImpl implements StatisticsController {
 
 	private StatisticsExternalService statisticsService;
-	private SigningRecordService signingRecordService;
+	private SigningRecordExternalService signingRecordService;
 
 	@Autowired
 	public void setStatisticsService(StatisticsExternalService statisticsService) {
@@ -26,7 +26,7 @@ public class StatisticsControllerImpl implements StatisticsController {
 	}
 
 	@Autowired
-	public void setSigningRecordService(SigningRecordService signingRecordService) {
+	public void setSigningRecordService(SigningRecordExternalService signingRecordService) {
 		this.signingRecordService = signingRecordService;
 	}
 

--- a/src/main/java/com/otilm/core/api/web/TimeQualityConfigurationControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/TimeQualityConfigurationControllerImpl.java
@@ -21,7 +21,7 @@ import com.otilm.core.logging.LogResource;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.SigningProfileService;
-import com.otilm.core.service.TimeQualityConfigurationService;
+import com.otilm.core.service.TimeQualityConfigurationExternalService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,11 +31,11 @@ import java.util.UUID;
 @RestController
 public class TimeQualityConfigurationControllerImpl implements TimeQualityConfigurationController {
 
-    private final TimeQualityConfigurationService timeQualityConfigurationService;
+    private final TimeQualityConfigurationExternalService timeQualityConfigurationService;
     private final SigningProfileService signingProfileService;
 
     @Autowired
-    public TimeQualityConfigurationControllerImpl(TimeQualityConfigurationService timeQualityConfigurationService,
+    public TimeQualityConfigurationControllerImpl(TimeQualityConfigurationExternalService timeQualityConfigurationService,
                                                   SigningProfileService signingProfileService) {
         this.timeQualityConfigurationService = timeQualityConfigurationService;
         this.signingProfileService = signingProfileService;

--- a/src/main/java/com/otilm/core/api/web/TspProfileBasicCredentialControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/TspProfileBasicCredentialControllerImpl.java
@@ -15,7 +15,7 @@ import com.otilm.core.aop.AuditLogged;
 import com.otilm.core.logging.LogResource;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.TspProfileBasicCredentialService;
+import com.otilm.core.service.TspProfileBasicCredentialExternalService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,10 +26,10 @@ import java.util.UUID;
 @RestController
 public class TspProfileBasicCredentialControllerImpl implements TspProfileBasicCredentialController {
 
-    private TspProfileBasicCredentialService service;
+    private TspProfileBasicCredentialExternalService service;
 
     @Autowired
-    public void setService(TspProfileBasicCredentialService service) {
+    public void setService(TspProfileBasicCredentialExternalService service) {
         this.service = service;
     }
 

--- a/src/main/java/com/otilm/core/api/web/TspProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/TspProfileControllerImpl.java
@@ -19,7 +19,7 @@ import com.otilm.core.auth.AuthEndpoint;
 import com.otilm.core.logging.LogResource;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.TspProfileService;
+import com.otilm.core.service.TspProfileExternalService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,10 +31,10 @@ import java.util.UUID;
 @RestController
 public class TspProfileControllerImpl implements TspProfileController {
 
-    private final TspProfileService tspProfileService;
+    private final TspProfileExternalService tspProfileService;
 
     @Autowired
-    public TspProfileControllerImpl(TspProfileService tspProfileService) {
+    public TspProfileControllerImpl(TspProfileExternalService tspProfileService) {
         this.tspProfileService = tspProfileService;
     }
 

--- a/src/main/java/com/otilm/core/config/SecurityConfig.java
+++ b/src/main/java/com/otilm/core/config/SecurityConfig.java
@@ -13,7 +13,7 @@ import com.otilm.core.security.authn.tsp.TspChallengeWriter;
 import com.otilm.core.security.authn.tsp.TspRouteResolver;
 import com.otilm.core.security.authn.tsp.TspSecurityContextWriter;
 import com.otilm.core.service.SigningProfileService;
-import com.otilm.core.service.TspProfileService;
+import com.otilm.core.service.TspProfileInternalService;
 import com.otilm.core.util.AuthHelper;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
@@ -56,7 +56,7 @@ public class SecurityConfig {
 
     private PlatformJwtAuthenticationConverter jwtAuthenticationConverter;
 
-    private TspProfileService tspProfileService;
+    private TspProfileInternalService tspProfileService;
 
     private SigningProfileService signingProfileService;
 
@@ -202,7 +202,7 @@ public class SecurityConfig {
     }
 
     @Autowired
-    public void setTspProfileService(TspProfileService tspProfileService) {
+    public void setTspProfileService(TspProfileInternalService tspProfileService) {
         this.tspProfileService = tspProfileService;
     }
 

--- a/src/main/java/com/otilm/core/security/authn/tsp/TspProfileSecretEvictionListener.java
+++ b/src/main/java/com/otilm/core/security/authn/tsp/TspProfileSecretEvictionListener.java
@@ -1,7 +1,7 @@
 package com.otilm.core.security.authn.tsp;
 
 import com.otilm.core.events.SecretContentUpdatedEvent;
-import com.otilm.core.service.TspProfileBasicCredentialService;
+import com.otilm.core.service.TspProfileBasicCredentialInternalService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -12,7 +12,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 /**
  * TSP-side adapter for {@link SecretContentUpdatedEvent}. Keeps the Secret subsystem decoupled from TSP:
  * when a secret's latest-version fingerprint flips (async rotation), this bridges the committed event to
- * {@link TspProfileBasicCredentialService#evictCachesForSecret}, which refreshes the TSP profile model
+ * {@link TspProfileBasicCredentialInternalService#evictCachesForSecret}, which refreshes the TSP profile model
  * cache and the credential-verification cache against the new fingerprint.
  *
  * <p>Runs AFTER_COMMIT so the eventual model reload reads the committed new fingerprint, not the stale one.
@@ -21,10 +21,10 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 public class TspProfileSecretEvictionListener {
 
-    private TspProfileBasicCredentialService credentialService;
+    private TspProfileBasicCredentialInternalService credentialService;
 
     @Autowired
-    public void setCredentialService(TspProfileBasicCredentialService credentialService) {
+    public void setCredentialService(TspProfileBasicCredentialInternalService credentialService) {
         this.credentialService = credentialService;
     }
 

--- a/src/main/java/com/otilm/core/security/authn/tsp/TspRouteResolver.java
+++ b/src/main/java/com/otilm/core/security/authn/tsp/TspRouteResolver.java
@@ -3,7 +3,7 @@ package com.otilm.core.security.authn.tsp;
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.core.model.signing.TspProfileModel;
 import com.otilm.core.service.SigningProfileService;
-import com.otilm.core.service.TspProfileService;
+import com.otilm.core.service.TspProfileInternalService;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Optional;
@@ -23,10 +23,10 @@ public class TspRouteResolver {
     private static final String TSP_PATH_PREFIX = "/v1/protocols/tsp/";
     private static final String SIGNING_PROFILES_SEGMENT = "signingProfiles/";
 
-    private final TspProfileService tspProfileService;
+    private final TspProfileInternalService tspProfileService;
     private final SigningProfileService signingProfileService;
 
-    public TspRouteResolver(TspProfileService tspProfileService, SigningProfileService signingProfileService) {
+    public TspRouteResolver(TspProfileInternalService tspProfileService, SigningProfileService signingProfileService) {
         this.tspProfileService = tspProfileService;
         this.signingProfileService = signingProfileService;
     }

--- a/src/main/java/com/otilm/core/service/SigningRecordExternalService.java
+++ b/src/main/java/com/otilm/core/service/SigningRecordExternalService.java
@@ -15,7 +15,7 @@ import com.otilm.core.security.authz.SecurityFilter;
 import java.util.List;
 import java.util.UUID;
 
-public interface SigningRecordService {
+public interface SigningRecordExternalService {
 
     List<SearchFieldDataByGroupDto> getSearchableFieldInformation();
 
@@ -41,8 +41,4 @@ public interface SigningRecordService {
     void deleteSigningRecord(SecuredUUID uuid) throws NotFoundException;
 
     List<BulkActionMessageDto> bulkDeleteSigningRecords(List<SecuredUUID> uuids);
-
-    boolean doesSigningRecordExistInternal(UUID uuid, int version);
-
-    boolean doesSigningRecordExistForProfileInternal(UUID signingProfileUuid);
 }

--- a/src/main/java/com/otilm/core/service/SigningRecordInternalService.java
+++ b/src/main/java/com/otilm/core/service/SigningRecordInternalService.java
@@ -1,0 +1,10 @@
+package com.otilm.core.service;
+
+import java.util.UUID;
+
+public interface SigningRecordInternalService {
+
+    boolean doesSigningRecordExistInternal(UUID uuid, int version);
+
+    boolean doesSigningRecordExistForProfileInternal(UUID signingProfileUuid);
+}

--- a/src/main/java/com/otilm/core/service/TimeQualityConfigurationExternalService.java
+++ b/src/main/java/com/otilm/core/service/TimeQualityConfigurationExternalService.java
@@ -10,14 +10,12 @@ import com.otilm.api.model.common.BulkActionMessageDto;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
 import com.otilm.api.model.common.PaginationResponseDto;
 import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
-import com.otilm.core.model.signing.timequality.TimeQualityConfigurationModel;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 
 import java.util.List;
-import java.util.UUID;
 
-public interface TimeQualityConfigurationService extends ResourceExtensionService {
+public interface TimeQualityConfigurationExternalService {
 
     List<SearchFieldDataByGroupDto> getSearchableFieldInformation();
 
@@ -30,11 +28,6 @@ public interface TimeQualityConfigurationService extends ResourceExtensionServic
     TimeQualityConfigurationDto updateTimeQualityConfiguration(SecuredUUID uuid, TimeQualityConfigurationRequestDto request) throws AlreadyExistException, AttributeException, NotFoundException;
 
     void deleteTimeQualityConfiguration(SecuredUUID uuid) throws NotFoundException;
-
-    /**
-     * Returns the cached model for the given UUID.
-     */
-    TimeQualityConfigurationModel getTimeQualityConfigurationModel(UUID uuid) throws NotFoundException;
 
     List<BulkActionMessageDto> bulkDeleteTimeQualityConfigurations(List<SecuredUUID> uuids);
 }

--- a/src/main/java/com/otilm/core/service/TimeQualityConfigurationInternalService.java
+++ b/src/main/java/com/otilm/core/service/TimeQualityConfigurationInternalService.java
@@ -1,0 +1,14 @@
+package com.otilm.core.service;
+
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.core.model.signing.timequality.TimeQualityConfigurationModel;
+
+import java.util.UUID;
+
+public interface TimeQualityConfigurationInternalService extends ResourceExtensionService {
+
+    /**
+     * Returns the cached model for the given UUID.
+     */
+    TimeQualityConfigurationModel getTimeQualityConfigurationModel(UUID uuid) throws NotFoundException;
+}

--- a/src/main/java/com/otilm/core/service/TspProfileBasicCredentialExternalService.java
+++ b/src/main/java/com/otilm/core/service/TspProfileBasicCredentialExternalService.java
@@ -11,9 +11,8 @@ import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 
 import java.util.List;
-import java.util.UUID;
 
-public interface TspProfileBasicCredentialService {
+public interface TspProfileBasicCredentialExternalService {
 
     List<TspBasicCredentialDto> list(SecuredParentUUID tspProfileUuid) throws NotFoundException;
 
@@ -24,16 +23,4 @@ public interface TspProfileBasicCredentialService {
     TspBasicCredentialDto update(SecuredParentUUID tspProfileUuid, SecuredUUID uuid, TspBasicCredentialUpdateRequestDto request) throws AlreadyExistException, AttributeException, ConnectorCommunicationException, NotFoundException;
 
     void delete(SecuredParentUUID tspProfileUuid, SecuredUUID uuid) throws AttributeException, ConnectorCommunicationException, NotFoundException;
-
-    /**
-     * Evicts the TSP profile model cache and credential-verification cache.
-     */
-    void evictCachesForSecret(UUID secretUuid);
-
-    /**
-     * Deletes the vault secret backing every Basic credential of the given TSP profile and evicts the
-     * corresponding credential-verification cache entries.
-     * Runs without an ambient transaction so the vault HTTP calls never hold a database transaction open.
-     */
-    void deleteSecretsForProfile(UUID tspProfileUuid);
 }

--- a/src/main/java/com/otilm/core/service/TspProfileBasicCredentialInternalService.java
+++ b/src/main/java/com/otilm/core/service/TspProfileBasicCredentialInternalService.java
@@ -1,0 +1,18 @@
+package com.otilm.core.service;
+
+import java.util.UUID;
+
+public interface TspProfileBasicCredentialInternalService {
+
+    /**
+     * Evicts the TSP profile model cache and credential-verification cache.
+     */
+    void evictCachesForSecret(UUID secretUuid);
+
+    /**
+     * Deletes the vault secret backing every Basic credential of the given TSP profile and evicts the
+     * corresponding credential-verification cache entries.
+     * Runs without an ambient transaction so the vault HTTP calls never hold a database transaction open.
+     */
+    void deleteSecretsForProfile(UUID tspProfileUuid);
+}

--- a/src/main/java/com/otilm/core/service/TspProfileExternalService.java
+++ b/src/main/java/com/otilm/core/service/TspProfileExternalService.java
@@ -10,39 +10,18 @@ import com.otilm.api.model.common.BulkActionMessageDto;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
 import com.otilm.api.model.common.PaginationResponseDto;
 import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
-import com.otilm.core.dao.entity.signing.TspProfile;
-import com.otilm.core.model.signing.TspProfileModel;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.model.SecuredList;
 
 import java.util.List;
-import java.util.UUID;
 
-public interface TspProfileService extends ResourceExtensionService {
+public interface TspProfileExternalService {
 
     List<SearchFieldDataByGroupDto> getSearchableFieldInformation();
 
     PaginationResponseDto<TspProfileListDto> listTspProfiles(SearchRequestDto request, SecurityFilter filter, String baseUrl);
 
-    SecuredList<TspProfile> listTspProfilesUsingSigningProfileAsDefault(SecuredUUID signingProfileUuid, SecurityFilter filter);
-
     TspProfileDto getTspProfile(SecuredUUID uuid, String baseUrl) throws NotFoundException;
-
-    TspProfile getTspProfileEntity(SecuredUUID uuid) throws NotFoundException;
-
-    List<String> findAllNames();
-
-    TspProfileModel getTspProfile(String name) throws NotFoundException;
-
-    /**
-     * Loads the TSP profile model by name without any authorization check.
-     *
-     * <p>Intended for use by {@code TspAuthenticationFilter}, which runs before a {@code SecurityContext} exists.
-     */
-    TspProfileModel resolveTspProfileForAuthentication(String name) throws NotFoundException;
-
-    TspProfileModel getTspProfile(UUID uuid) throws NotFoundException;
 
     TspProfileDto createTspProfile(TspProfileRequestDto request, String baseUrl) throws AlreadyExistException, AttributeException, NotFoundException;
 
@@ -59,9 +38,4 @@ public interface TspProfileService extends ResourceExtensionService {
     void disableTspProfile(SecuredUUID uuid) throws NotFoundException;
 
     List<BulkActionMessageDto> bulkDisableTspProfiles(List<SecuredUUID> uuids);
-
-    /**
-     * Clears every entry in the TSP profile cache.
-     */
-    void evictAllCachedModels();
 }

--- a/src/main/java/com/otilm/core/service/TspProfileInternalService.java
+++ b/src/main/java/com/otilm/core/service/TspProfileInternalService.java
@@ -1,0 +1,36 @@
+package com.otilm.core.service;
+
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.core.dao.entity.signing.TspProfile;
+import com.otilm.core.model.signing.TspProfileModel;
+import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.service.model.SecuredList;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface TspProfileInternalService extends ResourceExtensionService {
+
+    SecuredList<TspProfile> listTspProfilesUsingSigningProfileAsDefault(SecuredUUID signingProfileUuid, SecurityFilter filter);
+
+    TspProfile getTspProfileEntity(SecuredUUID uuid) throws NotFoundException;
+
+    List<String> findAllNames();
+
+    TspProfileModel getTspProfile(String name) throws NotFoundException;
+
+    /**
+     * Loads the TSP profile model by name without any authorization check.
+     *
+     * <p>Intended for use by {@code TspAuthenticationFilter}, which runs before a {@code SecurityContext} exists.
+     */
+    TspProfileModel resolveTspProfileForAuthentication(String name) throws NotFoundException;
+
+    TspProfileModel getTspProfile(UUID uuid) throws NotFoundException;
+
+    /**
+     * Clears every entry in the TSP profile cache.
+     */
+    void evictAllCachedModels();
+}

--- a/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
@@ -84,9 +84,10 @@ import com.otilm.core.service.ConnectorService;
 import com.otilm.core.service.CryptographicOperationInternalService;
 import com.otilm.core.service.RaProfileService;
 import com.otilm.core.service.SigningProfileService;
-import com.otilm.core.service.SigningRecordService;
+import com.otilm.core.service.SigningRecordExternalService;
+import com.otilm.core.service.SigningRecordInternalService;
 import com.otilm.core.service.TokenProfileInternalService;
-import com.otilm.core.service.TspProfileService;
+import com.otilm.core.service.TspProfileInternalService;
 import com.otilm.core.service.model.SecuredList;
 import com.otilm.core.service.writer.SigningProfileWriter;
 import com.otilm.core.util.CertificateEligibilityUtil;
@@ -127,14 +128,15 @@ public class SigningProfileServiceImpl implements SigningProfileService {
     private ConnectorService connectorService;
     private TokenProfileInternalService tokenProfileService;
     private RaProfileService raProfileService;
-    private SigningRecordService signingRecordService;
+    private SigningRecordExternalService signingRecordService;
+    private SigningRecordInternalService signingRecordInternalService;
 
     private CryptographicKeyItemRepository cryptographicKeyItemRepository;
     private SigningProfileRepository signingProfileRepository;
     private SigningProfileVersionRepository signingProfileVersionRepository;
     private SigningProfileWriter signingProfileWriter;
     private TimeQualityConfigurationRepository timeQualityConfigurationRepository;
-    private TspProfileService tspProfileService;
+    private TspProfileInternalService tspProfileService;
     private AttributeEngine attributeEngine;
     private ConnectorApiFactory connectorApiFactory;
     private CacheEvictor cacheEvictor;
@@ -426,7 +428,7 @@ public class SigningProfileServiceImpl implements SigningProfileService {
         int latestVersion = profile.getLatestVersion();
         SigningProfileVersion currentVersion = signingProfileVersionRepository.findBySigningProfileUuidAndVersion(profile.getUuid(), latestVersion)
                 .orElseThrow(() -> new NotFoundException("Signing Profile version " + latestVersion + " not found"));
-        boolean recordsExist = signingRecordService.doesSigningRecordExistInternal(profile.getUuid(), latestVersion);
+        boolean recordsExist = signingRecordInternalService.doesSigningRecordExistInternal(profile.getUuid(), latestVersion);
         boolean policyRecordDifferent = recordPolicyDiffersFromVersion(currentVersion, request.getRecordPolicy());
         boolean bump = recordsExist || policyRecordDifferent;
 
@@ -502,7 +504,7 @@ public class SigningProfileServiceImpl implements SigningProfileService {
             );
         }
 
-        if (signingRecordService.doesSigningRecordExistForProfileInternal(signingProfile.getUuid())) {
+        if (signingRecordInternalService.doesSigningRecordExistForProfileInternal(signingProfile.getUuid())) {
             throw new ValidationException(
                     ValidationError.create(String.format(
                             "Cannot delete Signing Profile '%s': it has signing records. Delete the signing records first.",
@@ -1018,13 +1020,18 @@ public class SigningProfileServiceImpl implements SigningProfileService {
     }
 
     @Autowired
-    public void setSigningRecordService(SigningRecordService signingRecordService) {
+    public void setSigningRecordService(SigningRecordExternalService signingRecordService) {
         this.signingRecordService = signingRecordService;
     }
 
     @Autowired
+    public void setSigningRecordInternalService(SigningRecordInternalService signingRecordInternalService) {
+        this.signingRecordInternalService = signingRecordInternalService;
+    }
+
+    @Autowired
     @Lazy
-    public void setTspProfileService(TspProfileService tspProfileService) {
+    public void setTspProfileService(TspProfileInternalService tspProfileService) {
         this.tspProfileService = tspProfileService;
     }
 

--- a/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningRecordServiceImpl.java
@@ -33,7 +33,8 @@ import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.PermissionEvaluator;
-import com.otilm.core.service.SigningRecordService;
+import com.otilm.core.service.SigningRecordExternalService;
+import com.otilm.core.service.SigningRecordInternalService;
 import com.otilm.core.service.writer.signingrecord.SigningRecordWriter;
 import com.otilm.core.util.FilterPredicatesBuilder;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -60,7 +61,7 @@ import java.util.UUID;
 
 @Service
 @Slf4j
-public class SigningRecordServiceImpl implements SigningRecordService {
+public class SigningRecordServiceImpl implements SigningRecordExternalService, SigningRecordInternalService {
 
     private static final String SIGNING_PROFILE_PARENT_REF = "signingProfileUuid";
     private static final int TOP_REQUESTERS = 10;

--- a/src/main/java/com/otilm/core/service/impl/TimeQualityConfigurationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TimeQualityConfigurationServiceImpl.java
@@ -38,7 +38,8 @@ import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.SigningProfileService;
-import com.otilm.core.service.TimeQualityConfigurationService;
+import com.otilm.core.service.TimeQualityConfigurationExternalService;
+import com.otilm.core.service.TimeQualityConfigurationInternalService;
 import com.otilm.core.service.model.SecuredList;
 import com.otilm.core.util.FilterPredicatesBuilder;
 import com.otilm.core.util.SearchHelper;
@@ -67,7 +68,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Service(Resource.Codes.TIME_QUALITY_CONFIGURATION)
-public class TimeQualityConfigurationServiceImpl implements TimeQualityConfigurationService {
+public class TimeQualityConfigurationServiceImpl implements TimeQualityConfigurationExternalService, TimeQualityConfigurationInternalService {
 
     private static final String NOT_FOUND_MSG = "Time Quality Configuration not found: ";
 

--- a/src/main/java/com/otilm/core/service/impl/TspProfileBasicCredentialServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TspProfileBasicCredentialServiceImpl.java
@@ -28,7 +28,8 @@ import com.otilm.core.security.authn.client.CredentialVerificationCache;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.TspProfileBasicCredentialService;
+import com.otilm.core.service.TspProfileBasicCredentialExternalService;
+import com.otilm.core.service.TspProfileBasicCredentialInternalService;
 import com.otilm.core.service.SecretExternalService;
 import com.otilm.core.service.UserManagementExternalService;
 import com.otilm.core.service.VaultProfileInternalService;
@@ -47,7 +48,7 @@ import java.util.UUID;
 
 @Service(Resource.Codes.TSP_PROFILE_BASIC_CREDENTIAL)
 @Slf4j
-public class TspProfileBasicCredentialServiceImpl implements TspProfileBasicCredentialService {
+public class TspProfileBasicCredentialServiceImpl implements TspProfileBasicCredentialExternalService, TspProfileBasicCredentialInternalService {
 
     private TspProfileRepository tspProfileRepository;
     private TspProfileBasicCredentialRepository credentialRepository;

--- a/src/main/java/com/otilm/core/service/impl/TspProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TspProfileServiceImpl.java
@@ -35,8 +35,9 @@ import com.otilm.core.model.signing.TspProfileModel;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.TspProfileService;
-import com.otilm.core.service.TspProfileBasicCredentialService;
+import com.otilm.core.service.TspProfileExternalService;
+import com.otilm.core.service.TspProfileInternalService;
+import com.otilm.core.service.TspProfileBasicCredentialInternalService;
 import com.otilm.core.service.SecretInternalService;
 import com.otilm.core.service.SigningProfileService;
 import com.otilm.core.service.VaultProfileInternalService;
@@ -68,7 +69,7 @@ import java.util.stream.Collectors;
 
 @Service(Resource.Codes.TSP_PROFILE)
 @Slf4j
-public class TspProfileServiceImpl implements TspProfileService {
+public class TspProfileServiceImpl implements TspProfileExternalService, TspProfileInternalService {
     private static final String TSP_PROFILE_NOT_FOUND = "TSP Profile not found: ";
 
     private AttributeEngine attributeEngine;
@@ -78,7 +79,7 @@ public class TspProfileServiceImpl implements TspProfileService {
     private VaultProfileInternalService vaultProfileService;
     private TspProfileRepository tspProfileRepository;
     private SecretInternalService secretService;
-    private TspProfileBasicCredentialService basicCredentialService;
+    private TspProfileBasicCredentialInternalService basicCredentialService;
 
     @Override
     @ExternalAuthorization(resource = Resource.TSP_PROFILE, action = ResourceAction.LIST)
@@ -487,7 +488,7 @@ public class TspProfileServiceImpl implements TspProfileService {
     }
 
     @Autowired
-    public void setBasicCredentialService(TspProfileBasicCredentialService basicCredentialService) {
+    public void setBasicCredentialService(TspProfileBasicCredentialInternalService basicCredentialService) {
         this.basicCredentialService = basicCredentialService;
     }
 

--- a/src/main/java/com/otilm/core/signing/tsa/impl/TsaServiceImpl.java
+++ b/src/main/java/com/otilm/core/signing/tsa/impl/TsaServiceImpl.java
@@ -14,7 +14,7 @@ import com.otilm.core.model.signing.workflow.SigningWorkflow;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.service.PermissionEvaluator;
 import com.otilm.core.service.SigningProfileService;
-import com.otilm.core.service.TspProfileService;
+import com.otilm.core.service.TspProfileInternalService;
 import com.otilm.core.signing.tsa.ManagedTimestampEngine;
 import com.otilm.core.signing.tsa.TsaService;
 import com.otilm.core.signing.tsa.resolver.SigningProfileResolverFactory;
@@ -29,13 +29,13 @@ import org.springframework.stereotype.Service;
 public class TsaServiceImpl implements TsaService {
 
     private final TspRequestValidator tspRequestValidator;
-    private final TspProfileService tspProfileService;
+    private final TspProfileInternalService tspProfileService;
     private final SigningProfileService signingProfileService;
     private final SigningProfileResolverFactory signingProfileResolverFactory;
     private final ManagedTimestampEngine managedTimestampEngine;
     private final PermissionEvaluator permissionEvaluator;
 
-    public TsaServiceImpl(TspRequestValidator tspRequestValidator, SigningProfileService signingProfileService, SigningProfileResolverFactory signingProfileResolverFactory, TspProfileService tspProfileService, ManagedTimestampEngine managedTimestampEngine, PermissionEvaluator permissionEvaluator) {
+    public TsaServiceImpl(TspRequestValidator tspRequestValidator, SigningProfileService signingProfileService, SigningProfileResolverFactory signingProfileResolverFactory, TspProfileInternalService tspProfileService, ManagedTimestampEngine managedTimestampEngine, PermissionEvaluator permissionEvaluator) {
         this.tspRequestValidator = tspRequestValidator;
         this.signingProfileService = signingProfileService;
         this.signingProfileResolverFactory = signingProfileResolverFactory;

--- a/src/main/java/com/otilm/core/signing/tsa/resolver/StaticKeyManagedTimestampingResolver.java
+++ b/src/main/java/com/otilm/core/signing/tsa/resolver/StaticKeyManagedTimestampingResolver.java
@@ -18,7 +18,7 @@ import com.otilm.core.model.signing.timequality.TimeQualityConfigurationModel;
 import com.otilm.core.model.signing.workflow.ManagedTimestampingWorkflow;
 import com.otilm.core.service.CertificateService;
 import com.otilm.core.service.CryptographicKeyService;
-import com.otilm.core.service.TimeQualityConfigurationService;
+import com.otilm.core.service.TimeQualityConfigurationInternalService;
 import com.otilm.core.service.v2.ConnectorService;
 import org.springframework.stereotype.Component;
 
@@ -42,12 +42,12 @@ public class StaticKeyManagedTimestampingResolver implements SigningProfileResol
 
     private final CertificateService certificateService;
     private final CryptographicKeyService cryptographicKeyService;
-    private final TimeQualityConfigurationService timeQualityConfigurationService;
+    private final TimeQualityConfigurationInternalService timeQualityConfigurationService;
     private final ConnectorService connectorService;
 
     public StaticKeyManagedTimestampingResolver(CertificateService certificateService,
                                                 CryptographicKeyService cryptographicKeyService,
-                                                TimeQualityConfigurationService timeQualityConfigurationService,
+                                                TimeQualityConfigurationInternalService timeQualityConfigurationService,
                                                 ConnectorService connectorService) {
         this.certificateService = certificateService;
         this.cryptographicKeyService = cryptographicKeyService;

--- a/src/test/java/com/otilm/core/api/tsp/integration/TspControllerIntegrationTest.java
+++ b/src/test/java/com/otilm/core/api/tsp/integration/TspControllerIntegrationTest.java
@@ -90,7 +90,7 @@ public class TspControllerIntegrationTest extends BaseSpringBootTest {
     @Autowired
     private SigningProfileService signingProfileService;
     @Autowired
-    private TspProfileService tspProfileService;
+    private TspProfileExternalService tspProfileService;
     @Autowired
     private ConnectorService connectorService;
     @Autowired

--- a/src/test/java/com/otilm/core/api/tsp/integration/TspSigningProfileControllerIntegrationTest.java
+++ b/src/test/java/com/otilm/core/api/tsp/integration/TspSigningProfileControllerIntegrationTest.java
@@ -96,7 +96,7 @@ public class TspSigningProfileControllerIntegrationTest extends BaseSpringBootTe
     @Autowired
     private SigningProfileService signingProfileService;
     @Autowired
-    private TspProfileService tspProfileService;
+    private TspProfileExternalService tspProfileService;
     @Autowired
     private ConnectorService connectorService;
     @Autowired

--- a/src/test/java/com/otilm/core/search/TimeQualityConfigurationSearchTest.java
+++ b/src/test/java/com/otilm/core/search/TimeQualityConfigurationSearchTest.java
@@ -19,7 +19,7 @@ import com.otilm.core.dao.entity.signing.TimeQualityConfiguration;
 import com.otilm.core.dao.repository.signing.TimeQualityConfigurationRepository;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.TimeQualityConfigurationService;
+import com.otilm.core.service.TimeQualityConfigurationExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +41,7 @@ class TimeQualityConfigurationSearchTest extends BaseSpringBootTest {
     private static final String CUSTOM_ATTR_VALUE = "strict-tag-value";
 
     @Autowired
-    private TimeQualityConfigurationService timeQualityConfigurationService;
+    private TimeQualityConfigurationExternalService timeQualityConfigurationService;
 
     @Autowired
     private AttributeEngine attributeEngine;

--- a/src/test/java/com/otilm/core/search/TspProfileSearchTest.java
+++ b/src/test/java/com/otilm/core/search/TspProfileSearchTest.java
@@ -23,7 +23,7 @@ import com.otilm.core.dao.repository.signing.SigningProfileRepository;
 import com.otilm.core.dao.repository.signing.TspProfileRepository;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.TspProfileService;
+import com.otilm.core.service.TspProfileExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,7 +45,7 @@ class TspProfileSearchTest extends BaseSpringBootTest {
     private static final String CUSTOM_ATTR_VALUE = "alpha-tag-value";
 
     @Autowired
-    private TspProfileService tspProfileService;
+    private TspProfileExternalService tspProfileService;
 
     @Autowired
     private AttributeEngine attributeEngine;

--- a/src/test/java/com/otilm/core/security/authn/tsp/TspAuthenticationFilterTest.java
+++ b/src/test/java/com/otilm/core/security/authn/tsp/TspAuthenticationFilterTest.java
@@ -12,7 +12,7 @@ import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.authn.client.CredentialVerificationCache;
 import com.otilm.core.security.authn.client.PlatformAuthenticationClient;
 import com.otilm.core.service.SigningProfileService;
-import com.otilm.core.service.TspProfileService;
+import com.otilm.core.service.TspProfileInternalService;
 import com.otilm.core.util.AuthHelper;
 import com.otilm.core.util.SecretsUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -53,7 +53,7 @@ class TspAuthenticationFilterTest {
     private static final String CERT_HEADER = "-----BEGIN CERTIFICATE-----\ndGVzdA==\n-----END CERTIFICATE-----\n";
     private static final String CERT_THUMBPRINT = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
 
-    @Mock private TspProfileService tspProfileService;
+    @Mock private TspProfileInternalService tspProfileService;
     @Mock private SigningProfileService signingProfileService;
     @Mock private PlatformAuthenticationClient authClient;
     @Mock private PlatformJwtDecoder jwtDecoder;

--- a/src/test/java/com/otilm/core/security/authn/tsp/TspProfileSecretEvictionIntegrationTest.java
+++ b/src/test/java/com/otilm/core/security/authn/tsp/TspProfileSecretEvictionIntegrationTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * End-to-end proof of the rotation-invalidation wiring that the unit tests can only cover link-by-link:
  * a committed {@link SecretContentUpdatedEvent} must flow through {@link TspProfileSecretEvictionListener}
- * (AFTER_COMMIT) into {@code TspProfileBasicCredentialService.evictCachesForSecret} and clear the real
+ * (AFTER_COMMIT) into {@code TspProfileBasicCredentialInternalService.evictCachesForSecret} and clear the real
  * caches. This is the path a password rotation relies on, since {@code update()} intentionally does not
  * evict the verification cache eagerly on rotation.
  */

--- a/src/test/java/com/otilm/core/security/authn/tsp/TspProfileSecretEvictionListenerTest.java
+++ b/src/test/java/com/otilm/core/security/authn/tsp/TspProfileSecretEvictionListenerTest.java
@@ -1,7 +1,7 @@
 package com.otilm.core.security.authn.tsp;
 
 import com.otilm.core.events.SecretContentUpdatedEvent;
-import com.otilm.core.service.TspProfileBasicCredentialService;
+import com.otilm.core.service.TspProfileBasicCredentialInternalService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.verify;
 class TspProfileSecretEvictionListenerTest {
 
     @Mock
-    private TspProfileBasicCredentialService credentialService;
+    private TspProfileBasicCredentialInternalService credentialService;
 
     @InjectMocks
     private TspProfileSecretEvictionListener listener;

--- a/src/test/java/com/otilm/core/security/authn/tsp/TspRouteResolverTest.java
+++ b/src/test/java/com/otilm/core/security/authn/tsp/TspRouteResolverTest.java
@@ -3,7 +3,7 @@ package com.otilm.core.security.authn.tsp;
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.core.model.signing.TspProfileModel;
 import com.otilm.core.service.SigningProfileService;
-import com.otilm.core.service.TspProfileService;
+import com.otilm.core.service.TspProfileInternalService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class TspRouteResolverTest {
 
-    @Mock private TspProfileService tspProfileService;
+    @Mock private TspProfileInternalService tspProfileService;
     @Mock private SigningProfileService signingProfileService;
 
     private TspRouteResolver resolver;

--- a/src/test/java/com/otilm/core/service/SigningProfileServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/SigningProfileServiceImplTest.java
@@ -113,7 +113,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
     private SigningProfileService signingProfileService;
 
     @Autowired
-    private TspProfileService tspProfileService;
+    private TspProfileExternalService tspProfileService;
 
     @Autowired
     private ConnectorService connectorService;
@@ -128,7 +128,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
     private CryptographicKeyService cryptographicKeyService;
 
     @Autowired
-    private TimeQualityConfigurationService timeQualityConfigurationService;
+    private TimeQualityConfigurationExternalService timeQualityConfigurationService;
 
     @Autowired
     private ConnectorMockFactory connectorMockFactory;

--- a/src/test/java/com/otilm/core/service/SigningRecordServiceTest.java
+++ b/src/test/java/com/otilm/core/service/SigningRecordServiceTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Drives {@link SigningRecordService} end to end: signing profiles are created through {@link SigningProfileService}
+ * Drives {@link SigningRecordExternalService} end to end: signing profiles are created through {@link SigningProfileService}
  * against a live {@link SignerConnectorMock}, signing records are persisted through {@link SigningRecordWriter}, and
  * every assertion reads back through the service under test. Nothing touches a repository directly.
  */
@@ -62,7 +62,10 @@ class SigningRecordServiceTest extends BaseSpringBootTest {
     private static final String BETA_RECORD_V1 = "beta-record-v1";
 
     @Autowired
-    private SigningRecordService signingRecordService;
+    private SigningRecordExternalService signingRecordService;
+
+    @Autowired
+    private SigningRecordInternalService signingRecordInternalService;
 
     @Autowired
     private SigningProfileService signingProfileService;
@@ -495,7 +498,7 @@ class SigningRecordServiceTest extends BaseSpringBootTest {
             Fixture fixture = seedRecordsAcrossProfilesAndVersions();
 
             // when
-            boolean exists = signingRecordService.doesSigningRecordExistInternal(
+            boolean exists = signingRecordInternalService.doesSigningRecordExistInternal(
                     UUID.fromString(fixture.alpha().getUuid()), VERSION_2);
 
             // then
@@ -509,7 +512,7 @@ class SigningRecordServiceTest extends BaseSpringBootTest {
             int versionWithoutRecords = 3;
 
             // when
-            boolean exists = signingRecordService.doesSigningRecordExistInternal(
+            boolean exists = signingRecordInternalService.doesSigningRecordExistInternal(
                     UUID.fromString(fixture.alpha().getUuid()), versionWithoutRecords);
 
             // then
@@ -523,7 +526,7 @@ class SigningRecordServiceTest extends BaseSpringBootTest {
             Fixture fixture = seedRecordsAcrossProfilesAndVersions();
 
             // when
-            boolean exists = signingRecordService.doesSigningRecordExistInternal(
+            boolean exists = signingRecordInternalService.doesSigningRecordExistInternal(
                     UUID.fromString(fixture.beta().getUuid()), VERSION_2);
 
             // then

--- a/src/test/java/com/otilm/core/service/TimeQualityConfigurationCacheTest.java
+++ b/src/test/java/com/otilm/core/service/TimeQualityConfigurationCacheTest.java
@@ -29,7 +29,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TimeQualityConfigurationCacheTest extends BaseSpringBootTest {
 
     @Autowired
-    private TimeQualityConfigurationService timeQualityConfigurationService;
+    private TimeQualityConfigurationExternalService timeQualityConfigurationService;
+
+    @Autowired
+    private TimeQualityConfigurationInternalService timeQualityConfigurationInternalService;
 
     @Autowired
     private TimeQualityConfigurationRepository timeQualityConfigurationRepository;
@@ -67,7 +70,7 @@ class TimeQualityConfigurationCacheTest extends BaseSpringBootTest {
         assertThat(cache.get(config.getUuid(), TimeQualityConfigurationModel.class)).isNull();
 
         // when
-        timeQualityConfigurationService.getTimeQualityConfigurationModel(config.getUuid());
+        timeQualityConfigurationInternalService.getTimeQualityConfigurationModel(config.getUuid());
 
         // then - model is stored in the cache keyed by UUID
         assertThat(cache.get(config.getUuid(), TimeQualityConfigurationModel.class)).isNotNull();
@@ -77,11 +80,11 @@ class TimeQualityConfigurationCacheTest extends BaseSpringBootTest {
     void secondLookupReturnsCachedInstance() throws NotFoundException {
         // given - populate cache on first call
         TimeQualityConfigurationModel first =
-                timeQualityConfigurationService.getTimeQualityConfigurationModel(config.getUuid());
+                timeQualityConfigurationInternalService.getTimeQualityConfigurationModel(config.getUuid());
 
         // when - second call for the same UUID
         TimeQualityConfigurationModel second =
-                timeQualityConfigurationService.getTimeQualityConfigurationModel(config.getUuid());
+                timeQualityConfigurationInternalService.getTimeQualityConfigurationModel(config.getUuid());
 
         // then - the same Java object is returned, proving no second DB round-trip was made
         assertThat(second).isSameAs(first);
@@ -90,7 +93,7 @@ class TimeQualityConfigurationCacheTest extends BaseSpringBootTest {
     @Test
     void cacheIsEvictedAfterUpdate() throws AlreadyExistException, AttributeException, NotFoundException {
         // given - cache is warm
-        timeQualityConfigurationService.getTimeQualityConfigurationModel(config.getUuid());
+        timeQualityConfigurationInternalService.getTimeQualityConfigurationModel(config.getUuid());
         Cache cache = cacheManager.getCache(CacheConfig.TIME_QUALITY_CONFIGURATION_CACHE);
         assertThat(cache.get(config.getUuid(), TimeQualityConfigurationModel.class)).isNotNull();
 
@@ -106,7 +109,7 @@ class TimeQualityConfigurationCacheTest extends BaseSpringBootTest {
     @Test
     void cacheIsEvictedAfterDelete() throws NotFoundException {
         // given - cache is warm
-        timeQualityConfigurationService.getTimeQualityConfigurationModel(config.getUuid());
+        timeQualityConfigurationInternalService.getTimeQualityConfigurationModel(config.getUuid());
         Cache cache = cacheManager.getCache(CacheConfig.TIME_QUALITY_CONFIGURATION_CACHE);
         assertThat(cache.get(config.getUuid(), TimeQualityConfigurationModel.class)).isNotNull();
 
@@ -133,8 +136,8 @@ class TimeQualityConfigurationCacheTest extends BaseSpringBootTest {
         second.setLeapSecondGuard(false);
         second = timeQualityConfigurationRepository.saveAndFlush(second);
 
-        timeQualityConfigurationService.getTimeQualityConfigurationModel(config.getUuid());
-        timeQualityConfigurationService.getTimeQualityConfigurationModel(second.getUuid());
+        timeQualityConfigurationInternalService.getTimeQualityConfigurationModel(config.getUuid());
+        timeQualityConfigurationInternalService.getTimeQualityConfigurationModel(second.getUuid());
 
         Cache cache = cacheManager.getCache(CacheConfig.TIME_QUALITY_CONFIGURATION_CACHE);
         assertThat(cache.get(config.getUuid(), TimeQualityConfigurationModel.class)).isNotNull();

--- a/src/test/java/com/otilm/core/service/TimeQualityConfigurationServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/TimeQualityConfigurationServiceImplTest.java
@@ -54,7 +54,7 @@ class TimeQualityConfigurationServiceImplTest extends BaseSpringBootTest {
     private static final String CUSTOM_ATTR_NAME = "tqcTestAttribute";
 
     @Autowired
-    private TimeQualityConfigurationService timeQualityConfigurationService;
+    private TimeQualityConfigurationExternalService timeQualityConfigurationService;
 
     @MockitoSpyBean
     private TimeQualityConfigurationRepository timeQualityConfigurationRepository;

--- a/src/test/java/com/otilm/core/service/TimeQualityConfigurationServiceJmsTest.java
+++ b/src/test/java/com/otilm/core/service/TimeQualityConfigurationServiceJmsTest.java
@@ -39,7 +39,7 @@ class TimeQualityConfigurationServiceJmsTest extends BaseMessagingIntTest {
     private static final long RECEIVE_TIMEOUT_MS = 5_000;
 
     @Autowired ApplicationEvents applicationEvents;
-    @Autowired TimeQualityConfigurationService service;
+    @Autowired TimeQualityConfigurationExternalService service;
     @Autowired TimeQualityConfigurationRepository repository;
     @Autowired JmsTemplate jmsTemplate;
     @Autowired MessagingProperties messagingProperties;

--- a/src/test/java/com/otilm/core/service/TspProfileBasicCredentialServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/TspProfileBasicCredentialServiceImplTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
 class TspProfileBasicCredentialServiceImplTest extends BaseSpringBootTest {
 
     @Autowired
-    private TspProfileBasicCredentialService service;
+    private TspProfileBasicCredentialExternalService service;
 
     @Autowired
     private TspProfileRepository tspProfileRepository;

--- a/src/test/java/com/otilm/core/service/TspProfileCacheTest.java
+++ b/src/test/java/com/otilm/core/service/TspProfileCacheTest.java
@@ -29,7 +29,10 @@ class TspProfileCacheTest extends BaseSpringBootTest {
     private static final String BASE_URL = "http://localhost";
 
     @Autowired
-    private TspProfileService tspProfileService;
+    private TspProfileExternalService tspProfileService;
+
+    @Autowired
+    private TspProfileInternalService tspProfileInternalService;
 
     @Autowired
     private TspProfileRepository tspProfileRepository;
@@ -61,7 +64,7 @@ class TspProfileCacheTest extends BaseSpringBootTest {
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNull();
 
         // when
-        tspProfileService.getTspProfile(profile.getName());
+        tspProfileInternalService.getTspProfile(profile.getName());
 
         // then - the model is stored in the cache keyed by profile name
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNotNull();
@@ -70,10 +73,10 @@ class TspProfileCacheTest extends BaseSpringBootTest {
     @Test
     void secondLookupReturnsCachedInstance() throws NotFoundException {
         // given - populate cache on first call
-        TspProfileModel first = tspProfileService.getTspProfile(profile.getName());
+        TspProfileModel first = tspProfileInternalService.getTspProfile(profile.getName());
 
         // when - second call for the same profile name
-        TspProfileModel second = tspProfileService.getTspProfile(profile.getName());
+        TspProfileModel second = tspProfileInternalService.getTspProfile(profile.getName());
 
         // then - the same Java object is returned, proving no second DB round-trip was made
         assertThat(second).isSameAs(first);
@@ -82,7 +85,7 @@ class TspProfileCacheTest extends BaseSpringBootTest {
     @Test
     void cacheIsEvictedAfterUpdate() throws AlreadyExistException, AttributeException, NotFoundException {
         // given - cache is warm under the original name
-        tspProfileService.getTspProfile(profile.getName());
+        tspProfileInternalService.getTspProfile(profile.getName());
         Cache cache = cacheManager.getCache(CacheConfig.TSP_PROFILE_CACHE);
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNotNull();
 
@@ -98,7 +101,7 @@ class TspProfileCacheTest extends BaseSpringBootTest {
         assertThat(cache.get(oldName, TspProfileModel.class)).isNull();
 
         // and - subsequent lookup under new name re-populates the cache
-        tspProfileService.getTspProfile("renamed-tsp-profile");
+        tspProfileInternalService.getTspProfile("renamed-tsp-profile");
         assertThat(cache.get("renamed-tsp-profile", TspProfileModel.class)).isNotNull();
     }
 
@@ -110,7 +113,7 @@ class TspProfileCacheTest extends BaseSpringBootTest {
         assertThat(cache.get(profile.getUuid(), TspProfileModel.class)).isNull();
 
         // when - looked up by UUID (the signing-profile hot path)
-        tspProfileService.getTspProfile(profile.getUuid());
+        tspProfileInternalService.getTspProfile(profile.getUuid());
 
         // then - the model is stored keyed by UUID
         assertThat(cache.get(profile.getUuid(), TspProfileModel.class)).isNotNull();
@@ -119,7 +122,7 @@ class TspProfileCacheTest extends BaseSpringBootTest {
     @Test
     void uuidLookupSurvivesRename() throws AlreadyExistException, AttributeException, NotFoundException {
         // given - cache is warm under the original UUID, the signing-profile path's stable reference
-        tspProfileService.getTspProfile(profile.getUuid());
+        tspProfileInternalService.getTspProfile(profile.getUuid());
         Cache cache = cacheManager.getCache(CacheConfig.TSP_PROFILE_CACHE);
         assertThat(cache.get(profile.getUuid(), TspProfileModel.class)).isNotNull();
 
@@ -134,7 +137,7 @@ class TspProfileCacheTest extends BaseSpringBootTest {
         assertThat(cache.get(profile.getUuid(), TspProfileModel.class)).isNull();
 
         // and - a fresh UUID lookup still resolves and reflects the new name; the rename never dangles
-        TspProfileModel repopulated = tspProfileService.getTspProfile(profile.getUuid());
+        TspProfileModel repopulated = tspProfileInternalService.getTspProfile(profile.getUuid());
         assertThat(repopulated.name()).isEqualTo("renamed-tsp-profile");
         assertThat(cache.get(profile.getUuid(), TspProfileModel.class)).isNotNull();
     }
@@ -142,7 +145,7 @@ class TspProfileCacheTest extends BaseSpringBootTest {
     @Test
     void cacheIsEvictedAfterSameNameUpdate() throws AlreadyExistException, AttributeException, NotFoundException {
         // given - cache is warm
-        tspProfileService.getTspProfile(profile.getName());
+        tspProfileInternalService.getTspProfile(profile.getName());
         Cache cache = cacheManager.getCache(CacheConfig.TSP_PROFILE_CACHE);
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNotNull();
 
@@ -160,7 +163,7 @@ class TspProfileCacheTest extends BaseSpringBootTest {
     @Test
     void cacheIsEvictedAfterDelete() throws NotFoundException {
         // given - cache is warm
-        tspProfileService.getTspProfile(profile.getName());
+        tspProfileInternalService.getTspProfile(profile.getName());
         Cache cache = cacheManager.getCache(CacheConfig.TSP_PROFILE_CACHE);
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNotNull();
 
@@ -176,7 +179,7 @@ class TspProfileCacheTest extends BaseSpringBootTest {
         // given - profile is disabled and cache is warm
         profile.setEnabled(false);
         profile = tspProfileRepository.saveAndFlush(profile);
-        tspProfileService.getTspProfile(profile.getName());
+        tspProfileInternalService.getTspProfile(profile.getName());
         Cache cache = cacheManager.getCache(CacheConfig.TSP_PROFILE_CACHE);
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNotNull();
 
@@ -187,7 +190,7 @@ class TspProfileCacheTest extends BaseSpringBootTest {
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNull();
 
         // and - subsequent lookup re-populates the cache with the updated state
-        TspProfileModel repopulated = tspProfileService.getTspProfile(profile.getName());
+        TspProfileModel repopulated = tspProfileInternalService.getTspProfile(profile.getName());
         assertThat(repopulated.enabled()).isTrue();
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNotNull();
     }
@@ -195,7 +198,7 @@ class TspProfileCacheTest extends BaseSpringBootTest {
     @Test
     void cacheIsEvictedAfterDisable() throws NotFoundException {
         // given - profile is enabled and cache is warm
-        tspProfileService.getTspProfile(profile.getName());
+        tspProfileInternalService.getTspProfile(profile.getName());
         Cache cache = cacheManager.getCache(CacheConfig.TSP_PROFILE_CACHE);
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNotNull();
 
@@ -206,7 +209,7 @@ class TspProfileCacheTest extends BaseSpringBootTest {
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNull();
 
         // and - subsequent lookup re-populates the cache with the updated state
-        TspProfileModel repopulated = tspProfileService.getTspProfile(profile.getName());
+        TspProfileModel repopulated = tspProfileInternalService.getTspProfile(profile.getName());
         assertThat(repopulated.enabled()).isFalse();
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNotNull();
     }
@@ -218,8 +221,8 @@ class TspProfileCacheTest extends BaseSpringBootTest {
         second.setName("second-tsp-profile");
         second.setEnabled(true);
         second = tspProfileRepository.saveAndFlush(second);
-        tspProfileService.getTspProfile(profile.getName());
-        tspProfileService.getTspProfile(second.getName());
+        tspProfileInternalService.getTspProfile(profile.getName());
+        tspProfileInternalService.getTspProfile(second.getName());
         Cache cache = cacheManager.getCache(CacheConfig.TSP_PROFILE_CACHE);
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNotNull();
         assertThat(cache.get(second.getName(), TspProfileModel.class)).isNotNull();
@@ -244,8 +247,8 @@ class TspProfileCacheTest extends BaseSpringBootTest {
         second.setName("second-tsp-profile");
         second.setEnabled(false);
         second = tspProfileRepository.saveAndFlush(second);
-        tspProfileService.getTspProfile(profile.getName());
-        tspProfileService.getTspProfile(second.getName());
+        tspProfileInternalService.getTspProfile(profile.getName());
+        tspProfileInternalService.getTspProfile(second.getName());
         Cache cache = cacheManager.getCache(CacheConfig.TSP_PROFILE_CACHE);
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNotNull();
         assertThat(cache.get(second.getName(), TspProfileModel.class)).isNotNull();
@@ -268,8 +271,8 @@ class TspProfileCacheTest extends BaseSpringBootTest {
         second.setName("second-tsp-profile");
         second.setEnabled(true);
         second = tspProfileRepository.saveAndFlush(second);
-        tspProfileService.getTspProfile(profile.getName());
-        tspProfileService.getTspProfile(second.getName());
+        tspProfileInternalService.getTspProfile(profile.getName());
+        tspProfileInternalService.getTspProfile(second.getName());
         Cache cache = cacheManager.getCache(CacheConfig.TSP_PROFILE_CACHE);
         assertThat(cache.get(profile.getName(), TspProfileModel.class)).isNotNull();
         assertThat(cache.get(second.getName(), TspProfileModel.class)).isNotNull();

--- a/src/test/java/com/otilm/core/service/TspProfileServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/TspProfileServiceImplTest.java
@@ -62,7 +62,10 @@ class TspProfileServiceImplTest extends BaseSpringBootTest {
     private static final String BASE_URL = "http://localhost";
 
     @Autowired
-    private TspProfileService tspService;
+    private TspProfileExternalService tspService;
+
+    @Autowired
+    private TspProfileInternalService tspInternalService;
 
     @Autowired
     private ResourceExternalService resourceService;
@@ -229,7 +232,7 @@ class TspProfileServiceImplTest extends BaseSpringBootTest {
 
     @Test
     void testGetTspProfileEntity_returnsCorrectEntity() throws NotFoundException {
-        TspProfile entity = tspService.getTspProfileEntity(savedTspProfile.getSecuredUuid());
+        TspProfile entity = tspInternalService.getTspProfileEntity(savedTspProfile.getSecuredUuid());
 
         assertNotNull(entity);
         assertEquals(savedTspProfile.getUuid(), entity.getUuid());
@@ -239,7 +242,7 @@ class TspProfileServiceImplTest extends BaseSpringBootTest {
     @Test
     void testGetTspProfileEntity_notFound() {
         assertThrows(NotFoundException.class,
-                () -> tspService.getTspProfileEntity(
+                () -> tspInternalService.getTspProfileEntity(
                         SecuredUUID.fromString("00000000-0000-0000-0000-000000000001")));
     }
 
@@ -249,7 +252,7 @@ class TspProfileServiceImplTest extends BaseSpringBootTest {
 
     @Test
     void testFindAllNames_returnsExistingNames() {
-        List<String> names = tspService.findAllNames();
+        List<String> names = tspInternalService.findAllNames();
 
         assertNotNull(names);
         assertEquals(1, names.size());
@@ -262,7 +265,7 @@ class TspProfileServiceImplTest extends BaseSpringBootTest {
         second.setName("second-tsp-profile");
         tspRepository.save(second);
 
-        List<String> names = tspService.findAllNames();
+        List<String> names = tspInternalService.findAllNames();
 
         assertEquals(2, names.size());
         assertTrue(names.contains(savedTspProfile.getName()));
@@ -273,7 +276,7 @@ class TspProfileServiceImplTest extends BaseSpringBootTest {
     void testFindAllNames_emptyWhenNoneExist() {
         tspRepository.delete(savedTspProfile);
 
-        List<String> names = tspService.findAllNames();
+        List<String> names = tspInternalService.findAllNames();
 
         assertNotNull(names);
         assertTrue(names.isEmpty());

--- a/src/test/java/com/otilm/core/service/impl/SigningRecordStatisticsServiceTest.java
+++ b/src/test/java/com/otilm/core/service/impl/SigningRecordStatisticsServiceTest.java
@@ -13,7 +13,7 @@ import com.otilm.core.dao.repository.signing.SigningProfileRepository;
 import com.otilm.core.dao.repository.signing.SigningProfileVersionRepository;
 import com.otilm.core.dao.repository.signing.SigningRecordRepository;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.SigningRecordService;
+import com.otilm.core.service.SigningRecordExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SigningRecordStatisticsServiceTest extends BaseSpringBootTest {
 
     @Autowired
-    private SigningRecordService signingRecordService;
+    private SigningRecordExternalService signingRecordService;
     @Autowired
     private SigningRecordRepository signingRecordRepository;
     @Autowired

--- a/src/test/java/com/otilm/core/service/signingprofile/SigningProfileCacheCoherenceTest.java
+++ b/src/test/java/com/otilm/core/service/signingprofile/SigningProfileCacheCoherenceTest.java
@@ -10,7 +10,7 @@ import com.otilm.core.config.cache.CacheConfig;
 import com.otilm.core.dao.entity.signing.TspProfile;
 import com.otilm.core.model.signing.TspProfileModel;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.TspProfileService;
+import com.otilm.core.service.TspProfileInternalService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
@@ -28,7 +28,7 @@ class SigningProfileCacheCoherenceTest extends SigningProfileTestBase {
     private static final String BASE_URL = "http://localhost";
 
     @Autowired
-    private TspProfileService tspProfileService;
+    private TspProfileInternalService tspProfileService;
 
     @Autowired
     private CacheManager cacheManager;

--- a/src/test/java/com/otilm/core/service/signingprofile/SigningProfileTestBase.java
+++ b/src/test/java/com/otilm/core/service/signingprofile/SigningProfileTestBase.java
@@ -63,7 +63,7 @@ import com.otilm.core.dao.repository.signing.TspProfileRepository;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.service.CertificateService;
 import com.otilm.core.service.SigningProfileService;
-import com.otilm.core.service.TimeQualityConfigurationService;
+import com.otilm.core.service.TimeQualityConfigurationExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.CertificateTestUtil;
 import com.otilm.core.util.MetaDefinitions;
@@ -93,7 +93,7 @@ abstract class SigningProfileTestBase extends BaseSpringBootTest {
     protected AttributeEngine attributeEngine;
 
     @Autowired
-    protected TimeQualityConfigurationService timeQualityConfigurationService;
+    protected TimeQualityConfigurationExternalService timeQualityConfigurationService;
 
     @Autowired
     protected ConnectorRepository connectorRepository;

--- a/src/test/java/com/otilm/core/signing/record/ImmediateSigningRecordStrategyTest.java
+++ b/src/test/java/com/otilm/core/signing/record/ImmediateSigningRecordStrategyTest.java
@@ -12,7 +12,7 @@ import com.otilm.core.dao.repository.signing.SigningProfileVersionRepository;
 import com.otilm.core.model.signing.SigningProfileModel;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.SigningRecordService;
+import com.otilm.core.service.SigningRecordExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,7 +44,7 @@ class ImmediateSigningRecordStrategyTest extends BaseSpringBootTest {
     private ImmediateSigningRecordStrategy strategy;
 
     @Autowired
-    private SigningRecordService signingRecordService;
+    private SigningRecordExternalService signingRecordService;
 
     @Autowired
     private SigningProfileRepository profileRepo;

--- a/src/test/java/com/otilm/core/signing/record/SigningRecordEndToEndTest.java
+++ b/src/test/java/com/otilm/core/signing/record/SigningRecordEndToEndTest.java
@@ -16,7 +16,7 @@ import com.otilm.core.dao.repository.signing.SigningRecordRepository;
 import com.otilm.core.model.signing.SigningProfileModel;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.SigningRecordService;
+import com.otilm.core.service.SigningRecordExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -70,7 +70,7 @@ class SigningRecordEndToEndTest extends BaseSpringBootTest {
     @Autowired
     private MeterRegistry registry;
     @Autowired
-    private SigningRecordService signingRecordService;
+    private SigningRecordExternalService signingRecordService;
 
     @Test
     void deferredDurableProfile_stagesWriteInOutbox_thenDrainsIntoSigningRecord_advancingIntakeThenPersistCounters()
@@ -151,7 +151,7 @@ class SigningRecordEndToEndTest extends BaseSpringBootTest {
     }
 
     /**
-     * Asserts that exactly one signing record is reachable through {@link SigningRecordService}, both in the
+     * Asserts that exactly one signing record is reachable through {@link SigningRecordExternalService}, both in the
      * list and when fetched by its own uuid — proving the persisted row is visible through the read path
      * operators use, not just present in the table. With the database isolated per test, that single record is
      * the one this test wrote.

--- a/src/test/java/com/otilm/core/signing/tsa/TsaServiceImplTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/TsaServiceImplTest.java
@@ -20,10 +20,10 @@ import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CryptographicKeyService;
 import com.otilm.core.service.SigningProfileService;
-import com.otilm.core.service.SigningRecordService;
+import com.otilm.core.service.SigningRecordExternalService;
 import com.otilm.core.service.TokenInstanceExternalService;
 import com.otilm.core.service.TokenProfileExternalService;
-import com.otilm.core.service.TspProfileService;
+import com.otilm.core.service.TspProfileExternalService;
 import com.otilm.core.service.v2.ConnectorService;
 import com.otilm.core.signing.tsa.messages.TspRequest;
 import com.otilm.core.signing.tsa.messages.TspResponse;
@@ -76,10 +76,10 @@ class TsaServiceImplTest extends BaseSpringBootTest {
     private SigningProfileService signingProfileService;
 
     @Autowired
-    private TspProfileService tspProfileService;
+    private TspProfileExternalService tspProfileService;
 
     @Autowired
-    private SigningRecordService signingRecordService;
+    private SigningRecordExternalService signingRecordService;
 
     @Autowired
     private ConnectorService connectorService;

--- a/src/test/java/com/otilm/core/signing/tsa/impl/TsaServiceImplUnitTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/impl/TsaServiceImplUnitTest.java
@@ -7,7 +7,7 @@ import com.otilm.core.model.signing.SigningProfileModel;
 import com.otilm.core.model.signing.workflow.DelegatedTimestampingWorkflow;
 import com.otilm.core.service.PermissionEvaluator;
 import com.otilm.core.service.SigningProfileService;
-import com.otilm.core.service.TspProfileService;
+import com.otilm.core.service.TspProfileInternalService;
 import com.otilm.core.signing.tsa.ManagedTimestampEngine;
 import com.otilm.core.signing.tsa.messages.TspResponse;
 import com.otilm.core.signing.tsa.resolver.SigningProfileResolverFactory;
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
 class TsaServiceImplUnitTest {
 
     @Mock
-    TspProfileService tspProfileService;
+    TspProfileInternalService tspProfileService;
     @Mock
     SigningProfileService signingProfileService;
     @Mock
@@ -76,7 +76,7 @@ class TsaServiceImplUnitTest {
         void propagatesNotFound_whenTspProfileDoesNotExist() throws NotFoundException {
             // given
             when(tspProfileService.getTspProfile("nonexistent"))
-                    .thenThrow(new NotFoundException(TspProfileService.class, "nonexistent"));
+                    .thenThrow(new NotFoundException(TspProfileInternalService.class, "nonexistent"));
 
             // when
             Executable call = () -> tsaService.processTspRequestForTspProfile("nonexistent", aTspRequest().build());
@@ -396,7 +396,7 @@ class TsaServiceImplUnitTest {
             // given
             doReturn(aDefaultSigningProfile()).when(signingProfileService).getSigningProfileModel("signing-profile");
             when(tspProfileService.getTspProfile(TSP_PROFILE_UUID))
-                    .thenThrow(new NotFoundException(TspProfileService.class, "tsp-profile"));
+                    .thenThrow(new NotFoundException(TspProfileInternalService.class, "tsp-profile"));
 
             // when
             Executable call = () -> tsaService.processTspRequestForSigningProfile("signing-profile", aTspRequest().build());

--- a/src/test/java/com/otilm/core/signing/tsa/resolver/StaticKeyManagedTimestampingResolverTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/resolver/StaticKeyManagedTimestampingResolverTest.java
@@ -26,7 +26,7 @@ import com.otilm.core.model.signing.workflow.ManagedTimestampingWorkflow;
 import com.otilm.core.model.signing.workflow.SigningWorkflow;
 import com.otilm.core.service.CertificateService;
 import com.otilm.core.service.CryptographicKeyService;
-import com.otilm.core.service.TimeQualityConfigurationService;
+import com.otilm.core.service.TimeQualityConfigurationInternalService;
 import com.otilm.core.service.v2.ConnectorService;
 import com.otilm.core.util.CertificateTestUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +61,7 @@ class StaticKeyManagedTimestampingResolverTest {
     @Mock
     private CryptographicKeyService cryptographicKeyService;
     @Mock
-    private TimeQualityConfigurationService timeQualityConfigurationService;
+    private TimeQualityConfigurationInternalService timeQualityConfigurationService;
     @Mock
     private ConnectorService connectorService;
 


### PR DESCRIPTION
## Summary

Part 11 of the ongoing effort to split monolithic service interfaces into separate **External** and **Internal** service interfaces.

This round splits the following services:

- `SigningRecordService` → `SigningRecordExternalService` + `SigningRecordInternalService`
- `TimeQualityConfigurationService` → `TimeQualityConfigurationExternalService` + `TimeQualityConfigurationInternalService`
- `TspProfileBasicCredentialService` → `TspProfileBasicCredentialExternalService` + `TspProfileBasicCredentialInternalService`
- `TspProfileService` → `TspProfileExternalService` + `TspProfileInternalService`

## Test plan

- [ ] CI build passes
- [ ] Existing tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
