### PR TITLE
Implement v3 authority instance attribute listing endpoint

### DIFF
--- a/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
@@ -23,11 +23,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 public class AuthorityInstanceControllerImpl implements AuthorityInstanceController {
@@ -90,6 +92,13 @@ public class AuthorityInstanceControllerImpl implements AuthorityInstanceControl
     @AuditLogged(module = Module.CERTIFICATES, resource = Resource.END_ENTITY_PROFILE, affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST_CAS)
     public List<NameAndIdDto> listCAsInProfile(@LogResource(uuid = true, affiliated = true) @PathVariable String uuid, @PathVariable Integer endEntityProfileId) throws ConnectorException, NotFoundException {
         return authorityInstanceService.listCAsInProfile(SecuredUUID.fromString(uuid), endEntityProfileId);
+    }
+
+    @Override
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "authority", affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
+    public List<BaseAttribute> listAuthorityInstanceAttributes(@LogResource(uuid = true, affiliated = true) @PathVariable String connectorUuid, @RequestParam(required = false) String interfaceUuid) throws ConnectorException, NotFoundException, AttributeException {
+        return authorityInstanceService.listAuthorityInstanceAttributes(SecuredUUID.fromString(connectorUuid),
+                interfaceUuid != null ? UUID.fromString(interfaceUuid) : null);
     }
 
     @Override

--- a/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
@@ -95,7 +95,7 @@ public class AuthorityInstanceControllerImpl implements AuthorityInstanceControl
 
     @Override
     @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "authority", affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
-    public List<BaseAttribute> listAuthorityInstanceAttributes(@LogResource(uuid = true, affiliated = true) @PathVariable String connectorUuid, @RequestParam(required = false) String interfaceUuid) throws ConnectorException, NotFoundException, AttributeException {
+    public List<BaseAttribute> listAuthorityInstanceAttributes(@LogResource(uuid = true, affiliated = true) @PathVariable("connectorUuid") String connectorUuid, @RequestParam(name = "interfaceUuid", required = false) String interfaceUuid) throws ConnectorException, NotFoundException, AttributeException {
         return authorityInstanceService.listAuthorityInstanceAttributes(SecuredUUID.fromString(connectorUuid),
                 interfaceUuid != null ? SecuredUUID.fromString(interfaceUuid).getValue() : null);
     }

--- a/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
@@ -94,8 +94,8 @@ public class AuthorityInstanceControllerImpl implements AuthorityInstanceControl
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "authority", affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
-    public List<BaseAttribute> listAuthorityInstanceAttributes(@LogResource(uuid = true, affiliated = true) @PathVariable("connectorUuid") String connectorUuid, @RequestParam(name = "interfaceUuid", required = false) String interfaceUuid) throws ConnectorException, NotFoundException, AttributeException {
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "authority", affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST_ATTRIBUTES)
+    public List<BaseAttribute> listAuthorityInstanceAttributes(@PathVariable("connectorUuid") String connectorUuid, @RequestParam(name = "interfaceUuid", required = false) String interfaceUuid) throws ConnectorException, NotFoundException, AttributeException {
         return authorityInstanceService.listAuthorityInstanceAttributes(SecuredUUID.fromString(connectorUuid),
                 interfaceUuid != null ? SecuredUUID.fromString(interfaceUuid).getValue() : null);
     }

--- a/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
@@ -97,7 +97,7 @@ public class AuthorityInstanceControllerImpl implements AuthorityInstanceControl
     @Override
     @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "authority", affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listAuthorityInstanceAttributes(@LogResource(uuid = true, affiliated = true) @PathVariable String connectorUuid, @RequestParam(required = false) String interfaceUuid) throws ConnectorException, NotFoundException, AttributeException {
-        return authorityInstanceService.listAuthorityInstanceAttributes(SecuredUUID.fromString(connectorUuid),
+        return authorityInstanceService.listAuthorityInstanceAttributes(UUID.fromString(connectorUuid),
                 interfaceUuid != null ? UUID.fromString(interfaceUuid) : null);
     }
 

--- a/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
@@ -29,7 +29,6 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 public class AuthorityInstanceControllerImpl implements AuthorityInstanceController {
@@ -97,8 +96,8 @@ public class AuthorityInstanceControllerImpl implements AuthorityInstanceControl
     @Override
     @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "authority", affiliatedResource = Resource.CONNECTOR, operation = Operation.LIST_ATTRIBUTES)
     public List<BaseAttribute> listAuthorityInstanceAttributes(@LogResource(uuid = true, affiliated = true) @PathVariable String connectorUuid, @RequestParam(required = false) String interfaceUuid) throws ConnectorException, NotFoundException, AttributeException {
-        return authorityInstanceService.listAuthorityInstanceAttributes(UUID.fromString(connectorUuid),
-                interfaceUuid != null ? UUID.fromString(interfaceUuid) : null);
+        return authorityInstanceService.listAuthorityInstanceAttributes(SecuredUUID.fromString(connectorUuid),
+                interfaceUuid != null ? SecuredUUID.fromString(interfaceUuid).getValue() : null);
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/AuthorityInstanceExternalService.java
+++ b/src/main/java/com/otilm/core/service/AuthorityInstanceExternalService.java
@@ -31,7 +31,14 @@ public interface AuthorityInstanceExternalService {
 
     List<NameAndIdDto> listCAsInProfile(SecuredUUID uuid, Integer endEntityProfileId) throws ConnectorException, NotFoundException;
 
-    List<BaseAttribute> listAuthorityInstanceAttributes(UUID connectorUuid, UUID interfaceUuid) throws ConnectorException, AttributeException, NotFoundException;
+    /**
+     * Lists the authority attribute schema for a stateless v3 authority connector (used by the
+     * create-authority form), keyed by connector UUID. v3-only: throws ValidationException when the
+     * connector has no AUTHORITY interface or a non-v3 one. {@code interfaceUuid} is optional and only
+     * disambiguates a connector that exposes more than one AUTHORITY interface. Side effect: persists
+     * the returned definitions via the attribute engine for later validation and content preparation.
+     */
+    List<BaseAttribute> listAuthorityInstanceAttributes(SecuredUUID connectorUuid, UUID interfaceUuid) throws ConnectorException, AttributeException, NotFoundException;
 
     List<BaseAttribute> listRAProfileAttributes(SecuredUUID uuid) throws ConnectorException, NotFoundException;
 

--- a/src/main/java/com/otilm/core/service/AuthorityInstanceExternalService.java
+++ b/src/main/java/com/otilm/core/service/AuthorityInstanceExternalService.java
@@ -12,6 +12,7 @@ import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface AuthorityInstanceExternalService {
     List<AuthorityInstanceDto> listAuthorityInstances(SecurityFilter filter);
@@ -29,6 +30,8 @@ public interface AuthorityInstanceExternalService {
     List<NameAndIdDto> listCertificateProfiles(SecuredUUID uuid, Integer endEntityProfileId) throws ConnectorException, NotFoundException;
 
     List<NameAndIdDto> listCAsInProfile(SecuredUUID uuid, Integer endEntityProfileId) throws ConnectorException, NotFoundException;
+
+    List<BaseAttribute> listAuthorityInstanceAttributes(SecuredUUID connectorUuid, UUID interfaceUuid) throws ConnectorException, AttributeException, NotFoundException;
 
     List<BaseAttribute> listRAProfileAttributes(SecuredUUID uuid) throws ConnectorException, NotFoundException;
 

--- a/src/main/java/com/otilm/core/service/AuthorityInstanceExternalService.java
+++ b/src/main/java/com/otilm/core/service/AuthorityInstanceExternalService.java
@@ -31,7 +31,7 @@ public interface AuthorityInstanceExternalService {
 
     List<NameAndIdDto> listCAsInProfile(SecuredUUID uuid, Integer endEntityProfileId) throws ConnectorException, NotFoundException;
 
-    List<BaseAttribute> listAuthorityInstanceAttributes(SecuredUUID connectorUuid, UUID interfaceUuid) throws ConnectorException, AttributeException, NotFoundException;
+    List<BaseAttribute> listAuthorityInstanceAttributes(UUID connectorUuid, UUID interfaceUuid) throws ConnectorException, AttributeException, NotFoundException;
 
     List<BaseAttribute> listRAProfileAttributes(SecuredUUID uuid) throws ConnectorException, NotFoundException;
 

--- a/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
@@ -27,6 +27,7 @@ import com.otilm.api.model.core.connector.FunctionGroupDto;
 import com.otilm.api.model.core.scheduler.PaginationRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
+import com.otilm.core.events.transaction.TransactionHandler;
 import com.otilm.core.dao.entity.*;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.RaProfile;
@@ -44,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -65,6 +67,7 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceExternalSe
     private ResourceInternalService resourceService;
     private ConnectorRepository connectorRepository;
     private AuthorityProviderAdapterFactory adapterFactory;
+    private TransactionHandler transactionHandler;
 
     @Autowired
     public void setResourceService(ResourceInternalService resourceService) {
@@ -109,6 +112,11 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceExternalSe
     @Autowired
     public void setAdapterFactory(AuthorityProviderAdapterFactory adapterFactory) {
         this.adapterFactory = adapterFactory;
+    }
+
+    @Autowired
+    public void setTransactionHandler(TransactionHandler transactionHandler) {
+        this.transactionHandler = transactionHandler;
     }
 
     @Override
@@ -313,25 +321,34 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceExternalSe
     }
 
     @Override
-    @ExternalAuthorization(resource = Resource.AUTHORITY, action = ResourceAction.ANY)
-    public List<BaseAttribute> listAuthorityInstanceAttributes(UUID connectorUuid, UUID interfaceUuid) throws ConnectorException, AttributeException, NotFoundException {
-        SecuredUUID securedConnectorUuid = SecuredUUID.fromUUID(connectorUuid);
-        ConnectorDto connector = connectorService.getConnector(securedConnectorUuid);
-        ConnectorInterfaceEntity iface = resolveAuthorityInterface(connectorUuid, interfaceUuid);
-        if (!isV3(iface)) {
-            // Only stateless v3 authority connectors list attributes without a bound instance. Legacy
-            // v1/v2 connectors resolve their attributes by function group + kind through the connector
-            // attributes endpoint; direct callers there rather than guess a kind here.
+    // Connector-scoped: a SecuredUUID connectorUuid lets ExternalMethodAuthorizationManager perform the
+    // object-level CONNECTOR check (a plain UUID would degrade this to an unscoped resource-type check).
+    @ExternalAuthorization(resource = Resource.CONNECTOR, action = ResourceAction.ANY)
+    // NOT_SUPPORTED so the connector HTTP call below runs outside any DB transaction (core CLAUDE.md,
+    // "Transactions and external calls"). The lazy interface read is wrapped in a short tx; the
+    // definition write opens its own tx via AttributeEngine (@Transactional).
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public List<BaseAttribute> listAuthorityInstanceAttributes(SecuredUUID connectorUuid, UUID interfaceUuid) throws ConnectorException, AttributeException, NotFoundException {
+        ConnectorDto connector = connectorService.getConnector(connectorUuid);
+        // resolveAuthorityInterface reads the connector's LAZY interfaces collection, so it must run
+        // inside a transaction.
+        ConnectorInterfaceEntity iface = transactionHandler.runInTransaction(
+                () -> resolveAuthorityInterface(connectorUuid.getValue(), interfaceUuid));
+        if (iface == null) {
             throw new ValidationException(
-                    "Connector " + connectorUuid + " has no stateless (v3) AUTHORITY interface; "
-                            + "list attributes for v1/v2 authority connectors via the connector attributes endpoint (function group and kind).");
+                    "Connector " + connectorUuid.getValue() + " has no AUTHORITY interface; it is not an authority connector.");
+        }
+        if (!isV3(iface)) {
+            throw new ValidationException(
+                    "Connector " + connectorUuid.getValue() + " has a v1/v2 AUTHORITY interface; "
+                            + "list its attributes via the connector attributes endpoint (function group and kind).");
         }
         // v3 is stateless and kind-less: definitions come from GET /v3/authorityProvider/authorities/attributes.
-        AuthorityInstanceReference probeRef = transientAuthorityRef(securedConnectorUuid, connector, iface, null);
+        AuthorityInstanceReference probeRef = transientAuthorityRef(connectorUuid, connector, iface, null);
         List<BaseAttribute> attributes = adapterFactory.forAuthority(probeRef).listAuthorityInstanceAttributes(probeRef);
-        // Persist the definitions so later validation and content preparation can resolve them, mirroring
-        // VaultInstanceServiceImpl.listVaultInstanceAttributes for the stateless secret-provider flow.
-        attributeEngine.updateDataAttributeDefinitions(connectorUuid, null, attributes);
+        // Persist the definitions (AttributeEngine opens its own tx) so later validation and content
+        // preparation can resolve them, mirroring VaultInstanceServiceImpl.listVaultInstanceAttributes.
+        attributeEngine.updateDataAttributeDefinitions(connectorUuid.getValue(), null, attributes);
         return attributes;
     }
 

--- a/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
@@ -314,6 +314,28 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceExternalSe
 
     @Override
     @ExternalAuthorization(resource = Resource.AUTHORITY, action = ResourceAction.ANY)
+    public List<BaseAttribute> listAuthorityInstanceAttributes(SecuredUUID connectorUuid, UUID interfaceUuid) throws ConnectorException, AttributeException, NotFoundException {
+        ConnectorDto connector = connectorService.getConnector(connectorUuid);
+        ConnectorInterfaceEntity iface = resolveAuthorityInterface(connectorUuid.getValue(), interfaceUuid);
+        if (!isV3(iface)) {
+            // Only stateless v3 authority connectors list attributes without a bound instance. Legacy
+            // v1/v2 connectors resolve their attributes by function group + kind through the connector
+            // attributes endpoint; direct callers there rather than guess a kind here.
+            throw new ValidationException(
+                    "Connector " + connectorUuid.getValue() + " has no stateless (v3) AUTHORITY interface; "
+                            + "list attributes for v1/v2 authority connectors via the connector attributes endpoint (function group and kind).");
+        }
+        // v3 is stateless and kind-less: definitions come from GET /v3/authorityProvider/authorities/attributes.
+        AuthorityInstanceReference probeRef = transientAuthorityRef(connectorUuid, connector, iface, null);
+        List<BaseAttribute> attributes = adapterFactory.forAuthority(probeRef).listAuthorityInstanceAttributes(probeRef);
+        // Persist the definitions so later validation and content preparation can resolve them, mirroring
+        // VaultInstanceServiceImpl.listVaultInstanceAttributes for the stateless secret-provider flow.
+        attributeEngine.updateDataAttributeDefinitions(connectorUuid.getValue(), null, attributes);
+        return attributes;
+    }
+
+    @Override
+    @ExternalAuthorization(resource = Resource.AUTHORITY, action = ResourceAction.ANY)
     public List<BaseAttribute> listRAProfileAttributes(SecuredUUID uuid) throws ConnectorException, NotFoundException {
         AuthorityInstanceReference authorityInstance = getAuthorityInstanceReferenceEntity(uuid);
         return adapterFactory.forAuthority(authorityInstance).listRaProfileAttributes(authorityInstance);

--- a/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
@@ -321,12 +321,7 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceExternalSe
     }
 
     @Override
-    // Connector-scoped: a SecuredUUID connectorUuid lets ExternalMethodAuthorizationManager perform the
-    // object-level CONNECTOR check (a plain UUID would degrade this to an unscoped resource-type check).
     @ExternalAuthorization(resource = Resource.CONNECTOR, action = ResourceAction.ANY)
-    // NOT_SUPPORTED so the connector HTTP call below runs outside any DB transaction (core CLAUDE.md,
-    // "Transactions and external calls"). The lazy interface read is wrapped in a short tx; the
-    // definition write opens its own tx via AttributeEngine (@Transactional).
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public List<BaseAttribute> listAuthorityInstanceAttributes(SecuredUUID connectorUuid, UUID interfaceUuid) throws ConnectorException, AttributeException, NotFoundException {
         ConnectorDto connector = connectorService.getConnector(connectorUuid);
@@ -346,8 +341,6 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceExternalSe
         // v3 is stateless and kind-less: definitions come from GET /v3/authorityProvider/authorities/attributes.
         AuthorityInstanceReference probeRef = transientAuthorityRef(connectorUuid, connector, iface, null);
         List<BaseAttribute> attributes = adapterFactory.forAuthority(probeRef).listAuthorityInstanceAttributes(probeRef);
-        // Persist the definitions (AttributeEngine opens its own tx) so later validation and content
-        // preparation can resolve them, mirroring VaultInstanceServiceImpl.listVaultInstanceAttributes.
         attributeEngine.updateDataAttributeDefinitions(connectorUuid.getValue(), null, attributes);
         return attributes;
     }

--- a/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
@@ -314,23 +314,24 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceExternalSe
 
     @Override
     @ExternalAuthorization(resource = Resource.AUTHORITY, action = ResourceAction.ANY)
-    public List<BaseAttribute> listAuthorityInstanceAttributes(SecuredUUID connectorUuid, UUID interfaceUuid) throws ConnectorException, AttributeException, NotFoundException {
-        ConnectorDto connector = connectorService.getConnector(connectorUuid);
-        ConnectorInterfaceEntity iface = resolveAuthorityInterface(connectorUuid.getValue(), interfaceUuid);
+    public List<BaseAttribute> listAuthorityInstanceAttributes(UUID connectorUuid, UUID interfaceUuid) throws ConnectorException, AttributeException, NotFoundException {
+        SecuredUUID securedConnectorUuid = SecuredUUID.fromUUID(connectorUuid);
+        ConnectorDto connector = connectorService.getConnector(securedConnectorUuid);
+        ConnectorInterfaceEntity iface = resolveAuthorityInterface(connectorUuid, interfaceUuid);
         if (!isV3(iface)) {
             // Only stateless v3 authority connectors list attributes without a bound instance. Legacy
             // v1/v2 connectors resolve their attributes by function group + kind through the connector
             // attributes endpoint; direct callers there rather than guess a kind here.
             throw new ValidationException(
-                    "Connector " + connectorUuid.getValue() + " has no stateless (v3) AUTHORITY interface; "
+                    "Connector " + connectorUuid + " has no stateless (v3) AUTHORITY interface; "
                             + "list attributes for v1/v2 authority connectors via the connector attributes endpoint (function group and kind).");
         }
         // v3 is stateless and kind-less: definitions come from GET /v3/authorityProvider/authorities/attributes.
-        AuthorityInstanceReference probeRef = transientAuthorityRef(connectorUuid, connector, iface, null);
+        AuthorityInstanceReference probeRef = transientAuthorityRef(securedConnectorUuid, connector, iface, null);
         List<BaseAttribute> attributes = adapterFactory.forAuthority(probeRef).listAuthorityInstanceAttributes(probeRef);
         // Persist the definitions so later validation and content preparation can resolve them, mirroring
         // VaultInstanceServiceImpl.listVaultInstanceAttributes for the stateless secret-provider flow.
-        attributeEngine.updateDataAttributeDefinitions(connectorUuid.getValue(), null, attributes);
+        attributeEngine.updateDataAttributeDefinitions(connectorUuid, null, attributes);
         return attributes;
     }
 

--- a/src/test/java/com/otilm/core/service/impl/AuthorityInstanceServiceImplV3Test.java
+++ b/src/test/java/com/otilm/core/service/impl/AuthorityInstanceServiceImplV3Test.java
@@ -22,6 +22,7 @@ import com.otilm.core.service.ResourceInternalService;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapter;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
 import com.otilm.core.client.ConnectorApiFactory;
+import com.otilm.core.events.transaction.TransactionHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,6 +36,7 @@ import org.mockito.quality.Strictness;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -47,12 +49,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for the v3-specific branch in
- * {@link AuthorityInstanceServiceImpl#createAuthorityInstance}.
- *
- * <p>The v3 path skips the legacy {@code createAuthorityInstance} connector call and instead
- * validates connectivity via {@link AuthorityProviderAdapter#checkAuthorityConnection}. These
- * tests verify the branch logic without a Spring application context.</p>
+ * Unit tests for the v3-specific branches in {@link AuthorityInstanceServiceImpl} —
+ * {@code createAuthorityInstance} / {@code editAuthorityInstance} (skip the legacy connector
+ * lifecycle call and validate connectivity via
+ * {@link AuthorityProviderAdapter#checkAuthorityConnection}), {@code validateRAProfileAttributes},
+ * and {@code listAuthorityInstanceAttributes}. These tests verify the branch logic without a
+ * Spring application context.
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -68,6 +70,7 @@ class AuthorityInstanceServiceImplV3Test {
     @Mock private ConnectorRepository connectorRepository;
     @Mock private AuthorityProviderAdapterFactory adapterFactory;
     @Mock private AuthorityProviderAdapter v3Adapter;
+    @Mock private TransactionHandler transactionHandler;
 
     @InjectMocks
     private AuthorityInstanceServiceImpl service;
@@ -100,6 +103,8 @@ class AuthorityInstanceServiceImplV3Test {
         when(attributeEngine.getDataAttributesByContent(any(), any())).thenReturn(List.of());
         when(connectorRepository.findByUuid(connectorUuid)).thenReturn(Optional.of(connectorEntity));
         when(adapterFactory.forAuthority(any())).thenReturn(v3Adapter);
+        // runInTransaction executes the supplier inline (no real tx in unit tests)
+        when(transactionHandler.runInTransaction(any())).thenAnswer(inv -> ((Supplier<?>) inv.getArgument(0)).get());
 
         // save returns the passed entity after assigning a UUID (simulates @PrePersist)
         when(authorityInstanceReferenceRepository.save(any())).thenAnswer(inv -> {
@@ -338,7 +343,7 @@ class AuthorityInstanceServiceImplV3Test {
         List<BaseAttribute> definitions = List.of(mock(BaseAttribute.class));
         when(v3Adapter.listAuthorityInstanceAttributes(any())).thenReturn(definitions);
 
-        List<BaseAttribute> result = service.listAuthorityInstanceAttributes(connectorUuid, null);
+        List<BaseAttribute> result = service.listAuthorityInstanceAttributes(SecuredUUID.fromUUID(connectorUuid), null);
 
         assertThat(result).isSameAs(definitions);
         // definitions are persisted so later validation / content preparation can resolve them
@@ -355,9 +360,20 @@ class AuthorityInstanceServiceImplV3Test {
         v2Connector.getInterfaces().add(v2Iface);
         when(connectorRepository.findByUuid(connectorUuid)).thenReturn(Optional.of(v2Connector));
 
-        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(connectorUuid, null))
+        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(SecuredUUID.fromUUID(connectorUuid), null))
                 .isInstanceOf(ValidationException.class)
-                .hasMessageContaining("stateless (v3)");
+                .hasMessageContaining("v1/v2 AUTHORITY interface");
+        verify(v3Adapter, never()).listAuthorityInstanceAttributes(any());
+    }
+
+    @Test
+    void listAuthorityInstanceAttributesRejectsConnectorWithNoAuthorityInterface() throws Exception {
+        Connector plainConnector = new Connector(); // no AUTHORITY interface at all
+        when(connectorRepository.findByUuid(connectorUuid)).thenReturn(Optional.of(plainConnector));
+
+        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(SecuredUUID.fromUUID(connectorUuid), null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("no AUTHORITY interface");
         verify(v3Adapter, never()).listAuthorityInstanceAttributes(any());
     }
 
@@ -369,7 +385,7 @@ class AuthorityInstanceServiceImplV3Test {
         secondIface.setConnectorUuid(connectorUuid);
         connectorEntity.getInterfaces().add(secondIface);
 
-        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(connectorUuid, null))
+        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(SecuredUUID.fromUUID(connectorUuid), null))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("multiple AUTHORITY interfaces");
     }
@@ -388,9 +404,14 @@ class AuthorityInstanceServiceImplV3Test {
         List<BaseAttribute> definitions = List.of(mock(BaseAttribute.class));
         when(v3Adapter.listAuthorityInstanceAttributes(any())).thenReturn(definitions);
 
-        List<BaseAttribute> result = service.listAuthorityInstanceAttributes(connectorUuid, ifaceUuid);
+        List<BaseAttribute> result = service.listAuthorityInstanceAttributes(SecuredUUID.fromUUID(connectorUuid), ifaceUuid);
 
         assertThat(result).isSameAs(definitions);
+        // the explicitly-selected v3 interface (not the v2 one) is the one bound on the probe ref
+        ArgumentCaptor<AuthorityInstanceReference> captor = ArgumentCaptor.forClass(AuthorityInstanceReference.class);
+        verify(v3Adapter).listAuthorityInstanceAttributes(captor.capture());
+        assertThat(captor.getValue().getConnectorInterface()).isSameAs(v3Iface);
+        verify(attributeEngine).updateDataAttributeDefinitions(eq(connectorUuid), any(), eq(definitions));
     }
 
     // ---- helpers ----

--- a/src/test/java/com/otilm/core/service/impl/AuthorityInstanceServiceImplV3Test.java
+++ b/src/test/java/com/otilm/core/service/impl/AuthorityInstanceServiceImplV3Test.java
@@ -360,7 +360,8 @@ class AuthorityInstanceServiceImplV3Test {
         v2Connector.getInterfaces().add(v2Iface);
         when(connectorRepository.findByUuid(connectorUuid)).thenReturn(Optional.of(v2Connector));
 
-        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(SecuredUUID.fromUUID(connectorUuid), null))
+        SecuredUUID id = SecuredUUID.fromUUID(connectorUuid);
+        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(id, null))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("v1/v2 AUTHORITY interface");
         verify(v3Adapter, never()).listAuthorityInstanceAttributes(any());
@@ -371,7 +372,8 @@ class AuthorityInstanceServiceImplV3Test {
         Connector plainConnector = new Connector(); // no AUTHORITY interface at all
         when(connectorRepository.findByUuid(connectorUuid)).thenReturn(Optional.of(plainConnector));
 
-        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(SecuredUUID.fromUUID(connectorUuid), null))
+        SecuredUUID id = SecuredUUID.fromUUID(connectorUuid);
+        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(id, null))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("no AUTHORITY interface");
         verify(v3Adapter, never()).listAuthorityInstanceAttributes(any());
@@ -385,7 +387,8 @@ class AuthorityInstanceServiceImplV3Test {
         secondIface.setConnectorUuid(connectorUuid);
         connectorEntity.getInterfaces().add(secondIface);
 
-        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(SecuredUUID.fromUUID(connectorUuid), null))
+        SecuredUUID id = SecuredUUID.fromUUID(connectorUuid);
+        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(id, null))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("multiple AUTHORITY interfaces");
     }

--- a/src/test/java/com/otilm/core/service/impl/AuthorityInstanceServiceImplV3Test.java
+++ b/src/test/java/com/otilm/core/service/impl/AuthorityInstanceServiceImplV3Test.java
@@ -333,6 +333,66 @@ class AuthorityInstanceServiceImplV3Test {
         assertThat(service.validateRAProfileAttributes(SecuredUUID.fromUUID(existing.uuid), null)).isTrue();
     }
 
+    @Test
+    void listAuthorityInstanceAttributesListsAndPersistsForV3() throws Exception {
+        List<BaseAttribute> definitions = List.of(mock(BaseAttribute.class));
+        when(v3Adapter.listAuthorityInstanceAttributes(any())).thenReturn(definitions);
+
+        List<BaseAttribute> result = service.listAuthorityInstanceAttributes(connectorUuid, null);
+
+        assertThat(result).isSameAs(definitions);
+        // definitions are persisted so later validation / content preparation can resolve them
+        verify(attributeEngine).updateDataAttributeDefinitions(eq(connectorUuid), any(), eq(definitions));
+    }
+
+    @Test
+    void listAuthorityInstanceAttributesRejectsNonV3Connector() throws Exception {
+        Connector v2Connector = new Connector();
+        ConnectorInterfaceEntity v2Iface = new ConnectorInterfaceEntity();
+        v2Iface.setInterfaceCode(ConnectorInterface.AUTHORITY);
+        v2Iface.setVersion("v2");
+        v2Iface.setConnectorUuid(connectorUuid);
+        v2Connector.getInterfaces().add(v2Iface);
+        when(connectorRepository.findByUuid(connectorUuid)).thenReturn(Optional.of(v2Connector));
+
+        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(connectorUuid, null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("stateless (v3)");
+        verify(v3Adapter, never()).listAuthorityInstanceAttributes(any());
+    }
+
+    @Test
+    void listAuthorityInstanceAttributesRejectsMultipleAuthorityInterfacesWithoutInterfaceUuid() {
+        ConnectorInterfaceEntity secondIface = new ConnectorInterfaceEntity();
+        secondIface.setInterfaceCode(ConnectorInterface.AUTHORITY);
+        secondIface.setVersion("v2");
+        secondIface.setConnectorUuid(connectorUuid);
+        connectorEntity.getInterfaces().add(secondIface);
+
+        assertThatThrownBy(() -> service.listAuthorityInstanceAttributes(connectorUuid, null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("multiple AUTHORITY interfaces");
+    }
+
+    @Test
+    void listAuthorityInstanceAttributesWithExplicitInterfaceUuidSelectsThatInterface() throws Exception {
+        UUID ifaceUuid = UUID.randomUUID();
+        v3Iface.setUuid(ifaceUuid);
+        // second AUTHORITY interface so interfaceUuid is required to disambiguate
+        ConnectorInterfaceEntity secondIface = new ConnectorInterfaceEntity();
+        secondIface.setInterfaceCode(ConnectorInterface.AUTHORITY);
+        secondIface.setVersion("v2");
+        secondIface.setUuid(UUID.randomUUID());
+        secondIface.setConnectorUuid(connectorUuid);
+        connectorEntity.getInterfaces().add(secondIface);
+        List<BaseAttribute> definitions = List.of(mock(BaseAttribute.class));
+        when(v3Adapter.listAuthorityInstanceAttributes(any())).thenReturn(definitions);
+
+        List<BaseAttribute> result = service.listAuthorityInstanceAttributes(connectorUuid, ifaceUuid);
+
+        assertThat(result).isSameAs(definitions);
+    }
+
     // ---- helpers ----
 
     private AuthorityInstanceRequestDto buildRequest() {


### PR DESCRIPTION
## What

Implements the operator endpoint `GET /v1/authorities/{connectorUuid}/attributes` (contract in OmniTrustILM/interfaces#753) that lists a stateless **v3 authority connector**'s attribute schema for the create-authority flow, mirroring `VaultInstanceServiceImpl.listVaultInstanceAttributes`.

- Routes through `AuthorityProviderV3Adapter.listAuthorityInstanceAttributes` → the connector's kind-less `GET /v3/authorityProvider/authorities/attributes`, then persists the definitions via `AttributeEngine.updateDataAttributeDefinitions` (same as the Vault flow).
- **v3-only:** a non-v3 (or ambiguous-interface) connector resolves to a `ValidationException` (422); v1/v2 connectors continue to use the function-group connector-attributes endpoint.
- Service takes a plain `UUID connectorUuid` with type-level `@ExternalAuthorization(AUTHORITY, ANY)` — **no per-connector object-access evaluation**, matching the Vault service. Both path/query UUIDs parse via `UUID.fromString` (consistent 400 on malformed input).

## Why

Exposes the already-present v3 adapter method as an operator endpoint so the FE (and API clients) can render the create-authority form for stateless v3 connectors. Part of the Authority Provider v3 epic (OmniTrustILM/ilm#110). FE wiring is tracked in OmniTrustILM/fe-administrator#1796.

## Coordination

⚠️ **Paired with OmniTrustILM/interfaces#753 — merge / version-bump together**, or this fails to compile against a new `interfaces` release.

## Testing

`mvn compile` — BUILD SUCCESS. (Full `verify` not run here.)
