### PR TITLE
Move config/ auth/ aop/ provisioning/ evaluator/ cluster/ tests into integration root - part 4

### DIFF
--- a/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
+++ b/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
@@ -127,8 +127,7 @@ class CiTestSplitTest {
      */
     private static final Set<String> MIGRATION_ALLOWLIST = Set.of(
             "service", "util", "signing", "messaging", "security",
-            "api", "attribute", "config", "auth",
-            "aop", "model", "provisioning", "evaluator", "cryptography", "cluster");
+            "api", "attribute", "model", "cryptography");
 
     /**
      * Root-level test files live directly in com/otilm/core (no sub-package) — e.g. ApplicationTests,

--- a/src/test/java/com/otilm/core/integration/aop/AuditLogAspectITest.java
+++ b/src/test/java/com/otilm/core/integration/aop/AuditLogAspectITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.aop;
+package com.otilm.core.integration.aop;
 
 import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.exception.NotFoundException;
@@ -16,6 +16,8 @@ import com.otilm.api.model.core.settings.SettingsSection;
 import com.otilm.api.model.core.settings.logging.AuditLoggingSettingsDto;
 import com.otilm.api.model.core.settings.logging.LoggingSettingsDto;
 import com.otilm.api.model.core.settings.logging.ResourceLoggingSettingsDto;
+import com.otilm.core.aop.AuditLogged;
+import com.otilm.core.aop.AuditResultOverride;
 import com.otilm.core.dao.entity.AuditLog;
 import com.otilm.core.dao.repository.AuditLogRepository;
 import com.otilm.core.logging.LoggingHelper;
@@ -37,7 +39,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-class AuditLogAspectTest extends BaseSpringBootTest {
+class AuditLogAspectITest extends BaseSpringBootTest {
 
     /**
      * Minimal bean that demonstrates the AuditResultOverride contract: the method swallows an

--- a/src/test/java/com/otilm/core/integration/auth/oauth2/OAuth2LoginControllerITest.java
+++ b/src/test/java/com/otilm/core/integration/auth/oauth2/OAuth2LoginControllerITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.auth.oauth2;
+package com.otilm.core.integration.auth.oauth2;
 
 import com.otilm.api.model.core.logging.enums.Operation;
 import com.otilm.api.model.core.logging.enums.OperationResult;
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class OAuth2LoginControllerTest {
+class OAuth2LoginControllerITest {
 
     private static WireMockServer mockServer;
 

--- a/src/test/java/com/otilm/core/integration/cluster/ClusterOperationSynchronizerITest.java
+++ b/src/test/java/com/otilm/core/integration/cluster/ClusterOperationSynchronizerITest.java
@@ -1,9 +1,10 @@
-package com.otilm.core.cluster;
+package com.otilm.core.integration.cluster;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.otilm.core.cluster.ClusterOperationSynchronizer;
 import com.otilm.core.cluster.ClusterOperationSynchronizer.Operation;
 import com.otilm.core.util.BaseSpringBootTest;
 
@@ -34,7 +35,7 @@ import org.springframework.transaction.support.TransactionTemplate;
  * nodes, each on its own thread (its own pooled connection) holding its transaction open, so the
  * nodes genuinely compete for the lock.
  */
