### PR TITLE
TsaServiceAuthzTest + system-user guard tests

### DIFF
--- a/src/test/java/com/otilm/core/service/TspProfileBasicCredentialServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/TspProfileBasicCredentialServiceImplTest.java
@@ -207,6 +207,23 @@ class TspProfileBasicCredentialServiceImplTest extends BaseSpringBootTest {
                     .isInstanceOf(AttributeException.class);
             assertThat(service.list(parent)).isEmpty();
         }
+
+        @Test
+        void throwsValidationAndCreatesNoSecret_whenMappedToSystemUser() throws Exception {
+            // given — the mapped user resolves to a system user
+            UserDetailDto systemUser = new UserDetailDto();
+            systemUser.setUuid(mappedUserUuid.toString());
+            systemUser.setUsername("acme");
+            systemUser.setSystemUser(true);
+            when(userManagementService.getUser(anyString())).thenReturn(systemUser);
+
+            // when / then
+            assertThatThrownBy(() -> service.create(SecuredParentUUID.fromUUID(profileWithVault.getUuid()), createRequest("svc", "secret")))
+                    .isInstanceOf(ValidationException.class);
+
+            // then — guard runs before any vault secret is provisioned
+            verify(secretService, never()).createSecret(any(), any(), any());
+        }
     }
 
     // ── Update ────────────────────────────────────────────────────────────────
@@ -344,6 +361,26 @@ class TspProfileBasicCredentialServiceImplTest extends BaseSpringBootTest {
             // then the collision is rejected BEFORE the vault is touched, so vault and DB stay aligned
             assertThatThrownBy(() -> service.update(parent, credentialBUuid, updateRequest("svc-a", "newsecret")))
                     .isInstanceOf(AlreadyExistException.class);
+            verify(secretService, never()).updateSecret(any(), any());
+        }
+
+        @Test
+        void throwsValidation_whenRemappedToSystemUser() throws Exception {
+            // given — an existing credential mapped to a regular user
+            SecuredParentUUID parent = SecuredParentUUID.fromUUID(profileWithVault.getUuid());
+            TspBasicCredentialDto created = service.create(parent, createRequest("svc", "secret"));
+            SecuredUUID credentialUuid = SecuredUUID.fromUUID(created.getUuid());
+
+            // when the update remaps it to a system user
+            UserDetailDto systemUser = new UserDetailDto();
+            systemUser.setUuid(mappedUserUuid.toString());
+            systemUser.setUsername("acme");
+            systemUser.setSystemUser(true);
+            when(userManagementService.getUser(anyString())).thenReturn(systemUser);
+
+            // then — rejected, and no secret rotation is attempted
+            assertThatThrownBy(() -> service.update(parent, credentialUuid, updateRequest("svc", "newsecret")))
+                    .isInstanceOf(ValidationException.class);
             verify(secretService, never()).updateSecret(any(), any());
         }
     }

--- a/src/test/java/com/otilm/core/service/TspProfileBasicCredentialServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/TspProfileBasicCredentialServiceImplTest.java
@@ -218,7 +218,9 @@ class TspProfileBasicCredentialServiceImplTest extends BaseSpringBootTest {
             when(userManagementService.getUser(anyString())).thenReturn(systemUser);
 
             // when / then
-            assertThatThrownBy(() -> service.create(SecuredParentUUID.fromUUID(profileWithVault.getUuid()), createRequest("svc", "secret")))
+            SecuredParentUUID parent = SecuredParentUUID.fromUUID(profileWithVault.getUuid());
+            var request = createRequest("svc", "secret");
+            assertThatThrownBy(() -> service.create(parent, request))
                     .isInstanceOf(ValidationException.class);
 
             // then — guard runs before any vault secret is provisioned
@@ -379,7 +381,8 @@ class TspProfileBasicCredentialServiceImplTest extends BaseSpringBootTest {
             when(userManagementService.getUser(anyString())).thenReturn(systemUser);
 
             // then — rejected, and no secret rotation is attempted
-            assertThatThrownBy(() -> service.update(parent, credentialUuid, updateRequest("svc", "newsecret")))
+            var request = updateRequest("svc", "newsecret");
+            assertThatThrownBy(() -> service.update(parent, credentialUuid, request))
                     .isInstanceOf(ValidationException.class);
             verify(secretService, never()).updateSecret(any(), any());
         }

--- a/src/test/java/com/otilm/core/signing/tsa/TsaServiceAuthzTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/TsaServiceAuthzTest.java
@@ -166,7 +166,8 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
             denyTimestampForObject(tspProfileA.getUuid());
 
             // when / then
-            assertThatThrownBy(() -> tsaService.processTspRequestForTspProfile("tsp-a", aTspRequest().build()))
+            var request = aTspRequest().build();
+            assertThatThrownBy(() -> tsaService.processTspRequestForTspProfile("tsp-a", request))
                     .isInstanceOf(AccessDeniedException.class);
         }
 
