### PR TITLE
Fix SCEP profile edit: keep secrets, toggle challenge password, clear stale Intune config

### DIFF
--- a/src/main/java/com/otilm/core/dao/entity/scep/ScepProfile.java
+++ b/src/main/java/com/otilm/core/dao/entity/scep/ScepProfile.java
@@ -71,6 +71,7 @@ public class ScepProfile extends UniquelyIdentifiedAndAudited implements Seriali
     private boolean includeCaCertificateChain = false;
 
     @Column(name = "challenge_password")
+    @ToString.Exclude
     private String challengePassword;
 
     @Column(name = "intune_enabled")
@@ -83,6 +84,7 @@ public class ScepProfile extends UniquelyIdentifiedAndAudited implements Seriali
     private String intuneApplicationId;
 
     @Column(name = "intune_application_key")
+    @ToString.Exclude
     private String intuneApplicationKey;
 
     @Column(name = "certificate_associations_uuid")

--- a/src/main/java/com/otilm/core/dao/entity/scep/ScepProfile.java
+++ b/src/main/java/com/otilm/core/dao/entity/scep/ScepProfile.java
@@ -110,6 +110,7 @@ public class ScepProfile extends UniquelyIdentifiedAndAudited implements Seriali
         scepProfileDto.setIncludeCaCertificateChain(includeCaCertificateChain);
         scepProfileDto.setRenewThreshold(renewalThreshold);
         scepProfileDto.setEnableIntune(intuneEnabled);
+        scepProfileDto.setEnableChallengePassword(challengePassword != null);
         return scepProfileDto;
     }
 
@@ -131,6 +132,7 @@ public class ScepProfile extends UniquelyIdentifiedAndAudited implements Seriali
                     + ScepServiceImpl.SCEP_URL_PREFIX + "/" + name + "/pkiclient.exe");
         }
         scepProfileDto.setEnableIntune(intuneEnabled);
+        scepProfileDto.setEnableChallengePassword(challengePassword != null);
         scepProfileDto.setIntuneTenant(intuneTenant);
         scepProfileDto.setIntuneApplicationId(intuneApplicationId);
         // Custom Attributes for the DTO should be set in the methods which require the detail DTO

--- a/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
@@ -153,9 +153,12 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
         scepProfile.setRequireManualApproval(false);
         scepProfile.setCaCertificateUuid(UUID.fromString(request.getCaCertificateUuid()));
         scepProfile.setIntuneEnabled(intuneEnabled);
-        scepProfile.setIntuneTenant(request.getIntuneTenant());
-        scepProfile.setIntuneApplicationId(request.getIntuneApplicationId());
-        scepProfile.setIntuneApplicationKey(request.getIntuneApplicationKey());
+        // Unset fields stay null on a fresh profile, so a disabled profile stores no stale Intune secret.
+        if (intuneEnabled) {
+            scepProfile.setIntuneTenant(request.getIntuneTenant());
+            scepProfile.setIntuneApplicationId(request.getIntuneApplicationId());
+            scepProfile.setIntuneApplicationKey(request.getIntuneApplicationKey());
+        }
         scepProfile.setRaProfile(raProfile);
 
         if (request.getCertificateAssociations() != null && !request.getCertificateAssociations().isEmpty()) {

--- a/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
@@ -273,21 +273,6 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
     }
 
     /**
-     * Applies the write-only challenge password according to the tri-state {@code enableChallengePassword} toggle.
-     * The toggle MUST be treated as keep-when-null: an absent toggle (legacy clients, or clients that do not send
-     * the field) must never wipe a stored password. Do NOT collapse it with {@code Boolean.TRUE.equals(...)} the way
-     * {@code enableIntune} is handled — that would turn a missing toggle into {@code false} and silently clear the
-     * stored secret.
-     *
-     * <ul>
-     *   <li>toggle {@code null} — set when a value is supplied, otherwise leave the entity untouched
-     *       (keep on edit, no password on create).</li>
-     *   <li>toggle {@code false} — clear the challenge password.</li>
-     *   <li>toggle {@code true} + non-blank value — set the new password.</li>
-     *   <li>toggle {@code true} + blank value — keep the stored password, or reject when none is stored.</li>
-     * </ul>
-     */
-    /**
      * Persists the Intune sub-config, shared by create and edit. When Intune is enabled the tenant and
      * application id are set from the request and the application key is treated as a write-only secret —
      * kept as stored when the request omits it (blank on a fresh entity means no key). When Intune is
@@ -312,6 +297,21 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
         return request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isBlank();
     }
 
+    /**
+     * Applies the write-only challenge password according to the tri-state {@code enableChallengePassword} toggle.
+     * The toggle MUST be treated as keep-when-null: an absent toggle (legacy clients, or clients that do not send
+     * the field) must never wipe a stored password. Do NOT collapse it with {@code Boolean.TRUE.equals(...)} the way
+     * {@code enableIntune} is handled — that would turn a missing toggle into {@code false} and silently clear the
+     * stored secret.
+     *
+     * <ul>
+     *   <li>toggle {@code null} — set when a value is supplied, otherwise leave the entity untouched
+     *       (keep on edit, no password on create).</li>
+     *   <li>toggle {@code false} — clear the challenge password.</li>
+     *   <li>toggle {@code true} + non-blank value — set the new password.</li>
+     *   <li>toggle {@code true} + blank value — keep the stored password, or reject when none is stored.</li>
+     * </ul>
+     */
     private void applyChallengePassword(ScepProfile scepProfile, BaseScepProfileRequestDto request) {
         Boolean enable = request.getEnableChallengePassword();
         boolean valueProvided = request.getChallengePassword() != null && !request.getChallengePassword().isBlank();

--- a/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
@@ -127,7 +127,9 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
         }
 
         boolean intuneKeyProvided = request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isBlank();
-        if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneApplicationId() == null || !intuneKeyProvided)) {
+        if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneTenant().isBlank()
+                || request.getIntuneApplicationId() == null || request.getIntuneApplicationId().isBlank()
+                || !intuneKeyProvided)) {
             throw new ValidationException(ValidationError.create("Invalid Intune configuration. Intune tenant, application ID and application key are required when Intune is enabled"));
         }
 
