### PR TITLE
Route ClientOperationServiceImpl state transitions through CertificateStateMachine

### DIFF
--- a/src/main/java/com/otilm/core/service/handler/authority/lifecycle/CertificateStateMachine.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/lifecycle/CertificateStateMachine.java
@@ -50,11 +50,18 @@ public class CertificateStateMachine {
         this.eventHistoryService = eventHistoryService;
     }
 
+    /** Whether a {@code (from, to)} transition is defined in {@link CertificateStateTransition}.
+     *  Lets callers stay idempotent — skip a redelivered or raced action rather than letting
+     *  {@link #transition} throw — without reaching into the transition table directly. */
+    public boolean canTransition(CertificateState fromState, CertificateState toState) {
+        return CertificateStateTransition.lookup(fromState, toState).isPresent();
+    }
+
     /** Convenience overload: the audit event and the reason message are both auto-derived — the
      *  event from the transition row's {@code defaultAuditEvent}, the message from the from/to states. */
     @Transactional
     public void transition(Certificate cert, CertificateState toState) {
-        applyTransition(cert, toState, null, null);
+        applyTransition(cert, toState, null, null, null);
     }
 
     /**
@@ -65,14 +72,58 @@ public class CertificateStateMachine {
     public void transition(Certificate cert, CertificateState toState,
                            @Nullable CertificateEvent auditEventOverride,
                            @Nullable String reasonMessage) {
-        applyTransition(cert, toState, auditEventOverride, reasonMessage);
+        applyTransition(cert, toState, auditEventOverride, reasonMessage, null);
+    }
+
+    /**
+     * @param auditDetail if non-null, stored as the audit-history entry's detail payload (e.g. a
+     *                    serialized additional-information map); otherwise the detail is empty.
+     */
+    @Transactional
+    public void transition(Certificate cert, CertificateState toState,
+                           @Nullable CertificateEvent auditEventOverride,
+                           @Nullable String reasonMessage,
+                           @Nullable String auditDetail) {
+        applyTransition(cert, toState, auditEventOverride, reasonMessage, auditDetail);
+    }
+
+    /**
+     * Validate + mutate + persist the state WITHOUT writing an audit-history entry, for transitions
+     * whose certificate history is owned by another component. The approval flow is the case in
+     * point: {@code ApprovalRequestedEventHandler} already records the {@code APPROVAL_REQUEST}
+     * entry (with approval-profile context) when an approval is created, so routing
+     * {@code approvalCreatedAction} through {@link #transition} would write a duplicate row. The
+     * (from, to) pair is still validated against {@link CertificateStateTransition}, so an illegal
+     * transition still throws — only the audit is skipped.
+     */
+    @Transactional
+    public void transitionAuditedExternally(Certificate cert, CertificateState toState) {
+        applyStateChange(cert, toState);
     }
 
     /** Private so the {@code @Transactional} public overloads are reached through the Spring proxy
      *  rather than by self-invocation. */
     private void applyTransition(Certificate cert, CertificateState toState,
                                  @Nullable CertificateEvent auditEventOverride,
-                                 @Nullable String reasonMessage) {
+                                 @Nullable String reasonMessage,
+                                 @Nullable String auditDetail) {
+        CertificateState fromState = cert.getState();
+        CertificateStateTransition row = applyStateChange(cert, toState);
+
+        CertificateEvent auditEvent = auditEventOverride != null ? auditEventOverride : row.defaultAuditEvent;
+        String message = reasonMessage != null
+            ? reasonMessage
+            : "State changed from %s to %s".formatted(fromState.getLabel(), toState.getLabel());
+        // Status comes from the transition row: failure/rejection/failed-restore rows are audited
+        // FAILED, not SUCCESS (the destination state alone can't tell them apart).
+        eventHistoryService.addEventHistory(cert.getUuid(), auditEvent,
+            row.defaultStatus, message, auditDetail != null ? auditDetail : "");
+    }
+
+    /** Validate the (from, to) pair against {@link CertificateStateTransition}, then apply and
+     *  persist the new state. Shared by the audited and externally-audited entry points; returns the
+     *  matched row so an audited caller can derive the event and status. */
+    private CertificateStateTransition applyStateChange(Certificate cert, CertificateState toState) {
         Objects.requireNonNull(cert, "cert");
         Objects.requireNonNull(toState, "toState");
         CertificateState fromState = cert.getState();
@@ -82,14 +133,6 @@ public class CertificateStateMachine {
 
         cert.setState(toState);
         certificateRepository.save(cert);
-
-        CertificateEvent auditEvent = auditEventOverride != null ? auditEventOverride : row.defaultAuditEvent;
-        String message = reasonMessage != null
-            ? reasonMessage
-            : "State changed from %s to %s".formatted(fromState.getLabel(), toState.getLabel());
-        // Status comes from the transition row: failure/rejection/failed-restore rows are audited
-        // FAILED, not SUCCESS (the destination state alone can't tell them apart).
-        eventHistoryService.addEventHistory(cert.getUuid(), auditEvent,
-            row.defaultStatus, message, "");
+        return row;
     }
 }