@@ -248,7 +249,8 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
             denyTimestampForObject(linkedTspProfile.getUuid());
 
             // when / then
-            assertThatThrownBy(() -> tsaService.processTspRequestForSigningProfile("sp-indirect-denied", aTspRequest().build()))
+            var request = aTspRequest().build();
+            assertThatThrownBy(() -> tsaService.processTspRequestForSigningProfile("sp-indirect-denied", request))
                     .isInstanceOf(AccessDeniedException.class);
         }
 

--- a/src/test/java/com/otilm/core/signing/tsa/TsaServiceAuthzTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/TsaServiceAuthzTest.java
@@ -1,0 +1,282 @@
+package com.otilm.core.signing.tsa;
+
+import com.otilm.api.interfaces.core.tsp.error.TspException;
+import com.otilm.api.interfaces.core.tsp.error.TspFailureInfo;
+import com.otilm.api.model.client.signing.profile.scheme.ManagedSigningType;
+import com.otilm.api.model.client.signing.profile.scheme.SigningScheme;
+import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.signing.SigningProtocol;
+import com.otilm.core.model.signing.SigningCertificateBuilder;
+import com.otilm.core.dao.entity.signing.SigningProfile;
+import com.otilm.core.dao.entity.signing.SigningProfileVersion;
+import com.otilm.core.dao.entity.signing.TspProfile;
+import com.otilm.core.dao.repository.signing.SigningProfileRepository;
+import com.otilm.core.dao.repository.signing.SigningProfileVersionRepository;
+import com.otilm.core.dao.repository.signing.TspProfileRepository;
+import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.model.signing.SigningProfileModel;
+import com.otilm.core.model.signing.resolved.ResolvedManagedTimestampingProfile;
+import com.otilm.core.model.signing.resolved.ResolvedStaticKeyManagedSigning;
+import com.otilm.core.model.signing.timequality.LocalClockTimeQualityConfiguration;
+import com.otilm.core.security.authz.opa.dto.OpaRequestedResource;
+import com.otilm.core.security.authz.opa.dto.OpaResourceAccessResult;
+import com.otilm.core.signing.tsa.messages.TspResponse;
+import com.otilm.core.signing.tsa.resolver.SigningProfileResolverFactory;
+import com.otilm.core.util.BaseSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static com.otilm.core.signing.tsa.messages.TspRequestBuilder.aTspRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TsaServiceAuthzTest extends BaseSpringBootTest {
+
+    @Autowired
+    private TsaService tsaService;
+
+    @MockitoBean
+    private ManagedTimestampEngine managedTimestampEngine;
+
+    @MockitoBean
+    private SigningProfileResolverFactory signingProfileResolverFactory;
+
+    @Autowired
+    private SigningProfileRepository signingProfileRepository;
+
+    @Autowired
+    private SigningProfileVersionRepository signingProfileVersionRepository;
+
+    @Autowired
+    private TspProfileRepository tspProfileRepository;
+
+    @BeforeEach
+    void stubEngineAndResolver() throws TspException {
+        lenient().when(managedTimestampEngine.process(any(), any(), any()))
+                .thenReturn(TspResponse.granted(new byte[]{1, 2, 3}));
+
+        lenient().when(signingProfileResolverFactory.resolve(any())).thenAnswer(invocation -> {
+            SigningProfileModel<?, ?> model = invocation.getArgument(0);
+            return new ResolvedManagedTimestampingProfile(
+                    model.uuid(), model.name(), model.description(), model.version(), model.enabled(),
+                    List.of(SigningProtocol.TSP), Boolean.FALSE, "1.2.3.4.5",
+                    List.of(), List.of(), false, List.of(),
+                    LocalClockTimeQualityConfiguration.INSTANCE, null,
+                    new ResolvedStaticKeyManagedSigning(SigningCertificateBuilder.valid(), List.of(), null, List.of()));
+        });
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private SigningProfile createTimestampingSigningProfile(String name, boolean enabled) {
+        SigningProfile profile = new SigningProfile();
+        profile.setName(name);
+        profile.setWorkflowType(SigningWorkflowType.TIMESTAMPING);
+        profile.setSigningScheme(SigningScheme.MANAGED);
+        profile.setLatestVersion(1);
+        profile.setEnabled(enabled);
+        profile = signingProfileRepository.saveAndFlush(profile);
+
+        SigningProfileVersion version = new SigningProfileVersion();
+        version.setSigningProfile(profile);
+        version.setVersion(1);
+        version.setWorkflowType(SigningWorkflowType.TIMESTAMPING);
+        version.setSigningScheme(SigningScheme.MANAGED);
+        version.setManagedSigningType(ManagedSigningType.STATIC_KEY);
+        version.setAllowedDigestAlgorithms(List.of());
+        version.setAllowedPolicyIds(List.of());
+        signingProfileVersionRepository.saveAndFlush(version);
+
+        return profile;
+    }
+
+    private TspProfile createTspProfileFor(String name, boolean enabled, SigningProfile defaultSigningProfile) {
+        TspProfile profile = new TspProfile();
+        profile.setName(name);
+        profile.setEnabled(enabled);
+        profile.setDefaultSigningProfile(defaultSigningProfile);
+        return tspProfileRepository.saveAndFlush(profile);
+    }
+
+    /** Establish the signing-profile → TSP-profile back-link the indirect route authorizes against. */
+    private void linkTspProfile(SigningProfile signingProfile, TspProfile tspProfile) {
+        signingProfile.setTspProfile(tspProfile);
+        signingProfileRepository.saveAndFlush(signingProfile);
+    }
+
+    /** Deny the object-level OPA check only for the given TSP profile UUID + TIMESTAMP action. */
+    private void denyTimestampForObject(java.util.UUID forbiddenUuid) {
+        OpaResourceAccessResult denied = new OpaResourceAccessResult();
+        denied.setAuthorized(false);
+        when(opaClient.checkResourceAccess(any(), org.mockito.ArgumentMatchers.argThat(req -> isTimestampFor(req, forbiddenUuid)), any(), any()))
+                .thenReturn(denied);
+    }
+
+    private static boolean isTimestampFor(OpaRequestedResource req, java.util.UUID uuid) {
+        return req != null
+                && req.getProperties() != null
+                && Resource.TSP_PROFILE.getCode().equals(req.getProperties().get("name"))
+                && ResourceAction.TIMESTAMP.getCode().equals(req.getProperties().get("action"))
+                && req.getObjectUUIDs() != null
+                && req.getObjectUUIDs().contains(uuid.toString());
+    }
+
+    // ── ProcessTspRequestForTspProfile ────────────────────────────────────────
+
+    @Nested
+    class ProcessTspRequestForTspProfile {
+
+        @Test
+        void authorizesObjectLevel_withTspProfileUuid_andTimestampAction() throws Exception {
+            // given
+            SigningProfile signingProfile = createTimestampingSigningProfile("sp-authz", true);
+            TspProfile tspProfile = createTspProfileFor("tsp-authz", true, signingProfile);
+
+            // when
+            tsaService.processTspRequestForTspProfile("tsp-authz", aTspRequest().build());
+
+            // then
+            verify(opaClient, atLeastOnce()).checkResourceAccess(
+                    any(),
+                    org.mockito.ArgumentMatchers.argThat(req -> isTimestampFor(req, tspProfile.getUuid())),
+                    any(), any());
+            verify(managedTimestampEngine).process(any(), any(), any());
+        }
+
+        @Test
+        void deniesObjectLevel_whenNotAuthorizedForThatTspProfile() {
+            // given
+            SigningProfile signingProfileA = createTimestampingSigningProfile("sp-a", true);
+            SigningProfile signingProfileB = createTimestampingSigningProfile("sp-b", true);
+            TspProfile tspProfileA = createTspProfileFor("tsp-a", true, signingProfileA);
+            createTspProfileFor("tsp-b", true, signingProfileB);
+
+            denyTimestampForObject(tspProfileA.getUuid());
+
+            // when / then
+            assertThatThrownBy(() -> tsaService.processTspRequestForTspProfile("tsp-a", aTspRequest().build()))
+                    .isInstanceOf(AccessDeniedException.class);
+        }
+
+        @Test
+        void rejectsDisabledTspProfile_withBadRequest() {
+            // given
+            SigningProfile signingProfile = createTimestampingSigningProfile("sp-for-disabled-tsp", true);
+            createTspProfileFor("disabled-tsp", false, signingProfile);
+
+            // when / then
+            assertThatThrownBy(() -> tsaService.processTspRequestForTspProfile("disabled-tsp", aTspRequest().build()))
+                    .isInstanceOf(TspException.class)
+                    .satisfies(ex -> {
+                        assertThat(((TspException) ex).getFailureInfo()).isEqualTo(TspFailureInfo.BAD_REQUEST);
+                        assertThat(((TspException) ex).getClientMessage()).contains("disabled");
+                    });
+        }
+
+        @Test
+        void rejectsDisabledSigningProfile_withBadRequest() {
+            // given
+            SigningProfile disabledSigningProfile = createTimestampingSigningProfile("disabled-sp", false);
+            createTspProfileFor("tsp-with-disabled-sp", true, disabledSigningProfile);
+
+            // when / then
+            assertThatThrownBy(() -> tsaService.processTspRequestForTspProfile("tsp-with-disabled-sp", aTspRequest().build()))
+                    .isInstanceOf(TspException.class)
+                    .satisfies(ex -> {
+                        assertThat(((TspException) ex).getFailureInfo()).isEqualTo(TspFailureInfo.BAD_REQUEST);
+                        assertThat(((TspException) ex).getClientMessage()).contains("disabled");
+                    });
+        }
+
+        @Test
+        void succeeds_whenBothProfilesEnabled_andAuthorized() throws Exception {
+            // given
+            SigningProfile signingProfile = createTimestampingSigningProfile("sp-ok", true);
+            createTspProfileFor("tsp-ok", true, signingProfile);
+
+            // when
+            TspResponse response = tsaService.processTspRequestForTspProfile("tsp-ok", aTspRequest().build());
+
+            // then
+            assertThat(response).isInstanceOf(TspResponse.Granted.class);
+            verify(managedTimestampEngine).process(any(), any(), any());
+        }
+    }
+
+    // ── ProcessTspRequestForSigningProfile ────────────────────────────────────
+
+    @Nested
+    class ProcessTspRequestForSigningProfile {
+
+        @Test
+        void authorizesAgainstLinkedTspProfileUuid_andTimestampAction() throws Exception {
+            // given
+            SigningProfile signingProfile = createTimestampingSigningProfile("sp-indirect-authz", true);
+            TspProfile linkedTspProfile = createTspProfileFor("tsp-indirect-authz", true, signingProfile);
+            linkTspProfile(signingProfile, linkedTspProfile);
+
+            // when
+            tsaService.processTspRequestForSigningProfile("sp-indirect-authz", aTspRequest().build());
+
+            // then
+            verify(opaClient, atLeastOnce()).checkResourceAccess(
+                    any(),
+                    org.mockito.ArgumentMatchers.argThat(req -> isTimestampFor(req, linkedTspProfile.getUuid())),
+                    any(), any());
+            verify(managedTimestampEngine).process(any(), any(), any());
+        }
+
+        @Test
+        void deniesObjectLevel_whenNotAuthorizedForLinkedTspProfile() {
+            // given
+            SigningProfile signingProfile = createTimestampingSigningProfile("sp-indirect-denied", true);
+            TspProfile linkedTspProfile = createTspProfileFor("tsp-indirect-denied", true, signingProfile);
+            linkTspProfile(signingProfile, linkedTspProfile);
+
+            denyTimestampForObject(linkedTspProfile.getUuid());
+
+            // when / then
+            assertThatThrownBy(() -> tsaService.processTspRequestForSigningProfile("sp-indirect-denied", aTspRequest().build()))
+                    .isInstanceOf(AccessDeniedException.class);
+        }
+
+        @Test
+        void rejectsDisabledLinkedTspProfile_withBadRequest() {
+            // given
+            SigningProfile signingProfile = createTimestampingSigningProfile("sp-indirect-disabled-tsp", true);
+            TspProfile linkedTspProfile = createTspProfileFor("tsp-indirect-disabled", false, signingProfile);
+            linkTspProfile(signingProfile, linkedTspProfile);
+
+            // when / then
+            assertThatThrownBy(() -> tsaService.processTspRequestForSigningProfile("sp-indirect-disabled-tsp", aTspRequest().build()))
+                    .isInstanceOf(TspException.class)
+                    .satisfies(ex -> {
+                        assertThat(((TspException) ex).getFailureInfo()).isEqualTo(TspFailureInfo.BAD_REQUEST);
+                        assertThat(((TspException) ex).getClientMessage()).contains("disabled");
+                    });
+        }
+
+        @Test
+        void rejectsSigningProfileWithNoLinkedTspProfile_withBadRequest() {
+            // given
+            createTimestampingSigningProfile("sp-indirect-unlinked", true);
+
+            // when / then
+            assertThatThrownBy(() -> tsaService.processTspRequestForSigningProfile("sp-indirect-unlinked", aTspRequest().build()))
+                    .isInstanceOf(TspException.class)
+                    .satisfies(ex -> assertThat(((TspException) ex).getFailureInfo()).isEqualTo(TspFailureInfo.BAD_REQUEST));
+        }
+    }
+}

--- a/src/test/java/com/otilm/core/signing/tsa/TsaServiceAuthzTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/TsaServiceAuthzTest.java
@@ -32,11 +32,13 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
+import java.util.UUID;
 
 import static com.otilm.core.signing.tsa.messages.TspRequestBuilder.aTspRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -117,14 +119,14 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
     }
 
     /** Deny the object-level OPA check only for the given TSP profile UUID + TIMESTAMP action. */