@@ -199,7 +201,8 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
         // The Intune application key is write-only: when Intune stays enabled and the request omits the key,
         // keep the stored one (the form does not prefill it). Requiring re-entry otherwise would 422 or wipe it.
         boolean intuneKeyProvided = request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isBlank();
-        if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneApplicationId() == null
+        if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneTenant().isBlank()
+                || request.getIntuneApplicationId() == null || request.getIntuneApplicationId().isBlank()
                 || (!intuneKeyProvided && scepProfile.getIntuneApplicationKey() == null))) {
             throw new ValidationException(ValidationError.create("Invalid Intune configuration. Intune tenant, application ID and application key are required when Intune is enabled (the application key may be omitted only if one is already stored)"));
         }

--- a/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
@@ -126,8 +126,9 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
             throw new ValidationException(ValidationError.create("CA Certificate is not acceptable as SCEP CA certificate for this profile"));
         }
 
-        if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneApplicationId() == null || request.getIntuneApplicationKey() == null)) {
-            throw new ValidationException(ValidationError.create("Invalid Intune configuration. Missing Intune tenant and/or intune app identification"));
+        boolean intuneKeyProvided = request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isEmpty();
+        if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneApplicationId() == null || !intuneKeyProvided)) {
+            throw new ValidationException(ValidationError.create("Invalid Intune configuration. Intune tenant, application ID and application key are required when Intune is enabled"));
         }
 
         RaProfile raProfile = null;
@@ -197,7 +198,7 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
         boolean intuneKeyProvided = request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isEmpty();
         if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneApplicationId() == null
                 || (!intuneKeyProvided && scepProfile.getIntuneApplicationKey() == null))) {
-            throw new ValidationException(ValidationError.create("Invalid Intune configuration. Missing Intune tenant and/or intune app identification"));
+            throw new ValidationException(ValidationError.create("Invalid Intune configuration. Intune tenant, application ID and application key are required when Intune is enabled (the application key may be omitted only if one is already stored)"));
         }
 
         attributeEngine.validateCustomAttributesContent(Resource.SCEP_PROFILE, request.getCustomAttributes());

--- a/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
@@ -126,7 +126,7 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
             throw new ValidationException(ValidationError.create("CA Certificate is not acceptable as SCEP CA certificate for this profile"));
         }
 
-        boolean intuneKeyProvided = request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isEmpty();
+        boolean intuneKeyProvided = request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isBlank();
         if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneApplicationId() == null || !intuneKeyProvided)) {
             throw new ValidationException(ValidationError.create("Invalid Intune configuration. Intune tenant, application ID and application key are required when Intune is enabled"));
         }
@@ -198,7 +198,7 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
 
         // The Intune application key is write-only: when Intune stays enabled and the request omits the key,
         // keep the stored one (the form does not prefill it). Requiring re-entry otherwise would 422 or wipe it.
-        boolean intuneKeyProvided = request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isEmpty();
+        boolean intuneKeyProvided = request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isBlank();
         if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneApplicationId() == null
                 || (!intuneKeyProvided && scepProfile.getIntuneApplicationKey() == null))) {
             throw new ValidationException(ValidationError.create("Invalid Intune configuration. Intune tenant, application ID and application key are required when Intune is enabled (the application key may be omitted only if one is already stored)"));
@@ -307,7 +307,7 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
      */
     private void applyChallengePassword(ScepProfile scepProfile, BaseScepProfileRequestDto request) {
         Boolean enable = request.getEnableChallengePassword();
-        boolean valueProvided = request.getChallengePassword() != null && !request.getChallengePassword().isEmpty();
+        boolean valueProvided = request.getChallengePassword() != null && !request.getChallengePassword().isBlank();
 
         if (enable == null) {
             if (valueProvided) scepProfile.setChallengePassword(request.getChallengePassword());

--- a/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
@@ -189,7 +189,14 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
             throw new ValidationException(ValidationError.create("CA Certificate is not acceptable as SCEP CA certificate for this profile"));
         }
 
-        if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneApplicationId() == null || request.getIntuneApplicationKey() == null)) {
+        ScepProfile scepProfile = getScepProfileEntity(uuid);
+
+        // Secrets (Intune application key, challenge password) are write-only on edit: a blank or omitted
+        // value keeps the stored secret, mirroring OAuth2 clientSecret handling. The form does not prefill
+        // them, so requiring re-entry on every edit would 422 or silently wipe the existing value.
+        boolean intuneKeyProvided = request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isEmpty();
+        if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneApplicationId() == null
+                || (!intuneKeyProvided && scepProfile.getIntuneApplicationKey() == null))) {
             throw new ValidationException(ValidationError.create("Invalid Intune configuration. Missing Intune tenant and/or intune app identification"));
         }
 
@@ -201,12 +208,11 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
             extendedAttributeService.mergeAndValidateIssueAttributes(raProfile, request.getIssueCertificateAttributes());
         }
 
-        ScepProfile scepProfile = getScepProfileEntity(uuid);
         scepProfile.setRequireManualApproval(false);
         scepProfile.setIncludeCaCertificate(request.isIncludeCaCertificate());
         scepProfile.setIncludeCaCertificateChain(request.isIncludeCaCertificateChain());
         if (request.getRenewalThreshold() != null) scepProfile.setRenewalThreshold(request.getRenewalThreshold());
-        if (scepProfile.getChallengePassword() != null)
+        if (request.getChallengePassword() != null && !request.getChallengePassword().isEmpty())
             scepProfile.setChallengePassword(request.getChallengePassword());
 
         // delete old connector data attributes content
@@ -221,7 +227,9 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
         scepProfile.setIntuneEnabled(intuneEnabled);
         scepProfile.setIntuneTenant(request.getIntuneTenant());
         scepProfile.setIntuneApplicationId(request.getIntuneApplicationId());
-        scepProfile.setIntuneApplicationKey(request.getIntuneApplicationKey());
+        if (intuneKeyProvided) {
+            scepProfile.setIntuneApplicationKey(request.getIntuneApplicationKey());
+        }
 
         UUID certificateAssociationUuid = null;
         ProtocolCertificateAssociations certificateAssociation = null;

