### PR TITLE
Fix core build: remove duplicate archunit-junit5 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
         <mockwebserver.version>5.3.2</mockwebserver.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <testcontainers.version>1.21.4</testcontainers.version>
-        <archunit.version>1.4.2</archunit.version>
         <git-commit-id-maven.version>9.0.2</git-commit-id-maven.version>
         <java.version>21</java.version>
         <!-- Temporary override for CVE-2026-41293 and CVE-2026-43512.
@@ -308,12 +307,6 @@
             <groupId>eu.rekawek.toxiproxy</groupId>
             <artifactId>toxiproxy-java</artifactId>
             <version>2.1.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.tngtech.archunit</groupId>
-            <artifactId>archunit-junit5</artifactId>
-            <version>${archunit.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Problem
Core `main` does not build. `pom.xml` declares `com.tngtech.archunit:archunit-junit5` **twice** → Maven hard duplicate-coordinate model error (`'dependencies.dependency…' must be unique … line 313`); the project cannot be read at all. The `archunit.version` property is also declared twice.

## Fix
Remove the duplicate dependency block + the duplicate property. One declaration of each remains, intact. pom-only change.

## Verify
`mvn validate` → fails on `main` (duplicate-coordinate error), passes after. Build is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