--- a/src/main/java/com/otilm/core/service/handler/authority/lifecycle/CertificateStateTransition.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/lifecycle/CertificateStateTransition.java
@@ -44,12 +44,14 @@ public enum CertificateStateTransition {
     ISSUED_TO_PENDING_APPROVAL        (ISSUED,               PENDING_APPROVAL,     CertificateEvent.APPROVAL_REQUEST, CertificateEventStatus.SUCCESS),
     PENDING_APPROVAL_TO_PENDING_REVOKE(PENDING_APPROVAL,     PENDING_REVOKE,       CertificateEvent.APPROVAL_CLOSE,   CertificateEventStatus.SUCCESS),
     PENDING_APPROVAL_TO_ISSUED        (PENDING_APPROVAL,     ISSUED,               CertificateEvent.APPROVAL_CLOSE,   CertificateEventStatus.FAILED),  // revoke rejected — restore
+    PENDING_APPROVAL_TO_REVOKED       (PENDING_APPROVAL,     REVOKED,              CertificateEvent.REVOKE,           CertificateEventStatus.SUCCESS), // approved revoke completed synchronously (connector 200)
 
     // v3 register lifecycle
     REQUESTED_TO_PENDING_REGISTRATION (REQUESTED,            PENDING_REGISTRATION, CertificateEvent.UPDATE_STATE,     CertificateEventStatus.SUCCESS),
     PENDING_REGISTRATION_TO_REGISTERED(PENDING_REGISTRATION, REGISTERED,           CertificateEvent.UPDATE_STATE,     CertificateEventStatus.SUCCESS),
     PENDING_REGISTRATION_TO_FAILED    (PENDING_REGISTRATION, FAILED,               CertificateEvent.UPDATE_STATE,     CertificateEventStatus.FAILED),
     REGISTERED_TO_PENDING_ISSUE       (REGISTERED,           PENDING_ISSUE,        CertificateEvent.ISSUE,            CertificateEventStatus.SUCCESS),
+    REGISTERED_TO_FAILED              (REGISTERED,           FAILED,               CertificateEvent.ISSUE,            CertificateEventStatus.FAILED),  // issuing a registered placeholder failed
 
     // Compliance rejection
     REQUESTED_TO_REJECTED             (REQUESTED,            REJECTED,             CertificateEvent.UPDATE_STATE,     CertificateEventStatus.FAILED),

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -446,8 +446,9 @@ public class ClientOperationServiceImpl implements ClientOperationService {
     @Override
     public void approvalCreatedAction(UUID certificateUuid) throws NotFoundException {
         final Certificate certificate = certificateRepository.findByUuid(certificateUuid).orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
-        certificate.setState(CertificateState.PENDING_APPROVAL);
-        certificateRepository.save(certificate);
+        // Invoked from both the issue (REQUESTED) and revoke (ISSUED) approval-request paths;
+        // the SM resolves the correct (from, PENDING_APPROVAL) row from the cert's current state.
+        stateMachine.transition(certificate, CertificateState.PENDING_APPROVAL);
     }
 
     @Override
@@ -555,17 +556,10 @@ public class ClientOperationServiceImpl implements ClientOperationService {
             }
         }
 
-        certificate.setState(CertificateState.PENDING_ISSUE);
-        certificateRepository.save(certificate);
+        stateMachine.transition(certificate, CertificateState.PENDING_ISSUE, CertificateEvent.ISSUE,
+                "Issuance accepted; awaiting asynchronous completion.");
 
         scheduleStatusPoll(certificate, pollOperationFor(originatingAction));
-
-        certificateEventHistoryService.addEventHistory(
-                certificate.getUuid(),
-                CertificateEvent.ISSUE,
-                CertificateEventStatus.SUCCESS,
-                "Issuance accepted; awaiting asynchronous completion.",
-                "");
 
         eventProducer.produceMessage(
                 CertificateActionPerformedEventHandler.constructEventMessage(
@@ -650,25 +644,27 @@ public class ClientOperationServiceImpl implements ClientOperationService {
             }
         }
         CertificateState oldState = certificate.getState();
-        certificate.setState(state);
-        certificateRepository.save(certificate);
+
+        // The SM writes the state-change audit; its status comes from the transition row (FAILED
+        // for both the failed-issue and the rejected rows). Preserve the original event/message:
+        // a rejection with no caller message keeps the UPDATE_STATE "state changed" wording, every
+        // other case records an ISSUE event carrying the failure message.
+        CertificateEvent auditEvent = (state == CertificateState.REJECTED && message == null)
+                ? CertificateEvent.UPDATE_STATE : CertificateEvent.ISSUE;
+        String auditMessage = (state == CertificateState.REJECTED && message == null)
+                ? "Certificate state changed from %s to %s.".formatted(oldState.getLabel(), CertificateState.REJECTED.getLabel())
+                : message;
+        stateMachine.transition(certificate, state, auditEvent, auditMessage);
 
         certificateRelationRepository.deleteAll(certificate.getPredecessorRelations());
 
+        // A failed renew/rekey also records the failure against the predecessor certificate so its
+        // history reflects the abandoned operation (the SM call above only audits the new cert).
         if (state == CertificateState.FAILED) {
-            certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.ISSUE, CertificateEventStatus.FAILED, message, MetaDefinitions.serialize(additionalInformation));
             if (event == CertificateEvent.RENEW)
                 certificateEventHistoryService.addEventHistory(oldCertificateUuid, CertificateEvent.RENEW, CertificateEventStatus.FAILED, message, MetaDefinitions.serialize(additionalInformation));
             if (event == CertificateEvent.REKEY)
                 certificateEventHistoryService.addEventHistory(oldCertificateUuid, CertificateEvent.REKEY, CertificateEventStatus.FAILED, message, MetaDefinitions.serialize(additionalInformation));
-        }
-
-        if (state == CertificateState.REJECTED) {
-            if (message == null) {
-                certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.UPDATE_STATE, CertificateEventStatus.SUCCESS, "Certificate state changed from %s to %s.".formatted(oldState.getLabel(), CertificateState.REJECTED.getLabel()), "");
-            } else {
-                certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.ISSUE, CertificateEventStatus.FAILED, message, MetaDefinitions.serialize(additionalInformation));
-            }
         }
     }
 