--- a/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
@@ -126,10 +126,9 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
             throw new ValidationException(ValidationError.create("CA Certificate is not acceptable as SCEP CA certificate for this profile"));
         }
 
-        boolean intuneKeyProvided = request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isBlank();
         if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneTenant().isBlank()
                 || request.getIntuneApplicationId() == null || request.getIntuneApplicationId().isBlank()
-                || !intuneKeyProvided)) {
+                || !isIntuneKeyProvided(request))) {
             throw new ValidationException(ValidationError.create("Invalid Intune configuration. Intune tenant, application ID and application key are required when Intune is enabled"));
         }
 
@@ -154,13 +153,7 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
         applyChallengePassword(scepProfile, request);
         scepProfile.setRequireManualApproval(false);
         scepProfile.setCaCertificateUuid(UUID.fromString(request.getCaCertificateUuid()));
-        scepProfile.setIntuneEnabled(intuneEnabled);
-        // Unset fields stay null on a fresh profile, so a disabled profile stores no stale Intune secret.
-        if (intuneEnabled) {
-            scepProfile.setIntuneTenant(request.getIntuneTenant());
-            scepProfile.setIntuneApplicationId(request.getIntuneApplicationId());
-            scepProfile.setIntuneApplicationKey(request.getIntuneApplicationKey());
-        }
+        applyIntuneConfig(scepProfile, request, intuneEnabled);
         scepProfile.setRaProfile(raProfile);
 
         if (request.getCertificateAssociations() != null && !request.getCertificateAssociations().isEmpty()) {
@@ -200,10 +193,9 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
 
         // The Intune application key is write-only: when Intune stays enabled and the request omits the key,
         // keep the stored one (the form does not prefill it). Requiring re-entry otherwise would 422 or wipe it.
-        boolean intuneKeyProvided = request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isBlank();
         if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneTenant().isBlank()
                 || request.getIntuneApplicationId() == null || request.getIntuneApplicationId().isBlank()
-                || (!intuneKeyProvided && scepProfile.getIntuneApplicationKey() == null))) {
+                || (!isIntuneKeyProvided(request) && scepProfile.getIntuneApplicationKey() == null))) {
             throw new ValidationException(ValidationError.create("Invalid Intune configuration. Intune tenant, application ID and application key are required when Intune is enabled (the application key may be omitted only if one is already stored)"));
         }
 
@@ -230,20 +222,7 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
         scepProfile.setRaProfile(raProfile);
         scepProfile.setDescription(request.getDescription());
         scepProfile.setCaCertificateUuid(UUID.fromString(request.getCaCertificateUuid()));
-        scepProfile.setIntuneEnabled(intuneEnabled);
-        if (intuneEnabled) {
-            scepProfile.setIntuneTenant(request.getIntuneTenant());
-            scepProfile.setIntuneApplicationId(request.getIntuneApplicationId());
-            // Keep the stored key when the request omits it (write-only secret, not prefilled by the form).
-            if (intuneKeyProvided) {
-                scepProfile.setIntuneApplicationKey(request.getIntuneApplicationKey());
-            }
-        } else {
-            // Intune disabled: clear the whole sub-config so no stale secret lingers or gets silently reused.
-            scepProfile.setIntuneTenant(null);
-            scepProfile.setIntuneApplicationId(null);
-            scepProfile.setIntuneApplicationKey(null);
-        }
+        applyIntuneConfig(scepProfile, request, intuneEnabled);
 
         UUID certificateAssociationUuid = null;
         ProtocolCertificateAssociations certificateAssociation = null;
@@ -308,6 +287,31 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
      *   <li>toggle {@code true} + blank value — keep the stored password, or reject when none is stored.</li>
      * </ul>
      */