-    private void denyTimestampForObject(java.util.UUID forbiddenUuid) {
+    private void denyTimestampForObject(UUID forbiddenUuid) {
         OpaResourceAccessResult denied = new OpaResourceAccessResult();
         denied.setAuthorized(false);
-        when(opaClient.checkResourceAccess(any(), org.mockito.ArgumentMatchers.argThat(req -> isTimestampFor(req, forbiddenUuid)), any(), any()))
+        when(opaClient.checkResourceAccess(any(), argThat(req -> isTimestampFor(req, forbiddenUuid)), any(), any()))
                 .thenReturn(denied);
     }
 
-    private static boolean isTimestampFor(OpaRequestedResource req, java.util.UUID uuid) {
+    private static boolean isTimestampFor(OpaRequestedResource req, UUID uuid) {
         return req != null
                 && req.getProperties() != null
                 && Resource.TSP_PROFILE.getCode().equals(req.getProperties().get("name"))
@@ -141,8 +143,9 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
         @Test
         void authorizesObjectLevel_withTspProfileUuid_andTimestampAction() throws Exception {
             // given
-            SigningProfile signingProfile = createTimestampingSigningProfile("sp-authz", true);
-            TspProfile tspProfile = createTspProfileFor("tsp-authz", true, signingProfile);
+            boolean enabled = true;
+            SigningProfile signingProfile = createTimestampingSigningProfile("sp-authz", enabled);
+            TspProfile tspProfile = createTspProfileFor("tsp-authz", enabled, signingProfile);
 
             // when
             tsaService.processTspRequestForTspProfile("tsp-authz", aTspRequest().build());
@@ -150,7 +153,7 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
             // then
             verify(opaClient, atLeastOnce()).checkResourceAccess(
                     any(),
-                    org.mockito.ArgumentMatchers.argThat(req -> isTimestampFor(req, tspProfile.getUuid())),
+                    argThat(req -> isTimestampFor(req, tspProfile.getUuid())),
                     any(), any());
             verify(managedTimestampEngine).process(any(), any(), any());
         }
@@ -158,10 +161,11 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
         @Test
         void deniesObjectLevel_whenNotAuthorizedForThatTspProfile() {
             // given
-            SigningProfile signingProfileA = createTimestampingSigningProfile("sp-a", true);
-            SigningProfile signingProfileB = createTimestampingSigningProfile("sp-b", true);
-            TspProfile tspProfileA = createTspProfileFor("tsp-a", true, signingProfileA);
-            createTspProfileFor("tsp-b", true, signingProfileB);
+            boolean enabled = true;
+            SigningProfile signingProfileA = createTimestampingSigningProfile("sp-a", enabled);
+            SigningProfile signingProfileB = createTimestampingSigningProfile("sp-b", enabled);
+            TspProfile tspProfileA = createTspProfileFor("tsp-a", enabled, signingProfileA);
+            createTspProfileFor("tsp-b", enabled, signingProfileB);
 
             denyTimestampForObject(tspProfileA.getUuid());
 
@@ -174,8 +178,10 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
         @Test
         void rejectsDisabledTspProfile_withBadRequest() {
             // given
-            SigningProfile signingProfile = createTimestampingSigningProfile("sp-for-disabled-tsp", true);
-            createTspProfileFor("disabled-tsp", false, signingProfile);
+            boolean enabled = true;
+            boolean disabled = false;
+            SigningProfile signingProfile = createTimestampingSigningProfile("sp-for-disabled-tsp", enabled);
+            createTspProfileFor("disabled-tsp", disabled, signingProfile);
 
             // when / then
             assertThatThrownBy(() -> tsaService.processTspRequestForTspProfile("disabled-tsp", aTspRequest().build()))
@@ -189,8 +195,10 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
         @Test
         void rejectsDisabledSigningProfile_withBadRequest() {
             // given
-            SigningProfile disabledSigningProfile = createTimestampingSigningProfile("disabled-sp", false);
-            createTspProfileFor("tsp-with-disabled-sp", true, disabledSigningProfile);
+            boolean enabled = true;
+            boolean disabled = false;
+            SigningProfile disabledSigningProfile = createTimestampingSigningProfile("disabled-sp", disabled);
+            createTspProfileFor("tsp-with-disabled-sp", enabled, disabledSigningProfile);
 
             // when / then
             assertThatThrownBy(() -> tsaService.processTspRequestForTspProfile("tsp-with-disabled-sp", aTspRequest().build()))
@@ -204,8 +212,9 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
         @Test
         void succeeds_whenBothProfilesEnabled_andAuthorized() throws Exception {
             // given
-            SigningProfile signingProfile = createTimestampingSigningProfile("sp-ok", true);
-            createTspProfileFor("tsp-ok", true, signingProfile);
+            boolean enabled = true;
+            SigningProfile signingProfile = createTimestampingSigningProfile("sp-ok", enabled);
+            createTspProfileFor("tsp-ok", enabled, signingProfile);
 
             // when
             TspResponse response = tsaService.processTspRequestForTspProfile("tsp-ok", aTspRequest().build());
@@ -224,8 +233,9 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
         @Test
         void authorizesAgainstLinkedTspProfileUuid_andTimestampAction() throws Exception {
             // given
-            SigningProfile signingProfile = createTimestampingSigningProfile("sp-indirect-authz", true);
-            TspProfile linkedTspProfile = createTspProfileFor("tsp-indirect-authz", true, signingProfile);
+            boolean enabled = true;
+            SigningProfile signingProfile = createTimestampingSigningProfile("sp-indirect-authz", enabled);
+            TspProfile linkedTspProfile = createTspProfileFor("tsp-indirect-authz", enabled, signingProfile);
             linkTspProfile(signingProfile, linkedTspProfile);
 
             // when
@@ -234,7 +244,7 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
             // then
             verify(opaClient, atLeastOnce()).checkResourceAccess(
                     any(),
-                    org.mockito.ArgumentMatchers.argThat(req -> isTimestampFor(req, linkedTspProfile.getUuid())),
+                    argThat(req -> isTimestampFor(req, linkedTspProfile.getUuid())),
                     any(), any());
             verify(managedTimestampEngine).process(any(), any(), any());
         }
@@ -242,8 +252,9 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
         @Test
         void deniesObjectLevel_whenNotAuthorizedForLinkedTspProfile() {
             // given
-            SigningProfile signingProfile = createTimestampingSigningProfile("sp-indirect-denied", true);
-            TspProfile linkedTspProfile = createTspProfileFor("tsp-indirect-denied", true, signingProfile);
+            boolean enabled = true;
+            SigningProfile signingProfile = createTimestampingSigningProfile("sp-indirect-denied", enabled);
+            TspProfile linkedTspProfile = createTspProfileFor("tsp-indirect-denied", enabled, signingProfile);
             linkTspProfile(signingProfile, linkedTspProfile);
 
             denyTimestampForObject(linkedTspProfile.getUuid());
@@ -257,8 +268,10 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
         @Test
         void rejectsDisabledLinkedTspProfile_withBadRequest() {
             // given
-            SigningProfile signingProfile = createTimestampingSigningProfile("sp-indirect-disabled-tsp", true);
-            TspProfile linkedTspProfile = createTspProfileFor("tsp-indirect-disabled", false, signingProfile);
+            boolean enabled = true;
+            boolean disabled = false;
+            SigningProfile signingProfile = createTimestampingSigningProfile("sp-indirect-disabled-tsp", enabled);
+            TspProfile linkedTspProfile = createTspProfileFor("tsp-indirect-disabled", disabled, signingProfile);
             linkTspProfile(signingProfile, linkedTspProfile);
 
             // when / then
@@ -273,7 +286,8 @@ class TsaServiceAuthzTest extends BaseSpringBootTest {
         @Test
         void rejectsSigningProfileWithNoLinkedTspProfile_withBadRequest() {
             // given
-            createTimestampingSigningProfile("sp-indirect-unlinked", true);
+            boolean enabled = true;
+            createTimestampingSigningProfile("sp-indirect-unlinked", enabled);
 
             // when / then
             assertThatThrownBy(() -> tsaService.processTspRequestForSigningProfile("sp-indirect-unlinked", aTspRequest().build()))


### PR DESCRIPTION
Test-only backport of coverage that exists on `feat/signing` but is missing on `main`, even though the production code it exercises already lives on `main`.

## What's ported
- **`TsaServiceAuthzTest`** (new) — integration test asserting **object-level OPA authorization scoping** for TSP timestamping: verifies `opaClient.checkResourceAccess` is queried with the correct TSP-profile `UUID` and `TIMESTAMP` action for both the direct (`processTspRequestForTspProfile`) and indirect (`processTspRequestForSigningProfile`, via the linked TSP profile) routes, plus denial (`AccessDeniedException`) and disabled-profile rejection (`TspException`/`BAD_REQUEST`). `main`'s existing `TsaServiceImplUnitTest` only stubs a denial and never verifies *which* object/action OPA was asked about; `TsaServiceImplTest` doesn't touch OPA. Production `TsaServiceImpl` is identical on both branches.
- **`TspProfileBasicCredentialServiceImplTest`** — two tests for the system-user guard (present but untested on `main`): reject credential **create** and **update** mapped to a system user, with no secret provisioned/rotated.

## Excluded (already covered on `main`)
- `evictBySecretUuid` delete-path assertions → `TspProfileBasicCredentialServiceImplEvictionTest`
- `resolveForAuthentication` direct test → covered by `TspRouteResolverTest` / `TspAuthenticationFilterTest`

## Verification
- `TsaServiceAuthzTest`: 9/9 pass
- `TspProfileBasicCredentialServiceImplTest`: 16/16 pass (incl. the 2 new), 0 failures / 0 errors
- No production-code changes.

Refs #1665

🤖 Generated with [Claude Code](https://claude.com/claude-code)