@@ -1149,11 +1145,13 @@ public class ClientOperationServiceImpl implements ClientOperationService {
                 return;
             }
 
-            certificate.setState(CertificateState.REVOKED);
-            certificateRepository.save(certificate);
+            // Connector revoked synchronously (200). Drive state to REVOKED before the fallible
+            // attribute write below, so a local failure afterwards cannot leave the cert out of
+            // sync with an authority that has already revoked it (state-divergence rule).
+            stateMachine.transition(certificate, CertificateState.REVOKED, CertificateEvent.REVOKE,
+                    "Certificate revoked. Reason: " + caRequest.getReason().getLabel());
 
             attributeEngine.updateObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(raProfile.getAuthorityInstanceReference().getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_REVOKE).build(), request.getAttributes());
-            certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.REVOKE, CertificateEventStatus.SUCCESS, "Certificate revoked. Reason: " + caRequest.getReason().getLabel(), "");
         } catch (Exception e) {
             if (connectorAccepted) {
                 // Connector accepted the operation (200/202) but a subsequent local step failed.
@@ -1167,8 +1165,11 @@ public class ClientOperationServiceImpl implements ClientOperationService {
                         certificate.getUuid(), e.getMessage(), e);
                 throw new CertificateOperationException(msg);
             }
-            // Connector itself failed — restore the entry state so a PENDING_APPROVAL cert
-            // doesn't get silently flipped to ISSUED.
+            // Connector itself failed. Nothing transitioned the cert before the connector call, so
+            // this restores it to its entry state — a defensive no-op, not a real transition, and so
+            // intentionally not routed through the SM (there is no self-transition row, and the SM
+            // governs state changes rather than idempotent restores). The FAILED audit below is the
+            // meaningful record of the failed revoke attempt.
             certificate.setState(entryState);
             certificateRepository.save(certificate);
             certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.REVOKE, CertificateEventStatus.FAILED, e.getMessage(), "");