+    /**
+     * Persists the Intune sub-config, shared by create and edit. When Intune is enabled the tenant and
+     * application id are set from the request and the application key is treated as a write-only secret —
+     * kept as stored when the request omits it (blank on a fresh entity means no key). When Intune is
+     * disabled the whole sub-config is cleared so no stale secret lingers or is silently reused on re-enable.
+     */
+    private void applyIntuneConfig(ScepProfile scepProfile, BaseScepProfileRequestDto request, boolean intuneEnabled) {
+        scepProfile.setIntuneEnabled(intuneEnabled);
+        if (intuneEnabled) {
+            scepProfile.setIntuneTenant(request.getIntuneTenant());
+            scepProfile.setIntuneApplicationId(request.getIntuneApplicationId());
+            if (isIntuneKeyProvided(request)) {
+                scepProfile.setIntuneApplicationKey(request.getIntuneApplicationKey());
+            }
+        } else {
+            scepProfile.setIntuneTenant(null);
+            scepProfile.setIntuneApplicationId(null);
+            scepProfile.setIntuneApplicationKey(null);
+        }
+    }
+
+    private static boolean isIntuneKeyProvided(BaseScepProfileRequestDto request) {
+        return request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isBlank();
+    }
+
     private void applyChallengePassword(ScepProfile scepProfile, BaseScepProfileRequestDto request) {
         Boolean enable = request.getEnableChallengePassword();
         boolean valueProvided = request.getChallengePassword() != null && !request.getChallengePassword().isBlank();

--- a/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
@@ -3,6 +3,7 @@ package com.otilm.core.service.impl;
 import com.otilm.api.exception.*;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.certificate.SearchFilterRequestDto;
+import com.otilm.api.model.client.scep.BaseScepProfileRequestDto;
 import com.otilm.api.model.client.scep.ScepProfileEditRequestDto;
 import com.otilm.api.model.client.scep.ScepProfileRequestDto;
 import com.otilm.api.model.common.BulkActionMessageDto;
@@ -147,7 +148,7 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
         scepProfile.setRenewalThreshold(request.getRenewalThreshold());
         scepProfile.setIncludeCaCertificateChain(request.isIncludeCaCertificateChain());
         scepProfile.setIncludeCaCertificate(request.isIncludeCaCertificate());
-        scepProfile.setChallengePassword(request.getChallengePassword());
+        applyChallengePassword(scepProfile, request);
         scepProfile.setRequireManualApproval(false);
         scepProfile.setCaCertificateUuid(UUID.fromString(request.getCaCertificateUuid()));
         scepProfile.setIntuneEnabled(intuneEnabled);
@@ -191,9 +192,8 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
 
         ScepProfile scepProfile = getScepProfileEntity(uuid);
 
-        // Secrets (Intune application key, challenge password) are write-only on edit: a blank or omitted
-        // value keeps the stored secret, mirroring OAuth2 clientSecret handling. The form does not prefill
-        // them, so requiring re-entry on every edit would 422 or silently wipe the existing value.
+        // The Intune application key is write-only: when Intune stays enabled and the request omits the key,
+        // keep the stored one (the form does not prefill it). Requiring re-entry otherwise would 422 or wipe it.
         boolean intuneKeyProvided = request.getIntuneApplicationKey() != null && !request.getIntuneApplicationKey().isEmpty();
         if (intuneEnabled && (request.getIntuneTenant() == null || request.getIntuneApplicationId() == null
                 || (!intuneKeyProvided && scepProfile.getIntuneApplicationKey() == null))) {
@@ -212,8 +212,7 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
         scepProfile.setIncludeCaCertificate(request.isIncludeCaCertificate());
         scepProfile.setIncludeCaCertificateChain(request.isIncludeCaCertificateChain());
         if (request.getRenewalThreshold() != null) scepProfile.setRenewalThreshold(request.getRenewalThreshold());
-        if (request.getChallengePassword() != null && !request.getChallengePassword().isEmpty())
-            scepProfile.setChallengePassword(request.getChallengePassword());
+        applyChallengePassword(scepProfile, request);
 
         // delete old connector data attributes content
         UUID oldConnectorUuid = scepProfile.getRaProfile() == null ? null : scepProfile.getRaProfile().getAuthorityInstanceReference().getConnectorUuid();
@@ -225,10 +224,18 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
         scepProfile.setDescription(request.getDescription());
         scepProfile.setCaCertificateUuid(UUID.fromString(request.getCaCertificateUuid()));
         scepProfile.setIntuneEnabled(intuneEnabled);
-        scepProfile.setIntuneTenant(request.getIntuneTenant());
-        scepProfile.setIntuneApplicationId(request.getIntuneApplicationId());
-        if (intuneKeyProvided) {
-            scepProfile.setIntuneApplicationKey(request.getIntuneApplicationKey());
+        if (intuneEnabled) {
+            scepProfile.setIntuneTenant(request.getIntuneTenant());
+            scepProfile.setIntuneApplicationId(request.getIntuneApplicationId());
+            // Keep the stored key when the request omits it (write-only secret, not prefilled by the form).
+            if (intuneKeyProvided) {
+                scepProfile.setIntuneApplicationKey(request.getIntuneApplicationKey());
+            }
+        } else {
+            // Intune disabled: clear the whole sub-config so no stale secret lingers or gets silently reused.
+            scepProfile.setIntuneTenant(null);
+            scepProfile.setIntuneApplicationId(null);
+            scepProfile.setIntuneApplicationKey(null);
         }
 
         UUID certificateAssociationUuid = null;
@@ -277,6 +284,40 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
         }
 
         return dto;
+    }
+
+    /**
+     * Applies the write-only challenge password according to the tri-state {@code enableChallengePassword} toggle.
+     * The toggle MUST be treated as keep-when-null: an absent toggle (legacy clients, or clients that do not send
+     * the field) must never wipe a stored password. Do NOT collapse it with {@code Boolean.TRUE.equals(...)} the way
+     * {@code enableIntune} is handled — that would turn a missing toggle into {@code false} and silently clear the
+     * stored secret.
+     *
+     * <ul>
+     *   <li>toggle {@code null} — set when a value is supplied, otherwise leave the entity untouched
+     *       (keep on edit, no password on create).</li>
+     *   <li>toggle {@code false} — clear the challenge password.</li>
+     *   <li>toggle {@code true} + non-blank value — set the new password.</li>
+     *   <li>toggle {@code true} + blank value — keep the stored password, or reject when none is stored.</li>
+     * </ul>
+     */
+    private void applyChallengePassword(ScepProfile scepProfile, BaseScepProfileRequestDto request) {
+        Boolean enable = request.getEnableChallengePassword();
+        boolean valueProvided = request.getChallengePassword() != null && !request.getChallengePassword().isEmpty();
+
+        if (enable == null) {
+            if (valueProvided) scepProfile.setChallengePassword(request.getChallengePassword());
+            return;
+        }
+        if (!enable) {
+            scepProfile.setChallengePassword(null);
+            return;
+        }
+        if (valueProvided) {
+            scepProfile.setChallengePassword(request.getChallengePassword());
+        } else if (scepProfile.getChallengePassword() == null) {
+            throw new ValidationException(ValidationError.create("Challenge password is required when challenge password protection is enabled"));
+        }
     }
 
     private static ProtocolCertificateAssociations getCertificateAssociation(ScepProfileEditRequestDto request, ScepProfile scepProfile) {

--- a/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
+++ b/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
@@ -466,6 +466,87 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
     }
 
     @Test
+    void testEditScepProfile_updatesIntuneKeyWhenProvided() throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setIntuneEnabled(true);
+        scepProfile.setIntuneTenant("tenant");
+        scepProfile.setIntuneApplicationId("appId");
+        scepProfile.setIntuneApplicationKey("originalKey");
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableIntune(true);
+        request.setIntuneTenant("tenant");
+        request.setIntuneApplicationId("appId");
+        request.setIntuneApplicationKey("newKey");
+
+        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
+
+        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertEquals("newKey", updated.getIntuneApplicationKey());
+    }
+
+    @Test
+    void testEditScepProfile_keepsChallengePasswordWhenBlankValueAndNullToggle() throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setChallengePassword("originalChallenge");
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setChallengePassword(""); // blank, not just omitted -> keep
+
+        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
+
+        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertEquals("originalChallenge", updated.getChallengePassword());
+    }
+
+    @Test
+    void testEditScepProfile_rejectsWhenIntuneEnabledAndNoKeyStored() {
+        scepProfile.setIntuneEnabled(false);
+        scepProfile.setIntuneApplicationKey(null);
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableIntune(true);
+        request.setIntuneTenant("tenant");
+        request.setIntuneApplicationId("appId");
+        // key omitted and none stored -> reject
+
+        Assertions.assertThrows(ValidationException.class,
+                () -> scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request));
+    }
+
+    @Test
+    void testEditScepProfile_intuneDisableThenReEnableWithFreshKey() throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setIntuneEnabled(true);
+        scepProfile.setIntuneTenant("tenant");
+        scepProfile.setIntuneApplicationId("appId");
+        scepProfile.setIntuneApplicationKey("originalKey");
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto disable = new ScepProfileEditRequestDto();
+        disable.setCaCertificateUuid(certificate.getUuid().toString());
+        disable.setEnableIntune(false);
+        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), disable);
+        ScepProfile cleared = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertNull(cleared.getIntuneApplicationKey());
+
+        ScepProfileEditRequestDto reEnable = new ScepProfileEditRequestDto();
+        reEnable.setCaCertificateUuid(certificate.getUuid().toString());
+        reEnable.setEnableIntune(true);
+        reEnable.setIntuneTenant("tenant2");
+        reEnable.setIntuneApplicationId("appId2");
+        reEnable.setIntuneApplicationKey("freshKey");
+        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), reEnable);
+
+        ScepProfile reEnabled = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertTrue(reEnabled.isIntuneEnabled());
+        Assertions.assertEquals("freshKey", reEnabled.getIntuneApplicationKey());
+    }
+
+    @Test
     void testEditScepProfile_validationFail() {
         ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
         Assertions.assertThrows(ValidationException.class, () -> scepProfileService.editScepProfile(SecuredUUID.fromString("abfbc322-29e1-11ed-a261-0242ac120002"), request));

--- a/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
+++ b/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
@@ -519,6 +519,41 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
     }
 
     @Test
