### PR TITLE
Split InternalService and ExternalService - part 12

### DIFF
--- a/src/main/java/com/otilm/core/api/web/DiscoveryControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/DiscoveryControllerImpl.java
@@ -18,7 +18,7 @@ import com.otilm.core.aop.AuditLogged;
 import com.otilm.core.logging.LogResource;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.DiscoveryService;
+import com.otilm.core.service.DiscoveryExternalService;
 import com.otilm.core.service.SchedulerExternalService;
 import com.otilm.core.tasks.DiscoveryCertificateTask;
 import org.slf4j.Logger;
@@ -39,7 +39,7 @@ public class DiscoveryControllerImpl implements DiscoveryController {
 
     private final Logger logger = LoggerFactory.getLogger(DiscoveryControllerImpl.class);
 
-    private DiscoveryService discoveryService;
+    private DiscoveryExternalService discoveryService;
 
     private SchedulerExternalService schedulerService;
 
@@ -49,7 +49,7 @@ public class DiscoveryControllerImpl implements DiscoveryController {
     }
 
     @Autowired
-    public void setDiscoveryService(DiscoveryService discoveryService) {
+    public void setDiscoveryService(DiscoveryExternalService discoveryService) {
         this.discoveryService = discoveryService;
     }
 

--- a/src/main/java/com/otilm/core/api/web/LocationManagementControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/LocationManagementControllerImpl.java
@@ -21,7 +21,7 @@ import com.otilm.core.logging.LogResource;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.LocationService;
+import com.otilm.core.service.LocationExternalService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,10 +33,10 @@ import java.util.List;
 @RestController
 public class LocationManagementControllerImpl implements LocationManagementController {
 
-    private LocationService locationService;
+    private LocationExternalService locationService;
 
     @Autowired
-    public void setLocationService(LocationService locationService) {
+    public void setLocationService(LocationExternalService locationService) {
         this.locationService = locationService;
     }
 

--- a/src/main/java/com/otilm/core/service/DiscoveryExternalService.java
+++ b/src/main/java/com/otilm/core/service/DiscoveryExternalService.java
@@ -9,12 +9,11 @@ import com.otilm.api.model.client.discovery.DiscoveryHistoryDetailDto;
 import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.tasks.ScheduledJobInfo;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface DiscoveryService extends ResourceExtensionService {
+public interface DiscoveryExternalService {
 
     DiscoveryResponseDto listDiscoveries(final SecurityFilter filter, final SearchRequestDto searchRequestDto);
 
@@ -33,20 +32,12 @@ public interface DiscoveryService extends ResourceExtensionService {
     DiscoveryCertificateResponseDto getDiscoveryCertificates(SecuredUUID uuid, Boolean newlyDiscovered, int itemsPerPage, int pageNumber) throws NotFoundException;
 
     DiscoveryHistoryDetailDto createDiscovery(DiscoveryDto request, boolean saveEntity) throws AlreadyExistException, ConnectorException, AttributeException, NotFoundException;
-    DiscoveryHistoryDetailDto runDiscovery(UUID discoveryUuid, ScheduledJobInfo scheduledJobInfo);
+
     void runDiscoveryAsync(UUID discoveryUuid);
 
     void deleteDiscovery(SecuredUUID uuid) throws NotFoundException;
 
     void bulkRemoveDiscovery(List<SecuredUUID> discoveryUuids) throws NotFoundException;
 
-    /**
-     * Get the number of discoveries per user for dashboard
-     *
-     * @return Number of discoveries
-     */
-    Long statisticsDiscoveryCount(SecurityFilter filter);
-
     List<SearchFieldDataByGroupDto> getSearchableFieldInformationByGroup();
-
 }

--- a/src/main/java/com/otilm/core/service/DiscoveryInternalService.java
+++ b/src/main/java/com/otilm/core/service/DiscoveryInternalService.java
@@ -1,0 +1,19 @@
+package com.otilm.core.service;
+
+import com.otilm.api.model.client.discovery.DiscoveryHistoryDetailDto;
+import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.tasks.ScheduledJobInfo;
+
+import java.util.UUID;
+
+public interface DiscoveryInternalService extends ResourceExtensionService {
+
+    DiscoveryHistoryDetailDto runDiscovery(UUID discoveryUuid, ScheduledJobInfo scheduledJobInfo);
+
+    /**
+     * Get the number of discoveries per user for dashboard
+     *
+     * @return Number of discoveries
+     */
+    Long statisticsDiscoveryCount(SecurityFilter filter);
+}

--- a/src/main/java/com/otilm/core/service/LocationExternalService.java
+++ b/src/main/java/com/otilm/core/service/LocationExternalService.java
@@ -10,14 +10,13 @@ import com.otilm.api.model.client.location.PushToLocationRequestDto;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.core.location.LocationDto;
 import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
-import com.otilm.core.dao.entity.CertificateLocationId;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 
 import java.util.List;
 
-public interface LocationService extends ResourceExtensionService {
+public interface LocationExternalService {
 
     /**
      * List all locations based on the status.
@@ -119,26 +118,6 @@ public interface LocationService extends ResourceExtensionService {
     LocationDto removeCertificateFromLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid, String certificateUuid) throws NotFoundException, LocationException;
 
     /**
-     * Removes existing Certificate from all associated Locations when the certificates are going to be deleted.
-     *
-     * <p>
-     * <b>WARNING:</b> Call this method only when the associated certificate is going to be deleted.
-     * Do not call this method from any other context!
-     * </p>
-     *
-     * @param certificateUuids UUIDs of existing Certificates to be removed from locations managed by a connector
-     */
-    void removeCertificatesFromLocationsOnDelete(List<SecuredUUID> certificateUuids);
-
-    /**
-     * Remove rejected new Certificate from location as result of async issue approval reject process.
-     *
-     * @param certificateLocationId    ID of CertificateLocation entity
-     * @throws NotFoundException when the CertificateLocation with the given Id is not found.
-     */
-    void removeRejectedOrFailedCertificateFromLocationAction(CertificateLocationId certificateLocationId) throws ConnectorException, NotFoundException;
-
-    /**
      * Push existing Certificate to the given Location.
      *
      * @param entityUuid               UUID of entity
@@ -150,16 +129,6 @@ public interface LocationService extends ResourceExtensionService {
      * @throws LocationException when the Certificate failed to be pushed to the Location.
      */
     LocationDto pushCertificateToLocation(SecuredParentUUID entityUuid, SecuredUUID locationUuid, String certificateUuid, PushToLocationRequestDto pushToLocationRequestDto) throws NotFoundException, LocationException, AttributeException;
-
-    /**
-     * Push existing requested Certificate to the given Location as result of async issue process.
-     *
-     * @param certificateLocationId    ID of CertificateLocation entity
-     * @param isRenewal       indication if certificate to be pushed was renewed
-     * @throws NotFoundException when the CertificateLocation with the given Id is not found.
-     * @throws LocationException when the Certificate failed to be pushed to the Location.
-     */
-    void pushRequestedCertificateToLocationAction(CertificateLocationId certificateLocationId, boolean isRenewal) throws NotFoundException, LocationException, AttributeException;
 
     /**
      * Issue new Certificate to the given Location.

--- a/src/main/java/com/otilm/core/service/LocationInternalService.java
+++ b/src/main/java/com/otilm/core/service/LocationInternalService.java
@@ -1,0 +1,40 @@
+package com.otilm.core.service;
+
+import com.otilm.api.exception.*;
+import com.otilm.core.dao.entity.CertificateLocationId;
+import com.otilm.core.security.authz.SecuredUUID;
+
+import java.util.List;
+
+public interface LocationInternalService extends ResourceExtensionService {
+
+    /**
+     * Removes existing Certificate from all associated Locations when the certificates are going to be deleted.
+     *
+     * <p>
+     * <b>WARNING:</b> Call this method only when the associated certificate is going to be deleted.
+     * Do not call this method from any other context!
+     * </p>
+     *
+     * @param certificateUuids UUIDs of existing Certificates to be removed from locations managed by a connector
+     */
+    void removeCertificatesFromLocationsOnDelete(List<SecuredUUID> certificateUuids);
+
+    /**
+     * Remove rejected new Certificate from location as result of async issue approval reject process.
+     *
+     * @param certificateLocationId    ID of CertificateLocation entity
+     * @throws NotFoundException when the CertificateLocation with the given Id is not found.
+     */
+    void removeRejectedOrFailedCertificateFromLocationAction(CertificateLocationId certificateLocationId) throws ConnectorException, NotFoundException;
+
+    /**
+     * Push existing requested Certificate to the given Location as result of async issue process.
+     *
+     * @param certificateLocationId    ID of CertificateLocation entity
+     * @param isRenewal       indication if certificate to be pushed was renewed
+     * @throws NotFoundException when the CertificateLocation with the given Id is not found.
+     * @throws LocationException when the Certificate failed to be pushed to the Location.
+     */
+    void pushRequestedCertificateToLocationAction(CertificateLocationId certificateLocationId, boolean isRenewal) throws NotFoundException, LocationException, AttributeException;
+}

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -158,7 +158,8 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
     private ComplianceInternalService complianceService;
     private ComplianceExternalService complianceExternalService;
     private CertificateEventHistoryInternalService certificateEventHistoryService;
-    private LocationService locationService;
+    private LocationExternalService locationService;
+    private LocationInternalService locationInternalService;
     private CryptographicKeyService cryptographicKeyService;
     private PermissionEvaluator permissionEvaluator;
     private EventProducer eventProducer;
@@ -237,8 +238,14 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
 
     @Lazy
     @Autowired
-    public void setLocationService(LocationService locationService) {
+    public void setLocationService(LocationExternalService locationService) {
         this.locationService = locationService;
+    }
+
+    @Lazy
+    @Autowired
+    public void setLocationInternalService(LocationInternalService locationInternalService) {
+        this.locationInternalService = locationInternalService;
     }
 
     @Autowired
@@ -537,7 +544,7 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
             throw new ValidationException("Could not delete certificate %s with UUID %s: Certificate is used by some user.".formatted(certificate.getCommonName(), certificate.getUuid().toString()));
         }
 
-        locationService.removeCertificatesFromLocationsOnDelete(List.of(uuid));
+        locationInternalService.removeCertificatesFromLocationsOnDelete(List.of(uuid));
 
         // If there is some CRL for this certificate, clear its CA certificate UUID.
         crlService.clearCrlsForCaCertificate(List.of(uuid.getValue()));
@@ -746,7 +753,7 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
         List<Certificate> certificates = certificateRepository.findAllWithAssociationsByUuidIn(permittedUuids);
 
         // 3. Do the work.
-        locationService.removeCertificatesFromLocationsOnDelete(permittedSecuredUuids);
+        locationInternalService.removeCertificatesFromLocationsOnDelete(permittedSecuredUuids);
 
         scepProfileRepository.clearCaCertificateReferenceIn(permittedUuids);
         cmpProfileRepository.clearSigningCertificateReferenceIn(permittedUuids);

--- a/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/DiscoveryServiceImpl.java
@@ -48,6 +48,7 @@ import com.otilm.core.messaging.model.NotificationRecipient;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.model.discovery.DiscoveryContext;
 import com.otilm.core.security.authz.ExternalAuthorization;
+import com.otilm.core.security.authz.ExternalAuthorizationMissing;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.*;
@@ -79,7 +80,7 @@ import java.util.concurrent.*;
 
 @Service(Resource.Codes.DISCOVERY)
 @Transactional
-public class DiscoveryServiceImpl implements DiscoveryService {
+public class DiscoveryServiceImpl implements DiscoveryExternalService, DiscoveryInternalService {
 
     private static final Logger logger = LoggerFactory.getLogger(DiscoveryServiceImpl.class);
 
@@ -740,6 +741,7 @@ public class DiscoveryServiceImpl implements DiscoveryService {
     }
 
     @Override
+    @ExternalAuthorizationMissing
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformationByGroup() {
         final List<SearchFieldDataByGroupDto> searchFieldDataByGroupDtos = attributeEngine.getResourceSearchableFields(Resource.DISCOVERY, false);
 

--- a/src/main/java/com/otilm/core/service/impl/LocationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/LocationServiceImpl.java
@@ -39,12 +39,14 @@ import com.otilm.core.enums.FilterField;
 import com.otilm.core.events.transaction.CertificateValidationEvent;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.ExternalAuthorization;
+import com.otilm.core.security.authz.ExternalAuthorizationMissing;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CertificateEventHistoryInternalService;
 import com.otilm.core.service.CertificateService;
-import com.otilm.core.service.LocationService;
+import com.otilm.core.service.LocationExternalService;
+import com.otilm.core.service.LocationInternalService;
 import com.otilm.core.service.PermissionEvaluator;
 import com.otilm.core.service.v2.ClientOperationService;
 import com.otilm.core.service.v2.ConnectorService;
@@ -74,7 +76,7 @@ import java.util.*;
 
 @Service(Resource.Codes.LOCATION)
 @Transactional
-public class LocationServiceImpl implements LocationService {
+public class LocationServiceImpl implements LocationExternalService, LocationInternalService {
 
     private static final Logger logger = LoggerFactory.getLogger(LocationServiceImpl.class);
 
@@ -1133,6 +1135,7 @@ public class LocationServiceImpl implements LocationService {
     }
 
     @Override
+    @ExternalAuthorizationMissing
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformationByGroup() {
         final List<SearchFieldDataByGroupDto> searchFieldDataByGroupDtos = attributeEngine.getResourceSearchableFields(Resource.LOCATION, false);
 

--- a/src/main/java/com/otilm/core/service/impl/StatisticsServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/StatisticsServiceImpl.java
@@ -4,7 +4,7 @@ import com.otilm.api.model.client.dashboard.StatisticsDto;
 import com.otilm.core.security.authz.AnyPrincipalEndpoint;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CertificateService;
-import com.otilm.core.service.DiscoveryService;
+import com.otilm.core.service.DiscoveryInternalService;
 import com.otilm.core.service.GroupInternalService;
 import com.otilm.core.service.RaProfileService;
 import com.otilm.core.service.SecretInternalService;
@@ -26,7 +26,7 @@ public class StatisticsServiceImpl implements StatisticsExternalService {
     private static final Logger logger = LoggerFactory.getLogger(StatisticsServiceImpl.class);
 
     private CertificateService certificateService;
-    private DiscoveryService discoveryService;
+    private DiscoveryInternalService discoveryService;
     private GroupInternalService groupService;
     private RaProfileService raProfileService;
     private SecretInternalService secretService;
@@ -85,7 +85,7 @@ public class StatisticsServiceImpl implements StatisticsExternalService {
     }
 
     @Autowired
-    public void setDiscoveryService(DiscoveryService discoveryService) {
+    public void setDiscoveryService(DiscoveryInternalService discoveryService) {
         this.discoveryService = discoveryService;
     }
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -104,7 +104,8 @@ public class ClientOperationServiceImpl implements ClientOperationService {
 
     private RaProfileRepository raProfileRepository;
     private CertificateRepository certificateRepository;
-    private LocationService locationService;
+    private LocationExternalService locationService;
+    private LocationInternalService locationInternalService;
     private CertificateService certificateService;
     private ComplianceInternalService complianceService;
     private CertificateEventHistoryInternalService certificateEventHistoryService;
@@ -151,8 +152,14 @@ public class ClientOperationServiceImpl implements ClientOperationService {
 
     @Lazy
     @Autowired
-    public void setLocationService(LocationService locationService) {
+    public void setLocationService(LocationExternalService locationService) {
         this.locationService = locationService;
+    }
+
+    @Lazy
+    @Autowired
+    public void setLocationInternalService(LocationInternalService locationInternalService) {
+        this.locationInternalService = locationInternalService;
     }
 
     @Autowired
@@ -361,7 +368,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
         // push certificate to locations
         for (CertificateLocation cl : certificate.getLocations()) {
             try {
-                locationService.pushRequestedCertificateToLocationAction(cl.getId(), false);
+                locationInternalService.pushRequestedCertificateToLocationAction(cl.getId(), false);
             } catch (Exception e) {
                 logger.error("Failed to push issued certificate to location: {}", e.getMessage());
             }
@@ -488,7 +495,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
     private void handleFailedOrRejectedEvent(Certificate certificate, UUID oldCertificateUuid, CertificateState state, CertificateEvent event, Map<String, Object> additionalInformation, String message) {
         for (CertificateLocation location : certificate.getLocations()) {
             try {
-                locationService.removeRejectedOrFailedCertificateFromLocationAction(location.getId());
+                locationInternalService.removeRejectedOrFailedCertificateFromLocationAction(location.getId());
             } catch (ConnectorException | NotFoundException ex) {
                 logger.error("Failed to remove certificate with UUID {} from location with UUID {}: {}", certificate.getUuid(), location.getId().getLocationUuid(), message);
             }
@@ -688,7 +695,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
             // push certificate to locations
             for (CertificateLocation cl : certificate.getLocations()) {
                 try {
-                    locationService.pushRequestedCertificateToLocationAction(cl.getId(), true);
+                    locationInternalService.pushRequestedCertificateToLocationAction(cl.getId(), true);
                 } catch (Exception e) {
                     logger.error("Failed to push renewed certificate to location: {}", e.getMessage());
                 }
@@ -1510,7 +1517,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
     private void pushFinalizedCertificateToAllLocations(Certificate certificate) {
         for (CertificateLocation cl : certificate.getLocations()) {
             try {
-                locationService.pushRequestedCertificateToLocationAction(cl.getId(), false);
+                locationInternalService.pushRequestedCertificateToLocationAction(cl.getId(), false);
             } catch (Exception e) {
                 logger.error("Failed to push manually-finalized certificate {} to location {}: {}",
                         certificate.getUuid(), cl.getId().getLocationUuid(), e.getMessage(), e);

--- a/src/main/java/com/otilm/core/tasks/DiscoveryCertificateTask.java
+++ b/src/main/java/com/otilm/core/tasks/DiscoveryCertificateTask.java
@@ -6,7 +6,8 @@ import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.discovery.DiscoveryStatus;
 import com.otilm.api.model.scheduler.SchedulerJobExecutionStatus;
 import com.otilm.core.model.ScheduledTaskResult;
-import com.otilm.core.service.DiscoveryService;
+import com.otilm.core.service.DiscoveryExternalService;
+import com.otilm.core.service.DiscoveryInternalService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NoArgsConstructor;
 import org.slf4j.Logger;
@@ -30,7 +31,9 @@ public class DiscoveryCertificateTask implements ScheduledJobTask {
 
     private static final Logger logger = LoggerFactory.getLogger(DiscoveryCertificateTask.class);
 
-    private DiscoveryService discoveryService;
+    private DiscoveryExternalService discoveryService;
+
+    private DiscoveryInternalService discoveryInternalService;
 
     private final ObjectMapper mapper = new ObjectMapper();
 
@@ -44,8 +47,13 @@ public class DiscoveryCertificateTask implements ScheduledJobTask {
     }
 
     @Autowired
-    public void setDiscoveryService(DiscoveryService discoveryService) {
+    public void setDiscoveryService(DiscoveryExternalService discoveryService) {
         this.discoveryService = discoveryService;
+    }
+
+    @Autowired
+    public void setDiscoveryInternalService(DiscoveryInternalService discoveryInternalService) {
+        this.discoveryInternalService = discoveryInternalService;
     }
 
     public String getDefaultJobName() {
@@ -88,7 +96,7 @@ public class DiscoveryCertificateTask implements ScheduledJobTask {
         }
 
         // After the discovery is created and commited, run discovery
-        discovery = discoveryService.runDiscovery(UUID.fromString(discovery.getUuid()), scheduledJobInfo);
+        discovery = discoveryInternalService.runDiscovery(UUID.fromString(discovery.getUuid()), scheduledJobInfo);
         if (discovery.getStatus() != DiscoveryStatus.PROCESSING) {
             return new ScheduledTaskResult(discovery.getStatus() == DiscoveryStatus.FAILED ? SchedulerJobExecutionStatus.FAILED : SchedulerJobExecutionStatus.SUCCESS, discovery.getMessage(), Resource.DISCOVERY, discovery.getUuid());
         }

--- a/src/test/java/com/otilm/core/search/DiscoveryHistorySearchTest.java
+++ b/src/test/java/com/otilm/core/search/DiscoveryHistorySearchTest.java
@@ -34,7 +34,7 @@ import com.otilm.core.dao.repository.DiscoveryRepository;
 import com.otilm.core.dao.repository.FunctionGroupRepository;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.DiscoveryService;
+import com.otilm.core.service.DiscoveryExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.MetaDefinitions;
 import org.junit.jupiter.api.Assertions;
@@ -66,7 +66,7 @@ class DiscoveryHistorySearchTest extends BaseSpringBootTest {
     @Autowired
     private Connector2FunctionGroupRepository connector2FunctionGroupRepository;
     @Autowired
-    private DiscoveryService discoveryService;
+    private DiscoveryExternalService discoveryService;
     private AttributeEngine attributeEngine;
 
     @Autowired

--- a/src/test/java/com/otilm/core/search/LocationsSearchTest.java
+++ b/src/test/java/com/otilm/core/search/LocationsSearchTest.java
@@ -28,7 +28,7 @@ import com.otilm.core.dao.repository.EntityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.LocationRepository;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.LocationService;
+import com.otilm.core.service.LocationExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,7 +55,7 @@ class LocationsSearchTest extends BaseSpringBootTest {
     @Autowired
     private LocationRepository locationRepository;
     @Autowired
-    private LocationService locationService;
+    private LocationExternalService locationService;
 
     private EntityInstanceReference entityInstanceReference;
 

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -59,7 +59,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -983,7 +982,6 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
     }
 
     @Test
-    @Transactional
     void testIssueCertificateRejectedAction_removesCertificateFromAssociatedLocations() throws NotFoundException {
         // given: a rejected certificate that is associated with a location on a connected entity
         EntityInstanceReference entityInstanceReference = new EntityInstanceReference();
@@ -992,6 +990,7 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
         entityInstanceReference = entityInstanceReferenceRepository.save(entityInstanceReference);
 
         Location location = new Location();
+        location.setUuid(UUID.randomUUID());
         location.setName("rejected-cert-location");
         location.setEnabled(true);
         location.setEntityInstanceReference(entityInstanceReference);
@@ -1001,8 +1000,7 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
         certificateLocation.setCertificate(certificate);
         certificateLocation.setLocation(location);
         location.getCertificates().add(certificateLocation);
-        certificate.getLocations().add(certificateLocation);
-        locationRepository.saveAndFlush(location);
+        locationRepository.save(location);
 
         mockServer.stubFor(WireMock
                 .post(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/remove"))

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -59,6 +59,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -111,6 +112,12 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
 
     @MockitoBean
     private CryptographicOperationExternalService cryptographicOperationExternalService;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private EntityInstanceReferenceRepository entityInstanceReferenceRepository;
 
     @Autowired
     private RaProfileRepository raProfileRepository;
@@ -973,6 +980,45 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
 
 
 
+    }
+
+    @Test
+    @Transactional
+    void testIssueCertificateRejectedAction_removesCertificateFromAssociatedLocations() throws NotFoundException {
+        // given: a rejected certificate that is associated with a location on a connected entity
+        EntityInstanceReference entityInstanceReference = new EntityInstanceReference();
+        entityInstanceReference.setEntityInstanceUuid("e1e2e3e4-0000-0000-0000-000000000001");
+        entityInstanceReference.setConnector(connector);
+        entityInstanceReference = entityInstanceReferenceRepository.save(entityInstanceReference);
+
+        Location location = new Location();
+        location.setName("rejected-cert-location");
+        location.setEnabled(true);
+        location.setEntityInstanceReference(entityInstanceReference);
+        location.setEntityInstanceReferenceUuid(entityInstanceReference.getUuid());
+
+        CertificateLocation certificateLocation = new CertificateLocation();
+        certificateLocation.setCertificate(certificate);
+        certificateLocation.setLocation(location);
+        location.getCertificates().add(certificateLocation);
+        certificate.getLocations().add(certificateLocation);
+        locationRepository.saveAndFlush(location);
+
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/remove"))
+                .willReturn(WireMock.okJson("{}")));
+
+        UUID certificateUuid = certificate.getUuid();
+
+        // when
+        clientOperationService.issueCertificateRejectedAction(certificateUuid);
+
+        // then: every location the certificate sat on is told to drop it via its entity-provider connector
+        mockServer.verify(WireMock.moreThanOrExactly(1),
+                WireMock.postRequestedFor(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/remove")));
+
+        certificate = certificateRepository.findByUuid(certificateUuid).orElseThrow();
+        Assertions.assertEquals(CertificateState.REJECTED, certificate.getState());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -1962,6 +1962,60 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
     }
 
     @Test
+    void manuallyIssueCertificate_pushesToAssociatedLocations() throws Exception {
+        KeyPair kp = setupRequestedCertWithRealCsr();
+
+        // connector accepts asynchronously, so the certificate parks in PENDING_ISSUE
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue"))
+                .willReturn(WireMock.aResponse().withStatus(202)));
+        clientOperationService.issueCertificateAction(certificate.getUuid(), true);
+
+        // associate the pending certificate with a location on a connected entity
+        EntityInstanceReference entityInstanceReference = new EntityInstanceReference();
+        entityInstanceReference.setEntityInstanceUuid("e1e2e3e4-0000-0000-0000-000000000002");
+        entityInstanceReference.setConnector(connector);
+        entityInstanceReference = entityInstanceReferenceRepository.save(entityInstanceReference);
+
+        Location location = new Location();
+        location.setUuid(UUID.randomUUID());
+        location.setName("finalized-cert-location");
+        location.setEnabled(true);
+        location.setEntityInstanceReference(entityInstanceReference);
+        location.setEntityInstanceReferenceUuid(entityInstanceReference.getUuid());
+
+        CertificateLocation certificateLocation = new CertificateLocation();
+        certificateLocation.setCertificate(certificate);
+        certificateLocation.setLocation(location);
+        location.getCertificates().add(certificateLocation);
+        locationRepository.save(location);
+
+        // finalize: operator uploads the issued certificate, which is then pushed to its locations
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/identify"))
+                .willReturn(WireMock.okJson("{\"meta\":[]}")));
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/push"))
+                .willReturn(WireMock.okJson("{\"withKey\": false}")));
+
+        UploadCertificateRequestDto finalizeReq = new UploadCertificateRequestDto();
+        finalizeReq.setCertificate(buildSelfSignedCertBase64(kp, "finalized-loc-push"));
+        finalizeReq.setCustomAttributes(List.of());
+
+        clientOperationService.manuallyIssueCertificate(
+                SecuredParentUUID.fromUUID(raProfile.getAuthorityInstanceReferenceUuid()),
+                raProfile.getSecuredUuid(),
+                certificate.getUuid().toString(),
+                finalizeReq);
+
+        // the finalized certificate is pushed to every location it is associated with
+        mockServer.verify(WireMock.moreThanOrExactly(1),
+                WireMock.postRequestedFor(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/push")));
+        Assertions.assertEquals(CertificateState.ISSUED,
+                certificateRepository.findByUuid(certificate.getUuid()).orElseThrow().getState());
+    }
+
+    @Test
     void smoke_asyncRevokeLifecycle_endToEnd() {
         // certificate is in ISSUED state from setUp()
 

--- a/src/test/java/com/otilm/core/service/DiscoveryServiceIntTest.java
+++ b/src/test/java/com/otilm/core/service/DiscoveryServiceIntTest.java
@@ -33,7 +33,7 @@ class DiscoveryServiceIntTest extends BaseMessagingIntTest {
     private static final String DISCOVERY_NAME = "testDiscovery1";
 
     @Autowired
-    private DiscoveryService discoveryService;
+    private DiscoveryExternalService discoveryService;
     @Autowired
     private DiscoveryRepository discoveryRepository;
     @Autowired

--- a/src/test/java/com/otilm/core/service/DiscoveryServiceTest.java
+++ b/src/test/java/com/otilm/core/service/DiscoveryServiceTest.java
@@ -44,7 +44,10 @@ class DiscoveryServiceTest extends BaseSpringBootTest {
 
 
     @Autowired
-    private DiscoveryService discoveryService;
+    private DiscoveryExternalService discoveryService;
+
+    @Autowired
+    private DiscoveryInternalService discoveryInternalService;
 
     @Autowired
     private DiscoveryRepository discoveryRepository;
@@ -173,7 +176,7 @@ class DiscoveryServiceTest extends BaseSpringBootTest {
     @Disabled("Async method is not throwing exception")
     void testDiscoverCertificates_notFound() {
         // connector uui not set
-        Assertions.assertThrows(NotFoundException.class, () -> discoveryService.runDiscovery(discovery.getUuid(), null));
+        Assertions.assertThrows(NotFoundException.class, () -> discoveryInternalService.runDiscovery(discovery.getUuid(), null));
     }
 
     @Test
@@ -183,7 +186,7 @@ class DiscoveryServiceTest extends BaseSpringBootTest {
                 .post(WireMock.urlPathMatching("/v1/discoveryProvider/[^/]+/attributes/validate"))
                 .willReturn(WireMock.okJson("false")));
 
-        Assertions.assertThrows(ValidationException.class, () -> discoveryService.runDiscovery(discovery.getUuid(), null));
+        Assertions.assertThrows(ValidationException.class, () -> discoveryInternalService.runDiscovery(discovery.getUuid(), null));
     }
 
     @Test
@@ -217,7 +220,7 @@ class DiscoveryServiceTest extends BaseSpringBootTest {
         persisted.setConnectorUuid(UUID.randomUUID());
         discoveryRepository.save(persisted);
 
-        discoveryService.runDiscovery(discoveryUuid, null);
+        discoveryInternalService.runDiscovery(discoveryUuid, null);
         persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
 
         Assertions.assertEquals(DiscoveryStatus.FAILED, persisted.getStatus());
@@ -236,7 +239,7 @@ class DiscoveryServiceTest extends BaseSpringBootTest {
 
         mockServer.resetMappings();
 
-        discoveryService.runDiscovery(discoveryUuid, null);
+        discoveryInternalService.runDiscovery(discoveryUuid, null);
         DiscoveryHistory persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
 
         Assertions.assertEquals(DiscoveryStatus.FAILED, persisted.getStatus());
@@ -253,7 +256,7 @@ class DiscoveryServiceTest extends BaseSpringBootTest {
 
         UUID discoveryUuid = UUID.fromString(discoveryService.createDiscovery(dto, true).getUuid());
 
-        discoveryService.runDiscovery(discoveryUuid, null);
+        discoveryInternalService.runDiscovery(discoveryUuid, null);
 
         DiscoveryHistory persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
         Assertions.assertEquals(DiscoveryStatus.PROCESSING, persisted.getStatus());
@@ -273,7 +276,7 @@ class DiscoveryServiceTest extends BaseSpringBootTest {
 
         dto.setName("RunDiscoveryDuplicated-" + UUID.randomUUID());
         discoveryUuid = UUID.fromString(discoveryService.createDiscovery(dto, true).getUuid());
-        discoveryService.runDiscovery(discoveryUuid, null);
+        discoveryInternalService.runDiscovery(discoveryUuid, null);
 
         persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
         Assertions.assertEquals(DiscoveryStatus.COMPLETED, persisted.getStatus());
@@ -314,7 +317,7 @@ class DiscoveryServiceTest extends BaseSpringBootTest {
         dto.setName("RunDiscoveryLongRunning-" + UUID.randomUUID());
         discoveryUuid = UUID.fromString(discoveryService.createDiscovery(dto, true).getUuid());
 
-        discoveryService.runDiscovery(discoveryUuid, null);
+        discoveryInternalService.runDiscovery(discoveryUuid, null);
 
         persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
         Assertions.assertEquals(DiscoveryStatus.COMPLETED, persisted.getStatus());
@@ -341,7 +344,7 @@ class DiscoveryServiceTest extends BaseSpringBootTest {
         persisted.setStartTime(Date.from(Instant.now().minus(7, java.time.temporal.ChronoUnit.DAYS)));
         discoveryRepository.save(persisted);
 
-        discoveryService.runDiscovery(discoveryUuid, null);
+        discoveryInternalService.runDiscovery(discoveryUuid, null);
 
         persisted = discoveryRepository.findByUuid(discoveryUuid).orElseThrow();
         Assertions.assertEquals(DiscoveryStatus.FAILED, persisted.getStatus());
@@ -350,11 +353,11 @@ class DiscoveryServiceTest extends BaseSpringBootTest {
 
     @Test
     void testGetResourceObject() throws NotFoundException {
-        NameAndUuidDto nameAndUuidDto = discoveryService.getResourceObjectInternal(discovery.getUuid());
+        NameAndUuidDto nameAndUuidDto = discoveryInternalService.getResourceObjectInternal(discovery.getUuid());
         Assertions.assertEquals(discovery.getUuid().toString(), nameAndUuidDto.getUuid());
         Assertions.assertEquals(discovery.getName(), nameAndUuidDto.getName());
 
-        nameAndUuidDto = discoveryService.getResourceObjectExternal(discovery.getSecuredUuid());
+        nameAndUuidDto = discoveryInternalService.getResourceObjectExternal(discovery.getSecuredUuid());
         Assertions.assertEquals(discovery.getUuid().toString(), nameAndUuidDto.getUuid());
         Assertions.assertEquals(discovery.getName(), nameAndUuidDto.getName());
     }

--- a/src/test/java/com/otilm/core/service/DiscoveryServiceTest.java
+++ b/src/test/java/com/otilm/core/service/DiscoveryServiceTest.java
@@ -176,7 +176,8 @@ class DiscoveryServiceTest extends BaseSpringBootTest {
     @Disabled("Async method is not throwing exception")
     void testDiscoverCertificates_notFound() {
         // connector uui not set
-        Assertions.assertThrows(NotFoundException.class, () -> discoveryInternalService.runDiscovery(discovery.getUuid(), null));
+        UUID discoveryUuid = discovery.getUuid();
+        Assertions.assertThrows(NotFoundException.class, () -> discoveryInternalService.runDiscovery(discoveryUuid, null));
     }
 
     @Test
@@ -186,7 +187,8 @@ class DiscoveryServiceTest extends BaseSpringBootTest {
                 .post(WireMock.urlPathMatching("/v1/discoveryProvider/[^/]+/attributes/validate"))
                 .willReturn(WireMock.okJson("false")));
 
-        Assertions.assertThrows(ValidationException.class, () -> discoveryInternalService.runDiscovery(discovery.getUuid(), null));
+        UUID discoveryUuid = discovery.getUuid();
+        Assertions.assertThrows(ValidationException.class, () -> discoveryInternalService.runDiscovery(discoveryUuid, null));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/LocationServiceTest.java
+++ b/src/test/java/com/otilm/core/service/LocationServiceTest.java
@@ -58,7 +58,9 @@ class LocationServiceTest extends BaseSpringBootTest {
     private static final String LOCATION_NAME_NOKEYMANAGEMENT = "testLocation-noKeyManagement";
 
     @Autowired
-    private LocationService locationService;
+    private LocationExternalService locationService;
+    @Autowired
+    private LocationInternalService locationInternalService;
     @Autowired
     private LocationRepository locationRepository;
     @Autowired
@@ -578,7 +580,7 @@ class LocationServiceTest extends BaseSpringBootTest {
 
     @Test
     void testGetObjectsForResource() {
-        List<NameAndUuidDto> dtos = locationService.listResourceObjects(SecurityFilter.create(), null, null);
+        List<NameAndUuidDto> dtos = locationInternalService.listResourceObjects(SecurityFilter.create(), null, null);
         Assertions.assertEquals(3, dtos.size());
     }
 
@@ -681,7 +683,7 @@ class LocationServiceTest extends BaseSpringBootTest {
 
         mockServer.stubFor(WireMock.post(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/remove")).willReturn(WireMock.okJson("{}")));
 
-        locationService.removeCertificatesFromLocationsOnDelete(List.of(certificateUuid));
+        locationInternalService.removeCertificatesFromLocationsOnDelete(List.of(certificateUuid));
 
         mockServer.verify(WireMock.moreThanOrExactly(1), WireMock.postRequestedFor(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/remove")));
 
@@ -691,11 +693,11 @@ class LocationServiceTest extends BaseSpringBootTest {
 
     @Test
     void testGetResourceObject() throws NotFoundException {
-        NameAndUuidDto nameAndUuidDto = locationService.getResourceObjectInternal(location.getUuid());
+        NameAndUuidDto nameAndUuidDto = locationInternalService.getResourceObjectInternal(location.getUuid());
         Assertions.assertEquals(location.getUuid().toString(), nameAndUuidDto.getUuid());
         Assertions.assertEquals(location.getName(), nameAndUuidDto.getName());
 
-        nameAndUuidDto = locationService.getResourceObjectExternal(location.getSecuredUuid());
+        nameAndUuidDto = locationInternalService.getResourceObjectExternal(location.getSecuredUuid());
         Assertions.assertEquals(location.getUuid().toString(), nameAndUuidDto.getUuid());
         Assertions.assertEquals(location.getName(), nameAndUuidDto.getName());
     }

--- a/src/test/java/com/otilm/core/service/SchedulerServiceTest.java
+++ b/src/test/java/com/otilm/core/service/SchedulerServiceTest.java
@@ -100,7 +100,7 @@ class SchedulerServiceTest extends BaseSpringBootTest {
     private CertificateEventHistoryRepository certificateEventHistoryRepository;
 
     @Autowired
-    private DiscoveryService discoveryService;
+    private DiscoveryExternalService discoveryService;
     @Autowired
     private DiscoveryRepository discoveryRepository;
     @Autowired

--- a/src/test/java/com/otilm/core/service/impl/StatisticsServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/impl/StatisticsServiceImplTest.java
@@ -19,7 +19,7 @@ class StatisticsServiceImplTest {
     private StatisticsServiceImpl statisticsService;
 
     @Mock private CertificateService certificateService;
-    @Mock private DiscoveryService discoveryService;
+    @Mock private DiscoveryInternalService discoveryService;
     @Mock private GroupInternalService groupService;
     @Mock private RaProfileService raProfileService;
     @Mock private SecretInternalService secretService;

--- a/src/test/resources/archunit_store/dc319b8f-4aa8-4995-960d-775b2144f2a2
+++ b/src/test/resources/archunit_store/dc319b8f-4aa8-4995-960d-775b2144f2a2
@@ -5,3 +5,5 @@ Method <com.otilm.core.service.impl.VaultInstanceServiceImpl.getSearchableFieldI
 Method <com.otilm.core.service.impl.VaultProfileServiceImpl.getSearchableFieldInformation()> is annotated with @ExternalAuthorizationMissing in (VaultProfileServiceImpl.java:239)
 Method <com.otilm.core.service.impl.CustomOidEntryServiceImpl.getSearchableFieldInformation()> is annotated with @ExternalAuthorizationMissing in (CustomOidEntryServiceImpl.java:222)
 Method <com.otilm.core.service.impl.EntityInstanceServiceImpl.getSearchableFieldInformationByGroup()> is annotated with @ExternalAuthorizationMissing in (EntityInstanceServiceImpl.java:315)
+Method <com.otilm.core.service.impl.DiscoveryServiceImpl.getSearchableFieldInformationByGroup()> is annotated with @ExternalAuthorizationMissing in (DiscoveryServiceImpl.java:746)
+Method <com.otilm.core.service.impl.LocationServiceImpl.getSearchableFieldInformationByGroup()> is annotated with @ExternalAuthorizationMissing in (LocationServiceImpl.java:1140)


### PR DESCRIPTION
Splits DiscoveryService and LocationService into *ExternalService + *InternalService interface pairs (inventory / discovery cluster) so controllers depend only on externally-callable methods. Both InternalServices keep `extends ResourceExtensionService`; the ExternalServices are flat.

DiscoveryService.getSearchableFieldInformationByGroup() and LocationService.getSearchableFieldInformationByGroup() are controller-callable but lacked an authorization annotation, so they are marked @ExternalAuthorizationMissing (matching the existing Secret/Vault/CustomOid/EntityInstance precedent), growing the ArchUnit freeze store from 7 to 9 entries.

Part 12 of the service interface categorization series (#1467).