@@ -1198,9 +1199,8 @@ public class ClientOperationServiceImpl implements ClientOperationService {
             logger.debug("Certificate {} is in state {}, not PENDING_APPROVAL; skipping revoke-rejection state restore", certificateUuid, certificate.getState().getLabel());
             return;
         }
-        certificate.setState(CertificateState.ISSUED);
-        certificateRepository.save(certificate);
-        certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.REVOKE, CertificateEventStatus.FAILED, "Revocation approval was rejected; certificate restored to " + CertificateState.ISSUED.getLabel() + ".", "");
+        stateMachine.transition(certificate, CertificateState.ISSUED, CertificateEvent.REVOKE,
+                "Revocation approval was rejected; certificate restored to " + CertificateState.ISSUED.getLabel() + ".");
     }
 
     /**
@@ -1213,17 +1213,10 @@ public class ClientOperationServiceImpl implements ClientOperationService {
     private void transitionToPendingRevoke(Certificate certificate, ClientCertificateRevocationDto request) {
         certificate.setPendingRevokeDestroyKey(request.isDestroyKey());
         certificate.setPendingRevokeAttributes(request.getAttributes());
-        certificate.setState(CertificateState.PENDING_REVOKE);
-        certificateRepository.save(certificate);
+        stateMachine.transition(certificate, CertificateState.PENDING_REVOKE, CertificateEvent.REVOKE,
+                "Revocation accepted; awaiting asynchronous completion.");
 
         scheduleStatusPoll(certificate, CertificateOperation.REVOKE);
-
-        certificateEventHistoryService.addEventHistory(
-                certificate.getUuid(),
-                CertificateEvent.REVOKE,
-                CertificateEventStatus.SUCCESS,
-                "Revocation accepted; awaiting asynchronous completion.",
-                "");
 
         eventProducer.produceMessage(
                 CertificateActionPerformedEventHandler.constructEventMessage(
@@ -1787,11 +1780,8 @@ public class ClientOperationServiceImpl implements ClientOperationService {
             keyUuid = cert.getKey() != null ? cert.getKeyUuid() : null;
             cert.setPendingRevokeDestroyKey(null);
             cert.setPendingRevokeAttributes(null);
-            cert.setState(CertificateState.REVOKED);
-            certificateRepository.save(cert);
-
-            certificateEventHistoryService.addEventHistory(cert.getUuid(), CertificateEvent.REVOKE,
-                    CertificateEventStatus.SUCCESS, "Revocation confirmed manually", "");
+            stateMachine.transition(cert, CertificateState.REVOKED, CertificateEvent.REVOKE,
+                    "Revocation confirmed manually");
             transactionManager.commit(tx);
         } catch (NotFoundException | RuntimeException e) {
             transactionManager.rollback(tx);
@@ -1854,12 +1844,8 @@ public class ClientOperationServiceImpl implements ClientOperationService {
         String reason = request != null && request.getReason() != null ? request.getReason() : "";
 
         invokeConnectorCancelOrThrow(cert, target);
-        commitLocalCancel(cert, target);
+        commitLocalCancel(cert, target, reason);
 
-        String label = target.isCancelIssue ? "Pending issue cancelled" : "Pending revocation cancelled";
-        String msg = reason.isEmpty() ? label : (label + ". Reason: " + reason);
-        certificateEventHistoryService.addEventHistory(cert.getUuid(), target.eventKind(),
-                CertificateEventStatus.SUCCESS, msg, "");
         eventProducer.produceMessage(
                 CertificateActionPerformedEventHandler.constructEventMessage(cert.getUuid(), ResourceAction.UPDATE));
         logger.info("Pending {} for certificate {} cancelled (target state: {})",
@@ -2015,7 +2001,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
      * renew/rekey predecessor would otherwise still link to a now-{@code FAILED}
      * successor.</p>
      */