+    void testCreateScepProfile_doesNotPersistIntuneWhenDisabled() throws ConnectorException, AlreadyExistException, AttributeException, NotFoundException {
+        ScepProfileRequestDto request = new ScepProfileRequestDto();
+        request.setName("IntuneDisabledOnCreate");
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableIntune(false);
+        request.setIntuneTenant("tenant");
+        request.setIntuneApplicationId("appId");
+        request.setIntuneApplicationKey("leakedKey");
+
+        ScepProfileDetailDto dto = scepProfileService.createScepProfile(request);
+
+        ScepProfile created = scepProfileRepository.findByUuid(UUID.fromString(dto.getUuid())).orElseThrow();
+        Assertions.assertFalse(created.isIntuneEnabled());
+        Assertions.assertNull(created.getIntuneTenant());
+        Assertions.assertNull(created.getIntuneApplicationId());
+        Assertions.assertNull(created.getIntuneApplicationKey());
+    }
+
+    @Test
+    void testEditScepProfile_clearWinsOverValueWhenToggleFalse() throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setChallengePassword("originalChallenge");
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableChallengePassword(false);
+        request.setChallengePassword("ignoredValue"); // clear wins over any value
+
+        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
+
+        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertNull(updated.getChallengePassword());
+    }
+
+    @Test
     void testEditScepProfile_intuneDisableThenReEnableWithFreshKey() throws ConnectorException, AttributeException, NotFoundException {
         scepProfile.setIntuneEnabled(true);
         scepProfile.setIntuneTenant("tenant");

--- a/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
+++ b/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
@@ -38,14 +38,19 @@ import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 class ScepProfileServiceTest extends BaseSpringBootTest {
     @Autowired
@@ -341,19 +346,36 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
         Assertions.assertEquals("originalKey", updated.getIntuneApplicationKey());
     }
 
-    @Test
-    void testEditScepProfile_updatesSecretsWhenProvided() throws ConnectorException, AttributeException, NotFoundException {
-        scepProfile.setChallengePassword("originalChallenge");
+    static Stream<Arguments> challengePasswordEditCases() {
+        return Stream.of(
+                //         stored,         toggle, requestValue,   expectedStored
+                arguments("originalPass",  null,  "newPass",       "newPass"),       // null toggle + value -> set
+                arguments("originalPass",  null,  null,            "originalPass"),  // null toggle + omitted -> keep
+                arguments("originalPass",  null,  "",              "originalPass"),  // null toggle + blank -> keep
+                arguments("originalPass",  null,  "   ",           "originalPass"),  // null toggle + whitespace -> keep
+                arguments("originalPass",  false, "ignoredValue",  null),            // false -> clear, wins over value
+                arguments(null,            true,  "newPass",       "newPass"),       // true + value, nothing stored -> set
+                arguments("originalPass",  true,  null,            "originalPass"),  // true + blank + stored -> keep
+                arguments("originalPass",  true,  "   ",           "originalPass")   // true + whitespace + stored -> keep
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("challengePasswordEditCases")
+    void testEditScepProfile_challengePasswordMatrix(String stored, Boolean toggle, String requestValue, String expectedStored)
+            throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setChallengePassword(stored);
         scepProfileRepository.save(scepProfile);
 
         ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
         request.setCaCertificateUuid(certificate.getUuid().toString());
-        request.setChallengePassword("newChallenge");
+        request.setEnableChallengePassword(toggle);
+        request.setChallengePassword(requestValue);
 
         scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
 
         ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
-        Assertions.assertEquals("newChallenge", updated.getChallengePassword());
+        Assertions.assertEquals(expectedStored, updated.getChallengePassword());
     }
 
     @Test
@@ -384,22 +406,6 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
         ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
         Assertions.assertEquals("newChallenge", updated.getChallengePassword());
         Assertions.assertTrue(dto.isEnableChallengePassword());
-    }
-
-    @Test
-    void testEditScepProfile_keepsChallengePasswordWhenToggleTrueAndBlank() throws ConnectorException, AttributeException, NotFoundException {
-        scepProfile.setChallengePassword("originalChallenge");
-        scepProfileRepository.save(scepProfile);
-
-        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
-        request.setCaCertificateUuid(certificate.getUuid().toString());
-        request.setEnableChallengePassword(true);
-        // value omitted -> keep stored
-
-        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
-
-        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
-        Assertions.assertEquals("originalChallenge", updated.getChallengePassword());
     }
 
     @Test
@@ -488,36 +494,6 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
     }
 
     @Test
-    void testEditScepProfile_keepsChallengePasswordWhenBlankValueAndNullToggle() throws ConnectorException, AttributeException, NotFoundException {
-        scepProfile.setChallengePassword("originalChallenge");
-        scepProfileRepository.save(scepProfile);
-
-        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
-        request.setCaCertificateUuid(certificate.getUuid().toString());
-        request.setChallengePassword(""); // blank, not just omitted -> keep
-
-        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
-
-        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
-        Assertions.assertEquals("originalChallenge", updated.getChallengePassword());
-    }
-
-    @Test
-    void testEditScepProfile_treatsWhitespaceChallengeAsBlankAndKeeps() throws ConnectorException, AttributeException, NotFoundException {
-        scepProfile.setChallengePassword("originalChallenge");
-        scepProfileRepository.save(scepProfile);
-
-        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
-        request.setCaCertificateUuid(certificate.getUuid().toString());
-        request.setChallengePassword("   "); // whitespace-only -> blank -> keep, not stored verbatim
-
-        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
-
-        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
-        Assertions.assertEquals("originalChallenge", updated.getChallengePassword());
-    }
-
-    @Test
     void testEditScepProfile_rejectsWhenIntuneEnabledAndNoKeyStored() {
         scepProfile.setIntuneEnabled(false);
         scepProfile.setIntuneApplicationKey(null);
@@ -533,6 +509,32 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
         SecuredUUID uuid = scepProfile.getSecuredUuid();
         Assertions.assertThrows(ValidationException.class,
                 () -> scepProfileService.editScepProfile(uuid, request));
+    }
+
+    @Test
+    void testEditScepProfile_rejectsBlankIntuneTenant() {
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableIntune(true);
+        request.setIntuneTenant("   "); // whitespace-only tenant -> reject
+        request.setIntuneApplicationId("appId");
+        request.setIntuneApplicationKey("key");
+
+        SecuredUUID uuid = scepProfile.getSecuredUuid();
+        Assertions.assertThrows(ValidationException.class,
+                () -> scepProfileService.editScepProfile(uuid, request));
+    }
+
+    @Test
+    void testCreateScepProfile_rejectsWhitespaceChallengeWhenToggleTrue() {
+        ScepProfileRequestDto request = new ScepProfileRequestDto();
+        request.setName("WhitespaceChallenge");
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableChallengePassword(true);
+        request.setChallengePassword("   "); // whitespace -> blank, nothing stored -> reject
+
+        Assertions.assertThrows(ValidationException.class,
+                () -> scepProfileService.createScepProfile(request));
     }
 
     @Test
@@ -552,22 +554,6 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
         Assertions.assertNull(created.getIntuneTenant());
         Assertions.assertNull(created.getIntuneApplicationId());
         Assertions.assertNull(created.getIntuneApplicationKey());
-    }
-
-    @Test
-    void testEditScepProfile_clearWinsOverValueWhenToggleFalse() throws ConnectorException, AttributeException, NotFoundException {
-        scepProfile.setChallengePassword("originalChallenge");
-        scepProfileRepository.save(scepProfile);
-
-        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
-        request.setCaCertificateUuid(certificate.getUuid().toString());
-        request.setEnableChallengePassword(false);
-        request.setChallengePassword("ignoredValue"); // clear wins over any value
-
-        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
-
-        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
-        Assertions.assertNull(updated.getChallengePassword());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
+++ b/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
@@ -598,6 +598,55 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
     }
 
     @Test