-class ClusterOperationSynchronizerTest extends BaseSpringBootTest {
+class ClusterOperationSynchronizerITest extends BaseSpringBootTest {
 
     private static final long AWAIT_TIMEOUT_SECONDS = 15;
 
@@ -176,7 +177,7 @@ class ClusterOperationSynchronizerTest extends BaseSpringBootTest {
         }
 
         private static long countWinners(List<Future<Boolean>> attempts) {
-            return attempts.stream().filter(ClusterOperationSynchronizerTest::awaitOutcome).count();
+            return attempts.stream().filter(ClusterOperationSynchronizerITest::awaitOutcome).count();
         }
 
         void shutdown() {

--- a/src/test/java/com/otilm/core/integration/config/SecurityConfigITest.java
+++ b/src/test/java/com/otilm/core/integration/config/SecurityConfigITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.config;
+package com.otilm.core.integration.config;
 
 import com.otilm.api.model.core.settings.SettingsSection;
 import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDto;
@@ -53,7 +53,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @SpringBootTest
-class SecurityConfigTest extends BaseSpringBootTestNoAuth {
+class SecurityConfigITest extends BaseSpringBootTestNoAuth {
 
     @Autowired
     MockMvc mvc;

--- a/src/test/java/com/otilm/core/integration/config/SessionConfigITest.java
+++ b/src/test/java/com/otilm/core/integration/config/SessionConfigITest.java
@@ -1,6 +1,7 @@
-package com.otilm.core.config;
+package com.otilm.core.integration.config;
 
 import com.otilm.api.model.core.logging.enums.AuthMethod;
+import com.otilm.core.config.CookieConfig;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.authn.client.PlatformAuthenticationClient;
 import com.otilm.core.util.BaseSpringBootTestNoAuth;
@@ -33,7 +34,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
  */
 @AutoConfigureMockMvc
 @SpringBootTest
-class SessionConfigTest extends BaseSpringBootTestNoAuth {
+class SessionConfigITest extends BaseSpringBootTestNoAuth {
 
     /**
      * Permit-all endpoint used for session-resolution assertions.

--- a/src/test/java/com/otilm/core/integration/config/TspSecurityChainITest.java
+++ b/src/test/java/com/otilm/core/integration/config/TspSecurityChainITest.java
@@ -1,5 +1,6 @@
-package com.otilm.core.config;
+package com.otilm.core.integration.config;
 
+import com.otilm.core.config.CookieConfig;
 import com.otilm.core.security.authn.client.AuthenticationCache;
 import com.otilm.core.util.BaseSpringBootTestNoAuth;
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -41,7 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * </ul>
  */
 @AutoConfigureMockMvc
-class TspSecurityChainIntegrationTest extends BaseSpringBootTestNoAuth {
+class TspSecurityChainITest extends BaseSpringBootTestNoAuth {
 
     @Autowired
     MockMvc mvc;

--- a/src/test/java/com/otilm/core/integration/evaluator/TriggerEvaluatorITest.java
+++ b/src/test/java/com/otilm/core/integration/evaluator/TriggerEvaluatorITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.evaluator;
+package com.otilm.core.integration.evaluator;
 
 import com.otilm.api.exception.*;
 import com.otilm.api.model.client.attribute.RequestAttributeV2;
@@ -45,6 +45,8 @@ import com.otilm.core.dao.repository.workflows.ExecutionItemRepository;
 import com.otilm.core.dao.repository.workflows.ExecutionRepository;
 import com.otilm.core.dao.repository.workflows.TriggerRepository;
 import com.otilm.core.enums.FilterField;
+import com.otilm.core.evaluator.CertificateTriggerEvaluator;
+import com.otilm.core.evaluator.TriggerEvaluator;
 import com.otilm.core.service.*;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -64,7 +66,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
 
-class TriggerEvaluatorTest extends BaseSpringBootTest {
+class TriggerEvaluatorITest extends BaseSpringBootTest {
 
     @DynamicPropertySource
     static void authServiceProperties(DynamicPropertyRegistry registry) {

--- a/src/test/java/com/otilm/core/integration/provisioning/ProxyProvisioningServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/provisioning/ProxyProvisioningServiceITest.java
@@ -1,5 +1,7 @@
-package com.otilm.core.provisioning;
+package com.otilm.core.integration.provisioning;
 
+import com.otilm.core.provisioning.ProvisioningException;
+import com.otilm.core.provisioning.ProxyProvisioningService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import org.junit.jupiter.api.Test;
@@ -13,7 +15,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.*;
 
-class ProxyProvisioningServiceTest extends BaseSpringBootTest {
+class ProxyProvisioningServiceITest extends BaseSpringBootTest {
 
     private static final String PROXY_CODE = "TEST_PROXY";
     private static final String INSTALLATION_INSTRUCTIONS_JSON = """


### PR DESCRIPTION
## What

PR 4 of the per-package integration-test migration series (#1710). Moves the context-loading test classes of **six 100%-context packages** — `config/`, `auth/`, `aop/`, `provisioning/`, `evaluator/`, `cluster/` — into the single integration root `com.otilm.core.integration.**`, renames them `*ITest`, and drops those six entries from the `CiTestSplitTest` `MIGRATION_ALLOWLIST`.

| From | To |
|---|---|
| `config/SecurityConfigTest` | `integration/config/SecurityConfigITest` |
| `config/SessionConfigTest` | `integration/config/SessionConfigITest` |
| `config/TspSecurityChainIntegrationTest` | `integration/config/TspSecurityChainITest` |
| `auth/oauth2/OAuth2LoginControllerTest` | `integration/auth/oauth2/OAuth2LoginControllerITest` |
| `aop/AuditLogAspectTest` | `integration/aop/AuditLogAspectITest` |
| `provisioning/ProxyProvisioningServiceTest` | `integration/provisioning/ProxyProvisioningServiceITest` |
| `evaluator/TriggerEvaluatorTest` | `integration/evaluator/TriggerEvaluatorITest` |
| `cluster/ClusterOperationSynchronizerTest` | `integration/cluster/ClusterOperationSynchronizerITest` |

## Why

Establishes each context-loading test under the integration root so the three-way CI split (`test-services` / `test-non-services` / `test-integration`, #1693) routes it into the integration leg and its coverage lands in the right JaCoCo artifact. Follows #1700 (scaffold), #1709 (PR 1, `migration/`), #1715 (PR 2, `search/`) and #1719 (PR 3, `tasks/`+`events/`+`dao/`+`repository/`). Groups the six small leaf packages whose context classes are unambiguous straight move+rename cases.

## Classification

All eight moved classes `extend BaseSpringBootTest`/`BaseSpringBootTestNoAuth` or carry `@SpringBootTest` and exercise the Spring context throughout — MockMvc security-chain flows, a `RANDOM_PORT` live-server HTTP client, WireMock, Testcontainers `pg_try_advisory_xact_lock`, and autowired beans/repositories — so each is a **pure integration** straight move + rename with no class splitting.

Same-package production references that no longer resolve after the move gained explicit imports (`CookieConfig`; `AuditLogged`/`AuditResultOverride`; `ProxyProvisioningService`/`ProvisioningException`; `TriggerEvaluator`/`CertificateTriggerEvaluator`; `ClusterOperationSynchronizer`). `TspSecurityChainIntegrationTest`'s retired `*IntegrationTest` suffix is normalized to `*ITest`, and the `ClusterOperationSynchronizerTest::awaitOutcome` self-reference was renamed with the class.

## Scope note

`model/` and `cryptography/` each retain a single `@SpringBootTest`/`BaseSpringBootTest` class (`CertificateRequestTest`, `PQCTests`) with no injected beans — those need a genuine integration-vs-unit judgment rather than a mechanical move, so they stay allowlisted for a focused follow-up. The larger mixed packages (`attribute/`, `security/`, `api/`, `signing/`, `messaging/`, `util/`, `service/`) remain for their own PRs.

## Verification

- Baseline full suite green before the change (3644 tests; the sole failure was a known environmental fixed-port WireMock/IntelliJ collision that passes on isolated re-run).
- `mvn test-compile` clean; `CiTestSplitTest` + `TestClassTaxonomyTest` guards green (including the self-prune guard that fails if an allowlist entry has no remaining pending context test, and the placement guard that fails if a context test remains outside `com.otilm.core.integration.**` for a migrated package).
- All 8 moved classes green in their new location (64 tests).

Part of #1710 · Epic OmniTrustILM/ilm#252