-    private void commitLocalCancel(Certificate cert, CancelTarget target) {
+    private void commitLocalCancel(Certificate cert, CancelTarget target, String reason) {
         TransactionStatus cleanupTx = transactionManager.getTransaction(new DefaultTransactionDefinition());
         try {
             // Re-read the cert under the new transaction. The method runs as
@@ -2049,13 +2035,16 @@ public class ClientOperationServiceImpl implements ClientOperationService {
             if (target.isCancelIssue()) {
                 certificateRelationRepository.deleteAll(fresh.getPredecessorRelations());
                 fresh.getPredecessorRelations().clear();
-            }
-            fresh.setState(target.targetState());
-            if (!target.isCancelIssue()) {
+            } else {
                 fresh.setPendingRevokeDestroyKey(null);
                 fresh.setPendingRevokeAttributes(null);
             }
-            certificateRepository.save(fresh);
+            // Cancelling a pending operation is a non-success outcome. Routing through the SM records
+            // the audit with the transition row's status — FAILED for both PENDING_ISSUE→FAILED and
+            // the PENDING_REVOKE→ISSUED restore — so a cancelled issue is no longer logged SUCCESS.
+            String label = target.isCancelIssue() ? "Pending issue cancelled" : "Pending revocation cancelled";
+            String auditMessage = reason.isEmpty() ? label : (label + ". Reason: " + reason);
+            stateMachine.transition(fresh, target.targetState(), target.eventKind(), auditMessage);
             transactionManager.commit(cleanupTx);
         } catch (RuntimeException e) {
             transactionManager.rollback(cleanupTx);

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -446,9 +446,18 @@ public class ClientOperationServiceImpl implements ClientOperationService {
     @Override
     public void approvalCreatedAction(UUID certificateUuid) throws NotFoundException {
         final Certificate certificate = certificateRepository.findByUuid(certificateUuid).orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
-        // Invoked from both the issue (REQUESTED) and revoke (ISSUED) approval-request paths;
-        // the SM resolves the correct (from, PENDING_APPROVAL) row from the cert's current state.
-        stateMachine.transition(certificate, CertificateState.PENDING_APPROVAL);
+        // Only REQUESTED (issue approval) and ISSUED (revoke approval) can enter PENDING_APPROVAL.
+        // A redelivered approval-created message for a certificate that already advanced past those
+        // states is a no-op: without this guard the SM would reject the now-illegal transition and
+        // fail the message. The APPROVAL_REQUEST history entry is owned by ApprovalRequestedEventHandler,
+        // so the SM only gates and mutates the state here — transitionAuditedExternally avoids a
+        // duplicate history row.
+        if (certificate.getState() != CertificateState.REQUESTED && certificate.getState() != CertificateState.ISSUED) {
+            logger.debug("Certificate {} is in state {}, not awaiting an approval request; skipping PENDING_APPROVAL transition",
+                    certificateUuid, certificate.getState().getLabel());
+            return;
+        }
+        stateMachine.transitionAuditedExternally(certificate, CertificateState.PENDING_APPROVAL);
     }
 
     @Override
@@ -636,6 +645,15 @@ public class ClientOperationServiceImpl implements ClientOperationService {
     }
 
     private void handleFailedOrRejectedEvent(Certificate certificate, UUID oldCertificateUuid, CertificateState state, CertificateEvent event, Map<String, Object> additionalInformation, String message) {
+        // Idempotent on redelivery / state races: if the certificate can no longer transition to the
+        // target state (e.g. a redelivered reject for an already-REJECTED cert — REJECTED->REJECTED
+        // has no row), skip rather than letting the SM throw and fail the JMS message. Mirrors the
+        // guards on approvalCreatedAction and revokeCertificateRejectedAction.
+        if (!stateMachine.canTransition(certificate.getState(), state)) {
+            logger.debug("Certificate {} is in state {}; no transition to {} — skipping failed/rejected handling",
+                    certificate.getUuid(), certificate.getState().getLabel(), state.getLabel());
+            return;
+        }
         for (CertificateLocation location : certificate.getLocations()) {
             try {
                 locationInternalService.removeRejectedOrFailedCertificateFromLocationAction(location.getId());
@@ -646,15 +664,23 @@ public class ClientOperationServiceImpl implements ClientOperationService {
         CertificateState oldState = certificate.getState();
 
         // The SM writes the state-change audit; its status comes from the transition row (FAILED
-        // for both the failed-issue and the rejected rows). Preserve the original event/message:
-        // a rejection with no caller message keeps the UPDATE_STATE "state changed" wording, every
-        // other case records an ISSUE event carrying the failure message.
-        CertificateEvent auditEvent = (state == CertificateState.REJECTED && message == null)
-                ? CertificateEvent.UPDATE_STATE : CertificateEvent.ISSUE;
-        String auditMessage = (state == CertificateState.REJECTED && message == null)
-                ? "Certificate state changed from %s to %s.".formatted(oldState.getLabel(), CertificateState.REJECTED.getLabel())
-                : message;
-        stateMachine.transition(certificate, state, auditEvent, auditMessage);
+        // for both the failed-issue and the rejected rows). Preserve the original event, message,
+        // and detail: a rejection with no caller message keeps the UPDATE_STATE "state changed"
+        // wording with no detail; every other case records an ISSUE event with the failure message
+        // and the serialized additional information.
+        final CertificateEvent auditEvent;
+        final String auditMessage;
+        final String auditDetail;
+        if (state == CertificateState.REJECTED && message == null) {
+            auditEvent = CertificateEvent.UPDATE_STATE;
+            auditMessage = "Certificate state changed from %s to %s.".formatted(oldState.getLabel(), CertificateState.REJECTED.getLabel());
+            auditDetail = "";
+        } else {
+            auditEvent = CertificateEvent.ISSUE;
+            auditMessage = message;
+            auditDetail = additionalInformation != null ? MetaDefinitions.serialize(additionalInformation) : "";
+        }
+        stateMachine.transition(certificate, state, auditEvent, auditMessage, auditDetail);
 
         certificateRelationRepository.deleteAll(certificate.getPredecessorRelations());
 

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -949,6 +949,11 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
         Assertions.assertFalse(certificateRelationRepository.existsById(relation.getId()));
         certificate = certificateRepository.findByUuid(certificateUuid).orElseThrow();
         Assertions.assertEquals(CertificateState.REJECTED, certificate.getState());
+        Assertions.assertTrue(
+                certificateEventHistoryRepository.findByCertificateOrderByCreatedDesc(certificate).stream()
+                        .anyMatch(h -> h.getEvent() == CertificateEvent.UPDATE_STATE
+                                && h.getStatus() == CertificateEventStatus.FAILED),
+                "a rejected issue with no message must record UPDATE_STATE/FAILED, not SUCCESS");
 
         certificateRelationRepository.save(relation);
         certificate.setState(CertificateState.REQUESTED);
@@ -1016,6 +1021,20 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
                 WireMock.postRequestedFor(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/remove")));
 
         certificate = certificateRepository.findByUuid(certificateUuid).orElseThrow();
+        Assertions.assertEquals(CertificateState.REJECTED, certificate.getState());
+    }
+
+    @Test
+    void issueCertificateRejectedAction_isIdempotent_whenAlreadyRejected() {
+        // A redelivered reject for an already-REJECTED certificate must be a no-op, not an
+        // InvalidTransitionException that fails the JMS message (REJECTED->REJECTED has no row).
+        certificate.setState(CertificateState.REJECTED);
+        certificate = certificateRepository.save(certificate);
+        UUID rejectedUuid = certificate.getUuid();
+
+        Assertions.assertDoesNotThrow(() -> clientOperationService.issueCertificateRejectedAction(rejectedUuid));
+
+        certificate = certificateRepository.findByUuid(rejectedUuid).orElseThrow();
         Assertions.assertEquals(CertificateState.REJECTED, certificate.getState());
     }
 

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -1653,6 +1653,13 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
 
         Certificate after = certificateRepository.findByUuid(certificate.getUuid()).orElseThrow();
         Assertions.assertEquals(CertificateState.FAILED, after.getState());
+
+        var history = certificateEventHistoryRepository.findByCertificateOrderByCreatedDesc(after);
+        Assertions.assertTrue(
+                history.stream().anyMatch(h ->
+                        h.getEvent() == CertificateEvent.ISSUE
+                                && h.getStatus() == CertificateEventStatus.FAILED),
+                "cancelling a pending issue must record ISSUE/FAILED, not SUCCESS");
     }
 
     @Test
@@ -1678,6 +1685,13 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
         Assertions.assertEquals(CertificateState.ISSUED, after.getState());
         Assertions.assertNull(after.getPendingRevokeDestroyKey());
         Assertions.assertNull(after.getPendingRevokeAttributes());
+
+        var history = certificateEventHistoryRepository.findByCertificateOrderByCreatedDesc(after);
+        Assertions.assertTrue(
+                history.stream().anyMatch(h ->
+                        h.getEvent() == CertificateEvent.REVOKE
+                                && h.getStatus() == CertificateEventStatus.FAILED),
+                "cancelling a pending revoke must record REVOKE/FAILED for the restored cert");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/handler/authority/lifecycle/CertificateStateMachineTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/lifecycle/CertificateStateMachineTest.java
@@ -94,6 +94,29 @@ class CertificateStateMachineTest {
             any(), anyString(), anyString());
     }
 
+    @Test
+    void approvedRevokeCompletingSynchronouslyIsAuditedRevokeSuccess() {
+        // PENDING_APPROVAL -> REVOKED: an approved revoke the connector completes synchronously (200).
+        Certificate cert = certWithState(CertificateState.PENDING_APPROVAL);
+        sm.transition(cert, CertificateState.REVOKED, CertificateEvent.REVOKE, "Certificate revoked");
+
+        assertEquals(CertificateState.REVOKED, cert.getState());
+        verify(certificateRepository).save(cert);
+        verify(eventHistoryService).addEventHistory(eq(cert.getUuid()), eq(CertificateEvent.REVOKE),
+            eq(CertificateEventStatus.SUCCESS), anyString(), eq(""));
+    }
+
+    @Test
+    void registeredCertificateIssueFailureIsAuditedIssueFailed() {
+        // REGISTERED -> FAILED: issuing a registered placeholder failed at the connector.
+        Certificate cert = certWithState(CertificateState.REGISTERED);
+        sm.transition(cert, CertificateState.FAILED, null, "Connector rejected the request");
+
+        assertEquals(CertificateState.FAILED, cert.getState());
+        verify(eventHistoryService).addEventHistory(eq(cert.getUuid()), eq(CertificateEvent.ISSUE),
+            eq(CertificateEventStatus.FAILED), anyString(), eq(""));
+    }
+
     private Certificate certWithState(CertificateState state) {
         Certificate cert = new Certificate();
         cert.setUuid(UUID.randomUUID());

--- a/src/test/java/com/otilm/core/service/handler/authority/lifecycle/CertificateStateMachineTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/lifecycle/CertificateStateMachineTest.java
@@ -117,6 +117,48 @@ class CertificateStateMachineTest {
             eq(CertificateEventStatus.FAILED), anyString(), eq(""));
     }
 
+    @Test
+    void callerProvidedAuditDetailIsStored() {
+        // The 5-arg overload carries a detail payload (e.g. serialized additionalInformation)
+        // into the audit-history entry instead of the default empty detail.
+        Certificate cert = certWithState(CertificateState.PENDING_ISSUE);
+        sm.transition(cert, CertificateState.FAILED, CertificateEvent.ISSUE, "boom",
+            "{\"New Certificate UUID\":\"x\"}");
+
+        verify(eventHistoryService).addEventHistory(eq(cert.getUuid()), eq(CertificateEvent.ISSUE),
+            eq(CertificateEventStatus.FAILED), eq("boom"), eq("{\"New Certificate UUID\":\"x\"}"));
+    }
+
+    @Test
+    void externallyAuditedTransitionMutatesStateButWritesNoHistory() {
+        // approvalCreatedAction uses this: the APPROVAL_REQUEST history is owned by the approval
+        // event handler, so the SM gates + mutates the state without writing a (duplicate) entry.
+        Certificate cert = certWithState(CertificateState.REQUESTED);
+        sm.transitionAuditedExternally(cert, CertificateState.PENDING_APPROVAL);
+
+        assertEquals(CertificateState.PENDING_APPROVAL, cert.getState());
+        verify(certificateRepository).save(cert);
+        verify(eventHistoryService, never()).addEventHistory(any(), any(), any(), anyString(), anyString());
+    }
+
+    @Test
+    void externallyAuditedTransitionStillValidates() {
+        // Validation is not skipped — only the audit. An illegal (from, to) still throws.
+        Certificate cert = certWithState(CertificateState.REVOKED);
+        assertThrows(InvalidTransitionException.class,
+            () -> sm.transitionAuditedExternally(cert, CertificateState.PENDING_APPROVAL));
+
+        assertEquals(CertificateState.REVOKED, cert.getState());
+        verify(certificateRepository, never()).save(any());
+    }
+
+    @Test
+    void canTransitionReflectsTheTransitionTable() {
+        assertTrue(sm.canTransition(CertificateState.REQUESTED, CertificateState.PENDING_ISSUE));
+        assertFalse(sm.canTransition(CertificateState.REJECTED, CertificateState.REJECTED));
+        assertFalse(sm.canTransition(CertificateState.REVOKED, CertificateState.ISSUED));
+    }
+
     private Certificate certWithState(CertificateState state) {
         Certificate cert = new Certificate();
         cert.setUuid(UUID.randomUUID());


### PR DESCRIPTION
Routes the certificate `setState` writes in `ClientOperationServiceImpl` through `CertificateStateMachine`, so every operator-driven state change is validated against the transition table and audited consistently. Authority-provider-v3 epic (ilm#110), milestone M1 (#1682).

**Stacked on `v3-register`** (the register slice, #1681) — base will retarget to `main` once #1681 merges.

## What changed

- **8 operator transitions routed through the SM:** approval-created, async pending-issue, the failure/rejection handler, sync revoke (200), revoke-rejected restore, async pending-revoke, manual revoke confirm, and cancel. One site stays a direct `setState` — the revoke connector-failure restore is a no-op self-restore (re-assigns the unchanged entry state; no self-transition row), documented inline.
- **Fixes the cancel-audit bug (#1677):** cancelling a pending operation now takes its audit status from the transition row (`FAILED`) instead of a hard-coded `SUCCESS`.
- **Two transition rows added** that the S1 table omitted but real flows need: `PENDING_APPROVAL → REVOKED` (an approved revoke the connector completes synchronously) and `REGISTERED → FAILED` (a registered placeholder whose issuance fails).
- **SM API additions** (from multi-angle review): `transitionAuditedExternally` (gates a state change but writes no audit — `approvalCreatedAction` uses it because `ApprovalRequestedEventHandler` owns the `APPROVAL_REQUEST` entry); `canTransition` (lets `approvalCreatedAction` / `handleFailedOrRejectedEvent` skip a redelivered or raced JMS action idempotently rather than throw); and a 5-arg `transition(..., auditDetail)` overload that preserves serialized `additionalInformation` on renew/rekey failure audits.
- **Audit-status correction:** a rejected issue with no message now records `UPDATE_STATE/FAILED` (was `SUCCESS`), matching the table's "rejections are failures" design.

## Test plan

- 112 targeted tests green locally: `CertificateStateMachineTest` (12 — incl. the new rows, `transitionAuditedExternally`, `canTransition`, `auditDetail`), `ClientOperationServiceV2Test` (70 — incl. the #1677 cancel-audit assertions and the redelivery-idempotency test), `ClientOperationServiceRegisterTest` (20), `ActionsListenerTest` (10).
- Behavior-preserving except the deliberate audit-status corrections above.
- CI runs the full suite + SonarCloud + CodeQL.

## Follow-ups (filed)

- #1683 — complete `CertificateStateMachine` coverage for the remaining cert-state writers (`prepareIssuedCertificate` → ISSUED incl. async-issue completion; `revokeCertificate(serialNumber)` → REVOKED).
- #1684 — unify approval-driven event-history ownership (the `transitionAuditedExternally` seam + the handlers' cross-resource TODO).

Closes #1677.
Closes #1682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