+    void testCreateScepProfile_withIntuneEnabledStoresConfig() throws ConnectorException, AlreadyExistException, AttributeException, NotFoundException {
+        ScepProfileRequestDto request = new ScepProfileRequestDto();
+        request.setName("IntuneEnabledCreate");
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableIntune(true);
+        request.setIntuneTenant("tenant");
+        request.setIntuneApplicationId("appId");
+        request.setIntuneApplicationKey("appKey");
+
+        ScepProfileDetailDto dto = scepProfileService.createScepProfile(request);
+
+        ScepProfile created = scepProfileRepository.findByUuid(UUID.fromString(dto.getUuid())).orElseThrow();
+        Assertions.assertTrue(created.isIntuneEnabled());
+        Assertions.assertEquals("tenant", created.getIntuneTenant());
+        Assertions.assertEquals("appId", created.getIntuneApplicationId());
+        Assertions.assertEquals("appKey", created.getIntuneApplicationKey());
+    }
+
+    @Test
+    void testCreateScepProfile_rejectsIntuneEnabledWithoutKey() {
+        ScepProfileRequestDto request = new ScepProfileRequestDto();
+        request.setName("IntuneNoKey");
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableIntune(true);
+        request.setIntuneTenant("tenant");
+        request.setIntuneApplicationId("appId");
+        // application key missing -> reject
+
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
+                () -> scepProfileService.createScepProfile(request));
+        Assertions.assertTrue(ex.getMessage().contains("Invalid Intune configuration"), ex.getMessage());
+    }
+
+    @Test
+    void testCreateScepProfile_rejectsIntuneEnabledBlankApplicationId() {
+        ScepProfileRequestDto request = new ScepProfileRequestDto();
+        request.setName("IntuneBlankAppId");
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableIntune(true);
+        request.setIntuneTenant("tenant");
+        request.setIntuneApplicationId("   "); // blank application id -> reject
+        request.setIntuneApplicationKey("appKey");
+
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
+                () -> scepProfileService.createScepProfile(request));
+        Assertions.assertTrue(ex.getMessage().contains("Invalid Intune configuration"), ex.getMessage());
+    }
+
+    @Test
     void testEditScepProfile_intuneDisableThenReEnableWithFreshKey() throws ConnectorException, AttributeException, NotFoundException {
         scepProfile.setIntuneEnabled(true);
         scepProfile.setIntuneTenant("tenant");

--- a/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
+++ b/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
@@ -419,8 +419,9 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
         // no value and nothing stored -> reject
 
         SecuredUUID uuid = scepProfile.getSecuredUuid();
-        Assertions.assertThrows(ValidationException.class,
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
                 () -> scepProfileService.editScepProfile(uuid, request));
+        Assertions.assertTrue(ex.getMessage().contains("Challenge password is required"), ex.getMessage());
     }
 
     @Test
