### PR TITLE
Rename Signature Formatter -> Signature Formatting Provider

### DIFF
--- a/src/main/java/com/otilm/core/api/web/SigningProfileControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/SigningProfileControllerImpl.java
@@ -142,8 +142,8 @@ public class SigningProfileControllerImpl implements SigningProfileController {
 
     @Override
     @AuditLogged(module = Module.SIGNING, resource = Resource.SIGNING_PROFILE, operation = Operation.LIST_ATTRIBUTES)
-    public List<BaseAttribute> listSignatureFormatterConnectorAttributes(UUID connectorUuid, UUID signingProfileUuid) throws NotFoundException, ConnectorException, AttributeException {
-        return signingProfileService.listSignatureFormatterConnectorAttributes(connectorUuid, SecuredUUID.fromUUID(signingProfileUuid));
+    public List<BaseAttribute> listSignatureFormattingConnectorAttributes(UUID connectorUuid, UUID signingProfileUuid) throws NotFoundException, ConnectorException, AttributeException {
+        return signingProfileService.listSignatureFormattingConnectorAttributes(connectorUuid, SecuredUUID.fromUUID(signingProfileUuid));
     }
 
     @Override

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeOperation.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeOperation.java
@@ -7,7 +7,7 @@ public class AttributeOperation {
     public static final String CERTIFICATE_REQUEST_SIGN = "sign"; // legacy usage in database migration
     public static final String SIGN = "sign";
     public static final String ENCRYPT = "encrypt";
-    public static final String WORKFLOW_FORMATTER = "workflowFormatter";
+    public static final String WORKFLOW_FORMATTING = "workflowFormatting";
 
     private AttributeOperation() {
     }

--- a/src/main/java/com/otilm/core/client/ConnectorApiFactory.java
+++ b/src/main/java/com/otilm/core/client/ConnectorApiFactory.java
@@ -16,9 +16,9 @@ import com.otilm.api.clients.NotificationInstanceApiClient;
 import com.otilm.api.clients.cryptography.CryptographicOperationsApiClient;
 import com.otilm.api.clients.cryptography.KeyManagementApiClient;
 import com.otilm.api.clients.cryptography.TokenInstanceApiClient;
-import com.otilm.api.clients.signing.SignatureFormatterApiClient;
+import com.otilm.api.clients.signing.SignatureFormattingApiClient;
 import com.otilm.api.interfaces.client.v1.AttributeSyncApiClient;
-import com.otilm.api.interfaces.client.v1.signing.SignatureFormatterSyncApiClient;
+import com.otilm.api.interfaces.client.v1.signing.SignatureFormattingSyncApiClient;
 import com.otilm.api.interfaces.client.v1.AuthorityInstanceSyncApiClient;
 import com.otilm.api.interfaces.client.v2.CertificateSyncApiClient;
 import com.otilm.api.interfaces.client.v2.ComplianceSyncApiClient;
@@ -119,8 +119,8 @@ public class ConnectorApiFactory {
     private final Optional<com.otilm.api.clients.mq.v3.AuthorityApiClient> mqAuthorityApiClientV3;
 
     // Signing clients
-    private final SignatureFormatterApiClient restSignatureFormatterApiClient;
-    private final Optional<com.otilm.api.clients.mq.signing.SignatureFormatterApiClient> mqSignatureFormatterApiClient;
+    private final SignatureFormattingApiClient restSignatureFormattingApiClient;
+    private final Optional<com.otilm.api.clients.mq.signing.SignatureFormattingApiClient> mqSignatureFormattingApiClient;
 
     // Vault/Secret clients
     private final com.otilm.api.clients.secret.VaultApiClient restVaultApiClient;
@@ -136,8 +136,8 @@ public class ConnectorApiFactory {
 
     @PostConstruct
     void logInitialization() {
-        log.info("ConnectorApiFactory initialized. MQ clients available: attribute={}, authorityInstance={}, certificate={}, certificateV2={}, certificateV3={}, authorityV3={}, compliance={}, complianceV2={}, connector={}, discovery={}, endEntity={}, endEntityProfile={}, entityInstance={}, health={}, healthV2={}, infoV2={}, location={}, metricsV2={}, notificationInstance={}, tokenInstance={}, keyManagement={}, cryptographicOperations={}, signatureFormatter={}, vault={}, secret(REST-only)={}",
-                mqAttributeApiClient.isPresent(), mqAuthorityInstanceApiClient.isPresent(), mqCertificateApiClient.isPresent(), mqCertificateApiClientV2.isPresent(), mqCertificateApiClientV3.isPresent(), mqAuthorityApiClientV3.isPresent(), mqComplianceApiClient.isPresent(), mqComplianceApiClientV2.isPresent(), mqConnectorApiClient.isPresent(), mqDiscoveryApiClient.isPresent(), mqEndEntityApiClient.isPresent(), mqEndEntityProfileApiClient.isPresent(), mqEntityInstanceApiClient.isPresent(), mqHealthApiClient.isPresent(), mqHealthApiClientV2.isPresent(), mqInfoApiClientV2.isPresent(), mqLocationApiClient.isPresent(), mqMetricsApiClientV2.isPresent(), mqNotificationInstanceApiClient.isPresent(), mqTokenInstanceApiClient.isPresent(), mqKeyManagementApiClient.isPresent(), mqCryptographicOperationsApiClient.isPresent(), mqSignatureFormatterApiClient.isPresent(), mqVaultApiClient.isPresent(), true);
+        log.info("ConnectorApiFactory initialized. MQ clients available: attribute={}, authorityInstance={}, certificate={}, certificateV2={}, certificateV3={}, authorityV3={}, compliance={}, complianceV2={}, connector={}, discovery={}, endEntity={}, endEntityProfile={}, entityInstance={}, health={}, healthV2={}, infoV2={}, location={}, metricsV2={}, notificationInstance={}, tokenInstance={}, keyManagement={}, cryptographicOperations={}, signatureFormatting={}, vault={}, secret(REST-only)={}",
+                mqAttributeApiClient.isPresent(), mqAuthorityInstanceApiClient.isPresent(), mqCertificateApiClient.isPresent(), mqCertificateApiClientV2.isPresent(), mqCertificateApiClientV3.isPresent(), mqAuthorityApiClientV3.isPresent(), mqComplianceApiClient.isPresent(), mqComplianceApiClientV2.isPresent(), mqConnectorApiClient.isPresent(), mqDiscoveryApiClient.isPresent(), mqEndEntityApiClient.isPresent(), mqEndEntityProfileApiClient.isPresent(), mqEntityInstanceApiClient.isPresent(), mqHealthApiClient.isPresent(), mqHealthApiClientV2.isPresent(), mqInfoApiClientV2.isPresent(), mqLocationApiClient.isPresent(), mqMetricsApiClientV2.isPresent(), mqNotificationInstanceApiClient.isPresent(), mqTokenInstanceApiClient.isPresent(), mqKeyManagementApiClient.isPresent(), mqCryptographicOperationsApiClient.isPresent(), mqSignatureFormattingApiClient.isPresent(), mqVaultApiClient.isPresent(), true);
     }
 
     /**
@@ -243,8 +243,8 @@ public class ConnectorApiFactory {
         return getClient(connector, restNotificationInstanceApiClient, mqNotificationInstanceApiClient);
     }
 
-    public SignatureFormatterSyncApiClient getSignatureFormatterApiClient(ApiClientConnectorInfo connector) {
-        return getClient(connector, restSignatureFormatterApiClient, mqSignatureFormatterApiClient);
+    public SignatureFormattingSyncApiClient getSignatureFormattingApiClient(ApiClientConnectorInfo connector) {
+        return getClient(connector, restSignatureFormattingApiClient, mqSignatureFormattingApiClient);
     }
 
     public com.otilm.api.interfaces.client.v1.secret.VaultSyncApiClient getVaultApiClient(ApiClientConnectorInfo connector) {

--- a/src/main/java/com/otilm/core/config/ApplicationConfig.java
+++ b/src/main/java/com/otilm/core/config/ApplicationConfig.java
@@ -19,7 +19,7 @@ import com.otilm.api.clients.cryptography.KeyManagementApiClient;
 import com.otilm.api.clients.cryptography.TokenInstanceApiClient;
 import com.otilm.api.clients.secret.SecretApiClient;
 import com.otilm.api.clients.secret.VaultApiClient;
-import com.otilm.api.clients.signing.SignatureFormatterApiClient;
+import com.otilm.api.clients.signing.SignatureFormattingApiClient;
 import com.otilm.api.clients.v2.InfoApiClient;
 import com.otilm.api.clients.v2.MetricsApiClient;
 import com.otilm.core.security.authn.client.ResourceApiClient;
@@ -208,7 +208,7 @@ public class ApplicationConfig {
     }
 
     @Bean
-    public SignatureFormatterApiClient signatureFormatterApiClient(WebClient webClient, TrustManager[] defaultTrustManagers) {
-        return new SignatureFormatterApiClient(webClient, defaultTrustManagers);
+    public SignatureFormattingApiClient signatureFormattingApiClient(WebClient webClient, TrustManager[] defaultTrustManagers) {
+        return new SignatureFormattingApiClient(webClient, defaultTrustManagers);
     }
 }

--- a/src/main/java/com/otilm/core/dao/entity/signing/SigningProfileVersion.java
+++ b/src/main/java/com/otilm/core/dao/entity/signing/SigningProfileVersion.java
@@ -90,13 +90,13 @@ public class SigningProfileVersion extends UniquelyIdentifiedAndAudited {
     @Enumerated(EnumType.STRING)
     private SigningWorkflowType workflowType;
 
-    @Column(name = "signature_formatter_connector_uuid")
-    private UUID signatureFormatterConnectorUuid;
+    @Column(name = "signature_formatting_connector_uuid")
+    private UUID signatureFormattingConnectorUuid;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "signature_formatter_connector_uuid", insertable = false, updatable = false)
+    @JoinColumn(name = "signature_formatting_connector_uuid", insertable = false, updatable = false)
     @ToString.Exclude
-    private Connector signatureFormatterConnector;
+    private Connector signatureFormattingConnector;
 
     @Column(name = "qualified_timestamp")
     private Boolean qualifiedTimestamp;
@@ -169,9 +169,9 @@ public class SigningProfileVersion extends UniquelyIdentifiedAndAudited {
         this.delegatedSignerConnectorUuid = delegatedSignerConnector != null ? delegatedSignerConnector.getUuid() : null;
     }
 
-    public void setSignatureFormatterConnector(Connector signatureFormatterConnector) {
-        this.signatureFormatterConnector = signatureFormatterConnector;
-        this.signatureFormatterConnectorUuid = signatureFormatterConnector != null ? signatureFormatterConnector.getUuid() : null;
+    public void setSignatureFormattingConnector(Connector signatureFormattingConnector) {
+        this.signatureFormattingConnector = signatureFormattingConnector;
+        this.signatureFormattingConnectorUuid = signatureFormattingConnector != null ? signatureFormattingConnector.getUuid() : null;
     }
 
     @Override

--- a/src/main/java/com/otilm/core/mapper/signing/SigningProfileMapper.java
+++ b/src/main/java/com/otilm/core/mapper/signing/SigningProfileMapper.java
@@ -41,12 +41,12 @@ public class SigningProfileMapper {
 
     /**
      * Transforms a {@link SigningProfile} and {@link SigningProfileVersion} entities to a full {@link SigningProfileDto},
-     * populating custom attributes, connector signing-operation attributes, and workflow formatter attributes.
+     * populating custom attributes, connector signing-operation attributes, and workflow formatting attributes.
      */
     public static SigningProfileDto toDto(SigningProfile header, SigningProfileVersion version,
                                           List<ResponseAttribute> customAttributes,
                                           List<ResponseAttribute> signingOperationAttributes,
-                                          List<ResponseAttribute> signatureFormatterConnectorAttributes) {
+                                          List<ResponseAttribute> signatureFormattingConnectorAttributes) {
         SigningProfileDto dto = new SigningProfileDto();
         dto.setUuid(header.getUuid().toString());
         dto.setName(header.getName());
@@ -95,9 +95,9 @@ public class SigningProfileMapper {
 
         // Build workflow DTO from version (timestamping also reads unversioned fields from header)
         dto.setWorkflow(switch (version.getWorkflowType()) {
-            case CONTENT_SIGNING -> buildContentSigningWorkflowDto(version, signatureFormatterConnectorAttributes);
+            case CONTENT_SIGNING -> buildContentSigningWorkflowDto(version, signatureFormattingConnectorAttributes);
             case RAW_SIGNING -> new RawSigningWorkflowDto();
-            case TIMESTAMPING -> buildTimestampingWorkflowDto(header, version, signatureFormatterConnectorAttributes);
+            case TIMESTAMPING -> buildTimestampingWorkflowDto(header, version, signatureFormattingConnectorAttributes);
         });
 
         dto.setEnabledProtocols(detectEnabledProtocols(header));
@@ -147,7 +147,7 @@ public class SigningProfileMapper {
             SigningProfile header,
             SigningProfileVersion version,
             List<RequestAttribute> signingOperationAttributes,
-            List<RequestAttribute> signatureFormatterConnectorAttributes) {
+            List<RequestAttribute> signatureFormattingConnectorAttributes) {
         if (version.getWorkflowType() != SigningWorkflowType.TIMESTAMPING) {
             throw new IllegalArgumentException("Signing Profile '%s' does not use a timestamping workflow".formatted(header.getName()));
         }
@@ -159,7 +159,7 @@ public class SigningProfileMapper {
                 header.getUuid(), header.getName(), header.getDescription(),
                 version.getVersion(), header.isEnabled(), detectEnabledProtocols(header),
                 header.getTspProfileUuid(),
-                buildManagedTimestampingWorkflowModel(header, version, signatureFormatterConnectorAttributes),
+                buildManagedTimestampingWorkflowModel(header, version, signatureFormattingConnectorAttributes),
                 buildManagedSchemeModel(version, signingOperationAttributes),
                 buildRecordPolicyModel(version));
     }
@@ -207,18 +207,18 @@ public class SigningProfileMapper {
     // ──────────────────────────────────────────────────────────────────────────
 
     private static ContentSigningWorkflowDto buildContentSigningWorkflowDto(
-            SigningProfileVersion version, List<ResponseAttribute> signatureFormatterConnectorAttributes) {
+            SigningProfileVersion version, List<ResponseAttribute> signatureFormattingConnectorAttributes) {
         ContentSigningWorkflowDto wf = new ContentSigningWorkflowDto();
-        setFormatterRef(version, wf::setSignatureFormatterConnector);
-        wf.setSignatureFormatterConnectorAttributes(safeList(signatureFormatterConnectorAttributes));
+        setFormattingRef(version, wf::setSignatureFormattingConnector);
+        wf.setSignatureFormattingConnectorAttributes(safeList(signatureFormattingConnectorAttributes));
         return wf;
     }
 
     private static TimestampingWorkflowDto buildTimestampingWorkflowDto(
-            SigningProfile header, SigningProfileVersion version, List<ResponseAttribute> signatureFormatterConnectorAttributes) {
+            SigningProfile header, SigningProfileVersion version, List<ResponseAttribute> signatureFormattingConnectorAttributes) {
         TimestampingWorkflowDto wf = new TimestampingWorkflowDto();
-        setFormatterRef(version, wf::setSignatureFormatterConnector);
-        wf.setSignatureFormatterConnectorAttributes(safeList(signatureFormatterConnectorAttributes));
+        setFormattingRef(version, wf::setSignatureFormattingConnector);
+        wf.setSignatureFormattingConnectorAttributes(safeList(signatureFormattingConnectorAttributes));
         wf.setQualifiedTimestamp(version.getQualifiedTimestamp());
         wf.setDefaultPolicyId(version.getDefaultPolicyId());
         wf.setAllowedPolicyIds(safeList(version.getAllowedPolicyIds()));
@@ -241,10 +241,10 @@ public class SigningProfileMapper {
     // ──────────────────────────────────────────────────────────────────────────
 
     private static ManagedTimestampingWorkflow buildManagedTimestampingWorkflowModel(
-            SigningProfile header, SigningProfileVersion version, List<RequestAttribute> signatureFormatterConnectorAttributes) {
+            SigningProfile header, SigningProfileVersion version, List<RequestAttribute> signatureFormattingConnectorAttributes) {
         return new ManagedTimestampingWorkflow(
-                version.getSignatureFormatterConnectorUuid(),
-                cacheSafeList(signatureFormatterConnectorAttributes),
+                version.getSignatureFormattingConnectorUuid(),
+                cacheSafeList(signatureFormattingConnectorAttributes),
                 version.getQualifiedTimestamp(),
                 header.getTimeQualityConfigurationUuid(),
                 version.getDefaultPolicyId(),
@@ -296,15 +296,15 @@ public class SigningProfileMapper {
     // Shared utilities
     // ──────────────────────────────────────────────────────────────────────────
 
-    private static void setFormatterRef(SigningProfileVersion profileVersion, Consumer<NameAndUuidDto> setter) {
-        if (profileVersion.getSignatureFormatterConnector() == null
-                || profileVersion.getSignatureFormatterConnectorUuid() == null) {
+    private static void setFormattingRef(SigningProfileVersion profileVersion, Consumer<NameAndUuidDto> setter) {
+        if (profileVersion.getSignatureFormattingConnector() == null
+                || profileVersion.getSignatureFormattingConnectorUuid() == null) {
             setter.accept(null);
             return;
         }
         NameAndUuidDto ref = new NameAndUuidDto();
-        ref.setName(profileVersion.getSignatureFormatterConnector().getName());
-        ref.setUuid(profileVersion.getSignatureFormatterConnectorUuid().toString());
+        ref.setName(profileVersion.getSignatureFormattingConnector().getName());
+        ref.setUuid(profileVersion.getSignatureFormattingConnectorUuid().toString());
         setter.accept(ref);
     }
 

--- a/src/main/java/com/otilm/core/model/signing/resolved/ResolvedManagedTimestampingProfile.java
+++ b/src/main/java/com/otilm/core/model/signing/resolved/ResolvedManagedTimestampingProfile.java
@@ -26,9 +26,9 @@ import java.util.UUID;
  * @param allowedPolicyIds                       Accepted TSA Policy IDs.
  * @param allowedDigestAlgorithms                Accepted digest algorithms.
  * @param validateTokenSignature                 Whether to validate the token signature after issuance.
- * @param signatureFormatterConnectorAttributes  Attributes controlling DTBS construction.
+ * @param signatureFormattingConnectorAttributes  Attributes controlling DTBS construction.
  * @param timeQualityConfiguration               Resolved Time Quality Configuration (from TQC cache).
- * @param signatureFormatterConnector            Resolved Signature Formatter Connector routing info
+ * @param signatureFormattingConnector            Resolved Signature Formatting Provider routing info
  *                                               (from {@code CONNECTOR_API_CLIENT_CACHE}).
  * @param resolvedScheme                         Resolved scheme (e.g. resolved certificate).
  */
@@ -44,9 +44,9 @@ public record ResolvedManagedTimestampingProfile(
         List<String> allowedPolicyIds,
         List<DigestAlgorithm> allowedDigestAlgorithms,
         Boolean validateTokenSignature,
-        List<RequestAttribute> signatureFormatterConnectorAttributes,
+        List<RequestAttribute> signatureFormattingConnectorAttributes,
         TimeQualityConfigurationModel timeQualityConfiguration,
-        ApiClientConnectorInfo signatureFormatterConnector,
+        ApiClientConnectorInfo signatureFormattingConnector,
         ResolvedManagedScheme resolvedScheme
 ) implements ResolvedSigningProfile {
 

--- a/src/main/java/com/otilm/core/model/signing/workflow/ManagedContentSigningWorkflow.java
+++ b/src/main/java/com/otilm/core/model/signing/workflow/ManagedContentSigningWorkflow.java
@@ -8,11 +8,11 @@ import java.util.UUID;
 /**
  * Content-signing workflow for ILM-managed signing.
  *
- * @param signatureFormatterConnectorUuid       UUID of the Signature Formatter Connector.
- * @param signatureFormatterConnectorAttributes Attributes controlling DTBS construction.
+ * @param signatureFormattingConnectorUuid       UUID of the Signature Formatting Provider.
+ * @param signatureFormattingConnectorAttributes Attributes controlling DTBS construction.
  */
 public record ManagedContentSigningWorkflow(
-        UUID signatureFormatterConnectorUuid,
-        List<RequestAttribute> signatureFormatterConnectorAttributes
+        UUID signatureFormattingConnectorUuid,
+        List<RequestAttribute> signatureFormattingConnectorAttributes
 ) implements ContentSigningWorkflow {
 }

--- a/src/main/java/com/otilm/core/model/signing/workflow/ManagedTimestampingWorkflow.java
+++ b/src/main/java/com/otilm/core/model/signing/workflow/ManagedTimestampingWorkflow.java
@@ -9,10 +9,10 @@ import java.util.UUID;
 /**
  * Timestamping workflow for ILM-managed signing.
  *
- * @param signatureFormatterConnectorUuid       UUID of the Signature Formatter Connector that
+ * @param signatureFormattingConnectorUuid       UUID of the Signature Formatting Provider that
  *                                              constructs the DTBS for Timestamping.
- * @param signatureFormatterConnectorAttributes Attributes controlling DTBS construction on the
- *                                              Signature Formatter Connector.
+ * @param signatureFormattingConnectorAttributes Attributes controlling DTBS construction on the
+ *                                              Signature Formatting Provider.
  * @param isQualifiedTimestamp                  ETSI qualified electronic timestamp flag.
  * @param timeQualityConfigurationUuid          UUID of the Time Quality Configuration validating
  *                                              clock accuracy at signing time; required when
@@ -24,8 +24,8 @@ import java.util.UUID;
  * @param validateTokenSignature                Whether to validate the token signature after issuance.
  */
 public record ManagedTimestampingWorkflow(
-        UUID signatureFormatterConnectorUuid,
-        List<RequestAttribute> signatureFormatterConnectorAttributes,
+        UUID signatureFormattingConnectorUuid,
+        List<RequestAttribute> signatureFormattingConnectorAttributes,
         Boolean isQualifiedTimestamp,
         UUID timeQualityConfigurationUuid,
         String defaultPolicyId,

--- a/src/main/java/com/otilm/core/model/signing/workflow/SigningWorkflow.java
+++ b/src/main/java/com/otilm/core/model/signing/workflow/SigningWorkflow.java
@@ -7,7 +7,7 @@ import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
  *
  * <p>Each workflow type is represented by a nested sealed interface that further splits into
  * scheme-specific record implementations ({@code Managed*} and {@code Delegated*}).
- * This ensures that fields valid only for managed signing (e.g. Signature Formatter Connector
+ * This ensures that fields valid only for managed signing (e.g. Signature Formatting Provider
  * references) are only accessible on the managed variant — enforced at compile time.</p>
  */
 public sealed interface SigningWorkflow

--- a/src/main/java/com/otilm/core/model/signing/workflow/TimestampingWorkflow.java
+++ b/src/main/java/com/otilm/core/model/signing/workflow/TimestampingWorkflow.java
@@ -11,7 +11,7 @@ import java.util.List;
  * <p>Common validation fields ({@code defaultPolicyId}, {@code allowedPolicyIds},
  * {@code allowedDigestAlgorithms}, {@code validateTokenSignature}) are accessible on this
  * interface for both managed and delegated signing. Fields that are only relevant for
- * ILM-managed signing (Signature Formatter Connector reference, {@code isQualifiedTimestamp},
+ * ILM-managed signing (Signature Formatting Provider reference, {@code isQualifiedTimestamp},
  * {@code timeQualityConfigurationUuid}) are scoped to {@link ManagedTimestampingWorkflow} only.</p>
  */
 public sealed interface TimestampingWorkflow extends SigningWorkflow

--- a/src/main/java/com/otilm/core/service/SigningProfileService.java
+++ b/src/main/java/com/otilm/core/service/SigningProfileService.java
@@ -96,7 +96,7 @@ public interface SigningProfileService extends ResourceExtensionService {
 
     List<BaseAttribute> listSignatureAttributesForCertificate(UUID certificateUuid) throws NotFoundException;
 
-    List<BaseAttribute> listSignatureFormatterConnectorAttributes(UUID connectorUuid, SecuredUUID signingProfileUuid) throws NotFoundException, ConnectorException, AttributeException;
+    List<BaseAttribute> listSignatureFormattingConnectorAttributes(UUID connectorUuid, SecuredUUID signingProfileUuid) throws NotFoundException, ConnectorException, AttributeException;
 
     PaginationResponseDto<SigningRecordListDto> listSigningRecordsForSigningProfile(SecuredUUID uuid, SearchRequestDto request, SecurityFilter filter) throws NotFoundException;
 

--- a/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
@@ -291,7 +291,7 @@ public class SigningProfileServiceImpl implements SigningProfileService {
         List<RequestAttribute> signatureFormattingConnectorAttributes = attributeEngine.getRequestObjectDataAttributesContent(
                 ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, profile.getUuid())
                         .connector(currentVersion.getSignatureFormattingConnectorUuid())
-                        .operation(AttributeOperation.WORKFLOW_FORMATTER)
+                        .operation(AttributeOperation.WORKFLOW_FORMATTING)
                         .version(currentVersion.getVersion()).build());
 
         // Narrow scope: only managed-timestamping profiles are cacheable for now.
@@ -824,7 +824,7 @@ public class SigningProfileServiceImpl implements SigningProfileService {
         List<ResponseAttribute> signatureFormattingConnectorAttributes = attributeEngine.getObjectDataAttributesContent(
                 ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, profile.getUuid())
                         .connector(spv.getSignatureFormattingConnectorUuid())
-                        .operation(AttributeOperation.WORKFLOW_FORMATTER)
+                        .operation(AttributeOperation.WORKFLOW_FORMATTING)
                         .version(spv.getVersion()).build());
         return SigningProfileMapper.toDto(profile, spv, customAttributes, signingOperationAttributes, signatureFormattingConnectorAttributes);
     }
@@ -869,11 +869,11 @@ public class SigningProfileServiceImpl implements SigningProfileService {
             throws AttributeException, NotFoundException {
         return switch (workflow) {
             case ContentSigningWorkflowRequestDto w -> {
-                attributeEngine.validateUpdateDataAttributes(w.getSignatureFormattingConnectorUuid(), AttributeOperation.WORKFLOW_FORMATTER, formattingDefinitions, w.getSignatureFormattingConnectorAttributes());
+                attributeEngine.validateUpdateDataAttributes(w.getSignatureFormattingConnectorUuid(), AttributeOperation.WORKFLOW_FORMATTING, formattingDefinitions, w.getSignatureFormattingConnectorAttributes());
                 yield attributeEngine.replaceObjectDataAttributesContent(
                         ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, p.getUuid())
                                 .connector(w.getSignatureFormattingConnectorUuid())
-                                .operation(AttributeOperation.WORKFLOW_FORMATTER)
+                                .operation(AttributeOperation.WORKFLOW_FORMATTING)
                                 .version(version.getVersion()).build(),
                         w.getSignatureFormattingConnectorAttributes());
             }
@@ -881,16 +881,16 @@ public class SigningProfileServiceImpl implements SigningProfileService {
                 // Raw signing has no formatting; clean up any formatting attributes that may remain for this version.
                 attributeEngine.deleteOperationObjectAttributesContent(AttributeType.DATA,
                         ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, p.getUuid())
-                                .operation(AttributeOperation.WORKFLOW_FORMATTER)
+                                .operation(AttributeOperation.WORKFLOW_FORMATTING)
                                 .version(version.getVersion()).build());
                 yield null;
             }
             case TimestampingWorkflowRequestDto w -> {
-                attributeEngine.validateUpdateDataAttributes(w.getSignatureFormattingConnectorUuid(), AttributeOperation.WORKFLOW_FORMATTER, formattingDefinitions, w.getSignatureFormattingConnectorAttributes());
+                attributeEngine.validateUpdateDataAttributes(w.getSignatureFormattingConnectorUuid(), AttributeOperation.WORKFLOW_FORMATTING, formattingDefinitions, w.getSignatureFormattingConnectorAttributes());
                 yield attributeEngine.replaceObjectDataAttributesContent(
                         ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, p.getUuid())
                                 .connector(w.getSignatureFormattingConnectorUuid())
-                                .operation(AttributeOperation.WORKFLOW_FORMATTER)
+                                .operation(AttributeOperation.WORKFLOW_FORMATTING)
                                 .version(version.getVersion()).build(),
                         w.getSignatureFormattingConnectorAttributes());
             }

--- a/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
@@ -236,8 +236,8 @@ public class SigningProfileServiceImpl implements SigningProfileService {
     @Override
     @ExternalAuthorization(resource = Resource.SIGNING_PROFILE, action = ResourceAction.ANY)
     @Transactional(readOnly = true)
-    public List<BaseAttribute> listSignatureFormatterConnectorAttributes(UUID connectorUuid, SecuredUUID signingProfileUuid) throws NotFoundException, ConnectorException, AttributeException {
-        return fetchFormatterAttributeDefinitions(connectorUuid);
+    public List<BaseAttribute> listSignatureFormattingConnectorAttributes(UUID connectorUuid, SecuredUUID signingProfileUuid) throws NotFoundException, ConnectorException, AttributeException {
+        return fetchFormattingAttributeDefinitions(connectorUuid);
     }
 
     @Override
@@ -288,15 +288,15 @@ public class SigningProfileServiceImpl implements SigningProfileService {
                 ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, profile.getUuid())
                         .operation(AttributeOperation.SIGN)
                         .version(currentVersion.getVersion()).build());
-        List<RequestAttribute> signatureFormatterConnectorAttributes = attributeEngine.getRequestObjectDataAttributesContent(
+        List<RequestAttribute> signatureFormattingConnectorAttributes = attributeEngine.getRequestObjectDataAttributesContent(
                 ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, profile.getUuid())
-                        .connector(currentVersion.getSignatureFormatterConnectorUuid())
+                        .connector(currentVersion.getSignatureFormattingConnectorUuid())
                         .operation(AttributeOperation.WORKFLOW_FORMATTER)
                         .version(currentVersion.getVersion()).build());
 
         // Narrow scope: only managed-timestamping profiles are cacheable for now.
         return SigningProfileMapper.toManagedTimestampingModel(
-                profile, currentVersion, signingOperationAttributes, signatureFormatterConnectorAttributes);
+                profile, currentVersion, signingOperationAttributes, signatureFormattingConnectorAttributes);
     }
 
     @Override
@@ -362,14 +362,14 @@ public class SigningProfileServiceImpl implements SigningProfileService {
         }
         validateSigningSchemeCoherence(request.getSigningScheme());
         attributeEngine.validateCustomAttributesContent(Resource.SIGNING_PROFILE, request.getCustomAttributes());
-        List<BaseAttribute> formatterDefinitions = fetchFormatterAttributeDefinitions(request.getWorkflow());
-        SigningProfileDto created = self.persistCreate(request, formatterDefinitions);
+        List<BaseAttribute> formattingDefinitions = fetchFormattingAttributeDefinitions(request.getWorkflow());
+        SigningProfileDto created = self.persistCreate(request, formattingDefinitions);
         evictSigningProfileCache(created.getName());
         return created;
     }
 
     @Transactional
-    SigningProfileDto persistCreate(SigningProfileRequestDto request, List<BaseAttribute> formatterDefinitions)
+    SigningProfileDto persistCreate(SigningProfileRequestDto request, List<BaseAttribute> formattingDefinitions)
             throws AttributeException, NotFoundException {
         SigningProfile profile = new SigningProfile();
         profile.setName(request.getName());
@@ -387,8 +387,8 @@ public class SigningProfileServiceImpl implements SigningProfileService {
 
         List<ResponseAttribute> customAttributes = attributeEngine.updateObjectCustomAttributesContent(Resource.SIGNING_PROFILE, profile.getUuid(), request.getCustomAttributes());
         List<ResponseAttribute> signingOperationAttributes = persistSigningOperationAttributes(profile, v1, request.getSigningScheme());
-        List<ResponseAttribute> signatureFormatterConnectorAttributes = persistSignatureFormatterConnectorAttributes(profile, v1, request.getWorkflow(), formatterDefinitions);
-        return SigningProfileMapper.toDto(profile, v1, customAttributes, signingOperationAttributes, signatureFormatterConnectorAttributes);
+        List<ResponseAttribute> signatureFormattingConnectorAttributes = persistSignatureFormattingConnectorAttributes(profile, v1, request.getWorkflow(), formattingDefinitions);
+        return SigningProfileMapper.toDto(profile, v1, customAttributes, signingOperationAttributes, signatureFormattingConnectorAttributes);
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -402,12 +402,12 @@ public class SigningProfileServiceImpl implements SigningProfileService {
             throws AlreadyExistException, AttributeException, ConnectorException, NotFoundException {
         validateSigningSchemeCoherence(request.getSigningScheme());
         attributeEngine.validateCustomAttributesContent(Resource.SIGNING_PROFILE, request.getCustomAttributes());
-        List<BaseAttribute> formatterDefinitions = fetchFormatterAttributeDefinitions(request.getWorkflow());
-        return self.persistUpdate(uuid, request, formatterDefinitions);
+        List<BaseAttribute> formattingDefinitions = fetchFormattingAttributeDefinitions(request.getWorkflow());
+        return self.persistUpdate(uuid, request, formattingDefinitions);
     }
 
     @Transactional
-    SigningProfileDto persistUpdate(SecuredUUID uuid, SigningProfileRequestDto request, List<BaseAttribute> formatterDefinitions)
+    SigningProfileDto persistUpdate(SecuredUUID uuid, SigningProfileRequestDto request, List<BaseAttribute> formattingDefinitions)
             throws AlreadyExistException, AttributeException, NotFoundException {
         // Serialize the bump decision per profile to prevent concurrent updates from racing.
         clusterSynchronizer.lock("signing-profile:" + uuid.getValue());
@@ -450,11 +450,11 @@ public class SigningProfileServiceImpl implements SigningProfileService {
 
         List<ResponseAttribute> customAttributes = attributeEngine.updateObjectCustomAttributesContent(Resource.SIGNING_PROFILE, profile.getUuid(), request.getCustomAttributes());
         List<ResponseAttribute> signingOperationAttributes = persistSigningOperationAttributes(profile, version, request.getSigningScheme());
-        List<ResponseAttribute> signatureFormatterConnectorAttributes = persistSignatureFormatterConnectorAttributes(profile, version, request.getWorkflow(), formatterDefinitions);
+        List<ResponseAttribute> signatureFormattingConnectorAttributes = persistSignatureFormattingConnectorAttributes(profile, version, request.getWorkflow(), formattingDefinitions);
         tspProfileService.evictAllCachedModels();
         evictSigningProfileCache(oldName);
         evictSigningProfileCache(profile.getName());
-        return SigningProfileMapper.toDto(profile, version, customAttributes, signingOperationAttributes, signatureFormatterConnectorAttributes);
+        return SigningProfileMapper.toDto(profile, version, customAttributes, signingOperationAttributes, signatureFormattingConnectorAttributes);
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -725,7 +725,7 @@ public class SigningProfileServiceImpl implements SigningProfileService {
         p.setTimeQualityConfiguration(null);
         p.setWorkflowType(workflow.getType()); // cache column
         version.setWorkflowType(workflow.getType());
-        version.setSignatureFormatterConnector(null);
+        version.setSignatureFormattingConnector(null);
         version.setQualifiedTimestamp(null);
         version.setDefaultPolicyId(null);
         version.setAllowedPolicyIds(new ArrayList<>());
@@ -734,25 +734,25 @@ public class SigningProfileServiceImpl implements SigningProfileService {
 
         switch (workflow) {
             case ContentSigningWorkflowRequestDto w -> {
-                if (w.getSignatureFormatterConnectorUuid() == null) {
-                    throw new ValidationException("Signature formatter connector is required for content signing workflow");
+                if (w.getSignatureFormattingConnectorUuid() == null) {
+                    throw new ValidationException("Signature formatting connector is required for content signing workflow");
                 }
                 Connector contentConnector =
-                        connectorService.getConnectorEntity(SecuredUUID.fromUUID(w.getSignatureFormatterConnectorUuid()));
-                validateFormatterConnectorFeature(contentConnector, FeatureFlag.CONTENT_SIGNING, SigningWorkflowType.CONTENT_SIGNING);
-                version.setSignatureFormatterConnector(contentConnector);
+                        connectorService.getConnectorEntity(SecuredUUID.fromUUID(w.getSignatureFormattingConnectorUuid()));
+                validateFormattingConnectorFeature(contentConnector, FeatureFlag.CONTENT_SIGNING, SigningWorkflowType.CONTENT_SIGNING);
+                version.setSignatureFormattingConnector(contentConnector);
             }
             case RawSigningWorkflowRequestDto ignored -> {
-                // RawSigningWorkflowRequestDto has no signatureFormatterConnectorUuid field — no formatter is allowed
+                // RawSigningWorkflowRequestDto has no signatureFormattingConnectorUuid field — no formatting is allowed
             }
             case TimestampingWorkflowRequestDto w -> {
-                if (w.getSignatureFormatterConnectorUuid() == null) {
-                    throw new ValidationException("Signature formatter connector is required for timestamping workflow");
+                if (w.getSignatureFormattingConnectorUuid() == null) {
+                    throw new ValidationException("Signature formatting connector is required for timestamping workflow");
                 }
                 Connector tsaConnector =
-                        connectorService.getConnectorEntity(SecuredUUID.fromUUID(w.getSignatureFormatterConnectorUuid()));
-                validateFormatterConnectorFeature(tsaConnector, FeatureFlag.TIMESTAMPING, SigningWorkflowType.TIMESTAMPING);
-                version.setSignatureFormatterConnector(tsaConnector);
+                        connectorService.getConnectorEntity(SecuredUUID.fromUUID(w.getSignatureFormattingConnectorUuid()));
+                validateFormattingConnectorFeature(tsaConnector, FeatureFlag.TIMESTAMPING, SigningWorkflowType.TIMESTAMPING);
+                version.setSignatureFormattingConnector(tsaConnector);
                 version.setQualifiedTimestamp(w.getQualifiedTimestamp());
                 version.setDefaultPolicyId(w.getDefaultPolicyId());
                 version.setAllowedPolicyIds(w.getAllowedPolicyIds() != null ? w.getAllowedPolicyIds() : new ArrayList<>());
@@ -802,12 +802,12 @@ public class SigningProfileServiceImpl implements SigningProfileService {
         return p.getPersistenceMode() != null ? p.getPersistenceMode() : SigningRecordPersistenceMode.DEFERRED_DURABLE;
     }
 
-    private void validateFormatterConnectorFeature(Connector connector, FeatureFlag requiredFeature, SigningWorkflowType workflowType) {
+    private void validateFormattingConnectorFeature(Connector connector, FeatureFlag requiredFeature, SigningWorkflowType workflowType) {
         boolean hasFeature = connector.getInterfaces().stream()
                 .filter(i -> ConnectorInterface.SIGNATURE_FORMATTING.equals(i.getInterfaceCode()))
                 .anyMatch(i -> i.getFeatures() != null && i.getFeatures().contains(requiredFeature));
         if (!hasFeature) {
-            throw new ValidationException("Formatter connector '%s' does not support the '%s' feature required for %s workflow"
+            throw new ValidationException("Signature Formatting Provider '%s' does not support the '%s' feature required for %s workflow"
                     .formatted(connector.getName(), requiredFeature.getLabel(), workflowType.getLabel()));
         }
     }
@@ -821,12 +821,12 @@ public class SigningProfileServiceImpl implements SigningProfileService {
                 ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, profile.getUuid())
                         .operation(AttributeOperation.SIGN)
                         .version(spv.getVersion()).build());
-        List<ResponseAttribute> signatureFormatterConnectorAttributes = attributeEngine.getObjectDataAttributesContent(
+        List<ResponseAttribute> signatureFormattingConnectorAttributes = attributeEngine.getObjectDataAttributesContent(
                 ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, profile.getUuid())
-                        .connector(spv.getSignatureFormatterConnectorUuid())
+                        .connector(spv.getSignatureFormattingConnectorUuid())
                         .operation(AttributeOperation.WORKFLOW_FORMATTER)
                         .version(spv.getVersion()).build());
-        return SigningProfileMapper.toDto(profile, spv, customAttributes, signingOperationAttributes, signatureFormatterConnectorAttributes);
+        return SigningProfileMapper.toDto(profile, spv, customAttributes, signingOperationAttributes, signatureFormattingConnectorAttributes);
     }
 
     private SigningProfileDto buildDtoFromProfile(SigningProfile profile) {
@@ -862,23 +862,23 @@ public class SigningProfileServiceImpl implements SigningProfileService {
         return List.of();
     }
 
-    private List<ResponseAttribute> persistSignatureFormatterConnectorAttributes(SigningProfile p,
+    private List<ResponseAttribute> persistSignatureFormattingConnectorAttributes(SigningProfile p,
                                                                                  SigningProfileVersion version,
                                                                                  WorkflowRequestDto workflow,
-                                                                                 List<BaseAttribute> formatterDefinitions)
+                                                                                 List<BaseAttribute> formattingDefinitions)
             throws AttributeException, NotFoundException {
         return switch (workflow) {
             case ContentSigningWorkflowRequestDto w -> {
-                attributeEngine.validateUpdateDataAttributes(w.getSignatureFormatterConnectorUuid(), AttributeOperation.WORKFLOW_FORMATTER, formatterDefinitions, w.getSignatureFormatterConnectorAttributes());
+                attributeEngine.validateUpdateDataAttributes(w.getSignatureFormattingConnectorUuid(), AttributeOperation.WORKFLOW_FORMATTER, formattingDefinitions, w.getSignatureFormattingConnectorAttributes());
                 yield attributeEngine.replaceObjectDataAttributesContent(
                         ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, p.getUuid())
-                                .connector(w.getSignatureFormatterConnectorUuid())
+                                .connector(w.getSignatureFormattingConnectorUuid())
                                 .operation(AttributeOperation.WORKFLOW_FORMATTER)
                                 .version(version.getVersion()).build(),
-                        w.getSignatureFormatterConnectorAttributes());
+                        w.getSignatureFormattingConnectorAttributes());
             }
             case RawSigningWorkflowRequestDto ignored -> {
-                // Raw signing has no formatter; clean up any formatter attributes that may remain for this version.
+                // Raw signing has no formatting; clean up any formatting attributes that may remain for this version.
                 attributeEngine.deleteOperationObjectAttributesContent(AttributeType.DATA,
                         ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, p.getUuid())
                                 .operation(AttributeOperation.WORKFLOW_FORMATTER)
@@ -886,36 +886,36 @@ public class SigningProfileServiceImpl implements SigningProfileService {
                 yield null;
             }
             case TimestampingWorkflowRequestDto w -> {
-                attributeEngine.validateUpdateDataAttributes(w.getSignatureFormatterConnectorUuid(), AttributeOperation.WORKFLOW_FORMATTER, formatterDefinitions, w.getSignatureFormatterConnectorAttributes());
+                attributeEngine.validateUpdateDataAttributes(w.getSignatureFormattingConnectorUuid(), AttributeOperation.WORKFLOW_FORMATTER, formattingDefinitions, w.getSignatureFormattingConnectorAttributes());
                 yield attributeEngine.replaceObjectDataAttributesContent(
                         ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, p.getUuid())
-                                .connector(w.getSignatureFormatterConnectorUuid())
+                                .connector(w.getSignatureFormattingConnectorUuid())
                                 .operation(AttributeOperation.WORKFLOW_FORMATTER)
                                 .version(version.getVersion()).build(),
-                        w.getSignatureFormatterConnectorAttributes());
+                        w.getSignatureFormattingConnectorAttributes());
             }
             default -> throw new IllegalStateException("Unexpected type for Signing Workflow: " + workflow);
         };
     }
 
     /**
-     * Fetches formatter attribute definitions from the connector without persisting them.
-     * Definitions are persisted later inside the transaction by {@link #persistSignatureFormatterConnectorAttributes}
+     * Fetches formatting attribute definitions from the connector without persisting them.
+     * Definitions are persisted later inside the transaction by {@link #persistSignatureFormattingConnectorAttributes}
      * via {@link AttributeEngine#validateUpdateDataAttributes}, which keeps the definition upsert and content write atomic.
      */
-    private List<BaseAttribute> fetchFormatterAttributeDefinitions(WorkflowRequestDto workflow) throws ConnectorException, NotFoundException {
+    private List<BaseAttribute> fetchFormattingAttributeDefinitions(WorkflowRequestDto workflow) throws ConnectorException, NotFoundException {
         return switch (workflow) {
             case ContentSigningWorkflowRequestDto w ->
-                    fetchFormatterAttributeDefinitions(w.getSignatureFormatterConnectorUuid());
+                    fetchFormattingAttributeDefinitions(w.getSignatureFormattingConnectorUuid());
             case TimestampingWorkflowRequestDto w ->
-                    fetchFormatterAttributeDefinitions(w.getSignatureFormatterConnectorUuid());
+                    fetchFormattingAttributeDefinitions(w.getSignatureFormattingConnectorUuid());
             default -> List.of();
         };
     }
 
-    private List<BaseAttribute> fetchFormatterAttributeDefinitions(UUID connectorUuid) throws ConnectorException, NotFoundException {
+    private List<BaseAttribute> fetchFormattingAttributeDefinitions(UUID connectorUuid) throws ConnectorException, NotFoundException {
         ApiClientConnectorInfo apiClientInfo = connectorService.getConnectorForApiClient(connectorUuid);
-        return connectorApiFactory.getSignatureFormatterApiClient(apiClientInfo).listFormatterAttributes(apiClientInfo);
+        return connectorApiFactory.getSignatureFormattingApiClient(apiClientInfo).listFormattingAttributes(apiClientInfo);
     }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/src/main/java/com/otilm/core/signing/tsa/StaticKeyManagedTimestampTokenGenerator.java
+++ b/src/main/java/com/otilm/core/signing/tsa/StaticKeyManagedTimestampTokenGenerator.java
@@ -5,7 +5,7 @@ import com.otilm.api.interfaces.core.tsp.error.TspFailureInfo;
 import com.otilm.api.model.common.enums.cryptography.SignatureAlgorithm;
 import com.otilm.core.model.signing.resolved.ResolvedManagedTimestampingProfile;
 import com.otilm.core.signing.tsa.messages.TspRequest;
-import com.otilm.core.signing.tsa.formatter.SignatureFormatterClient;
+import com.otilm.core.signing.tsa.formatting.SignatureFormattingClient;
 import com.otilm.core.signing.tsa.signer.Signer;
 import com.otilm.core.signing.tsa.signer.SignerFactory;
 import org.bouncycastle.cms.CMSException;
@@ -21,8 +21,8 @@ import java.time.Instant;
 /**
  * Builds an RFC 3161 timestamp token for a signing profile, using a statically configured signing key and certificate.
  *
- * <p>Token assembly is a two-round-trip exchange with the signature-formatter connector because the
- * core never holds the private key: the signature-formatter connector owns ASN.1 encoding while the core manages signing.
+ * <p>Token assembly is a two-round-trip exchange with the signature-formatting connector because the
+ * core never holds the private key: the signature-formatting connector owns ASN.1 encoding while the core manages signing.
  * <ol>
  *     <li><b>Format DTBS</b> — the connector encodes the TSTInfo and returns the exact data-to-be-signed.</li>
  *     <li><b>Sign</b> — the core's {@link Signer} signs that DTBS with the managed key.</li>
@@ -36,11 +36,11 @@ public class StaticKeyManagedTimestampTokenGenerator implements ManagedTimestamp
 
     private final SignerFactory signerFactory;
 
-    private final SignatureFormatterClient formatter;
+    private final SignatureFormattingClient formatting;
 
-    public StaticKeyManagedTimestampTokenGenerator(SignerFactory signerFactory, SignatureFormatterClient formatter) {
+    public StaticKeyManagedTimestampTokenGenerator(SignerFactory signerFactory, SignatureFormattingClient formatting) {
         this.signerFactory = signerFactory;
-        this.formatter = formatter;
+        this.formatting = formatting;
     }
 
     @Override
@@ -49,12 +49,12 @@ public class StaticKeyManagedTimestampTokenGenerator implements ManagedTimestamp
         Signer signer = signerFactory.create(timestampingProfile.resolvedScheme());
         SignatureAlgorithm signatureAlgorithm = signer.getSignatureAlgorithm();
 
-        byte[] dtbs = formatter.formatDtbs(request, timestampingProfile, serialNumber, genTime,
+        byte[] dtbs = formatting.formatDtbs(request, timestampingProfile, serialNumber, genTime,
                 certificateChain, signatureAlgorithm);
 
         byte[] signature = signer.sign(dtbs);
 
-        byte[] tokenBytes = formatter.formatSigningResponse(request, timestampingProfile, serialNumber, genTime, certificateChain, dtbs, signature, signatureAlgorithm);
+        byte[] tokenBytes = formatting.formatSigningResponse(request, timestampingProfile, serialNumber, genTime, certificateChain, dtbs, signature, signatureAlgorithm);
 
         try {
             return new TimeStampToken(new CMSSignedData(tokenBytes));

--- a/src/main/java/com/otilm/core/signing/tsa/formatting/SignatureFormattingClient.java
+++ b/src/main/java/com/otilm/core/signing/tsa/formatting/SignatureFormattingClient.java
@@ -1,4 +1,4 @@
-package com.otilm.core.signing.tsa.formatter;
+package com.otilm.core.signing.tsa.formatting;
 
 import com.otilm.api.interfaces.core.tsp.error.TspException;
 import com.otilm.api.model.common.enums.cryptography.SignatureAlgorithm;
@@ -10,7 +10,7 @@ import java.math.BigInteger;
 import java.time.Instant;
 
 /**
- * Two-phase formatter for RFC 3161 TimeStampTokens.
+ * Two-phase formatting for RFC 3161 TimeStampTokens.
  *
  * <p>Phase 1 — {@link #formatDtbs}: produces the DER-encoded SignedAttributes
  * (Data To Be Signed). The caller signs these bytes externally.
@@ -19,7 +19,7 @@ import java.time.Instant;
  * assembles the final TimeStampToken. Both phases are stateless — the same
  * parameters must be passed to both calls so phase 1 can be replayed.
  */
-public interface SignatureFormatterClient {
+public interface SignatureFormattingClient {
 
     /**
      * Drives BouncyCastle's TimeStampTokenGenerator to capture the SignedAttributes

--- a/src/main/java/com/otilm/core/signing/tsa/formatting/TimestampingConnectorSignatureFormattingClient.java
+++ b/src/main/java/com/otilm/core/signing/tsa/formatting/TimestampingConnectorSignatureFormattingClient.java
@@ -1,13 +1,13 @@
-package com.otilm.core.signing.tsa.formatter;
+package com.otilm.core.signing.tsa.formatting;
 
-import com.otilm.api.clients.signing.SignatureFormatterApiClient;
+import com.otilm.api.clients.signing.SignatureFormattingApiClient;
 import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.interfaces.core.tsp.error.TspException;
 import com.otilm.api.interfaces.core.tsp.error.TspFailureInfo;
 import com.otilm.api.model.common.enums.cryptography.SignatureAlgorithm;
-import com.otilm.api.model.connector.signatures.formatter.ExtensionDto;
-import com.otilm.api.model.connector.signatures.formatter.TimestampingFormatDtbsRequestDto;
-import com.otilm.api.model.connector.signatures.formatter.TimestampingFormatResponseRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.ExtensionDto;
+import com.otilm.api.model.connector.signatures.formatting.TimestampingFormatDtbsRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.TimestampingFormatResponseRequestDto;
 import com.otilm.api.clients.ApiClientConnectorInfo;
 import com.otilm.core.model.signing.resolved.ResolvedManagedTimestampingProfile;
 import com.otilm.core.signing.tsa.CertificateChain;
@@ -28,12 +28,12 @@ import java.util.Collections;
 import java.util.List;
 
 @Component
-public class TimestampingConnectorSignatureFormatterClient implements SignatureFormatterClient {
+public class TimestampingConnectorSignatureFormattingClient implements SignatureFormattingClient {
 
-    private SignatureFormatterApiClient apiClient;
+    private SignatureFormattingApiClient apiClient;
 
     @Autowired
-    public void setApiClient(SignatureFormatterApiClient apiClient) {
+    public void setApiClient(SignatureFormattingApiClient apiClient) {
         this.apiClient = apiClient;
     }
 
@@ -45,7 +45,7 @@ public class TimestampingConnectorSignatureFormatterClient implements SignatureF
                              CertificateChain certificateChain,
                              SignatureAlgorithm signatureAlgorithm) throws TspException {
 
-        ApiClientConnectorInfo connector = timestampingProfile.signatureFormatterConnector();
+        ApiClientConnectorInfo connector = timestampingProfile.signatureFormattingConnector();
 
         TimestampingFormatDtbsRequestDto requestDto = new TimestampingFormatDtbsRequestDto();
         requestDto.setData(request.hashedMessage());
@@ -60,12 +60,12 @@ public class TimestampingConnectorSignatureFormatterClient implements SignatureF
         requestDto.setAccuracy(timestampingProfile.timeQualityConfiguration().getAccuracy().orElse(null));
         requestDto.setSignatureAlgorithm(signatureAlgorithm);
         requestDto.setCertificateChain(encodeDerChain(certificateChain));
-        requestDto.setFormatAttributes(timestampingProfile.signatureFormatterConnectorAttributes());
+        requestDto.setFormatAttributes(timestampingProfile.signatureFormattingConnectorAttributes());
 
         try {
             return apiClient.formatDtbs(connector, requestDto).getDtbs();
         } catch (ConnectorException e) {
-            throw new TspException(TspFailureInfo.SYSTEM_FAILURE, "Signature formatter connector communication failed during DTBS phase: " + e.getMessage(), e, "Internal error during DTBS formatting");
+            throw new TspException(TspFailureInfo.SYSTEM_FAILURE, "Signature formatting connector communication failed during DTBS phase: " + e.getMessage(), e, "Internal error during DTBS formatting");
         }
     }
 
@@ -79,13 +79,13 @@ public class TimestampingConnectorSignatureFormatterClient implements SignatureF
                                         byte[] signature,
                                         SignatureAlgorithm signatureAlgorithm) throws TspException {
 
-        ApiClientConnectorInfo connector = timestampingProfile.signatureFormatterConnector();
+        ApiClientConnectorInfo connector = timestampingProfile.signatureFormattingConnector();
 
         TimestampingFormatResponseRequestDto requestDto = new TimestampingFormatResponseRequestDto();
         requestDto.setDtbs(dtbs);
         requestDto.setSignature(signature);
         requestDto.setCertificateChain(encodeDerChain(certificateChain));
-        requestDto.setFormatAttributes(timestampingProfile.signatureFormatterConnectorAttributes());
+        requestDto.setFormatAttributes(timestampingProfile.signatureFormattingConnectorAttributes());
         requestDto.setData(request.hashedMessage());
         requestDto.setHashAlgorithm(request.hashAlgorithm());
         requestDto.setPolicy(request.policy().orElse(timestampingProfile.defaultPolicyId()));
@@ -101,7 +101,7 @@ public class TimestampingConnectorSignatureFormatterClient implements SignatureF
         try {
             return apiClient.formatSigningResponse(connector, requestDto).getResponse();
         } catch (ConnectorException e) {
-            throw new TspException(TspFailureInfo.SYSTEM_FAILURE, "Signature formatter connector communication failed during response assembly: " + e.getMessage(), e, "Internal error assembling timestamp token");
+            throw new TspException(TspFailureInfo.SYSTEM_FAILURE, "Signature formatting connector communication failed during response assembly: " + e.getMessage(), e, "Internal error assembling timestamp token");
         }
     }
 

--- a/src/main/java/com/otilm/core/signing/tsa/resolver/StaticKeyManagedTimestampingResolver.java
+++ b/src/main/java/com/otilm/core/signing/tsa/resolver/StaticKeyManagedTimestampingResolver.java
@@ -34,7 +34,7 @@ import java.util.UUID;
  * consumed by the timestamping pipeline.
  *
  * <p>The cached model deliberately holds only UUIDs for objects owned by other caches or
- * repositories (Time Quality Configuration, Signature Formatter Connector, signing certificate).
+ * repositories (Time Quality Configuration, Signature Formatting Provider, signing certificate).
  * This resolver dereferences those UUIDs at request time. The resolved form is never cached.</p>
  */
 @Component
@@ -65,7 +65,7 @@ public class StaticKeyManagedTimestampingResolver implements SigningProfileResol
         ManagedTimestampingWorkflow workflow = (ManagedTimestampingWorkflow) model.workflow();
         ResolvedManagedScheme resolvedScheme = resolveScheme(model.name(), model.signingScheme());
         TimeQualityConfigurationModel timeQualityConfiguration = resolveTimeQualityConfiguration(workflow.timeQualityConfigurationUuid());
-        ApiClientConnectorInfo signatureFormatterConnector = resolveSignatureFormatterConnector(workflow.signatureFormatterConnectorUuid());
+        ApiClientConnectorInfo signatureFormattingConnector = resolveSignatureFormattingConnector(workflow.signatureFormattingConnectorUuid());
 
         return new ResolvedManagedTimestampingProfile(
                 model.uuid(),
@@ -79,9 +79,9 @@ public class StaticKeyManagedTimestampingResolver implements SigningProfileResol
                 workflow.allowedPolicyIds(),
                 workflow.allowedDigestAlgorithms(),
                 workflow.validateTokenSignature(),
-                workflow.signatureFormatterConnectorAttributes(),
+                workflow.signatureFormattingConnectorAttributes(),
                 timeQualityConfiguration,
-                signatureFormatterConnector,
+                signatureFormattingConnector,
                 resolvedScheme);
     }
 
@@ -156,12 +156,12 @@ public class StaticKeyManagedTimestampingResolver implements SigningProfileResol
         }
     }
 
-    private ApiClientConnectorInfo resolveSignatureFormatterConnector(UUID signatureFormatterConnectorUuid) throws TspException {
+    private ApiClientConnectorInfo resolveSignatureFormattingConnector(UUID signatureFormattingConnectorUuid) throws TspException {
         try {
-            return connectorService.getConnectorForApiClient(signatureFormatterConnectorUuid);
+            return connectorService.getConnectorForApiClient(signatureFormattingConnectorUuid);
         } catch (NotFoundException e) {
             throw new TspException(TspFailureInfo.SYSTEM_FAILURE,
-                    "Signature formatter connector not found: " + signatureFormatterConnectorUuid, e,
+                    "Signature formatting connector not found: " + signatureFormattingConnectorUuid, e,
                     "Internal error: signing configuration is invalid");
         }
     }

--- a/src/main/java/com/otilm/core/signing/tsa/signer/Signer.java
+++ b/src/main/java/com/otilm/core/signing/tsa/signer/Signer.java
@@ -12,7 +12,7 @@ public interface Signer {
 
     /**
      * The signature algorithm this signer uses, e.g. SHA256withRSA.
-     * Required so the formatter can configure the content signer and
+     * Required so the formatting can configure the content signer and
      * derive the content digest algorithm for the timestamp token generator.
      */
     SignatureAlgorithm getSignatureAlgorithm();

--- a/src/main/resources/db/migration/V202606261200__rename_signature_formatting_connector_column.sql
+++ b/src/main/resources/db/migration/V202606261200__rename_signature_formatting_connector_column.sql
@@ -7,3 +7,12 @@ ALTER TABLE "signing_profile_version"
 
 ALTER INDEX idx_spv_signature_formatter_connector_uuid
     RENAME TO idx_spv_signature_formatting_connector_uuid;
+
+-- Rename the attribute-engine operation scope for signing-profile workflow
+-- formatting attributes ("workflowFormatter" -> "workflowFormatting"). The value
+-- is persisted in attribute_definition.operation and all attribute-content reads
+-- join on it, so existing rows must be updated in place to avoid orphaning the
+-- formatting attribute data of existing signing profiles.
+UPDATE "attribute_definition"
+   SET operation = 'workflowFormatting'
+ WHERE operation = 'workflowFormatter';

--- a/src/main/resources/db/migration/V202606261200__rename_signature_formatting_connector_column.sql
+++ b/src/main/resources/db/migration/V202606261200__rename_signature_formatting_connector_column.sql
@@ -1,0 +1,9 @@
+-- Rename the signing_profile_version formatter-connector reference from the old
+-- "Signature Formatter" naming to the canonical "Signature Formatting Provider"
+-- (OmniTrustILM/ilm#258). The column and its index are renamed in place; the FK
+-- to "connector"("uuid") is preserved by RENAME COLUMN.
+ALTER TABLE "signing_profile_version"
+    RENAME COLUMN "signature_formatter_connector_uuid" TO "signature_formatting_connector_uuid";
+
+ALTER INDEX idx_spv_signature_formatter_connector_uuid
+    RENAME TO idx_spv_signature_formatting_connector_uuid;

--- a/src/test/java/com/otilm/core/api/tsp/integration/TspControllerIntegrationTest.java
+++ b/src/test/java/com/otilm/core/api/tsp/integration/TspControllerIntegrationTest.java
@@ -17,7 +17,7 @@ import com.otilm.core.service.v2.ConnectorService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.mocks.ConnectorMockFactory;
 import com.otilm.core.util.mocks.CryptographyProviderConnectorMock;
-import com.otilm.core.util.mocks.TimestampingFormatterConnectorMock;
+import com.otilm.core.util.mocks.TimestampingFormattingConnectorMock;
 import org.bouncycastle.asn1.cmp.PKIStatus;
 import org.bouncycastle.jcajce.spec.MLDSAParameterSpec;
 import org.bouncycastle.jcajce.spec.SLHDSAParameterSpec;
@@ -68,7 +68,7 @@ import static com.otilm.core.util.builders.TspProfileRequestDtoBuilder.aTspProfi
  * <p>Exercises the full timestamp-token production path via {@link TspControllerImpl#timestamp}:
  * infrastructure is created through the real service layer (connectors, token instance/profile, keys,
  * TSA certificates, signing and TSP profiles), the cryptography-provider mock signs each request's DTBS
- * with a real per-algorithm private key, and the timestamping-formatter mock assembles a genuine
+ * with a real per-algorithm private key, and the timestamping-formatting mock assembles a genuine
  * {@code TimeStampToken} from that live signature — so the {@code withSignatureValidation} variant
  * performs a real cryptographic verify.
  */
@@ -128,8 +128,8 @@ public class TspControllerIntegrationTest extends BaseSpringBootTest {
     );
 
     private CryptographyProviderConnectorMock cryptographyProviderMock;
-    private TimestampingFormatterConnectorMock timestampingFormatterMock;
-    private ConnectorDetailDto formatterConnector;
+    private TimestampingFormattingConnectorMock timestampingFormattingMock;
+    private ConnectorDetailDto formattingConnector;
 
     /**
      * Uploaded TSA certificate entities indexed by algorithm — populated in {@link #setUp()}.
@@ -151,9 +151,9 @@ public class TspControllerIntegrationTest extends BaseSpringBootTest {
                 .stubTokenInstanceCreation(UUID.randomUUID())
                 .stubTokenProfileCreation()
                 .stubRealSigning();
-        timestampingFormatterMock = connectorMockFactory.startTimestampingFormatter();
-        timestampingFormatterMock
-                .stubFormatterAttributes()
+        timestampingFormattingMock = connectorMockFactory.startTimestampingFormatting();
+        timestampingFormattingMock
+                .stubFormattingAttributes()
                 .stubFormatDtbs()
                 .stubFormatResponse();
 
@@ -162,10 +162,10 @@ public class TspControllerIntegrationTest extends BaseSpringBootTest {
                         .withName("tsp-cryptography-provider")
                         .withUrl(cryptographyProviderMock.getUrl())
                         .build());
-        formatterConnector = connectorService.createConnector(
+        formattingConnector = connectorService.createConnector(
                 aV2ConnectorRequest()
-                        .withName("tsp-timestamping-formatter")
-                        .withUrl(timestampingFormatterMock.getUrl())
+                        .withName("tsp-timestamping-formatting")
+                        .withUrl(timestampingFormattingMock.getUrl())
                         .build());
 
         TokenInstanceDetailDto tokenInstance = tokenInstanceService.createTokenInstance(
@@ -213,8 +213,8 @@ public class TspControllerIntegrationTest extends BaseSpringBootTest {
         if (cryptographyProviderMock != null) {
             cryptographyProviderMock.stop();
         }
-        if (timestampingFormatterMock != null) {
-            timestampingFormatterMock.stop();
+        if (timestampingFormattingMock != null) {
+            timestampingFormattingMock.stop();
         }
     }
 
@@ -243,7 +243,7 @@ public class TspControllerIntegrationTest extends BaseSpringBootTest {
     /**
      * Parameterized end-to-end flow with token signature validation enabled: for each supported signing
      * algorithm, the engine cryptographically verifies the assembled token's signature against the TSA
-     * certificate before granting — a real verify, since the formatter mock embeds the live signature.
+     * certificate before granting — a real verify, since the formatting mock embeds the live signature.
      */
     @ParameterizedTest(name = "{0}")
     @MethodSource("allSigningAlgorithmParameters")
@@ -402,7 +402,7 @@ public class TspControllerIntegrationTest extends BaseSpringBootTest {
                         .withName("tsp-signing-profile-" + label)
                         .withStaticKeyManagedSigning(tsaCertificates.get(keyAlgorithm).getUuid(), signingAttributesFor(keyAlgorithm))
                         .withTimestamping(aTimestampingWorkflow()
-                                .withSignatureFormatterConnector(UUID.fromString(formatterConnector.getUuid()))
+                                .withSignatureFormattingConnector(UUID.fromString(formattingConnector.getUuid()))
                                 .withDefaultPolicyId(DEFAULT_POLICY_ID)
                                 .withQualifiedTimestamp(false)
                                 .withValidateTokenSignature(validateTokenSignature)

--- a/src/test/java/com/otilm/core/api/tsp/integration/TspSigningProfileControllerIntegrationTest.java
+++ b/src/test/java/com/otilm/core/api/tsp/integration/TspSigningProfileControllerIntegrationTest.java
@@ -17,7 +17,7 @@ import com.otilm.core.service.v2.ConnectorService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.mocks.ConnectorMockFactory;
 import com.otilm.core.util.mocks.CryptographyProviderConnectorMock;
-import com.otilm.core.util.mocks.TimestampingFormatterConnectorMock;
+import com.otilm.core.util.mocks.TimestampingFormattingConnectorMock;
 import org.bouncycastle.asn1.cmp.PKIFailureInfo;
 import org.bouncycastle.asn1.cmp.PKIStatus;
 import org.bouncycastle.jcajce.spec.MLDSAParameterSpec;
@@ -75,7 +75,7 @@ import static com.otilm.core.util.builders.TspProfileRequestDtoBuilder.aTspProfi
  *
  * <p>Infrastructure setup (connectors, token instance/profile, keys, TSA certificates, signing profiles) is
  * built through the real service layer; the cryptography-provider mock signs each request's DTBS with a real
- * per-algorithm private key, and the timestamping-formatter mock assembles a genuine {@code TimeStampToken}
+ * per-algorithm private key, and the timestamping-formatting mock assembles a genuine {@code TimeStampToken}
  * from that live signature — so the {@code withSignatureValidation} variant performs a real verify.
  */
 public class TspSigningProfileControllerIntegrationTest extends BaseSpringBootTest {
@@ -134,8 +134,8 @@ public class TspSigningProfileControllerIntegrationTest extends BaseSpringBootTe
     );
 
     private CryptographyProviderConnectorMock cryptographyProviderMock;
-    private TimestampingFormatterConnectorMock timestampingFormatterMock;
-    private ConnectorDetailDto formatterConnector;
+    private TimestampingFormattingConnectorMock timestampingFormattingMock;
+    private ConnectorDetailDto formattingConnector;
 
     /**
      * Uploaded TSA certificate entities indexed by algorithm — populated in {@link #setUp()}.
@@ -158,9 +158,9 @@ public class TspSigningProfileControllerIntegrationTest extends BaseSpringBootTe
                 .stubTokenInstanceCreation(UUID.randomUUID())
                 .stubTokenProfileCreation()
                 .stubRealSigning();
-        timestampingFormatterMock = connectorMockFactory.startTimestampingFormatter();
-        timestampingFormatterMock
-                .stubFormatterAttributes()
+        timestampingFormattingMock = connectorMockFactory.startTimestampingFormatting();
+        timestampingFormattingMock
+                .stubFormattingAttributes()
                 .stubFormatDtbs()
                 .stubFormatResponse();
 
@@ -169,10 +169,10 @@ public class TspSigningProfileControllerIntegrationTest extends BaseSpringBootTe
                         .withName("tsp-sp-cryptography-provider")
                         .withUrl(cryptographyProviderMock.getUrl())
                         .build());
-        formatterConnector = connectorService.createConnector(
+        formattingConnector = connectorService.createConnector(
                 aV2ConnectorRequest()
-                        .withName("tsp-sp-timestamping-formatter")
-                        .withUrl(timestampingFormatterMock.getUrl())
+                        .withName("tsp-sp-timestamping-formatting")
+                        .withUrl(timestampingFormattingMock.getUrl())
                         .build());
 
         TokenInstanceDetailDto tokenInstance = tokenInstanceService.createTokenInstance(
@@ -220,8 +220,8 @@ public class TspSigningProfileControllerIntegrationTest extends BaseSpringBootTe
         if (cryptographyProviderMock != null) {
             cryptographyProviderMock.stop();
         }
-        if (timestampingFormatterMock != null) {
-            timestampingFormatterMock.stop();
+        if (timestampingFormattingMock != null) {
+            timestampingFormattingMock.stop();
         }
     }
 
@@ -250,7 +250,7 @@ public class TspSigningProfileControllerIntegrationTest extends BaseSpringBootTe
     /**
      * Parameterized happy path with token signature validation enabled: the engine cryptographically verifies
      * the assembled token's signature against the TSA certificate before granting — a real verify, since the
-     * formatter mock embeds the live signature.
+     * formatting mock embeds the live signature.
      */
     @ParameterizedTest(name = "{0}")
     @MethodSource("allSigningAlgorithmParameters")
@@ -397,7 +397,7 @@ public class TspSigningProfileControllerIntegrationTest extends BaseSpringBootTe
                         .withName(signingProfileName)
                         .withStaticKeyManagedSigning(tsaCertificates.get(keyAlgorithm).getUuid(), signingAttributesFor(keyAlgorithm))
                         .withTimestamping(aTimestampingWorkflow()
-                                .withSignatureFormatterConnector(UUID.fromString(formatterConnector.getUuid()))
+                                .withSignatureFormattingConnector(UUID.fromString(formattingConnector.getUuid()))
                                 .withDefaultPolicyId(DEFAULT_POLICY_ID)
                                 .withQualifiedTimestamp(false)
                                 .withValidateTokenSignature(validateTokenSignature)

--- a/src/test/java/com/otilm/core/attribute/AttributeEngineVersioningTest.java
+++ b/src/test/java/com/otilm/core/attribute/AttributeEngineVersioningTest.java
@@ -50,7 +50,7 @@ class AttributeEngineVersioningTest extends BaseSpringBootTest {
 
     // ── Operation constants mimicking signing-profile usage ──────────────────
     private static final String OPERATION_SIGN = AttributeOperation.SIGN;
-    private static final String OPERATION_FORMAT = "connectorFormatter";
+    private static final String OPERATION_FORMAT = "connectorFormatting";
     private static final Resource VERSIONED_RESOURCE = Resource.CRYPTOGRAPHIC_KEY;
     private static final List<RequestAttribute> EMPTY_REQUEST_ATTRIBUTES = List.of();
 
@@ -384,8 +384,8 @@ class AttributeEngineVersioningTest extends BaseSpringBootTest {
         connectorB = connectorRepository.save(connectorB);
 
         // Register attribute definitions under each connector for the same operation
-        DataAttributeV3 defA = buildDataAttribute("formatter_attr_a");
-        DataAttributeV3 defB = buildDataAttribute("formatter_attr_b");
+        DataAttributeV3 defA = buildDataAttribute("formatting_attr_a");
+        DataAttributeV3 defB = buildDataAttribute("formatting_attr_b");
         attributeEngine.updateDataAttributeDefinitions(connectorA.getUuid(), OPERATION_FORMAT, List.of(defA));
         attributeEngine.updateDataAttributeDefinitions(connectorB.getUuid(), OPERATION_FORMAT, List.of(defB));
 

--- a/src/test/java/com/otilm/core/attribute/AttributeEngineVersioningTest.java
+++ b/src/test/java/com/otilm/core/attribute/AttributeEngineVersioningTest.java
@@ -50,7 +50,7 @@ class AttributeEngineVersioningTest extends BaseSpringBootTest {
 
     // ── Operation constants mimicking signing-profile usage ──────────────────
     private static final String OPERATION_SIGN = AttributeOperation.SIGN;
-    private static final String OPERATION_FORMAT = "connectorFormatting";
+    private static final String OPERATION_FORMAT = "formattingConnector";
     private static final Resource VERSIONED_RESOURCE = Resource.CRYPTOGRAPHIC_KEY;
     private static final List<RequestAttribute> EMPTY_REQUEST_ATTRIBUTES = List.of();
 

--- a/src/test/java/com/otilm/core/mapper/signing/SigningProfileMapperTest.java
+++ b/src/test/java/com/otilm/core/mapper/signing/SigningProfileMapperTest.java
@@ -29,7 +29,7 @@ class SigningProfileMapperTest {
 
     private static final UUID PROFILE_UUID = UUID.fromString("11111111-1111-1111-1111-111111111111");
     private static final UUID TQC_UUID = UUID.fromString("22222222-2222-2222-2222-222222222222");
-    private static final UUID FORMATTER_UUID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+    private static final UUID FORMATTING_UUID = UUID.fromString("33333333-3333-3333-3333-333333333333");
     private static final UUID CERT_UUID = UUID.fromString("44444444-4444-4444-4444-444444444444");
     private static final UUID RA_UUID = UUID.fromString("55555555-5555-5555-5555-555555555555");
     private static final UUID TOKEN_UUID = UUID.fromString("66666666-6666-6666-6666-666666666666");
@@ -123,7 +123,7 @@ class SigningProfileMapperTest {
 
             ManagedTimestampingWorkflow wf = model.workflow();
             assertThat(wf.timeQualityConfigurationUuid()).isEqualTo(TQC_UUID);
-            assertThat(wf.signatureFormatterConnectorUuid()).isEqualTo(FORMATTER_UUID);
+            assertThat(wf.signatureFormattingConnectorUuid()).isEqualTo(FORMATTING_UUID);
             assertThat(wf.defaultPolicyId()).isEqualTo("1.2.3.4.5");
             assertThat(wf.allowedDigestAlgorithms()).containsExactly(DigestAlgorithm.SHA_256);
             assertThat(wf.isQualifiedTimestamp()).isFalse();
@@ -342,7 +342,7 @@ class SigningProfileMapperTest {
             SigningProfileVersion v = new SigningProfileVersion();
             v.setVersion(1);
             v.setWorkflowType(SigningWorkflowType.TIMESTAMPING);
-            v.setSignatureFormatterConnectorUuid(FORMATTER_UUID);
+            v.setSignatureFormattingConnectorUuid(FORMATTING_UUID);
             v.setQualifiedTimestamp(false);
             v.setDefaultPolicyId("1.2.3.4.5");
             v.setAllowedPolicyIds(List.of("1.2.3.4.5"));

--- a/src/test/java/com/otilm/core/model/signing/resolved/ResolvedSigningProfileTest.java
+++ b/src/test/java/com/otilm/core/model/signing/resolved/ResolvedSigningProfileTest.java
@@ -56,9 +56,9 @@ class ResolvedSigningProfileTest {
         assertEquals(List.of("1.2.3.4.5", "1.2.3.4.6"), profile.allowedPolicyIds());
         assertEquals(List.of(DigestAlgorithm.SHA_256), profile.allowedDigestAlgorithms());
         assertEquals(Boolean.FALSE, profile.validateTokenSignature());
-        assertNotNull(profile.signatureFormatterConnectorAttributes());
+        assertNotNull(profile.signatureFormattingConnectorAttributes());
         assertNull(profile.timeQualityConfiguration());
-        assertNull(profile.signatureFormatterConnector());
+        assertNull(profile.signatureFormattingConnector());
         assertSame(scheme, profile.resolvedScheme());
 
         assertEquals(SigningWorkflowType.TIMESTAMPING, profile.workflowType());

--- a/src/test/java/com/otilm/core/model/signing/workflow/ManagedTimestampingWorkflowBuilder.java
+++ b/src/test/java/com/otilm/core/model/signing/workflow/ManagedTimestampingWorkflowBuilder.java
@@ -8,8 +8,8 @@ import java.util.UUID;
 
 public final class ManagedTimestampingWorkflowBuilder {
 
-    private UUID signatureFormatterConnectorUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
-    private List<RequestAttribute> signatureFormatterConnectorAttributes = List.of();
+    private UUID signatureFormattingConnectorUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private List<RequestAttribute> signatureFormattingConnectorAttributes = List.of();
     private Boolean isQualifiedTimestamp = false;
     private UUID timeQualityConfigurationUuid = null;
     private String defaultPolicyId = "1.2.3.4.5";
@@ -25,13 +25,13 @@ public final class ManagedTimestampingWorkflowBuilder {
         return aManagedTimestampingWorkflow().build();
     }
 
-    public ManagedTimestampingWorkflowBuilder signatureFormatterConnectorUuid(UUID v) {
-        this.signatureFormatterConnectorUuid = v;
+    public ManagedTimestampingWorkflowBuilder signatureFormattingConnectorUuid(UUID v) {
+        this.signatureFormattingConnectorUuid = v;
         return this;
     }
 
-    public ManagedTimestampingWorkflowBuilder signatureFormatterConnectorAttributes(List<RequestAttribute> v) {
-        this.signatureFormatterConnectorAttributes = v;
+    public ManagedTimestampingWorkflowBuilder signatureFormattingConnectorAttributes(List<RequestAttribute> v) {
+        this.signatureFormattingConnectorAttributes = v;
         return this;
     }
 
@@ -67,8 +67,8 @@ public final class ManagedTimestampingWorkflowBuilder {
 
     public ManagedTimestampingWorkflow build() {
         return new ManagedTimestampingWorkflow(
-                signatureFormatterConnectorUuid,
-                signatureFormatterConnectorAttributes,
+                signatureFormattingConnectorUuid,
+                signatureFormattingConnectorAttributes,
                 isQualifiedTimestamp,
                 timeQualityConfigurationUuid,
                 defaultPolicyId,

--- a/src/test/java/com/otilm/core/model/signing/workflow/SigningWorkflowModelsTest.java
+++ b/src/test/java/com/otilm/core/model/signing/workflow/SigningWorkflowModelsTest.java
@@ -39,8 +39,8 @@ class SigningWorkflowModelsTest {
         ManagedContentSigningWorkflow wf = new ManagedContentSigningWorkflow(connectorUuid, attrs);
 
         assertEquals(SigningWorkflowType.CONTENT_SIGNING, wf.getWorkflowType());
-        assertEquals(connectorUuid, wf.signatureFormatterConnectorUuid());
-        assertNotNull(wf.signatureFormatterConnectorAttributes());
+        assertEquals(connectorUuid, wf.signatureFormattingConnectorUuid());
+        assertNotNull(wf.signatureFormattingConnectorAttributes());
         assertInstanceOf(ContentSigningWorkflow.class, wf);
         assertInstanceOf(SigningWorkflow.class, wf);
     }

--- a/src/test/java/com/otilm/core/security/authn/client/PlatformAuthenticationClientTest.java
+++ b/src/test/java/com/otilm/core/security/authn/client/PlatformAuthenticationClientTest.java
@@ -39,7 +39,7 @@ class PlatformAuthenticationClientTest extends BaseSpringBootTest {
     @Autowired
     private AuthenticationCache authenticationCache;
 
-    // @formatter:off
+    // @formatting:off
     String RAW_DATA = "{" +
             "\"authenticated\": true," +
             "\"data\": {" +
@@ -94,7 +94,7 @@ class PlatformAuthenticationClientTest extends BaseSpringBootTest {
 
         // then
         assertEquals("FrantisekJednicka", info.getUsername());
-        // @formatter:off
+        // @formatting:off
         assertEquals("{" +
                         "\"user\":{" +
                         "\"uuid\":\"a1b2c3d4-0000-0000-0000-000000000001\"," +
@@ -109,7 +109,7 @@ class PlatformAuthenticationClientTest extends BaseSpringBootTest {
                 info.getRawData()
 
         );
-        // @formatter:on
+        // @formatting:on
         assertEquals(
                 List.of("ROLE_ADMINISTRATOR", "ROLE_USER"),
                 info.getAuthorities().stream()
@@ -395,7 +395,7 @@ class PlatformAuthenticationClientTest extends BaseSpringBootTest {
     RecordedRequest getLastRequest() throws InterruptedException {
         return authServiceMock.takeRequest(500, TimeUnit.MILLISECONDS);
     }
-    // @formatter:on
+    // @formatting:on
 
     void setUpSuccessfulAuthenticationResponse() {
         authServiceMock.enqueue(

--- a/src/test/java/com/otilm/core/security/authn/client/PlatformAuthenticationClientTest.java
+++ b/src/test/java/com/otilm/core/security/authn/client/PlatformAuthenticationClientTest.java
@@ -39,7 +39,7 @@ class PlatformAuthenticationClientTest extends BaseSpringBootTest {
     @Autowired
     private AuthenticationCache authenticationCache;
 
-    // @formatting:off
+    // @formatter:off
     String RAW_DATA = "{" +
             "\"authenticated\": true," +
             "\"data\": {" +
@@ -94,7 +94,7 @@ class PlatformAuthenticationClientTest extends BaseSpringBootTest {
 
         // then
         assertEquals("FrantisekJednicka", info.getUsername());
-        // @formatting:off
+        // @formatter:off
         assertEquals("{" +
                         "\"user\":{" +
                         "\"uuid\":\"a1b2c3d4-0000-0000-0000-000000000001\"," +
@@ -109,7 +109,7 @@ class PlatformAuthenticationClientTest extends BaseSpringBootTest {
                 info.getRawData()
 
         );
-        // @formatting:on
+        // @formatter:on
         assertEquals(
                 List.of("ROLE_ADMINISTRATOR", "ROLE_USER"),
                 info.getAuthorities().stream()
@@ -395,7 +395,7 @@ class PlatformAuthenticationClientTest extends BaseSpringBootTest {
     RecordedRequest getLastRequest() throws InterruptedException {
         return authServiceMock.takeRequest(500, TimeUnit.MILLISECONDS);
     }
-    // @formatting:on
+    // @formatter:on
 
     void setUpSuccessfulAuthenticationResponse() {
         authServiceMock.enqueue(

--- a/src/test/java/com/otilm/core/security/authz/opa/OpaClientTest.java
+++ b/src/test/java/com/otilm/core/security/authz/opa/OpaClientTest.java
@@ -99,7 +99,7 @@ class OpaClientTest {
         RecordedRequest request = getLastRequest();
         assertEquals(MediaType.APPLICATION_JSON.toString(), request.getHeader(HttpHeaders.CONTENT_TYPE));
         assertEquals(MediaType.APPLICATION_JSON.toString(), request.getHeader(HttpHeaders.ACCEPT));
-        //@formatting:off
+        //@formatter:off
         assertEquals("{" +
                     "\"input\":{" +
                         "\"requestedResource\":{" +
@@ -120,7 +120,7 @@ class OpaClientTest {
                         "}" +
                     "}" +
                 "}", request.getBody().readUtf8());
-        //@formatting:on
+        //@formatter:on
     }
 
     @Test
@@ -160,7 +160,7 @@ class OpaClientTest {
     }
 
     String getPrincipal() {
-        //@formatting:off
+        //@formatter:off
         return "{" +
                     "\"user\":{" +
                         "\"username\":\"FrantisekJednicka\"," +
@@ -171,7 +171,7 @@ class OpaClientTest {
                         "\"ROLE_AUTH_MANAGER\"" +
                     "]" +
                 "}";
-        //@formatting:on
+        //@formatter:on
     }
 
     RecordedRequest getLastRequest() throws InterruptedException {
@@ -183,14 +183,14 @@ class OpaClientTest {
                 new MockResponse()
                         .setResponseCode(200)
                         .setHeader("content-type", "application/json")
-                        //@formatting:off
+                        //@formatter:off
                         .setBody("{" +
                                     "\"result\": {" +
                                         "\"allow\": [\"SomeOpaRule\"]," +
                                         "\"authorized\": true" +
                                     "}" +
                                 "}")
-                        //@formatting:on
+                        //@formatter:on
         );
     }
 
@@ -199,7 +199,7 @@ class OpaClientTest {
                 new MockResponse()
                         .setResponseCode(200)
                         .setHeader("content-type", "application/json")
-                        //@formatting:off
+                        //@formatter:off
                         .setBody("{" +
                                     "\"result\": {" +
                                         "\"forbiddenObjects\": [\"f258cb3c-17b5-11ed-861d-0242ac120002\"]," +
@@ -207,7 +207,7 @@ class OpaClientTest {
                                         "\"actionAllowedForGroupOfObjects\": true" +
                                     "}" +
                                 "}")
-                        //@formatting:on
+                        //@formatter:on
         );
     }
 

--- a/src/test/java/com/otilm/core/security/authz/opa/OpaClientTest.java
+++ b/src/test/java/com/otilm/core/security/authz/opa/OpaClientTest.java
@@ -99,7 +99,7 @@ class OpaClientTest {
         RecordedRequest request = getLastRequest();
         assertEquals(MediaType.APPLICATION_JSON.toString(), request.getHeader(HttpHeaders.CONTENT_TYPE));
         assertEquals(MediaType.APPLICATION_JSON.toString(), request.getHeader(HttpHeaders.ACCEPT));
-        //@formatter:off
+        //@formatting:off
         assertEquals("{" +
                     "\"input\":{" +
                         "\"requestedResource\":{" +
@@ -120,7 +120,7 @@ class OpaClientTest {
                         "}" +
                     "}" +
                 "}", request.getBody().readUtf8());
-        //@formatter:on
+        //@formatting:on
     }
 
     @Test
@@ -160,7 +160,7 @@ class OpaClientTest {
     }
 
     String getPrincipal() {
-        //@formatter:off
+        //@formatting:off
         return "{" +
                     "\"user\":{" +
                         "\"username\":\"FrantisekJednicka\"," +
@@ -171,7 +171,7 @@ class OpaClientTest {
                         "\"ROLE_AUTH_MANAGER\"" +
                     "]" +
                 "}";
-        //@formatter:on
+        //@formatting:on
     }
 
     RecordedRequest getLastRequest() throws InterruptedException {
@@ -183,14 +183,14 @@ class OpaClientTest {
                 new MockResponse()
                         .setResponseCode(200)
                         .setHeader("content-type", "application/json")
-                        //@formatter:off
+                        //@formatting:off
                         .setBody("{" +
                                     "\"result\": {" +
                                         "\"allow\": [\"SomeOpaRule\"]," +
                                         "\"authorized\": true" +
                                     "}" +
                                 "}")
-                        //@formatter:on
+                        //@formatting:on
         );
     }
 
@@ -199,7 +199,7 @@ class OpaClientTest {
                 new MockResponse()
                         .setResponseCode(200)
                         .setHeader("content-type", "application/json")
-                        //@formatter:off
+                        //@formatting:off
                         .setBody("{" +
                                     "\"result\": {" +
                                         "\"forbiddenObjects\": [\"f258cb3c-17b5-11ed-861d-0242ac120002\"]," +
@@ -207,7 +207,7 @@ class OpaClientTest {
                                         "\"actionAllowedForGroupOfObjects\": true" +
                                     "}" +
                                 "}")
-                        //@formatter:on
+                        //@formatting:on
         );
     }
 

--- a/src/test/java/com/otilm/core/service/SigningProfileServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/SigningProfileServiceImplTest.java
@@ -68,10 +68,10 @@ import com.otilm.core.service.v2.ConnectorService;
 import com.otilm.core.service.writer.signingrecord.SigningRecordWriter;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.mocks.ConnectorMockFactory;
-import com.otilm.core.util.mocks.ContentSigningFormatterMock;
+import com.otilm.core.util.mocks.ContentSigningFormattingMock;
 import com.otilm.core.util.mocks.CryptographyProviderConnectorMock;
 import com.otilm.core.util.mocks.SignerConnectorMock;
-import com.otilm.core.util.mocks.TimestampingFormatterConnectorMock;
+import com.otilm.core.util.mocks.TimestampingFormattingConnectorMock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -136,12 +136,12 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
     @Autowired
     private TestCertificateAuthority testCertificateAuthority;
 
-    private ContentSigningFormatterMock contentSigningFormatterMock;
-    private TimestampingFormatterConnectorMock timestampingFormatterMock;
+    private ContentSigningFormattingMock contentSigningFormattingMock;
+    private TimestampingFormattingConnectorMock timestampingFormattingMock;
     private CryptographyProviderConnectorMock cryptographyProviderServerMock;
     private SignerConnectorMock signerConnectorServerMock;
-    private ConnectorDetailDto contentSigningFormatterConnector;
-    private ConnectorDetailDto timestampingFormatterConnector;
+    private ConnectorDetailDto contentSigningFormattingConnector;
+    private ConnectorDetailDto timestampingFormattingConnector;
     private ConnectorDetailDto cryptographyProviderConnector;
     private ConnectorDetailDto signerConnector;
     private TokenInstanceDetailDto tokenInstance;
@@ -198,8 +198,8 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
         // Set up mocks of connectors (the servers to call); the cryptography-provider mock also seeds
         // the function-group reference data normally provided by Flyway (wiped by per-test truncation)
         cryptographyProviderServerMock = connectorMockFactory.startCryptographyProvider();
-        contentSigningFormatterMock = connectorMockFactory.startContentSigningFormatter();
-        timestampingFormatterMock = connectorMockFactory.startTimestampingFormatter();
+        contentSigningFormattingMock = connectorMockFactory.startContentSigningFormatting();
+        timestampingFormattingMock = connectorMockFactory.startTimestampingFormatting();
         signerConnectorServerMock = connectorMockFactory.startSigner();
 
         // Register the connectors to ILM
@@ -209,16 +209,16 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                         .withUrl(this.cryptographyProviderServerMock.getUrl())
                         .build()
         );
-        contentSigningFormatterConnector = connectorService.createConnector(
+        contentSigningFormattingConnector = connectorService.createConnector(
                 aV2ConnectorRequest()
-                        .withName("content-signing-formatter")
-                        .withUrl(this.contentSigningFormatterMock.getUrl())
+                        .withName("content-signing-formatting")
+                        .withUrl(this.contentSigningFormattingMock.getUrl())
                         .build()
         );
-        timestampingFormatterConnector = connectorService.createConnector(
+        timestampingFormattingConnector = connectorService.createConnector(
                 aV2ConnectorRequest()
-                        .withName("timestamping-formatter")
-                        .withUrl(this.timestampingFormatterMock.getUrl())
+                        .withName("timestamping-formatting")
+                        .withUrl(this.timestampingFormattingMock.getUrl())
                         .build()
         );
         signerConnector = connectorService.createConnector(
@@ -282,22 +282,22 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                         .build()
         );
 
-        contentSigningFormatterMock.stubFormatterAttributes();
+        contentSigningFormattingMock.stubFormattingAttributes();
         defaultContentSigningProfile = signingProfileService.createSigningProfile(
                 aSigningProfileRequest()
                         .withName("default-content-signing-profile")
                         .withDelegatedSigning(signerConnector.getUuid())
-                        .withContentSigning(UUID.fromString(contentSigningFormatterConnector.getUuid()))
+                        .withContentSigning(UUID.fromString(contentSigningFormattingConnector.getUuid()))
                         .build()
         );
 
-        timestampingFormatterMock.stubFormatterAttributes();
+        timestampingFormattingMock.stubFormattingAttributes();
         defaultTimestampingProfile = signingProfileService.createSigningProfile(
                 aSigningProfileRequest()
                         .withName("default-timestamping-profile")
                         .withStaticKeyManagedSigning(defaultSigningCertificate.getUuid())
                         .withTimestamping(aTimestampingWorkflow()
-                                .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                 .build()
                         )
                         .build()
@@ -322,8 +322,8 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
 
     @AfterEach
     void tearDown() {
-        contentSigningFormatterMock.stop();
-        timestampingFormatterMock.stop();
+        contentSigningFormattingMock.stop();
+        timestampingFormattingMock.stop();
         cryptographyProviderServerMock.stop();
         signerConnectorServerMock.stop();
     }
@@ -553,7 +553,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
             signingProfileService.updateSigningProfile(
                     profileUuid,
                     aSigningProfileRequestFromExistingProfile(existingProfile)
-                            .withTimestamping(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                            .withTimestamping(UUID.fromString(timestampingFormattingConnector.getUuid()))
                             .build()
             );
 
@@ -589,7 +589,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                     aSigningProfileRequest()
                             .withName("some protocols-linked")
                             .withStaticKeyManagedSigning(defaultSigningCertificate.getUuid())
-                            .withTimestamping(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                            .withTimestamping(UUID.fromString(timestampingFormattingConnector.getUuid()))
                             .build()
             );
 
@@ -676,7 +676,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                     aSigningProfileRequest()
                             .withName("ct-delegated-content")
                             .withDelegatedSigning(signerConnector.getUuid())
-                            .withContentSigning(UUID.fromString(contentSigningFormatterConnector.getUuid()))
+                            .withContentSigning(UUID.fromString(contentSigningFormattingConnector.getUuid()))
                             .build()
             );
             SigningProfileDto getDto = signingProfileService.getSigningProfile(SecuredUUID.fromString(createdProfile.getUuid()), null);
@@ -694,7 +694,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
             assertEquals(signerConnector.getUuid(), scheme.getConnector().getUuid());
 
             ContentSigningWorkflowDto workflow = assertInstanceOf(ContentSigningWorkflowDto.class, createdProfile.getWorkflow());
-            assertEquals(contentSigningFormatterConnector.getUuid(), workflow.getSignatureFormatterConnector().getUuid());
+            assertEquals(contentSigningFormattingConnector.getUuid(), workflow.getSignatureFormattingConnector().getUuid());
         }
 
         @Test
@@ -705,7 +705,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                             .withName("ct-delegated-timestamping")
                             .withDelegatedSigning(signerConnector.getUuid())
                             .withTimestamping(aTimestampingWorkflow()
-                                    .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                    .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                     .withDefaultPolicyId("1.2.3.4.5")
                                     .withAllowedPolicyIds(List.of("1.2.3.4.5", "1.2.3.4.6"))
                                     .withAllowedDigestAlgorithms(List.of(DigestAlgorithm.SHA_256, DigestAlgorithm.SHA_384))
@@ -729,7 +729,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
             assertEquals(signerConnector.getUuid(), scheme.getConnector().getUuid());
 
             TimestampingWorkflowDto workflow = assertInstanceOf(TimestampingWorkflowDto.class, createdProfile.getWorkflow());
-            assertEquals(timestampingFormatterConnector.getUuid(), workflow.getSignatureFormatterConnector().getUuid());
+            assertEquals(timestampingFormattingConnector.getUuid(), workflow.getSignatureFormattingConnector().getUuid());
             assertEquals("1.2.3.4.5", workflow.getDefaultPolicyId());
             assertEquals(List.of("1.2.3.4.5", "1.2.3.4.6"), workflow.getAllowedPolicyIds());
             assertEquals(List.of(DigestAlgorithm.SHA_256, DigestAlgorithm.SHA_384), workflow.getAllowedDigestAlgorithms());
@@ -772,7 +772,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                     aSigningProfileRequest()
                             .withName("ct-static-content")
                             .withStaticKeyManagedSigning(defaultSigningCertificate.getUuid())
-                            .withContentSigning(UUID.fromString(contentSigningFormatterConnector.getUuid()))
+                            .withContentSigning(UUID.fromString(contentSigningFormattingConnector.getUuid()))
                             .build()
             );
             SigningProfileDto getDto = signingProfileService.getSigningProfile(SecuredUUID.fromString(createdProfile.getUuid()), null);
@@ -791,7 +791,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
             assertFalse(scheme.getSigningOperationAttributes().isEmpty());
 
             ContentSigningWorkflowDto workflow = assertInstanceOf(ContentSigningWorkflowDto.class, createdProfile.getWorkflow());
-            assertEquals(contentSigningFormatterConnector.getUuid(), workflow.getSignatureFormatterConnector().getUuid());
+            assertEquals(contentSigningFormattingConnector.getUuid(), workflow.getSignatureFormattingConnector().getUuid());
         }
 
         @Test
@@ -801,7 +801,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                     aSigningProfileRequest()
                             .withName("ct-static-timestamping")
                             .withStaticKeyManagedSigning(defaultSigningCertificate.getUuid())
-                            .withTimestamping(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                            .withTimestamping(UUID.fromString(timestampingFormattingConnector.getUuid()))
                             .build()
             );
             SigningProfileDto getDto = signingProfileService.getSigningProfile(SecuredUUID.fromString(createdProfile.getUuid()), null);
@@ -820,7 +820,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
             assertFalse(scheme.getSigningOperationAttributes().isEmpty());
 
             TimestampingWorkflowDto workflow = assertInstanceOf(TimestampingWorkflowDto.class, createdProfile.getWorkflow());
-            assertEquals(timestampingFormatterConnector.getUuid(), workflow.getSignatureFormatterConnector().getUuid());
+            assertEquals(timestampingFormattingConnector.getUuid(), workflow.getSignatureFormattingConnector().getUuid());
         }
 
         @Test
@@ -888,13 +888,13 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
             SigningProfileDto updated = signingProfileService.updateSigningProfile(
                     profileUuid,
                     aSigningProfileRequestFromExistingProfile(profile)
-                            .withContentSigning(UUID.fromString(contentSigningFormatterConnector.getUuid()))
+                            .withContentSigning(UUID.fromString(contentSigningFormattingConnector.getUuid()))
                             .build()
             );
 
             // then
             ContentSigningWorkflowDto workflow = assertInstanceOf(ContentSigningWorkflowDto.class, updated.getWorkflow());
-            assertEquals(contentSigningFormatterConnector.getUuid(), workflow.getSignatureFormatterConnector().getUuid());
+            assertEquals(contentSigningFormattingConnector.getUuid(), workflow.getSignatureFormattingConnector().getUuid());
         }
 
         @Test
@@ -914,13 +914,13 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
             SigningProfileDto updated = signingProfileService.updateSigningProfile(
                     profileUuid,
                     aSigningProfileRequestFromExistingProfile(profile)
-                            .withTimestamping(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                            .withTimestamping(UUID.fromString(timestampingFormattingConnector.getUuid()))
                             .build()
             );
 
             // then
             TimestampingWorkflowDto workflow = assertInstanceOf(TimestampingWorkflowDto.class, updated.getWorkflow());
-            assertEquals(timestampingFormatterConnector.getUuid(), workflow.getSignatureFormatterConnector().getUuid());
+            assertEquals(timestampingFormattingConnector.getUuid(), workflow.getSignatureFormattingConnector().getUuid());
         }
 
         @Test
@@ -938,7 +938,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                             .withDescription("Updated description for timestamping profile")
                             .withStaticKeyManagedSigning(qualifiedCert.getUuid())
                             .withTimestamping(aTimestampingWorkflow()
-                                    .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                    .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                     .withDefaultPolicyId("1.2.3.4.5")
                                     .withAllowedPolicyIds(List.of("1.2.3.4.5", "1.2.3.4.6"))
                                     .withAllowedDigestAlgorithms(List.of(DigestAlgorithm.SHA_256, DigestAlgorithm.SHA_384))
@@ -954,7 +954,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
             assertEquals("Updated description for timestamping profile", updated.getDescription());
 
             TimestampingWorkflowDto workflow = assertInstanceOf(TimestampingWorkflowDto.class, updated.getWorkflow());
-            assertEquals(timestampingFormatterConnector.getUuid(), workflow.getSignatureFormatterConnector().getUuid());
+            assertEquals(timestampingFormattingConnector.getUuid(), workflow.getSignatureFormattingConnector().getUuid());
             assertEquals("1.2.3.4.5", workflow.getDefaultPolicyId());
             assertEquals(List.of("1.2.3.4.5", "1.2.3.4.6"), workflow.getAllowedPolicyIds());
             assertEquals(List.of(DigestAlgorithm.SHA_256, DigestAlgorithm.SHA_384), workflow.getAllowedDigestAlgorithms());
@@ -1040,21 +1040,21 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
         }
 
         @Test
-        void versionBump_workflowFormatterAttributesDifferBetweenVersions()
+        void versionBump_workflowFormattingAttributesDifferBetweenVersions()
                 throws AlreadyExistException, AttributeException, ConnectorException, NotFoundException {
-            // given: stub the formatter connector to expose a single configurable attribute
-            UUID formatterAttrUuid = UUID.fromString("11111111-2222-3333-4444-555555555555");
-            String formatterAttrName = "data_testPolicy";
-            timestampingFormatterMock.stubFormatterAttributeDefinition(formatterAttrUuid, formatterAttrName, true);
+            // given: stub the formatting connector to expose a single configurable attribute
+            UUID formattingAttrUuid = UUID.fromString("11111111-2222-3333-4444-555555555555");
+            String formattingAttrName = "data_testPolicy";
+            timestampingFormattingMock.stubFormattingAttributeDefinition(formattingAttrUuid, formattingAttrName, true);
 
             SigningProfileDto v1Profile = signingProfileService.createSigningProfile(
                     aSigningProfileRequest()
-                            .withName("formatter-attrs-versioned")
+                            .withName("formatting-attrs-versioned")
                             .withStaticKeyManagedSigning(defaultSigningCertificate.getUuid())
                             .withTimestamping(aTimestampingWorkflow()
-                                    .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
-                                    .withSignatureFormatterConnectorAttributes(List.of(
-                                            aStringAttribute(formatterAttrUuid, formatterAttrName, "policy-v1")))
+                                    .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
+                                    .withSignatureFormattingConnectorAttributes(List.of(
+                                            aStringAttribute(formattingAttrUuid, formattingAttrName, "policy-v1")))
                                     .build())
                             .build()
             );
@@ -1066,23 +1066,23 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                     profileUuid,
                     aSigningProfileRequestFromExistingProfile(v1Profile)
                             .withTimestamping(aTimestampingWorkflow()
-                                    .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
-                                    .withSignatureFormatterConnectorAttributes(List.of(
-                                            aStringAttribute(formatterAttrUuid, formatterAttrName, "policy-v2")))
+                                    .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
+                                    .withSignatureFormattingConnectorAttributes(List.of(
+                                            aStringAttribute(formattingAttrUuid, formattingAttrName, "policy-v2")))
                                     .build())
                             .build()
             );
 
-            // then: each version exposes its own formatter attribute value
+            // then: each version exposes its own formatting attribute value
             TimestampingWorkflowDto v1Workflow = assertInstanceOf(TimestampingWorkflowDto.class,
                     signingProfileService.getSigningProfile(profileUuid, 1).getWorkflow());
             TimestampingWorkflowDto v2Workflow = assertInstanceOf(TimestampingWorkflowDto.class,
                     signingProfileService.getSigningProfile(profileUuid, 2).getWorkflow());
 
             assertEquals("policy-v1",
-                    extractStringAttrValue(v1Workflow.getSignatureFormatterConnectorAttributes(), formatterAttrName));
+                    extractStringAttrValue(v1Workflow.getSignatureFormattingConnectorAttributes(), formattingAttrName));
             assertEquals("policy-v2",
-                    extractStringAttrValue(v2Workflow.getSignatureFormatterConnectorAttributes(), formatterAttrName));
+                    extractStringAttrValue(v2Workflow.getSignatureFormattingConnectorAttributes(), formattingAttrName));
         }
     }
 
@@ -1698,114 +1698,114 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
     }
 
     @Nested
-    class FormatterAttributes {
+    class FormattingAttributes {
 
         @Test
         void create_contentSigning_attributesPersistedAndReturned()
                 throws AlreadyExistException, AttributeException, ConnectorException, NotFoundException {
-            // given: stub the content signing formatter to expose a single configurable attribute
+            // given: stub the content signing formatting to expose a single configurable attribute
             UUID attrUuid = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
-            String attrName = "data_testFormatterAttr";
-            contentSigningFormatterMock.stubFormatterAttributeDefinition(attrUuid, attrName);
+            String attrName = "data_testFormattingAttr";
+            contentSigningFormattingMock.stubFormattingAttributeDefinition(attrUuid, attrName);
 
             // when
             SigningProfileDto dto = signingProfileService.createSigningProfile(
                     aSigningProfileRequest()
-                            .withName("doc-profile-with-formatter-attrs")
+                            .withName("doc-profile-with-formatting-attrs")
                             .withDelegatedSigning(signerConnector.getUuid())
                             .withContentSigning(aContentSigningWorkflow()
-                                    .withSignatureFormatterConnector(UUID.fromString(contentSigningFormatterConnector.getUuid()))
-                                    .withSignatureFormatterConnectorAttributes(List.of(
+                                    .withSignatureFormattingConnector(UUID.fromString(contentSigningFormattingConnector.getUuid()))
+                                    .withSignatureFormattingConnectorAttributes(List.of(
                                             aStringAttribute(attrUuid, attrName, "testValue")))
                                     .build())
                             .build());
 
             // then: the attribute is returned in the DTO and its value matches what was sent
             ContentSigningWorkflowDto wfDto = assertInstanceOf(ContentSigningWorkflowDto.class, dto.getWorkflow());
-            List<ResponseAttribute> attrs = wfDto.getSignatureFormatterConnectorAttributes();
-            assertFalse(attrs.isEmpty(), "Formatter connector attributes should be populated after create");
+            List<ResponseAttribute> attrs = wfDto.getSignatureFormattingConnectorAttributes();
+            assertFalse(attrs.isEmpty(), "Signature Formatting Provider attributes should be populated after create");
             assertEquals("testValue", extractStringAttrValue(attrs, attrName));
         }
 
         @Test
-        void update_contentSigningConnectorChanged_oldFormatterAttributesCleared()
+        void update_contentSigningConnectorChanged_oldFormattingAttributesCleared()
                 throws AlreadyExistException, AttributeException, ConnectorException, NotFoundException {
-            // given: stub the existing content signing formatter connector with a specific attribute definition
+            // given: stub the existing content signing formatting connector with a specific attribute definition
             UUID attrUuid = UUID.fromString("11111111-2222-3333-4444-555555555556");
-            String attrName = "data_formatterSwitchTest";
-            contentSigningFormatterMock.stubFormatterAttributeDefinition(attrUuid, attrName);
+            String attrName = "data_formattingSwitchTest";
+            contentSigningFormattingMock.stubFormattingAttributeDefinition(attrUuid, attrName);
 
-            // and: a second content signing formatter connector (formatterB)
-            ContentSigningFormatterMock formatterBMock = connectorMockFactory.startContentSigningFormatter();
-            formatterBMock.stubFormatterAttributeDefinition(attrUuid, attrName);
-            ConnectorDetailDto formatterBConnector = connectorService.createConnector(
+            // and: a second content signing formatting connector (formattingB)
+            ContentSigningFormattingMock formattingBMock = connectorMockFactory.startContentSigningFormatting();
+            formattingBMock.stubFormattingAttributeDefinition(attrUuid, attrName);
+            ConnectorDetailDto formattingBConnector = connectorService.createConnector(
                     aV2ConnectorRequest()
-                            .withName("content-signing-formatter-b")
-                            .withUrl(formatterBMock.getUrl())
+                            .withName("content-signing-formatting-b")
+                            .withUrl(formattingBMock.getUrl())
                             .build()
             );
 
             try {
-                // and: a profile using formatterA (contentSigningFormatterConnector) with attribute "valueA"
+                // and: a profile using formattingA (contentSigningFormattingConnector) with attribute "valueA"
                 SigningProfileDto created = signingProfileService.createSigningProfile(
                         aSigningProfileRequest()
-                                .withName("formatter-switch-test")
+                                .withName("formatting-switch-test")
                                 .withDelegatedSigning(signerConnector.getUuid())
                                 .withContentSigning(aContentSigningWorkflow()
-                                        .withSignatureFormatterConnector(UUID.fromString(contentSigningFormatterConnector.getUuid()))
-                                        .withSignatureFormatterConnectorAttributes(List.of(
+                                        .withSignatureFormattingConnector(UUID.fromString(contentSigningFormattingConnector.getUuid()))
+                                        .withSignatureFormattingConnectorAttributes(List.of(
                                                 aStringAttribute(attrUuid, attrName, "valueA")))
                                         .build())
                                 .build());
                 SecuredUUID profileUuid = SecuredUUID.fromString(created.getUuid());
                 UUID profileUuidRaw = UUID.fromString(created.getUuid());
 
-                // when: update to formatterB with attribute "valueB"
+                // when: update to formattingB with attribute "valueB"
                 signingProfileService.updateSigningProfile(profileUuid,
                         aSigningProfileRequestFromExistingProfile(created)
                                 .withContentSigning(aContentSigningWorkflow()
-                                        .withSignatureFormatterConnector(UUID.fromString(formatterBConnector.getUuid()))
-                                        .withSignatureFormatterConnectorAttributes(List.of(
+                                        .withSignatureFormattingConnector(UUID.fromString(formattingBConnector.getUuid()))
+                                        .withSignatureFormattingConnectorAttributes(List.of(
                                                 aStringAttribute(attrUuid, attrName, "valueB")))
                                         .build())
                                 .build());
 
-                // then: formatterA's engine rows are gone (no stale attributes for the old connector)
+                // then: formattingA's engine rows are gone (no stale attributes for the old connector)
                 List<ResponseAttribute> oldAttrs = attributeEngine.getObjectDataAttributesContent(
                         ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, profileUuidRaw)
-                                .connector(UUID.fromString(contentSigningFormatterConnector.getUuid()))
+                                .connector(UUID.fromString(contentSigningFormattingConnector.getUuid()))
                                 .operation(AttributeOperation.WORKFLOW_FORMATTER).version(1).build());
                 assertTrue(oldAttrs.isEmpty(),
-                        "Attributes for the replaced formatter connector should be cleared from the engine");
+                        "Attributes for the replaced formatting connector should be cleared from the engine");
 
-                // then: formatterB's attributes are stored with the correct value
+                // then: formattingB's attributes are stored with the correct value
                 List<ResponseAttribute> newAttrs = attributeEngine.getObjectDataAttributesContent(
                         ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, profileUuidRaw)
-                                .connector(UUID.fromString(formatterBConnector.getUuid()))
+                                .connector(UUID.fromString(formattingBConnector.getUuid()))
                                 .operation(AttributeOperation.WORKFLOW_FORMATTER).version(1).build());
                 assertFalse(newAttrs.isEmpty(),
-                        "Attributes for the new formatter connector should be persisted after the update");
+                        "Attributes for the new formatting connector should be persisted after the update");
                 assertEquals("valueB", extractStringAttrValue(newAttrs, attrName));
             } finally {
-                formatterBMock.stop();
+                formattingBMock.stop();
             }
         }
 
         @Test
-        void delete_removesFormatterAttributesFromEngine()
+        void delete_removesFormattingAttributesFromEngine()
                 throws AlreadyExistException, AttributeException, ConnectorException, NotFoundException {
-            // given: a content signing profile with a formatter attribute
+            // given: a content signing profile with a formatting attribute
             UUID attrUuid = UUID.fromString("cccccccc-dddd-eeee-ffff-000000000001");
-            String attrName = "data_deleteFormatterAttr";
-            contentSigningFormatterMock.stubFormatterAttributeDefinition(attrUuid, attrName);
+            String attrName = "data_deleteFormattingAttr";
+            contentSigningFormattingMock.stubFormattingAttributeDefinition(attrUuid, attrName);
 
             SigningProfileDto created = signingProfileService.createSigningProfile(
                     aSigningProfileRequest()
-                            .withName("delete-clears-formatter-attrs")
+                            .withName("delete-clears-formatting-attrs")
                             .withDelegatedSigning(signerConnector.getUuid())
                             .withContentSigning(aContentSigningWorkflow()
-                                    .withSignatureFormatterConnector(UUID.fromString(contentSigningFormatterConnector.getUuid()))
-                                    .withSignatureFormatterConnectorAttributes(List.of(
+                                    .withSignatureFormattingConnector(UUID.fromString(contentSigningFormattingConnector.getUuid()))
+                                    .withSignatureFormattingConnectorAttributes(List.of(
                                             aStringAttribute(attrUuid, attrName, "toDelete")))
                                     .build())
                             .build());
@@ -1817,23 +1817,23 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
             // then: no stale engine rows remain for the deleted profile
             List<ResponseAttribute> remaining = attributeEngine.getObjectDataAttributesContent(
                     ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, profileUuid)
-                            .connector(UUID.fromString(contentSigningFormatterConnector.getUuid()))
+                            .connector(UUID.fromString(contentSigningFormattingConnector.getUuid()))
                             .operation(AttributeOperation.WORKFLOW_FORMATTER).version(1).build());
             assertTrue(remaining.isEmpty(),
-                    "Formatter attributes should be cleared from the engine when the profile is deleted");
+                    "Formatting attributes should be cleared from the engine when the profile is deleted");
         }
 
     }
 
     @Nested
-    class FormatterAttributeValidation {
+    class FormattingAttributeValidation {
 
         @Test
         void create_contentSigning_requiredAttributeMissing_throwsValidationException() {
-            // given: the formatter connector advertises a required attribute
+            // given: the formatting connector advertises a required attribute
             UUID attrUuid = UUID.fromString("00000000-dead-beef-0002-000000000001");
             String attrName = "req_content_attr";
-            contentSigningFormatterMock.stubFormatterAttributeDefinition(attrUuid, attrName, true);
+            contentSigningFormattingMock.stubFormattingAttributeDefinition(attrUuid, attrName, true);
 
             // when: create a profile omitting the required attribute
             Executable create = () -> signingProfileService.createSigningProfile(
@@ -1841,21 +1841,21 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                             .withName("content-missing-required-attr")
                             .withDelegatedSigning(signerConnector.getUuid())
                             .withContentSigning(aContentSigningWorkflow()
-                                    .withSignatureFormatterConnector(UUID.fromString(contentSigningFormatterConnector.getUuid()))
+                                    .withSignatureFormattingConnector(UUID.fromString(contentSigningFormattingConnector.getUuid()))
                                     .build())
                             .build());
 
             // then
             assertThrows(ValidationException.class, create,
-                    "createSigningProfile must reject a missing required formatter attribute");
+                    "createSigningProfile must reject a missing required formatting attribute");
         }
 
         @Test
         void create_timestamping_requiredAttributeMissing_throwsValidationException() {
-            // given: the formatter connector advertises a required attribute
+            // given: the formatting connector advertises a required attribute
             UUID attrUuid = UUID.fromString("00000000-dead-beef-0002-000000000001");
             String attrName = "req_content_attr";
-            timestampingFormatterMock.stubFormatterAttributeDefinition(attrUuid, attrName, true);
+            timestampingFormattingMock.stubFormattingAttributeDefinition(attrUuid, attrName, true);
 
             // when: create a profile omitting the required attribute
             Executable create = () -> signingProfileService.createSigningProfile(
@@ -1863,13 +1863,13 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                             .withName("timestamping-missing-required-attr")
                             .withDelegatedSigning(signerConnector.getUuid())
                             .withTimestamping(aTimestampingWorkflow()
-                                    .withSignatureFormatterConnector(UUID.fromString(contentSigningFormatterConnector.getUuid()))
+                                    .withSignatureFormattingConnector(UUID.fromString(contentSigningFormattingConnector.getUuid()))
                                     .build())
                             .build());
 
             // then
             assertThrows(ValidationException.class, create,
-                    "createSigningProfile must reject a missing required formatter attribute");
+                    "createSigningProfile must reject a missing required formatting attribute");
         }
     }
 
@@ -2063,7 +2063,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                             .withName("ts-managed-model")
                             .withStaticKeyManagedSigning(defaultSigningCertificate.getUuid())
                             .withTimestamping(aTimestampingWorkflow()
-                                    .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                    .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                     .build())
                             .build());
 
@@ -2087,7 +2087,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                             .withName("ts-managed-validation-props")
                             .withStaticKeyManagedSigning(defaultSigningCertificate.getUuid())
                             .withTimestamping(aTimestampingWorkflow()
-                                    .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                    .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                     .withDefaultPolicyId("1.2.3.4.5")
                                     .withAllowedPolicyIds(List.of("1.2.3.4.5", "1.2.3.4.6"))
                                     .withAllowedDigestAlgorithms(List.of(DigestAlgorithm.SHA_256))
@@ -2118,7 +2118,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                             .withDescription("expected ts description")
                             .withStaticKeyManagedSigning(defaultSigningCertificate.getUuid())
                             .withTimestamping(aTimestampingWorkflow()
-                                    .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                    .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                     .build())
                             .build());
 
@@ -2153,7 +2153,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                                 .withName("ts-with-tqc")
                                 .withDelegatedSigning(signerConnector.getUuid())
                                 .withTimestamping(aTimestampingWorkflow()
-                                        .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                        .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                         .withTimeQualityConfiguration(UUID.fromString(tqc.getUuid()))
                                         .build())
                                 .build());
@@ -2184,7 +2184,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                                 .withName("ts-bad-tqc")
                                 .withDelegatedSigning(signerConnector.getUuid())
                                 .withTimestamping(aTimestampingWorkflow()
-                                        .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                        .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                         .withTimeQualityConfiguration(nonExistentTqcUuid)
                                         .build())
                                 .build());
@@ -2208,7 +2208,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                                 .withName("ts-to-raw-profile")
                                 .withDelegatedSigning(signerConnector.getUuid())
                                 .withTimestamping(aTimestampingWorkflow()
-                                        .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                        .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                         .withTimeQualityConfiguration(UUID.fromString(tqc.getUuid()))
                                         .build())
                                 .build());
@@ -2246,7 +2246,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                                 .withName("list-ts-profile-one")
                                 .withDelegatedSigning(signerConnector.getUuid())
                                 .withTimestamping(aTimestampingWorkflow()
-                                        .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                        .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                         .withTimeQualityConfiguration(tqcUuid)
                                         .build())
                                 .build());
@@ -2255,7 +2255,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                                 .withName("list-ts-profile-two")
                                 .withDelegatedSigning(signerConnector.getUuid())
                                 .withTimestamping(aTimestampingWorkflow()
-                                        .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                        .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                         .withTimeQualityConfiguration(tqcUuid)
                                         .build())
                                 .build());
@@ -2288,7 +2288,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                                 .withName("profile-linked-to-tqc-A")
                                 .withDelegatedSigning(signerConnector.getUuid())
                                 .withTimestamping(aTimestampingWorkflow()
-                                        .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                        .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                         .withTimeQualityConfiguration(UUID.fromString(tqcA.getUuid()))
                                         .build())
                                 .build());
@@ -2297,7 +2297,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                                 .withName("profile-linked-to-tqc-B")
                                 .withDelegatedSigning(signerConnector.getUuid())
                                 .withTimestamping(aTimestampingWorkflow()
-                                        .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                        .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                         .withTimeQualityConfiguration(UUID.fromString(tqcB.getUuid()))
                                         .build())
                                 .build());

--- a/src/test/java/com/otilm/core/service/SigningProfileServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/SigningProfileServiceImplTest.java
@@ -1774,7 +1774,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                 List<ResponseAttribute> oldAttrs = attributeEngine.getObjectDataAttributesContent(
                         ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, profileUuidRaw)
                                 .connector(UUID.fromString(contentSigningFormattingConnector.getUuid()))
-                                .operation(AttributeOperation.WORKFLOW_FORMATTER).version(1).build());
+                                .operation(AttributeOperation.WORKFLOW_FORMATTING).version(1).build());
                 assertTrue(oldAttrs.isEmpty(),
                         "Attributes for the replaced formatting connector should be cleared from the engine");
 
@@ -1782,7 +1782,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
                 List<ResponseAttribute> newAttrs = attributeEngine.getObjectDataAttributesContent(
                         ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, profileUuidRaw)
                                 .connector(UUID.fromString(formattingBConnector.getUuid()))
-                                .operation(AttributeOperation.WORKFLOW_FORMATTER).version(1).build());
+                                .operation(AttributeOperation.WORKFLOW_FORMATTING).version(1).build());
                 assertFalse(newAttrs.isEmpty(),
                         "Attributes for the new formatting connector should be persisted after the update");
                 assertEquals("valueB", extractStringAttrValue(newAttrs, attrName));
@@ -1818,7 +1818,7 @@ class SigningProfileServiceImplTest extends BaseSpringBootTest {
             List<ResponseAttribute> remaining = attributeEngine.getObjectDataAttributesContent(
                     ObjectAttributeContentInfo.builder(Resource.SIGNING_PROFILE, profileUuid)
                             .connector(UUID.fromString(contentSigningFormattingConnector.getUuid()))
-                            .operation(AttributeOperation.WORKFLOW_FORMATTER).version(1).build());
+                            .operation(AttributeOperation.WORKFLOW_FORMATTING).version(1).build());
             assertTrue(remaining.isEmpty(),
                     "Formatting attributes should be cleared from the engine when the profile is deleted");
         }

--- a/src/test/java/com/otilm/core/service/signingprofile/SigningProfileTestBase.java
+++ b/src/test/java/com/otilm/core/service/signingprofile/SigningProfileTestBase.java
@@ -182,9 +182,9 @@ abstract class SigningProfileTestBase extends BaseSpringBootTest {
     protected Certificate tsaCertificate;
 
     /**
-     * A Connector used as the signature formatter connector in CONTENT_SIGNING and TIMESTAMPING workflow tests.
+     * A Connector used as the signature formatting connector in CONTENT_SIGNING and TIMESTAMPING workflow tests.
      */
-    protected Connector formatterConnector;
+    protected Connector formattingConnector;
 
     /**
      * A Connector used as the delegated signer connector in DELEGATED scheme tests.
@@ -192,7 +192,7 @@ abstract class SigningProfileTestBase extends BaseSpringBootTest {
     protected Connector delegatedConnector;
 
     /**
-     * WireMock server that backs every formatter connector URL created via {@link #createFormatterConnector}.
+     * WireMock server that backs every formatting connector URL created via {@link #createFormattingConnector}.
      */
     protected WireMockServer mockServer;
 
@@ -295,7 +295,7 @@ abstract class SigningProfileTestBase extends BaseSpringBootTest {
         tsaCertificate = certificateRepository.saveAndFlush(tsaCertificate);
         attachSelfSignedContent(tsaCertificate);
 
-        formatterConnector = createFormatterConnector("default-formatter-connector");
+        formattingConnector = createFormattingConnector("default-formatting-connector");
 
         Connector dc = new Connector();
         dc.setName("delegated-signer-connector");
@@ -407,7 +407,7 @@ abstract class SigningProfileTestBase extends BaseSpringBootTest {
         request.setDescription("Test description for " + name);
         request.setSigningScheme(buildDelegatedScheme());
         ContentSigningWorkflowRequestDto workflow = new ContentSigningWorkflowRequestDto();
-        workflow.setSignatureFormatterConnectorUuid(formatterConnector.getUuid());
+        workflow.setSignatureFormattingConnectorUuid(formattingConnector.getUuid());
         request.setWorkflow(workflow);
         return request;
     }
@@ -421,16 +421,16 @@ abstract class SigningProfileTestBase extends BaseSpringBootTest {
         request.setDescription("Test description for " + name);
         request.setSigningScheme(buildDelegatedScheme());
         TimestampingWorkflowRequestDto workflow = new TimestampingWorkflowRequestDto();
-        workflow.setSignatureFormatterConnectorUuid(formatterConnector.getUuid());
+        workflow.setSignatureFormattingConnectorUuid(formattingConnector.getUuid());
         request.setWorkflow(workflow);
         return request;
     }
 
     /**
      * Builds a request using a MANAGED/STATIC_KEY scheme and CONTENT_SIGNING workflow,
-     * optionally setting a Signature Formatter Connector UUID on the workflow.
+     * optionally setting a Signature Formatting Provider UUID on the workflow.
      */
-    protected SigningProfileRequestDto buildManagedStaticKeyContentRequest(String name, UUID formatterConnectorUuid) {
+    protected SigningProfileRequestDto buildManagedStaticKeyContentRequest(String name, UUID formattingConnectorUuid) {
         SigningProfileRequestDto request = new SigningProfileRequestDto();
         request.setName(name);
         request.setDescription("Test description for " + name);
@@ -438,7 +438,7 @@ abstract class SigningProfileTestBase extends BaseSpringBootTest {
         scheme.setCertificateUuid(certificate.getUuid());
         request.setSigningScheme(scheme);
         ContentSigningWorkflowRequestDto workflow = new ContentSigningWorkflowRequestDto();
-        workflow.setSignatureFormatterConnectorUuid(formatterConnectorUuid);
+        workflow.setSignatureFormattingConnectorUuid(formattingConnectorUuid);
         request.setWorkflow(workflow);
         return request;
     }
@@ -458,7 +458,7 @@ abstract class SigningProfileTestBase extends BaseSpringBootTest {
                 buildDigestAttribute(DigestAlgorithm.SHA_256)));
         request.setSigningScheme(scheme);
         TimestampingWorkflowRequestDto workflow = new TimestampingWorkflowRequestDto();
-        workflow.setSignatureFormatterConnectorUuid(formatterConnector.getUuid());
+        workflow.setSignatureFormattingConnectorUuid(formattingConnector.getUuid());
         request.setWorkflow(workflow);
         return request;
     }
@@ -478,7 +478,7 @@ abstract class SigningProfileTestBase extends BaseSpringBootTest {
                 buildDigestAttribute(DigestAlgorithm.SHA_256)));
         request.setSigningScheme(scheme);
         TimestampingWorkflowRequestDto wf = new TimestampingWorkflowRequestDto();
-        wf.setSignatureFormatterConnectorUuid(formatterConnector.getUuid());
+        wf.setSignatureFormattingConnectorUuid(formattingConnector.getUuid());
         wf.setDefaultPolicyId("1.2.3.4.5");
         wf.setAllowedPolicyIds(List.of("1.2.3.4.5", "1.2.3.4.6"));
         wf.setAllowedDigestAlgorithms(List.of(DigestAlgorithm.SHA_256));
@@ -514,10 +514,10 @@ abstract class SigningProfileTestBase extends BaseSpringBootTest {
     }
 
     /**
-     * Creates and persists a minimal {@link Connector} entity for use as a signature formatter connector,
+     * Creates and persists a minimal {@link Connector} entity for use as a signature formatting connector,
      * also pre-registering a simple data attribute definition so that AttributeEngine can accept content.
      */
-    protected Connector createFormatterConnector(String name) {
+    protected Connector createFormattingConnector(String name) {
         Connector connector = new Connector();
         connector.setName(name);
         connector.setUrl("http://localhost:" + mockServer.port() + "/" + name);
@@ -536,11 +536,11 @@ abstract class SigningProfileTestBase extends BaseSpringBootTest {
     }
 
     /**
-     * Builds a {@link RequestAttributeV2} to use as a formatter connector attribute in tests.
+     * Builds a {@link RequestAttributeV2} to use as a formatting connector attribute in tests.
      * The UUID and name must be pre-registered via
      * {@link AttributeEngine#updateDataAttributeDefinitions} before being stored.
      */
-    protected RequestAttributeV2 buildFormatterAttribute(UUID attrUuid, String attrName, String value) {
+    protected RequestAttributeV2 buildFormattingAttribute(UUID attrUuid, String attrName, String value) {
         RequestAttributeV2 attr = new RequestAttributeV2();
         attr.setUuid(attrUuid);
         attr.setName(attrName);

--- a/src/test/java/com/otilm/core/signing/tsa/StaticKeyManagedTimestampTokenGeneratorTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/StaticKeyManagedTimestampTokenGeneratorTest.java
@@ -8,7 +8,7 @@ import com.otilm.core.model.signing.SigningCertificateBuilder;
 import com.otilm.core.model.signing.resolved.ResolvedManagedTimestampingProfile;
 import com.otilm.core.model.signing.resolved.ResolvedStaticKeyManagedSigning;
 import com.otilm.core.model.signing.timequality.LocalClockTimeQualityConfiguration;
-import com.otilm.core.signing.tsa.formatter.SignatureFormatterClient;
+import com.otilm.core.signing.tsa.formatting.SignatureFormattingClient;
 import com.otilm.core.signing.tsa.signer.Signer;
 import com.otilm.core.signing.tsa.signer.SignerFactory;
 import org.bouncycastle.tsp.TimeStampToken;
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.when;
 class StaticKeyManagedTimestampTokenGeneratorTest {
 
     @Mock SignerFactory signerFactory;
-    @Mock SignatureFormatterClient formatter;
+    @Mock SignatureFormattingClient formatting;
     @Mock Signer signer;
 
     @InjectMocks
@@ -94,10 +94,10 @@ class StaticKeyManagedTimestampTokenGeneratorTest {
         byte[] dtbs = {1, 2, 3};
         byte[] signature = {4, 5, 6};
 
-        when(formatter.formatDtbs(request, profile, serialNumber, genTime, chain, SignatureAlgorithm.SHA256_WITH_RSA))
+        when(formatting.formatDtbs(request, profile, serialNumber, genTime, chain, SignatureAlgorithm.SHA256_WITH_RSA))
                 .thenReturn(dtbs);
         when(signer.sign(dtbs)).thenReturn(signature);
-        when(formatter.formatSigningResponse(request, profile, serialNumber, genTime, chain, dtbs, signature, SignatureAlgorithm.SHA256_WITH_RSA))
+        when(formatting.formatSigningResponse(request, profile, serialNumber, genTime, chain, dtbs, signature, SignatureAlgorithm.SHA256_WITH_RSA))
                 .thenReturn(validTokenBytes);
 
         // when
@@ -112,9 +112,9 @@ class StaticKeyManagedTimestampTokenGeneratorTest {
     void usesSigningSchemeFromProfile_toCreateSigner() throws Exception {
         // given — the factory must receive the scheme from the profile, not a default
         var profile = aTimestampingProfile();
-        when(formatter.formatDtbs(any(), any(), any(), any(), any(), any())).thenReturn(new byte[1]);
+        when(formatting.formatDtbs(any(), any(), any(), any(), any(), any())).thenReturn(new byte[1]);
         when(signer.sign(any())).thenReturn(new byte[1]);
-        when(formatter.formatSigningResponse(any(), any(), any(), any(), any(), any(), any(), any()))
+        when(formatting.formatSigningResponse(any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(validTokenBytes);
 
         // when
@@ -125,12 +125,12 @@ class StaticKeyManagedTimestampTokenGeneratorTest {
     }
 
     @Test
-    void passesAlgorithmFromSigner_toBothFormatterPhases() throws Exception {
-        // given — the formatter must receive the signer's reported algorithm in both the DTBS and signing-response phases
+    void passesAlgorithmFromSigner_toBothFormattingPhases() throws Exception {
+        // given — the formatting must receive the signer's reported algorithm in both the DTBS and signing-response phases
         when(signer.getSignatureAlgorithm()).thenReturn(SignatureAlgorithm.SHA384_WITH_ECDSA);
-        when(formatter.formatDtbs(any(), any(), any(), any(), any(), any())).thenReturn(new byte[1]);
+        when(formatting.formatDtbs(any(), any(), any(), any(), any(), any())).thenReturn(new byte[1]);
         when(signer.sign(any())).thenReturn(new byte[1]);
-        when(formatter.formatSigningResponse(any(), any(), any(), any(), any(), any(), any(), any()))
+        when(formatting.formatSigningResponse(any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(validTokenBytes);
 
         // when
@@ -138,19 +138,19 @@ class StaticKeyManagedTimestampTokenGeneratorTest {
                 mock(CertificateChain.class), BigInteger.ONE, Instant.now());
 
         // then
-        verify(formatter).formatDtbs(any(), any(), any(), any(), any(), eq(SignatureAlgorithm.SHA384_WITH_ECDSA));
-        verify(formatter).formatSigningResponse(any(), any(), any(), any(), any(), any(), any(),
+        verify(formatting).formatDtbs(any(), any(), any(), any(), any(), eq(SignatureAlgorithm.SHA384_WITH_ECDSA));
+        verify(formatting).formatSigningResponse(any(), any(), any(), any(), any(), any(), any(),
                 eq(SignatureAlgorithm.SHA384_WITH_ECDSA));
     }
 
     @Test
-    void passesDtbsBytesToSigner_andSignatureToFormatterSigningResponse() throws Exception {
+    void passesDtbsBytesToSigner_andSignatureToFormattingSigningResponse() throws Exception {
         // given — the DTBS from phase 1 must be fed to the signer, and the resulting signature must reach phase 2
         byte[] dtbs = {10, 20, 30};
         byte[] signature = {40, 50, 60};
-        when(formatter.formatDtbs(any(), any(), any(), any(), any(), any())).thenReturn(dtbs);
+        when(formatting.formatDtbs(any(), any(), any(), any(), any(), any())).thenReturn(dtbs);
         when(signer.sign(dtbs)).thenReturn(signature);
-        when(formatter.formatSigningResponse(any(), any(), any(), any(), any(), eq(dtbs), eq(signature), any()))
+        when(formatting.formatSigningResponse(any(), any(), any(), any(), any(), eq(dtbs), eq(signature), any()))
                 .thenReturn(validTokenBytes);
 
         // when
@@ -159,15 +159,15 @@ class StaticKeyManagedTimestampTokenGeneratorTest {
 
         // then
         verify(signer).sign(dtbs);
-        verify(formatter).formatSigningResponse(any(), any(), any(), any(), any(), eq(dtbs), eq(signature), any());
+        verify(formatting).formatSigningResponse(any(), any(), any(), any(), any(), eq(dtbs), eq(signature), any());
     }
 
     @Test
     void throwsSystemFailure_whenTokenBytesAreNotParseable() throws Exception {
-        // given — the formatter.formatSigningResponse returns garbage bytes; BouncyCastle fails to parse them as a CMS SignedData
-        when(formatter.formatDtbs(any(), any(), any(), any(), any(), any())).thenReturn(new byte[1]);
+        // given — the formatting.formatSigningResponse returns garbage bytes; BouncyCastle fails to parse them as a CMS SignedData
+        when(formatting.formatDtbs(any(), any(), any(), any(), any(), any())).thenReturn(new byte[1]);
         when(signer.sign(any())).thenReturn(new byte[1]);
-        when(formatter.formatSigningResponse(any(), any(), any(), any(), any(), any(), any(), any()))
+        when(formatting.formatSigningResponse(any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(new byte[]{0x00, 0x01, 0x02, 0x03});
 
         // when / then
@@ -193,10 +193,10 @@ class StaticKeyManagedTimestampTokenGeneratorTest {
     }
 
     @Test
-    void propagatesTspException_fromFormatterDtbs() throws Exception {
-        // given — the formatter fails to build the DTBS (e.g. malformed certificate)
+    void propagatesTspException_fromFormattingDtbs() throws Exception {
+        // given — the formatting fails to build the DTBS (e.g. malformed certificate)
         var cause = new TspException(TspFailureInfo.BAD_REQUEST, "cannot build DTBS", "bad request");
-        when(formatter.formatDtbs(any(), any(), any(), any(), any(), any())).thenThrow(cause);
+        when(formatting.formatDtbs(any(), any(), any(), any(), any(), any())).thenThrow(cause);
 
         // when / then
         assertThatThrownBy(() -> generator.generate(aTspRequest().build(), aTimestampingProfile(),
@@ -208,7 +208,7 @@ class StaticKeyManagedTimestampTokenGeneratorTest {
     void propagatesTspException_fromSigner() throws Exception {
         // given — the signing connector is unavailable
         var cause = new TspException(TspFailureInfo.SYSTEM_FAILURE, "signing failed", "signing connector error");
-        when(formatter.formatDtbs(any(), any(), any(), any(), any(), any())).thenReturn(new byte[1]);
+        when(formatting.formatDtbs(any(), any(), any(), any(), any(), any())).thenReturn(new byte[1]);
         when(signer.sign(any())).thenThrow(cause);
 
         // when / then
@@ -218,12 +218,12 @@ class StaticKeyManagedTimestampTokenGeneratorTest {
     }
 
     @Test
-    void propagatesTspException_fromFormatterSigningResponse() throws Exception {
-        // given — the formatter fails to assemble the final token from the signature
+    void propagatesTspException_fromFormattingSigningResponse() throws Exception {
+        // given — the formatting fails to assemble the final token from the signature
         var cause = new TspException(TspFailureInfo.SYSTEM_FAILURE, "cannot assemble token", "internal error");
-        when(formatter.formatDtbs(any(), any(), any(), any(), any(), any())).thenReturn(new byte[1]);
+        when(formatting.formatDtbs(any(), any(), any(), any(), any(), any())).thenReturn(new byte[1]);
         when(signer.sign(any())).thenReturn(new byte[1]);
-        when(formatter.formatSigningResponse(any(), any(), any(), any(), any(), any(), any(), any())).thenThrow(cause);
+        when(formatting.formatSigningResponse(any(), any(), any(), any(), any(), any(), any(), any())).thenThrow(cause);
 
         // when / then
         assertThatThrownBy(() -> generator.generate(aTspRequest().build(), aTimestampingProfile(),

--- a/src/test/java/com/otilm/core/signing/tsa/TimestampTokenTestUtil.java
+++ b/src/test/java/com/otilm/core/signing/tsa/TimestampTokenTestUtil.java
@@ -88,7 +88,7 @@ public final class TimestampTokenTestUtil {
 
     // ── External-signature token assembly ─────────────────────────────────────
     //
-    // The three helpers below implement the signature-formatter connector's side of the two-round-trip
+    // The three helpers below implement the signature-formatting connector's side of the two-round-trip
     // RFC 3161 contract: phase 1 produces the exact CMS data-to-be-signed (the DER SignedAttributes over
     // a TSTInfo), an external signer signs those bytes, and phase 2 embeds the external signature into a
     // CMS SignedData without ever holding the private key. Phase consistency relies on buildTstInfo being

--- a/src/test/java/com/otilm/core/signing/tsa/TsaServiceImplTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/TsaServiceImplTest.java
@@ -31,7 +31,7 @@ import com.otilm.core.signing.tsa.validator.TspRequestValidationException;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.mocks.ConnectorMockFactory;
 import com.otilm.core.util.mocks.CryptographyProviderConnectorMock;
-import com.otilm.core.util.mocks.TimestampingFormatterConnectorMock;
+import com.otilm.core.util.mocks.TimestampingFormattingConnectorMock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -62,9 +62,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * End-to-end test of the TSP timestamp flow over a real Spring context and Postgres: request validation,
  * signing-profile resolution, the {@link ManagedTimestampEngine}, token assembly, and signing-record
  * persistence all run for real. The only mocks are the external connectors — the cryptography provider (signs
- * the DTBS) and the timestamping signature formatter (assembles the RFC 3161 token) — served by WireMock.
+ * the DTBS) and the timestamping signature formatting (assembles the RFC 3161 token) — served by WireMock.
  *
- * <p>The formatter returns a pre-built, structurally valid timestamp token; the profiles disable
+ * <p>The formatting returns a pre-built, structurally valid timestamp token; the profiles disable
  * token-signature validation, so the token need not cryptographically verify against the signing certificate.
  */
 class TsaServiceImplTest extends BaseSpringBootTest {
@@ -100,20 +100,20 @@ class TsaServiceImplTest extends BaseSpringBootTest {
     private TestCertificateAuthority testCertificateAuthority;
 
     private CryptographyProviderConnectorMock cryptographyProviderMock;
-    private TimestampingFormatterConnectorMock timestampingFormatterMock;
-    private ConnectorDetailDto timestampingFormatterConnector;
+    private TimestampingFormattingConnectorMock timestampingFormattingMock;
+    private ConnectorDetailDto timestampingFormattingConnector;
     private Certificate signingCertificate;
     private byte[] timestampTokenBytes;
 
     @BeforeEach
     void setUp() throws Exception {
         cryptographyProviderMock = connectorMockFactory.startCryptographyProvider();
-        timestampingFormatterMock = connectorMockFactory.startTimestampingFormatter();
+        timestampingFormattingMock = connectorMockFactory.startTimestampingFormatting();
 
         ConnectorDetailDto cryptographyProviderConnector = connectorService.createConnector(
                 aV1ConnectorRequest().withName("soft-cryptography-provider").withUrl(cryptographyProviderMock.getUrl()).build());
-        timestampingFormatterConnector = connectorService.createConnector(
-                aV2ConnectorRequest().withName("timestamping-formatter").withUrl(timestampingFormatterMock.getUrl()).build());
+        timestampingFormattingConnector = connectorService.createConnector(
+                aV2ConnectorRequest().withName("timestamping-formatting").withUrl(timestampingFormattingMock.getUrl()).build());
 
         cryptographyProviderMock.stubTokenInstanceCreation(UUID.randomUUID());
         TokenInstanceDetailDto tokenInstance = tokenInstanceService.createTokenInstance(
@@ -140,7 +140,7 @@ class TsaServiceImplTest extends BaseSpringBootTest {
         // The connector signs the DTBS and assembles the token; the assembled token is a real RFC 3161 token.
         timestampTokenBytes = TimestampTokenTestUtil.createTimestampToken().getEncoded();
         cryptographyProviderMock.stubSignData("connector-signature".getBytes(StandardCharsets.UTF_8));
-        timestampingFormatterMock.stubFormatterAttributes().stubTokenAssembly(timestampTokenBytes);
+        timestampingFormattingMock.stubFormattingAttributes().stubTokenAssembly(timestampTokenBytes);
     }
 
     @AfterEach
@@ -148,8 +148,8 @@ class TsaServiceImplTest extends BaseSpringBootTest {
         if (cryptographyProviderMock != null) {
             cryptographyProviderMock.stop();
         }
-        if (timestampingFormatterMock != null) {
-            timestampingFormatterMock.stop();
+        if (timestampingFormattingMock != null) {
+            timestampingFormattingMock.stop();
         }
     }
 
@@ -171,7 +171,7 @@ class TsaServiceImplTest extends BaseSpringBootTest {
                         .withName(name)
                         .withStaticKeyManagedSigning(signingCertificate.getUuid())
                         .withTimestamping(aTimestampingWorkflow()
-                                .withSignatureFormatterConnector(UUID.fromString(timestampingFormatterConnector.getUuid()))
+                                .withSignatureFormattingConnector(UUID.fromString(timestampingFormattingConnector.getUuid()))
                                 .withValidateTokenSignature(false)
                                 .withQualifiedTimestamp(false)
                                 .withAllowedDigestAlgorithms(allowedDigestAlgorithms)
@@ -324,10 +324,10 @@ class TsaServiceImplTest extends BaseSpringBootTest {
         }
 
         @Test
-        void rejectsWithSystemFailure_whenFormatterConnectorFails() throws Exception {
-            // given — the signature formatter is unavailable during token assembly
-            SigningProfileDto profile = createTimestampingSigningProfile("sp-formatter-down");
-            timestampingFormatterMock.stubTokenAssemblyFailure();
+        void rejectsWithSystemFailure_whenFormattingConnectorFails() throws Exception {
+            // given — the signature formatting is unavailable during token assembly
+            SigningProfileDto profile = createTimestampingSigningProfile("sp-formatting-down");
+            timestampingFormattingMock.stubTokenAssemblyFailure();
 
             // when
             TspResponse response = tsaService.processTspRequestForSigningProfile(profile.getName(), aTspRequest().build());

--- a/src/test/java/com/otilm/core/signing/tsa/formatting/TimestampingSignatureFormattingClientTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/formatting/TimestampingSignatureFormattingClientTest.java
@@ -1,16 +1,16 @@
-package com.otilm.core.signing.tsa.formatter;
+package com.otilm.core.signing.tsa.formatting;
 
 import com.otilm.api.clients.ApiClientConnectorInfo;
-import com.otilm.api.clients.signing.SignatureFormatterApiClient;
+import com.otilm.api.clients.signing.SignatureFormattingApiClient;
 import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.interfaces.core.tsp.error.TspException;
 import com.otilm.api.interfaces.core.tsp.error.TspFailureInfo;
 import com.otilm.api.model.common.enums.cryptography.SignatureAlgorithm;
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
-import com.otilm.api.model.connector.signatures.formatter.FormatDtbsResponseDto;
-import com.otilm.api.model.connector.signatures.formatter.FormattedResponseDto;
-import com.otilm.api.model.connector.signatures.formatter.TimestampingFormatDtbsRequestDto;
-import com.otilm.api.model.connector.signatures.formatter.TimestampingFormatResponseRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatDtbsResponseDto;
+import com.otilm.api.model.connector.signatures.formatting.FormattedResponseDto;
+import com.otilm.api.model.connector.signatures.formatting.TimestampingFormatDtbsRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.TimestampingFormatResponseRequestDto;
 import com.otilm.api.model.core.signing.SigningProtocol;
 import com.otilm.core.helpers.CertificateGeneratorHelper;
 import com.otilm.core.util.CertificateTestUtil;
@@ -43,12 +43,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class TimestampingSignatureFormatterClientTest {
+class TimestampingSignatureFormattingClientTest {
 
     @Mock
-    private SignatureFormatterApiClient apiClient;
+    private SignatureFormattingApiClient apiClient;
 
-    private TimestampingConnectorSignatureFormatterClient client;
+    private TimestampingConnectorSignatureFormattingClient client;
     private ResolvedManagedTimestampingProfile profile;
     private CertificateChain chain;
 
@@ -59,7 +59,7 @@ class TimestampingSignatureFormatterClientTest {
 
     @BeforeEach
     void wireClientAndFixtures() {
-        client = new TimestampingConnectorSignatureFormatterClient();
+        client = new TimestampingConnectorSignatureFormattingClient();
         client.setApiClient(apiClient);
 
         profile = new ResolvedManagedTimestampingProfile(
@@ -94,7 +94,7 @@ class TimestampingSignatureFormatterClientTest {
 
         @Test
         void throwsSystemFailure_whenApiCallFails() throws Exception {
-            // given — the remote formatter call fails
+            // given — the remote formatting call fails
             when(apiClient.formatDtbs(any(), any()))
                     .thenThrow(new ConnectorException("connection refused"));
 

--- a/src/test/java/com/otilm/core/signing/tsa/resolver/StaticKeyManagedTimestampingResolverTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/resolver/StaticKeyManagedTimestampingResolverTest.java
@@ -150,7 +150,7 @@ class StaticKeyManagedTimestampingResolverTest {
             assertThat(result.allowedDigestAlgorithms()).containsExactly(DigestAlgorithm.SHA_256);
             assertThat(result.validateTokenSignature()).isTrue();
             assertThat(result.timeQualityConfiguration()).isSameAs(tqc);
-            assertThat(result.signatureFormatterConnector()).isSameAs(connector);
+            assertThat(result.signatureFormattingConnector()).isSameAs(connector);
             assertThat(result.resolvedScheme()).isInstanceOf(ResolvedStaticKeyManagedSigning.class);
             ResolvedStaticKeyManagedSigning resolvedScheme = (ResolvedStaticKeyManagedSigning) result.resolvedScheme();
             assertThat(resolvedScheme.certificate()).isSameAs(certificate);
@@ -265,7 +265,7 @@ class StaticKeyManagedTimestampingResolverTest {
         }
 
         @Test
-        void throwsSystemFailure_whenSignatureFormatterConnectorNotFound() throws Exception {
+        void throwsSystemFailure_whenSignatureFormattingConnectorNotFound() throws Exception {
             // given
             when(timeQualityConfigurationService.getTimeQualityConfigurationModel(TQC_UUID))
                     .thenReturn(LocalClockTimeQualityConfiguration.INSTANCE);

--- a/src/test/java/com/otilm/core/util/builders/ContentSigningWorkflowRequestDtoBuilder.java
+++ b/src/test/java/com/otilm/core/util/builders/ContentSigningWorkflowRequestDtoBuilder.java
@@ -9,27 +9,27 @@ import java.util.UUID;
 
 public class ContentSigningWorkflowRequestDtoBuilder {
 
-    private UUID signatureFormatterConnectorUuid = null;
-    private List<RequestAttribute> signatureFormatterConnectorAttributes = new ArrayList<>();
+    private UUID signatureFormattingConnectorUuid = null;
+    private List<RequestAttribute> signatureFormattingConnectorAttributes = new ArrayList<>();
 
     public static ContentSigningWorkflowRequestDtoBuilder aContentSigningWorkflow() {
         return new ContentSigningWorkflowRequestDtoBuilder();
     }
 
-    public ContentSigningWorkflowRequestDtoBuilder withSignatureFormatterConnector(UUID uuid) {
-        this.signatureFormatterConnectorUuid = uuid;
+    public ContentSigningWorkflowRequestDtoBuilder withSignatureFormattingConnector(UUID uuid) {
+        this.signatureFormattingConnectorUuid = uuid;
         return this;
     }
 
-    public ContentSigningWorkflowRequestDtoBuilder withSignatureFormatterConnectorAttributes(List<RequestAttribute> attrs) {
-        this.signatureFormatterConnectorAttributes = attrs;
+    public ContentSigningWorkflowRequestDtoBuilder withSignatureFormattingConnectorAttributes(List<RequestAttribute> attrs) {
+        this.signatureFormattingConnectorAttributes = attrs;
         return this;
     }
 
     public ContentSigningWorkflowRequestDto build() {
         ContentSigningWorkflowRequestDto dto = new ContentSigningWorkflowRequestDto();
-        dto.setSignatureFormatterConnectorUuid(signatureFormatterConnectorUuid);
-        dto.setSignatureFormatterConnectorAttributes(signatureFormatterConnectorAttributes);
+        dto.setSignatureFormattingConnectorUuid(signatureFormattingConnectorUuid);
+        dto.setSignatureFormattingConnectorAttributes(signatureFormattingConnectorAttributes);
         return dto;
     }
 }

--- a/src/test/java/com/otilm/core/util/builders/SigningProfileRequestDtoBuilder.java
+++ b/src/test/java/com/otilm/core/util/builders/SigningProfileRequestDtoBuilder.java
@@ -101,9 +101,9 @@ public class SigningProfileRequestDtoBuilder {
         return withWorkflow(new RawSigningWorkflowRequestDto());
     }
 
-    public SigningProfileRequestDtoBuilder withContentSigning(UUID signatureFormatterConnectorUuid) {
+    public SigningProfileRequestDtoBuilder withContentSigning(UUID signatureFormattingConnectorUuid) {
         ContentSigningWorkflowRequestDto contentSigningWorkflow = new ContentSigningWorkflowRequestDto();
-        contentSigningWorkflow.setSignatureFormatterConnectorUuid(signatureFormatterConnectorUuid);
+        contentSigningWorkflow.setSignatureFormattingConnectorUuid(signatureFormattingConnectorUuid);
         return withWorkflow(contentSigningWorkflow);
     }
 
@@ -111,8 +111,8 @@ public class SigningProfileRequestDtoBuilder {
         return withWorkflow(workflow);
     }
 
-    public SigningProfileRequestDtoBuilder withTimestamping(UUID signatureFormatterConnectorUuid) {
-        return withTimestamping(TimestampingWorkflowRequestDtoBuilder.aTimestampingWorkflow().withSignatureFormatterConnector(signatureFormatterConnectorUuid).build());
+    public SigningProfileRequestDtoBuilder withTimestamping(UUID signatureFormattingConnectorUuid) {
+        return withTimestamping(TimestampingWorkflowRequestDtoBuilder.aTimestampingWorkflow().withSignatureFormattingConnector(signatureFormattingConnectorUuid).build());
     }
 
     public SigningProfileRequestDtoBuilder withTimestamping(TimestampingWorkflowRequestDto workflow) {
@@ -160,18 +160,18 @@ public class SigningProfileRequestDtoBuilder {
             case RawSigningWorkflowDto ignored -> new RawSigningWorkflowRequestDto();
             case ContentSigningWorkflowDto c -> {
                 ContentSigningWorkflowRequestDto req = new ContentSigningWorkflowRequestDto();
-                if (c.getSignatureFormatterConnector() != null) {
-                    req.setSignatureFormatterConnectorUuid(UUID.fromString(c.getSignatureFormatterConnector().getUuid()));
+                if (c.getSignatureFormattingConnector() != null) {
+                    req.setSignatureFormattingConnectorUuid(UUID.fromString(c.getSignatureFormattingConnector().getUuid()));
                 }
-                req.setSignatureFormatterConnectorAttributes(requestAttributesFromResponse(c.getSignatureFormatterConnectorAttributes()));
+                req.setSignatureFormattingConnectorAttributes(requestAttributesFromResponse(c.getSignatureFormattingConnectorAttributes()));
                 yield req;
             }
             case TimestampingWorkflowDto t -> {
                 TimestampingWorkflowRequestDto req = new TimestampingWorkflowRequestDto();
-                if (t.getSignatureFormatterConnector() != null) {
-                    req.setSignatureFormatterConnectorUuid(UUID.fromString(t.getSignatureFormatterConnector().getUuid()));
+                if (t.getSignatureFormattingConnector() != null) {
+                    req.setSignatureFormattingConnectorUuid(UUID.fromString(t.getSignatureFormattingConnector().getUuid()));
                 }
-                req.setSignatureFormatterConnectorAttributes(requestAttributesFromResponse(t.getSignatureFormatterConnectorAttributes()));
+                req.setSignatureFormattingConnectorAttributes(requestAttributesFromResponse(t.getSignatureFormattingConnectorAttributes()));
                 req.setQualifiedTimestamp(t.getQualifiedTimestamp());
                 if (t.getTimeQualityConfiguration() != null) {
                     req.setTimeQualityConfigurationUuid(UUID.fromString(t.getTimeQualityConfiguration().getUuid()));

--- a/src/test/java/com/otilm/core/util/builders/TimestampingWorkflowRequestDtoBuilder.java
+++ b/src/test/java/com/otilm/core/util/builders/TimestampingWorkflowRequestDtoBuilder.java
@@ -10,8 +10,8 @@ import java.util.UUID;
 
 public class TimestampingWorkflowRequestDtoBuilder {
 
-    private UUID signatureFormatterConnectorUuid = null;
-    private List<RequestAttribute> signatureFormatterConnectorAttributes = new ArrayList<>();
+    private UUID signatureFormattingConnectorUuid = null;
+    private List<RequestAttribute> signatureFormattingConnectorAttributes = new ArrayList<>();
     private Boolean qualifiedTimestamp = null;
     private UUID timeQualityConfigurationUuid = null;
     private String defaultPolicyId = null;
@@ -23,13 +23,13 @@ public class TimestampingWorkflowRequestDtoBuilder {
         return new TimestampingWorkflowRequestDtoBuilder();
     }
 
-    public TimestampingWorkflowRequestDtoBuilder withSignatureFormatterConnector(UUID uuid) {
-        this.signatureFormatterConnectorUuid = uuid;
+    public TimestampingWorkflowRequestDtoBuilder withSignatureFormattingConnector(UUID uuid) {
+        this.signatureFormattingConnectorUuid = uuid;
         return this;
     }
 
-    public TimestampingWorkflowRequestDtoBuilder withSignatureFormatterConnectorAttributes(List<RequestAttribute> attrs) {
-        this.signatureFormatterConnectorAttributes = attrs;
+    public TimestampingWorkflowRequestDtoBuilder withSignatureFormattingConnectorAttributes(List<RequestAttribute> attrs) {
+        this.signatureFormattingConnectorAttributes = attrs;
         return this;
     }
 
@@ -65,8 +65,8 @@ public class TimestampingWorkflowRequestDtoBuilder {
 
     public TimestampingWorkflowRequestDto build() {
         TimestampingWorkflowRequestDto dto = new TimestampingWorkflowRequestDto();
-        dto.setSignatureFormatterConnectorUuid(signatureFormatterConnectorUuid);
-        dto.setSignatureFormatterConnectorAttributes(signatureFormatterConnectorAttributes);
+        dto.setSignatureFormattingConnectorUuid(signatureFormattingConnectorUuid);
+        dto.setSignatureFormattingConnectorAttributes(signatureFormattingConnectorAttributes);
         dto.setQualifiedTimestamp(qualifiedTimestamp);
         dto.setTimeQualityConfigurationUuid(timeQualityConfigurationUuid);
         dto.setDefaultPolicyId(defaultPolicyId);

--- a/src/test/java/com/otilm/core/util/mocks/BaseConnectorMock.java
+++ b/src/test/java/com/otilm/core/util/mocks/BaseConnectorMock.java
@@ -20,7 +20,7 @@ import static com.otilm.core.util.builders.ConnectorInfoBuilder.aConnectorInfo;
  * <p>
  * Owns the WireMock server lifecycle and the generic discovery stubs shared by every connector flavour:
  * {@code GET /v1} (V1 function-group discovery) and {@code GET /v2/info} (V2 interface discovery).
- * Concrete subclasses (e.g. {@link TimestampingFormatterConnectorMock}, {@link CryptographyProviderConnectorMock})
+ * Concrete subclasses (e.g. {@link TimestampingFormattingConnectorMock}, {@link CryptographyProviderConnectorMock})
  * add the function-specific stubs in their constructor.
  * Instances are created exclusively through {@link ConnectorMockFactory}, which injects any Spring beans
  * a mock needs at start. Call {@link #stop()} in {@code @AfterEach}.

--- a/src/test/java/com/otilm/core/util/mocks/ConnectorMockFactory.java
+++ b/src/test/java/com/otilm/core/util/mocks/ConnectorMockFactory.java
@@ -22,12 +22,12 @@ public class ConnectorMockFactory {
         return new CryptographyProviderConnectorMock(functionGroupSeeder);
     }
 
-    public ContentSigningFormatterMock startContentSigningFormatter() {
-        return new ContentSigningFormatterMock();
+    public ContentSigningFormattingMock startContentSigningFormatting() {
+        return new ContentSigningFormattingMock();
     }
 
-    public TimestampingFormatterConnectorMock startTimestampingFormatter() {
-        return new TimestampingFormatterConnectorMock();
+    public TimestampingFormattingConnectorMock startTimestampingFormatting() {
+        return new TimestampingFormattingConnectorMock();
     }
 
     public SignerConnectorMock startSigner() {

--- a/src/test/java/com/otilm/core/util/mocks/ContentSigningFormattingMock.java
+++ b/src/test/java/com/otilm/core/util/mocks/ContentSigningFormattingMock.java
@@ -12,13 +12,13 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Mock of a V2 content-signing formatter connector — stubs {@code GET /v2/info} advertising
+ * Mock of a V2 content-signing formatting connector — stubs {@code GET /v2/info} advertising
  * {@link ConnectorInterface#SIGNATURE_FORMATTING} with {@link FeatureFlag#CONTENT_SIGNING}.
  * Used to back {@code CONTENT_SIGNING} workflow profiles.
  */
-public class ContentSigningFormatterMock extends BaseConnectorMock {
+public class ContentSigningFormattingMock extends BaseConnectorMock {
 
-    ContentSigningFormatterMock() {
+    ContentSigningFormattingMock() {
         stubV2InfoDetails(List.of(
                 interfaceInfo(ConnectorInterface.INFO, List.of()),
                 interfaceInfo(ConnectorInterface.HEALTH, List.of()),
@@ -28,26 +28,26 @@ public class ContentSigningFormatterMock extends BaseConnectorMock {
         ));
     }
 
-    public ContentSigningFormatterMock stubFormatterAttributes() {
+    public ContentSigningFormattingMock stubFormattingAttributes() {
         server.stubFor(WireMock.get(WireMock.urlPathMatching(".*/v1/signatureProvider/formatting/attributes"))
                 .willReturn(WireMock.okJson("[]")));
         return this;
     }
 
     /**
-     * Stubs the signature-formatter attributes endpoint to advertise a single optional STRING attribute definition.
-     * Takes precedence over {@link #stubFormatterAttributes()} when called after it.
+     * Stubs the signature-formatting attributes endpoint to advertise a single optional STRING attribute definition.
+     * Takes precedence over {@link #stubFormattingAttributes()} when called after it.
      */
-    public ContentSigningFormatterMock stubFormatterAttributeDefinition(UUID attrUuid, String attrName) {
-        return stubFormatterAttributeDefinition(attrUuid, attrName, false);
+    public ContentSigningFormattingMock stubFormattingAttributeDefinition(UUID attrUuid, String attrName) {
+        return stubFormattingAttributeDefinition(attrUuid, attrName, false);
     }
 
     /**
-     * Stubs the signature-formatter attributes endpoint to advertise a single STRING attribute definition.
+     * Stubs the signature-formatting attributes endpoint to advertise a single STRING attribute definition.
      * When {@code required=true}, the service must reject requests that omit this attribute.
-     * Takes precedence over {@link #stubFormatterAttributes()} when called after it.
+     * Takes precedence over {@link #stubFormattingAttributes()} when called after it.
      */
-    public ContentSigningFormatterMock stubFormatterAttributeDefinition(UUID attrUuid, String attrName, boolean required) {
+    public ContentSigningFormattingMock stubFormattingAttributeDefinition(UUID attrUuid, String attrName, boolean required) {
         DataAttributeV2 def = new DataAttributeV2();
         def.setUuid(attrUuid.toString());
         def.setName(attrName);

--- a/src/test/java/com/otilm/core/util/mocks/TimestampingFormatDtbsTransformer.java
+++ b/src/test/java/com/otilm/core/util/mocks/TimestampingFormatDtbsTransformer.java
@@ -1,17 +1,17 @@
 package com.otilm.core.util.mocks;
 
-import com.otilm.api.model.connector.signatures.formatter.FormatDtbsResponseDto;
-import com.otilm.api.model.connector.signatures.formatter.TimestampingFormatDtbsRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.FormatDtbsResponseDto;
+import com.otilm.api.model.connector.signatures.formatting.TimestampingFormatDtbsRequestDto;
 import com.otilm.core.signing.tsa.TimestampTokenTestUtil;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 
 /**
- * Phase 1 of the RFC 3161 formatter contract ({@code formatDtbs}), backing
- * {@link TimestampingFormatterConnectorMock#stubFormatDtbs()}: returns the real CMS data-to-be-signed —
+ * Phase 1 of the RFC 3161 formatting contract ({@code formatDtbs}), backing
+ * {@link TimestampingFormattingConnectorMock#stubFormatDtbs()}: returns the real CMS data-to-be-signed —
  * the DER {@code SignedAttributes} over a TSTInfo built from the request fields.
  */
-class TimestampingFormatDtbsTransformer extends TimestampingFormatterTransformer {
+class TimestampingFormatDtbsTransformer extends TimestampingFormattingTransformer {
 
     static final String NAME = "tsp-format-dtbs";
 
@@ -24,7 +24,7 @@ class TimestampingFormatDtbsTransformer extends TimestampingFormatterTransformer
             response.setDtbs(signedAttributesDtbsFor(request));
             return jsonResponse(serveEvent, response);
         } catch (Exception e) {
-            throw new IllegalStateException("Failed to format DTBS in WireMock formatter transformer", e);
+            throw new IllegalStateException("Failed to format DTBS in WireMock formatting transformer", e);
         }
     }
 

--- a/src/test/java/com/otilm/core/util/mocks/TimestampingFormatResponseTransformer.java
+++ b/src/test/java/com/otilm/core/util/mocks/TimestampingFormatResponseTransformer.java
@@ -1,17 +1,17 @@
 package com.otilm.core.util.mocks;
 
-import com.otilm.api.model.connector.signatures.formatter.FormattedResponseDto;
-import com.otilm.api.model.connector.signatures.formatter.TimestampingFormatResponseRequestDto;
+import com.otilm.api.model.connector.signatures.formatting.FormattedResponseDto;
+import com.otilm.api.model.connector.signatures.formatting.TimestampingFormatResponseRequestDto;
 import com.otilm.core.signing.tsa.TimestampTokenTestUtil;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 
 /**
- * Phase 2 of the RFC 3161 formatter contract ({@code formatResponse}), backing
- * {@link TimestampingFormatterConnectorMock#stubFormatResponse()}: assembles a real
+ * Phase 2 of the RFC 3161 formatting contract ({@code formatResponse}), backing
+ * {@link TimestampingFormattingConnectorMock#stubFormatResponse()}: assembles a real
  * {@code TimeStampToken} embedding the externally produced signature carried by the request.
  */
-class TimestampingFormatResponseTransformer extends TimestampingFormatterTransformer {
+class TimestampingFormatResponseTransformer extends TimestampingFormattingTransformer {
 
     static final String NAME = "tsp-format-response";
 
@@ -24,7 +24,7 @@ class TimestampingFormatResponseTransformer extends TimestampingFormatterTransfo
             response.setResponse(timestampTokenFor(request));
             return jsonResponse(serveEvent, response);
         } catch (Exception e) {
-            throw new IllegalStateException("Failed to assemble timestamp token in WireMock formatter transformer", e);
+            throw new IllegalStateException("Failed to assemble timestamp token in WireMock formatting transformer", e);
         }
     }
 

--- a/src/test/java/com/otilm/core/util/mocks/TimestampingFormattingConnectorMock.java
+++ b/src/test/java/com/otilm/core/util/mocks/TimestampingFormattingConnectorMock.java
@@ -14,19 +14,19 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Mock of a V2 timestamping formatter connector — stubs {@code GET /v2/info} advertising
+ * Mock of a V2 timestamping formatting connector — stubs {@code GET /v2/info} advertising
  * {@link ConnectorInterface#SIGNATURE_FORMATTING} with {@link FeatureFlag#TIMESTAMPING}.
  * Used to back {@code TIMESTAMPING} workflow profiles.
  *
  * <p>Beyond discovery, {@link #stubFormatDtbs()} and {@link #stubFormatResponse()} implement the
- * runtime two-round-trip RFC 3161 formatter contract for real: phase 1 returns the genuine CMS
+ * runtime two-round-trip RFC 3161 formatting contract for real: phase 1 returns the genuine CMS
  * data-to-be-signed for the request's TSTInfo, and phase 2 assembles a real {@code TimeStampToken}
  * embedding the externally produced signature — so tokens it produces verify against the signer
  * certificate.
  */
-public class TimestampingFormatterConnectorMock extends BaseConnectorMock {
+public class TimestampingFormattingConnectorMock extends BaseConnectorMock {
 
-    TimestampingFormatterConnectorMock() {
+    TimestampingFormattingConnectorMock() {
         super(new TimestampingFormatDtbsTransformer(), new TimestampingFormatResponseTransformer());
         stubV2InfoDetails(List.of(
                 interfaceInfo(ConnectorInterface.INFO, List.of()),
@@ -38,19 +38,19 @@ public class TimestampingFormatterConnectorMock extends BaseConnectorMock {
     }
 
     /**
-     * Stubs the signature-formatter attributes endpoint to advertise no attributes (empty list).
+     * Stubs the signature-formatting attributes endpoint to advertise no attributes (empty list).
      */
-    public TimestampingFormatterConnectorMock stubFormatterAttributes() {
+    public TimestampingFormattingConnectorMock stubFormattingAttributes() {
         server.stubFor(WireMock.get(WireMock.urlPathMatching(".*/v1/signatureProvider/formatting/attributes"))
                 .willReturn(WireMock.okJson("[]")));
         return this;
     }
 
     /**
-     * Stubs the signature-formatter attributes endpoint to advertise a single STRING attribute definition.
-     * Takes precedence over {@link #stubFormatterAttributes()} when called after it.
+     * Stubs the signature-formatting attributes endpoint to advertise a single STRING attribute definition.
+     * Takes precedence over {@link #stubFormattingAttributes()} when called after it.
      */
-    public TimestampingFormatterConnectorMock stubFormatterAttributeDefinition(UUID attrUuid, String attrName, boolean required) {
+    public TimestampingFormattingConnectorMock stubFormattingAttributeDefinition(UUID attrUuid, String attrName, boolean required) {
         DataAttributeV2 def = new DataAttributeV2();
         def.setUuid(attrUuid.toString());
         def.setName(attrName);
@@ -69,10 +69,10 @@ public class TimestampingFormatterConnectorMock extends BaseConnectorMock {
     }
 
     /**
-     * Stubs phase 1 of the RFC 3161 formatter contract ({@code formatDtbs}) — see
+     * Stubs phase 1 of the RFC 3161 formatting contract ({@code formatDtbs}) — see
      * {@link TimestampingFormatDtbsTransformer}.
      */
-    public TimestampingFormatterConnectorMock stubFormatDtbs() {
+    public TimestampingFormattingConnectorMock stubFormatDtbs() {
         server.stubFor(WireMock.post(WireMock.urlPathMatching(".*/v1/signatureProvider/formatting/formatDtbs"))
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)
@@ -82,10 +82,10 @@ public class TimestampingFormatterConnectorMock extends BaseConnectorMock {
     }
 
     /**
-     * Stubs phase 2 of the RFC 3161 formatter contract ({@code formatResponse}) — see
+     * Stubs phase 2 of the RFC 3161 formatting contract ({@code formatResponse}) — see
      * {@link TimestampingFormatResponseTransformer}.
      */
-    public TimestampingFormatterConnectorMock stubFormatResponse() {
+    public TimestampingFormattingConnectorMock stubFormatResponse() {
         server.stubFor(WireMock.post(WireMock.urlPathMatching(".*/v1/signatureProvider/formatting/formatResponse"))
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)
@@ -103,7 +103,7 @@ public class TimestampingFormatterConnectorMock extends BaseConnectorMock {
      * The token must be structurally parseable as a CMS {@code TimeStampToken}; it need not cryptographically
      * verify unless the profile enables token-signature validation.
      */
-    public TimestampingFormatterConnectorMock stubTokenAssembly(byte[] timestampTokenBytes) {
+    public TimestampingFormattingConnectorMock stubTokenAssembly(byte[] timestampTokenBytes) {
         String dtbs = Base64.getEncoder().encodeToString("placeholder-dtbs".getBytes(StandardCharsets.UTF_8));
         String token = Base64.getEncoder().encodeToString(timestampTokenBytes);
         server.stubFor(WireMock.post(WireMock.urlPathMatching(".*/v1/signatureProvider/formatting/formatDtbs"))
@@ -116,7 +116,7 @@ public class TimestampingFormatterConnectorMock extends BaseConnectorMock {
     /**
      * Stubs the {@code formatDtbs} phase to fail, so the engine surfaces a {@code SYSTEM_FAILURE} rejection.
      */
-    public TimestampingFormatterConnectorMock stubTokenAssemblyFailure() {
+    public TimestampingFormattingConnectorMock stubTokenAssemblyFailure() {
         server.stubFor(WireMock.post(WireMock.urlPathMatching(".*/v1/signatureProvider/formatting/formatDtbs"))
                 .willReturn(WireMock.serverError()));
         return this;

--- a/src/test/java/com/otilm/core/util/mocks/TimestampingFormattingTransformer.java
+++ b/src/test/java/com/otilm/core/util/mocks/TimestampingFormattingTransformer.java
@@ -8,7 +8,7 @@ import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 
 /**
- * Base for the WireMock extensions implementing the two phases of the RFC 3161 formatter contract
+ * Base for the WireMock extensions implementing the two phases of the RFC 3161 formatting contract
  * ({@link TimestampingFormatDtbsTransformer}, {@link TimestampingFormatResponseTransformer}).
  *
  * <p>Both phases rebuild the TSTInfo deterministically from their request DTO's fields — the client
@@ -16,7 +16,7 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
  * so the messageDigest signed in phase 1 matches the TSTInfo embedded in phase 2 without any
  * cross-request state in the mock.
  */
-abstract class TimestampingFormatterTransformer implements ResponseDefinitionTransformerV2 {
+abstract class TimestampingFormattingTransformer implements ResponseDefinitionTransformerV2 {
 
     /**
      * The DTOs use Java time types ({@code Instant}, {@code Duration}); registering all discoverable


### PR DESCRIPTION
## Summary

Renames **Signature Formatter → Signature Formatting Provider** in `core`, consuming the renamed SPI from OmniTrustILM/interfaces#747. Closes OmniTrustILM/core#1672. Part of OmniTrustILM/ilm#258.

Mirrors the naming decisions made in interfaces (capability-based class names; `Provider` only in user-facing prose; wire/route namespace `/v1/signatureProvider/formatting` unchanged).

## Changes

**SPI consumption (must match interfaces#747)**
- imports/types `SignatureFormatterApiClient`/`SignatureFormatterSyncApiClient` → `SignatureFormatting*`, package `…signatures.formatter` → `…signatures.formatting`
- overridden controller/service method `listSignatureFormatterConnectorAttributes` → `listSignatureFormattingConnectorAttributes`; SPI call `listFormatterAttributes` → `listFormattingAttributes`

**Core-internal (full mirror)**
- `SignatureFormatterClient` → `SignatureFormattingClient`; `TimestampingConnectorSignatureFormatterClient` → `TimestampingConnectorSignatureFormattingClient`; package `signing/tsa/formatter` → `…/formatting`
- entity `SigningProfileVersion`: field `signatureFormatterConnector{,Uuid}` → `signatureFormattingConnector{,Uuid}` + setter
- `ConnectorApiFactory`, `ApplicationConfig` bean, `SigningProfileMapper`, services, resolvers, generators, test mocks (`TimestampingFormatterConnectorMock` → `TimestampingFormattingConnectorMock`, `ContentSigningFormatterMock` → `ContentSigningFormattingMock`, `TimestampingFormatterTransformer` → `TimestampingFormattingTransformer`)
- user-facing `ValidationException` message → "Signature Formatting Provider '%s' does not support …"

- attribute-engine operation key `AttributeOperation.WORKFLOW_FORMATTER = "workflowFormatter"` → `WORKFLOW_FORMATTING = "workflowFormatting"`, aligning the workflow formatting operation scope with the `signatureFormatting*` field naming
- test-only operation constant in `AttributeEngineVersioningTest` renamed to `"formattingConnector"`

**Database**
- forward migration `V202606261200__rename_signature_formatting_connector_column.sql`:
  - `RENAME COLUMN signature_formatter_connector_uuid → signature_formatting_connector_uuid` and the matching index. FK preserved by `RENAME COLUMN`. Entity `@Column`/`@JoinColumn` updated to the new column.
  - `UPDATE attribute_definition SET operation = 'workflowFormatting' WHERE operation = 'workflowFormatter'` — the operation key is persisted and all attribute-content reads join on it, so existing signing-profile formatting attributes are migrated in place to avoid orphaning them.

## Deliberately NOT changed

- The connector-facing route namespace `/v1/signatureProvider/formatting` (unchanged in interfaces#747).

## ⚠️ Breaking / sequencing

- Compiles against the renamed interfaces SNAPSHOT (`2.18.1-SNAPSHOT`) from interfaces#747 — **merge interfaces#747 first** so CI resolves the renamed types.
- DB migration renames a live column; every environment runs it on upgrade.

## Verification

`mvn -Dmaven.compiler.proc=full test` (against the renamed interfaces installed locally) — full suite green, including `SigningProfileServiceImplTest` (Testcontainers Postgres applies the new migration end-to-end) and `FormattingAttributes`/`FormattingAttributeValidation` (exercise the `WORKFLOW_FORMATTING` path against the renamed column). Repo-wide grep: no stale `Signature Formatter` / `signatureFormatter` / `signature_formatter` / `workflowFormatter` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

