### PR TITLE
Authorize resource-option listing used by attribute callbacks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
         <mockwebserver.version>5.3.2</mockwebserver.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <testcontainers.version>1.21.4</testcontainers.version>
-        <archunit.version>1.4.2</archunit.version>
         <git-commit-id-maven.version>9.0.2</git-commit-id-maven.version>
         <java.version>21</java.version>
         <!-- Temporary override for CVE-2026-41293 and CVE-2026-43512.
@@ -308,12 +307,6 @@
             <groupId>eu.rekawek.toxiproxy</groupId>
             <artifactId>toxiproxy-java</artifactId>
             <version>2.1.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.tngtech.archunit</groupId>
-            <artifactId>archunit-junit5</artifactId>
-            <version>${archunit.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/otilm/core/service/impl/CoreCallbackServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CoreCallbackServiceImpl.java
@@ -13,10 +13,11 @@ import com.otilm.api.model.core.auth.AttributeResource;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.search.FilterConditionOperator;
 import com.otilm.api.model.core.search.FilterFieldSource;
+import com.otilm.core.security.authz.SecuredResource;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CoreCallbackService;
 import com.otilm.core.service.CredentialInternalService;
-import com.otilm.core.service.ResourceInternalService;
+import com.otilm.core.service.ResourceExternalService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -32,10 +33,10 @@ public class CoreCallbackServiceImpl implements CoreCallbackService {
 
     private CredentialInternalService credentialService;
 
-    private ResourceInternalService resourceService;
+    private ResourceExternalService resourceService;
 
     @Autowired
-    public void setResourceService(ResourceInternalService resourceService) {
+    public void setResourceService(ResourceExternalService resourceService) {
         this.resourceService = resourceService;
     }
 
@@ -63,6 +64,18 @@ public class CoreCallbackServiceImpl implements CoreCallbackService {
         return jsonContent;
     }
 
+    /**
+     * Lists candidate resource objects for an attribute-callback dropdown.
+     * <p>
+     * Routes through {@link ResourceExternalService#getResourceObjects} rather than the internal
+     * {@code getResourceObjectsInternal} so the {@code @ExternalAuthorizationDynamic(LIST)} guard on
+     * {@code getResourceObjects} applies the caller's per-object ACL. This closes the CERTIFICATE
+     * listing gap (whose own {@code listResourceObjects} carries no {@code @ExternalAuthorization}) and
+     * installs uniform defense-in-depth so any future unannotated per-kind listing stays scoped.
+     * <p>
+     * Same-connector narrowing of the dropdown is deliberately not applied here (cross-connector
+     * references are legitimate); it is deferred to core #1643.
+     */
     @Override
     public List<ResourceObjectContent> coreGetResources(RequestAttributeCallback callback, AttributeResource resource) throws NotFoundException {
         // Filters are in form: property_name.operator
@@ -81,7 +94,11 @@ public class CoreCallbackServiceImpl implements CoreCallbackService {
                 filters.add(new SearchFilterRequestDto(FilterFieldSource.PROPERTY, filterFieldString, operator, callback.getFilter().get(filterDefinition)));
             }
         }
-        return resourceService.getResourceObjectsInternal(Resource.findByCode(resource.getCode()), filters, callback.getPagination())
+        return resourceService.getResourceObjects(
+                        SecuredResource.fromResource(Resource.findByCode(resource.getCode())),
+                        SecurityFilter.create(),
+                        filters,
+                        callback.getPagination())
                 .stream()
                 .map(id -> {
                     ResourceObjectContentData data = new ResourceObjectContentData(resource);

--- a/src/test/java/com/otilm/core/service/CoreCallbackServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CoreCallbackServiceTest.java
@@ -18,6 +18,7 @@ import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.dao.repository.CredentialRepository;
 import com.otilm.core.enums.FilterField;
+import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.opa.dto.OpaObjectAccessResult;
 import com.otilm.core.service.impl.CoreCallbackServiceImpl;
 import com.otilm.core.util.BaseSpringBootTest;
@@ -280,7 +281,8 @@ class CoreCallbackServiceTest extends BaseSpringBootTest {
                 Mockito.any(),
                 Mockito.argThat(req -> req != null
                         && req.getProperties() != null
-                        && resource.getCode().equals(req.getProperties().get("name"))),
+                        && resource.getCode().equals(req.getProperties().get("name"))
+                        && ResourceAction.LIST.getCode().equals(req.getProperties().get("action"))),
                 Mockito.any(), Mockito.any())
         ).thenReturn(restricted);
     }

--- a/src/test/java/com/otilm/core/service/CoreCallbackServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CoreCallbackServiceTest.java
@@ -7,6 +7,7 @@ import com.otilm.api.model.common.attribute.common.callback.RequestAttributeCall
 import com.otilm.api.model.common.attribute.v2.content.ObjectAttributeContentV2;
 import com.otilm.api.model.common.attribute.v3.content.ResourceObjectContent;
 import com.otilm.api.model.core.auth.AttributeResource;
+import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.scheduler.PaginationRequestDto;
 import com.otilm.api.model.core.search.FilterConditionOperator;
@@ -17,10 +18,12 @@ import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.dao.repository.CredentialRepository;
 import com.otilm.core.enums.FilterField;
+import com.otilm.core.security.authz.opa.dto.OpaObjectAccessResult;
 import com.otilm.core.service.impl.CoreCallbackServiceImpl;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Rollback;
@@ -28,7 +31,25 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+/**
+ * Covers the secured {@code coreGetResources} listing path (#1623).
+ * <p>
+ * SECRET double-aspect coverage is a deliberate follow-up before SECRET dropdowns ship. When listed via
+ * the guarded external path, two aspects populate the same {@link com.otilm.core.security.authz.SecurityFilter}:
+ * the outer {@code @ExternalAuthorizationDynamic(LIST)} on {@code ResourceServiceImpl.getResourceObjects},
+ * then the inner {@code @ExternalAuthorization(SECRET, LIST, parentResource=VAULT_PROFILE, parentAction=MEMBERS)}
+ * on {@code SecretServiceImpl.listResourceObjects}. Code-trace of
+ * {@link com.otilm.core.security.authz.ObjectFilterAspect#populateSecurityFilter} confirms the population is
+ * replace-not-append — {@code setResourceFilter}/{@code setParentResourceFilter} are last-write-wins setters,
+ * so the inner SECRET-scoped filter cleanly supersedes the outer one and additionally installs the
+ * VAULT_PROFILE/MEMBERS parent filter; no append, merge, or state corruption occurs. A runtime SECRET test is
+ * not added here because seeding a listable SECRET requires a Connector + VaultInstance + VaultProfile +
+ * SecretVersion graph (all NOT NULL FKs), which would make this focused security test fragile and is owned by
+ * the SECRET-dropdown work.
+ */
 @SpringBootTest
 @Transactional
 @Rollback
@@ -141,5 +162,127 @@ class CoreCallbackServiceTest extends BaseSpringBootTest {
         Assertions.assertEquals(2, result.size());
     }
 
+    /**
+     * Differential security test pinned to CERTIFICATE — the only kind whose own {@code listResourceObjects}
+     * carries no {@code @ExternalAuthorization} annotation, so it is the only kind that exercises the fix.
+     * Under a principal whose OPA object-access result allows only a subset of certificates, the listing
+     * must return that subset only. Fails on the bypassing internal path (returns all rows), passes once
+     * the call is routed through the {@code @ExternalAuthorizationDynamic(LIST)}-guarded external path.
+     */
+    @Test
+    void coreGetResources_certificate_restrictedPrincipal_seesOnlyAuthorizedSubset() throws NotFoundException {
+        Certificate certificate1 = new Certificate();
+        certificate1.setState(CertificateState.ISSUED);
+        certificate1.setCommonName("cn1");
+        certificate1.setArchived(false);
+        certificate1 = certificateRepository.save(certificate1);
+        Certificate certificate2 = new Certificate();
+        certificate2.setState(CertificateState.ISSUED);
+        certificate2.setCommonName("cn2");
+        certificate2.setArchived(false);
+        certificateRepository.save(certificate2);
+
+        restrictObjectAccess(Resource.CERTIFICATE, List.of(certificate1.getUuid().toString()));
+
+        List<ResourceObjectContent> result = coreCallbackService.coreGetResources(new RequestAttributeCallback(), AttributeResource.CERTIFICATE);
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(certificate1.getUuid().toString(), result.getFirst().getData().getUuid());
+    }
+
+    /**
+     * Fail-closed: a principal with no allowed certificates gets an empty list, not all rows and not an error.
+     */
+    @Test
+    void coreGetResources_certificate_noGrants_returnsEmpty() throws NotFoundException {
+        Certificate certificate = new Certificate();
+        certificate.setState(CertificateState.ISSUED);
+        certificate.setCommonName("cn");
+        certificate.setArchived(false);
+        certificateRepository.save(certificate);
+
+        restrictObjectAccess(Resource.CERTIFICATE, List.of());
+
+        List<ResourceObjectContent> result = coreCallbackService.coreGetResources(new RequestAttributeCallback(), AttributeResource.CERTIFICATE);
+
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    /**
+     * Characterization of an already-guarded kind. CREDENTIAL's own {@code listResourceObjects} is
+     * {@code @ExternalAuthorization(CREDENTIAL, LIST)}, so it is scoped on both {@code main} and after the fix.
+     * Guards against a future removal of that inner annotation and documents that CREDENTIAL was never the bypass.
+     */
+    @Test
+    void coreGetResources_credential_alreadyScopedOnMainAndAfter() throws NotFoundException {
+        Credential credential1 = new Credential();
+        credential1.setName("c1");
+        credential1.setEnabled(true);
+        credential1 = credentialRepository.save(credential1);
+        Credential credential2 = new Credential();
+        credential2.setName("c2");
+        credential2.setEnabled(true);
+        credentialRepository.save(credential2);
+
+        restrictObjectAccess(Resource.CREDENTIAL, List.of(credential1.getUuid().toString()));
+
+        List<ResourceObjectContent> result = coreCallbackService.coreGetResources(new RequestAttributeCallback(), AttributeResource.CREDENTIAL);
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(credential1.getUuid().toString(), result.getFirst().getData().getUuid());
+    }
+
+    /**
+     * AC3 positive multi-grant: with three ISSUED certificates and an OPA allow-list of two of them
+     * (areOnlySpecificObjectsAllowed = true), the listing returns exactly those two — proving the
+     * multi-UUID allow-list path returns the full authorized set, not just the first match, and that
+     * authorized dropdowns still populate after routing through the guarded external path.
+     */
+    @Test
+    void coreGetResources_certificate_multiGrant_returnsAllAuthorized() throws NotFoundException {
+        Certificate certificate1 = new Certificate();
+        certificate1.setState(CertificateState.ISSUED);
+        certificate1.setCommonName("cn1");
+        certificate1.setArchived(false);
+        certificate1 = certificateRepository.save(certificate1);
+        Certificate certificate2 = new Certificate();
+        certificate2.setState(CertificateState.ISSUED);
+        certificate2.setCommonName("cn2");
+        certificate2.setArchived(false);
+        certificate2 = certificateRepository.save(certificate2);
+        Certificate certificate3 = new Certificate();
+        certificate3.setState(CertificateState.ISSUED);
+        certificate3.setCommonName("cn3");
+        certificate3.setArchived(false);
+        certificate3 = certificateRepository.save(certificate3);
+
+        restrictObjectAccess(Resource.CERTIFICATE, List.of(certificate1.getUuid().toString(), certificate2.getUuid().toString()));
+
+        List<ResourceObjectContent> result = coreCallbackService.coreGetResources(new RequestAttributeCallback(), AttributeResource.CERTIFICATE);
+
+        Assertions.assertEquals(2, result.size());
+        Set<String> returnedUuids = result.stream().map(content -> content.getData().getUuid()).collect(Collectors.toSet());
+        Assertions.assertEquals(Set.of(certificate1.getUuid().toString(), certificate2.getUuid().toString()), returnedUuids);
+        Assertions.assertFalse(returnedUuids.contains(certificate3.getUuid().toString()));
+    }
+
+    /**
+     * Overrides the base allow-all object-access mock for a single resource so OPA reports that only the
+     * given object UUIDs are accessible (areOnlySpecificObjectsAllowed = true). Mirrors the production OPA
+     * response shape consumed by {@link com.otilm.core.security.authz.ObjectFilterAspect}.
+     */
+    private void restrictObjectAccess(Resource resource, List<String> allowedUuids) {
+        OpaObjectAccessResult restricted = new OpaObjectAccessResult();
+        restricted.setActionAllowedForGroupOfObjects(false);
+        restricted.setAllowedObjects(allowedUuids);
+        restricted.setForbiddenObjects(List.of());
+        Mockito.when(opaClient.checkObjectAccess(
+                Mockito.any(),
+                Mockito.argThat(req -> req != null
+                        && req.getProperties() != null
+                        && resource.getCode().equals(req.getProperties().get("name"))),
+                Mockito.any(), Mockito.any())
+        ).thenReturn(restricted);
+    }
 
 }

--- a/src/test/java/com/otilm/core/service/CoreCallbackServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CoreCallbackServiceTest.java
@@ -36,20 +36,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Covers the secured {@code coreGetResources} listing path (#1623).
+ * Covers the secured {@code coreGetResources} listing path.
  * <p>
- * SECRET double-aspect coverage is a deliberate follow-up before SECRET dropdowns ship. When listed via
- * the guarded external path, two aspects populate the same {@link com.otilm.core.security.authz.SecurityFilter}:
- * the outer {@code @ExternalAuthorizationDynamic(LIST)} on {@code ResourceServiceImpl.getResourceObjects},
- * then the inner {@code @ExternalAuthorization(SECRET, LIST, parentResource=VAULT_PROFILE, parentAction=MEMBERS)}
- * on {@code SecretServiceImpl.listResourceObjects}. Code-trace of
- * {@link com.otilm.core.security.authz.ObjectFilterAspect#populateSecurityFilter} confirms the population is
- * replace-not-append — {@code setResourceFilter}/{@code setParentResourceFilter} are last-write-wins setters,
- * so the inner SECRET-scoped filter cleanly supersedes the outer one and additionally installs the
- * VAULT_PROFILE/MEMBERS parent filter; no append, merge, or state corruption occurs. A runtime SECRET test is
- * not added here because seeding a listable SECRET requires a Connector + VaultInstance + VaultProfile +
- * SecretVersion graph (all NOT NULL FKs), which would make this focused security test fragile and is owned by
- * the SECRET-dropdown work.
+ * A runtime SECRET test is intentionally deferred to the SECRET-dropdown work: seeding a listable SECRET
+ * needs a Connector + VaultInstance + VaultProfile + SecretVersion graph (all NOT NULL FKs), which would make
+ * this focused security test fragile. Deferring adds no exposure — SECRET listing is strictly more guarded
+ * than the kind under test (its own per-kind LIST guard is parent-scoped to VAULT_PROFILE/MEMBERS).
  */
 @SpringBootTest
 @Transactional


### PR DESCRIPTION
Fixes #1623

> Stacked on #1670 (unbreaks the core build). Until #1670 merges, this PR's diff also shows the pom dedup; it drops out once #1670 lands.

## What
RESOURCE-typed callback dropdowns now show only objects the calling user may see. Route `CoreCallbackServiceImpl.coreGetResources` through the authorized `ResourceExternalService.getResourceObjects` (`@ExternalAuthorizationDynamic(LIST)`) instead of the auth-bypassing `getResourceObjectsInternal`. Closes a pre-existing authorization bypass (CERTIFICATE listing was unguarded — its `listResourceObjects` carries no `@ExternalAuthorization`; other kinds already guarded → uniform defense-in-depth).

## Not here (on purpose)
Connector-scoping. Cross-connector references are legitimate (e.g. an authority form picking a credential owned by another connector), so no Core-imposed connector filter — deferred to follow-up **#1643**. SECRET double-aspect runtime test deferred (needs Connector→VaultInstance→VaultProfile→SecretVersion scaffolding; replace-not-append filter semantics verified by trace).

## Tests
`CoreCallbackServiceTest` — real differential (FAIL on main, PASS after): restricted principal sees only its authorized subset; multi-grant returns the full authorized set; no-grants → empty (fail-closed); CREDENTIAL characterization (already-guarded, passes both). 13 tests green (incl. shared callback path, no regression).

## Review
Built TDD. Reviewed by fan-out Claude agents — structural/correctness, PR-structure, ticket-AC, epic-plan conformance — all SHIP, all 4 ACs MET. Plus two independent Copilot deep passes (gpt-5.5 + claude-sonnet-4.6): AOP guard traced firing end-to-end, differential test confirmed genuine — SHIP. Human reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