@@ -461,6 +462,27 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
     }
 
     @Test
+    void testEditScepProfile_omittedEnableIntuneClearsStoredConfig() throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setIntuneEnabled(true);
+        scepProfile.setIntuneTenant("tenant");
+        scepProfile.setIntuneApplicationId("appId");
+        scepProfile.setIntuneApplicationKey("originalKey");
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        // enableIntune omitted entirely: PUT full-replace semantics collapse it to false -> clear sub-config
+
+        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
+
+        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertFalse(updated.isIntuneEnabled());
+        Assertions.assertNull(updated.getIntuneTenant());
+        Assertions.assertNull(updated.getIntuneApplicationId());
+        Assertions.assertNull(updated.getIntuneApplicationKey());
+    }
+
+    @Test
     void testCreateScepProfile_rejectsToggleTrueWithoutPassword() {
         ScepProfileRequestDto request = new ScepProfileRequestDto();
         request.setName("ToggleNoPassword");
@@ -468,8 +490,24 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
         request.setEnableChallengePassword(true);
         // enabled but no password supplied -> reject
 
-        Assertions.assertThrows(ValidationException.class,
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
                 () -> scepProfileService.createScepProfile(request));
+        Assertions.assertTrue(ex.getMessage().contains("Challenge password is required"), ex.getMessage());
+    }
+
+    @Test
+    void testCreateScepProfile_setsChallengePasswordWhenToggleTrue() throws ConnectorException, AlreadyExistException, AttributeException, NotFoundException {
+        ScepProfileRequestDto request = new ScepProfileRequestDto();
+        request.setName("ToggleWithPassword");
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableChallengePassword(true);
+        request.setChallengePassword("createdPass");
+
+        ScepProfileDetailDto dto = scepProfileService.createScepProfile(request);
+
+        ScepProfile created = scepProfileRepository.findByUuid(UUID.fromString(dto.getUuid())).orElseThrow();
+        Assertions.assertEquals("createdPass", created.getChallengePassword());
+        Assertions.assertTrue(dto.isEnableChallengePassword());
     }
 
     @Test
@@ -507,8 +545,9 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
         // key omitted and none stored -> reject
 
         SecuredUUID uuid = scepProfile.getSecuredUuid();
-        Assertions.assertThrows(ValidationException.class,
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
                 () -> scepProfileService.editScepProfile(uuid, request));
+        Assertions.assertTrue(ex.getMessage().contains("Invalid Intune configuration"), ex.getMessage());
     }
 
     @Test
@@ -521,8 +560,9 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
         request.setIntuneApplicationKey("key");
 
         SecuredUUID uuid = scepProfile.getSecuredUuid();
-        Assertions.assertThrows(ValidationException.class,
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
                 () -> scepProfileService.editScepProfile(uuid, request));
+        Assertions.assertTrue(ex.getMessage().contains("Invalid Intune configuration"), ex.getMessage());
     }
 
     @Test
@@ -533,8 +573,9 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
         request.setEnableChallengePassword(true);
         request.setChallengePassword("   "); // whitespace -> blank, nothing stored -> reject
 
-        Assertions.assertThrows(ValidationException.class,
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
                 () -> scepProfileService.createScepProfile(request));
+        Assertions.assertTrue(ex.getMessage().contains("Challenge password is required"), ex.getMessage());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
+++ b/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
@@ -412,8 +412,9 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
         request.setEnableChallengePassword(true);
         // no value and nothing stored -> reject
 
+        SecuredUUID uuid = scepProfile.getSecuredUuid();
         Assertions.assertThrows(ValidationException.class,
-                () -> scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request));
+                () -> scepProfileService.editScepProfile(uuid, request));
     }
 
     @Test
@@ -502,6 +503,21 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
     }
 
     @Test
+    void testEditScepProfile_treatsWhitespaceChallengeAsBlankAndKeeps() throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setChallengePassword("originalChallenge");
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setChallengePassword("   "); // whitespace-only -> blank -> keep, not stored verbatim
+
+        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
+
+        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertEquals("originalChallenge", updated.getChallengePassword());
+    }
+
+    @Test
     void testEditScepProfile_rejectsWhenIntuneEnabledAndNoKeyStored() {
         scepProfile.setIntuneEnabled(false);
         scepProfile.setIntuneApplicationKey(null);
@@ -514,8 +530,9 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
         request.setIntuneApplicationId("appId");
         // key omitted and none stored -> reject
 
+        SecuredUUID uuid = scepProfile.getSecuredUuid();
         Assertions.assertThrows(ValidationException.class,
-                () -> scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request));
+                () -> scepProfileService.editScepProfile(uuid, request));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
+++ b/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
@@ -357,6 +357,115 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
     }
 
     @Test
+    void testEditScepProfile_clearsChallengePasswordWhenToggleFalse() throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setChallengePassword("originalChallenge");
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableChallengePassword(false);
+
+        ScepProfileDetailDto dto = scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
+
+        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertNull(updated.getChallengePassword());
+        Assertions.assertFalse(dto.isEnableChallengePassword());
+    }
+
+    @Test
+    void testEditScepProfile_setsChallengePasswordWhenToggleTrueWithValue() throws ConnectorException, AttributeException, NotFoundException {
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableChallengePassword(true);
+        request.setChallengePassword("newChallenge");
+
+        ScepProfileDetailDto dto = scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
+
+        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertEquals("newChallenge", updated.getChallengePassword());
+        Assertions.assertTrue(dto.isEnableChallengePassword());
+    }
+
+    @Test
+    void testEditScepProfile_keepsChallengePasswordWhenToggleTrueAndBlank() throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setChallengePassword("originalChallenge");
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableChallengePassword(true);
+        // value omitted -> keep stored
+
+        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
+
+        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertEquals("originalChallenge", updated.getChallengePassword());
+    }
+
+    @Test
+    void testEditScepProfile_rejectsToggleTrueWhenNothingStored() {
+        scepProfile.setChallengePassword(null);
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableChallengePassword(true);
+        // no value and nothing stored -> reject
+
+        Assertions.assertThrows(ValidationException.class,
+                () -> scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request));
+    }
+
+    @Test
+    void testEditScepProfile_nullToggleOnPasswordlessProfileKeepsNullWithoutError() throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setChallengePassword(null);
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        // enableChallengePassword omitted (legacy client) -> no clear, no 400
+
+        ScepProfileDetailDto dto = scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
+
+        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertNull(updated.getChallengePassword());
+        Assertions.assertFalse(dto.isEnableChallengePassword());
+    }
+
+    @Test
+    void testEditScepProfile_disablingIntuneClearsStoredConfig() throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setIntuneEnabled(true);
+        scepProfile.setIntuneTenant("tenant");
+        scepProfile.setIntuneApplicationId("appId");
+        scepProfile.setIntuneApplicationKey("originalKey");
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableIntune(false);
+
+        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
+
+        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertFalse(updated.isIntuneEnabled());
+        Assertions.assertNull(updated.getIntuneTenant());
+        Assertions.assertNull(updated.getIntuneApplicationId());
+        Assertions.assertNull(updated.getIntuneApplicationKey());
+    }
+
+    @Test
+    void testCreateScepProfile_rejectsToggleTrueWithoutPassword() {
+        ScepProfileRequestDto request = new ScepProfileRequestDto();
+        request.setName("ToggleNoPassword");
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableChallengePassword(true);
+        // enabled but no password supplied -> reject
+
+        Assertions.assertThrows(ValidationException.class,
+                () -> scepProfileService.createScepProfile(request));
+    }
+
+    @Test
     void testEditScepProfile_validationFail() {
         ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
         Assertions.assertThrows(ValidationException.class, () -> scepProfileService.editScepProfile(SecuredUUID.fromString("abfbc322-29e1-11ed-a261-0242ac120002"), request));

--- a/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
+++ b/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
@@ -319,6 +319,44 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
     }
 
     @Test
+    void testEditScepProfile_keepsSecretsWhenOmitted() throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setChallengePassword("originalChallenge");
+        scepProfile.setIntuneEnabled(true);
+        scepProfile.setIntuneTenant("tenant");
+        scepProfile.setIntuneApplicationId("appId");
+        scepProfile.setIntuneApplicationKey("originalKey");
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setEnableIntune(true);
+        request.setIntuneTenant("tenant");
+        request.setIntuneApplicationId("appId");
+        // challengePassword and intuneApplicationKey omitted (form does not prefill secrets)
+
+        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
+
+        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertEquals("originalChallenge", updated.getChallengePassword());
+        Assertions.assertEquals("originalKey", updated.getIntuneApplicationKey());
+    }
+
+    @Test
+    void testEditScepProfile_updatesSecretsWhenProvided() throws ConnectorException, AttributeException, NotFoundException {
+        scepProfile.setChallengePassword("originalChallenge");
+        scepProfileRepository.save(scepProfile);
+
+        ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
+        request.setCaCertificateUuid(certificate.getUuid().toString());
+        request.setChallengePassword("newChallenge");
+
+        scepProfileService.editScepProfile(scepProfile.getSecuredUuid(), request);
+
+        ScepProfile updated = scepProfileRepository.findByUuid(scepProfile.getUuid()).orElseThrow();
+        Assertions.assertEquals("newChallenge", updated.getChallengePassword());
+    }
+
+    @Test
     void testEditScepProfile_validationFail() {
         ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
         Assertions.assertThrows(ValidationException.class, () -> scepProfileService.editScepProfile(SecuredUUID.fromString("abfbc322-29e1-11ed-a261-0242ac120002"), request));


### PR DESCRIPTION
## Problem

Editing a SCEP profile mishandled its write-only secrets, which the Edit form does not prefill:

- **Challenge password** — a blank request silently wiped the stored password, and a profile that had none could never gain one on edit.
- **Intune application key** — required on every edit while Intune was enabled (→ 422), and a blank value wiped the stored key.
- There was **no way to remove** an optional challenge password, and **no signal** telling the client whether one is set.

Core half of the FE fix in OmniTrustILM/fe-administrator#1253 ([review thread](https://github.com/OmniTrustILM/fe-administrator/pull/1808#discussion_r3467089035)). Tracked by #1663, part of OmniTrustILM/ilm#238.

## Fix

**Write-only secrets, keep-on-omit.** Omitting the Intune key while Intune stays enabled keeps the stored key; a non-empty value updates it.

**Challenge password — tri-state `enableChallengePassword` toggle** (shared `applyChallengePassword` helper for create + edit):

| toggle | behavior |
|---|---|
| `null` (absent) | keep stored — legacy/opt-out, never wipes |
| `true` + value | set |
| `true` + blank | keep stored, or 400 if none stored |
| `false` | clear |

Nullable-by-design so existing clients that don't send the field never wipe a password. The toggle is **not** normalized like `enableIntune` (`Boolean.TRUE.equals`) — doing so would turn an absent toggle into a wipe; an isolated helper + Javadoc guard against that regression.

**Intune disabled → clear sub-config.** When `enableIntune=false`, tenant + appId + key are nulled so no stale secret lingers or gets silently reused on re-enable. (Matches prior behavior — old code already cleared Intune config when the flag was absent.)

**Response presence flag.** `ScepProfileDto.enableChallengePassword` = `challengePassword != null`, so the FE can initialize the switch. The password value itself remains write-only and is never returned.

## Backward compatibility

The toggle is purely opt-in. Clients that omit it get exactly the keep-on-omit behavior — no wipe, no 400 on passwordless profiles. The SCEP profile admin API has no generated SDK consumer (go-sdk is connector-only), and the field is `NOT_REQUIRED`, so codegen/TS clients omit it when unset rather than sending `false`.

## Dependency

Requires **OmniTrustILM/interfaces#743** (new DTO fields, `2.18.1-SNAPSHOT`) — must merge/publish before this PR's CI gate passes.

## Tests

`ScepProfileServiceTest` — keep-on-omit, set/keep/clear via toggle, reject-when-enabled-and-nothing-stored, null-toggle on passwordless profile (no wipe, no 400), Intune-disable clears config, response flag, and create-path rejection. **33/33 pass.**

Closes #1663
Part of OmniTrustILM/ilm#238

🤖 Generated with [Claude Code](https://claude.com/claude-code)