### PR TITLE
Lock the operator issue path against concurrent double-issue

### DIFF
--- a/src/main/java/com/otilm/core/dao/repository/CertificateRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CertificateRepository.java
@@ -285,6 +285,11 @@ public interface CertificateRepository extends SecurityFilterRepository<Certific
     @Query("SELECT c.state FROM Certificate c WHERE c.uuid = :uuid")
     Optional<CertificateState> findStateByUuid(@Param("uuid") UUID uuid);
 
+    /** Scalar projection of the RA-profile UUID — authorize without managing the full entity (so a later
+     * locking read returns fresh state, not an already-managed stale instance). */
+    @Query("SELECT c.raProfileUuid FROM Certificate c WHERE c.uuid = :uuid")
+    Optional<UUID> findRaProfileUuidByUuid(@Param("uuid") UUID uuid);
+
     @Modifying
     @Query(value = """
             INSERT INTO {h-schema}certificate (

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -1140,6 +1140,13 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
                 SecuredParentUUID.fromUUID(raProfileUuid));
         Certificate certificate = certificateRepository.findAndLockWithAssociationsByUuid(certificateUuid)
                 .orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
+        // The RA profile can change concurrently (switchRaProfile is allowed on REGISTERED and takes no row
+        // lock) between the authorization above and this locked read. Authorization was evaluated against
+        // raProfileUuid, so reject if the locked row now belongs to a different profile — otherwise a caller
+        // authorized on the old profile could attach a CSR to a certificate under one they do not control.
+        if (!raProfileUuid.equals(certificate.getRaProfileUuid())) {
+            throw new ValidationException("Certificate's RA profile changed during authorization; retry the operation. Certificate: %s".formatted(certificate.toStringShort()));
+        }
         // Defense-in-depth: a CSR is attached only while completing a registered placeholder. The sole
         // caller (issueExistingCertificate) already gates on this, but guard here too so this public method
         // cannot overwrite the request of an ISSUED / REQUESTED / pending certificate.

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -1129,10 +1129,15 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
         if (signRequest.getFormat() == null) {
             throw new CertificateRequestException("A certificate signing request format (PKCS10 or CRMF) is required");
         }
-        // Authorize on an unlocked read first — evaluateCertificateRaProfilePermissions makes an external
-        // OPA call and must not run while holding the row lock — then take the lock (SELECT ... FOR UPDATE)
-        // so a concurrent attach blocks here and the state re-assert below is authoritative.
-        getCertificateEntity(SecuredUUID.fromUUID(certificateUuid));
+        // Authorize before locking WITHOUT managing the entity: the RA-profile check makes an external OPA
+        // call (must not run while holding the row lock), and loading the full entity first would make the
+        // locking query below return the already-managed, stale-state instance — defeating the under-lock
+        // re-assert. Fetch only the RA-profile UUID (a scalar projection), authorize, then take the lock so
+        // findAndLockWithAssociationsByUuid loads fresh state under SELECT ... FOR UPDATE.
+        UUID raProfileUuid = certificateRepository.findRaProfileUuidByUuid(certificateUuid)
+                .orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
+        raProfileService.evaluateCertificateRaProfilePermissions(SecuredUUID.fromUUID(certificateUuid),
+                SecuredParentUUID.fromUUID(raProfileUuid));
         Certificate certificate = certificateRepository.findAndLockWithAssociationsByUuid(certificateUuid)
                 .orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
         // Defense-in-depth: a CSR is attached only while completing a registered placeholder. The sole

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -1129,7 +1129,13 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
         if (signRequest.getFormat() == null) {
             throw new CertificateRequestException("A certificate signing request format (PKCS10 or CRMF) is required");
         }
-        Certificate certificate = getCertificateEntity(SecuredUUID.fromUUID(certificateUuid));
+        // Locked read (SELECT ... FOR UPDATE): a concurrent attach on the same certificate blocks here
+        // instead of racing an unlocked read, so the state re-assert below is authoritative rather than
+        // a check the other transaction can still slip past.
+        SecuredUUID securedCertificateUuid = SecuredUUID.fromUUID(certificateUuid);
+        Certificate certificate = certificateRepository.findAndLockWithAssociationsByUuid(certificateUuid)
+                .orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
+        raProfileService.evaluateCertificateRaProfilePermissions(securedCertificateUuid, SecuredParentUUID.fromUUID(certificate.getRaProfileUuid()));
         // Defense-in-depth: a CSR is attached only while completing a registered placeholder. The sole
         // caller (issueExistingCertificate) already gates on this, but guard here too so this public method
         // cannot overwrite the request of an ISSUED / REQUESTED / pending certificate.

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -1129,13 +1129,12 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
         if (signRequest.getFormat() == null) {
             throw new CertificateRequestException("A certificate signing request format (PKCS10 or CRMF) is required");
         }
-        // Locked read (SELECT ... FOR UPDATE): a concurrent attach on the same certificate blocks here
-        // instead of racing an unlocked read, so the state re-assert below is authoritative rather than
-        // a check the other transaction can still slip past.
-        SecuredUUID securedCertificateUuid = SecuredUUID.fromUUID(certificateUuid);
+        // Authorize on an unlocked read first — evaluateCertificateRaProfilePermissions makes an external
+        // OPA call and must not run while holding the row lock — then take the lock (SELECT ... FOR UPDATE)
+        // so a concurrent attach blocks here and the state re-assert below is authoritative.
+        getCertificateEntity(SecuredUUID.fromUUID(certificateUuid));
         Certificate certificate = certificateRepository.findAndLockWithAssociationsByUuid(certificateUuid)
                 .orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
-        raProfileService.evaluateCertificateRaProfilePermissions(securedCertificateUuid, SecuredParentUUID.fromUUID(certificate.getRaProfileUuid()));
         // Defense-in-depth: a CSR is attached only while completing a registered placeholder. The sole
         // caller (issueExistingCertificate) already gates on this, but guard here too so this public method
         // cannot overwrite the request of an ISSUED / REQUESTED / pending certificate.

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -539,37 +539,72 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             certificateService.checkIssuePermissions();
         }
 
-        final Certificate certificate = certificateRepository.findWithAssociationsByUuid(certificateUuid).orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
-        if (certificate.isArchived())
-            throw new ValidationException(ValidationError.create(String.format("Cannot issue certificate that has been archived. Certificate: %s", certificate.toStringShort())));
-        if (certificate.getState() != CertificateState.REQUESTED && certificate.getState() != CertificateState.PENDING_APPROVAL && certificate.getState() != CertificateState.REGISTERED) {
-            throw new ValidationException(ValidationError.create(String.format("Cannot issue certificate with state %s. Certificate: %s", certificate.getState().getLabel(), certificate)));
-        }
-        if (certificate.getRaProfile() == null) {
-            throw new ValidationException(ValidationError.create(String.format("Cannot issue certificate with no RA Profile associated. Certificate: %s", certificate)));
-        }
-        if (certificate.getCertificateRequest() == null) {
-            throw new ValidationException(ValidationError.create(String.format("Cannot issue certificate with no certificate request. Certificate: %s", certificate)));
-        }
-
+        // Claim the certificate under a pessimistic row lock, committing before the connector call so
+        // the lock never spans HTTP. Two ISSUE actions can race (action-queue concurrency > 1, no
+        // @Version); serializing the claim lets one win the PENDING_ISSUE transition and the loser skip.
+        // Post-commit code uses data captured here because the entity detaches on commit. Mirrors
+        // manuallyConfirmRevoke.
+        Certificate certificate;
         CertificateSignRequestDto caRequest = new CertificateSignRequestDto();
-        caRequest.setRequest(certificate.getCertificateRequest().getContent());
-        caRequest.setFormat(certificate.getCertificateRequest().getCertificateRequestFormat());
-        caRequest.setAttributes(attributeEngine.getRequestObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(certificate.getRaProfile().getAuthorityInstanceReference().getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_ISSUE).build()));
-        caRequest.setRaProfileAttributes(attributeEngine.getRequestObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.RA_PROFILE, certificate.getRaProfile().getUuid()).connector(certificate.getRaProfile().getAuthorityInstanceReference().getConnectorUuid()).build()));
-
+        UUID connectorUuid;
+        String authorityInstanceUuid;
+        List<CertificateLocationId> locationIds;
+        TransactionStatus tx = transactionManager.getTransaction(new DefaultTransactionDefinition());
         try {
+            certificate = certificateRepository.findAndLockWithAssociationsByUuid(certificateUuid).orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
+            if (certificate.isArchived())
+                throw new ValidationException(ValidationError.create(String.format("Cannot issue certificate that has been archived. Certificate: %s", certificate.toStringShort())));
+
+            // Benign skip — kept OUTSIDE the connector-failure handling below. Re-asserted under the
+            // lock: if the state is no longer claimable, a concurrent ISSUE already claimed this
+            // certificate to PENDING_ISSUE (or it reached a terminal state). Commit and return rather
+            // than letting it fall into the connector catch, because PENDING_ISSUE -> FAILED is a
+            // *legal* transition — failing here would mark the concurrent winner's in-flight issuance
+            // FAILED. This also guarantees the duplicate never reaches the connector.
+            if (certificate.getState() != CertificateState.REQUESTED && certificate.getState() != CertificateState.PENDING_APPROVAL && certificate.getState() != CertificateState.REGISTERED) {
+                logger.info("Certificate {} is in state {} and no longer claimable for issuance; a concurrent ISSUE action likely won the claim — skipping", certificateUuid, certificate.getState().getLabel());
+                transactionManager.commit(tx);
+                return;
+            }
+            if (certificate.getRaProfile() == null) {
+                throw new ValidationException(ValidationError.create(String.format("Cannot issue certificate with no RA Profile associated. Certificate: %s", certificate)));
+            }
+            if (certificate.getCertificateRequest() == null) {
+                throw new ValidationException(ValidationError.create(String.format("Cannot issue certificate with no certificate request. Certificate: %s", certificate)));
+            }
+
+            connectorUuid = certificate.getRaProfile().getAuthorityInstanceReference().getConnectorUuid();
+            authorityInstanceUuid = certificate.getRaProfile().getAuthorityInstanceReference().getAuthorityInstanceUuid();
+
+            caRequest.setRequest(certificate.getCertificateRequest().getContent());
+            caRequest.setFormat(certificate.getCertificateRequest().getCertificateRequestFormat());
+            caRequest.setAttributes(attributeEngine.getRequestObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(connectorUuid).operation(AttributeOperation.CERTIFICATE_ISSUE).build()));
+            caRequest.setRaProfileAttributes(attributeEngine.getRequestObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.RA_PROFILE, certificate.getRaProfile().getUuid()).connector(connectorUuid).build()));
+
+            // Materialize location ids for the post-commit push loop while the collection is still
+            // attached to the session.
+            locationIds = certificate.getLocations().stream().map(CertificateLocation::getId).toList();
+
             // Move to PENDING_ISSUE before calling the connector so every path (sync 200 or async
             // 202) reaches issueRequestedCertificate / the poll cycle from a uniform PENDING_ISSUE
             // state via the state machine. The sync path creates no poll row, so a crash before the
             // terminal transition leaves the cert in PENDING_ISSUE until PendingIssueReaper reaps it.
             stateMachine.transition(certificate, CertificateState.PENDING_ISSUE, CertificateEvent.ISSUE,
                     "Issuance in progress");
+            transactionManager.commit(tx);
+        } catch (NotFoundException | RuntimeException e) {
+            transactionManager.rollback(tx);
+            throw e;
+        }
 
-            ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(certificate.getRaProfile().getAuthorityInstanceReference().getConnectorUuid());
+        // Connector call runs after the claim tx has committed and released the lock. The
+        // certificate is now detached; failures here still route to handleFailedOrRejectedEvent
+        // (PENDING_ISSUE -> FAILED) exactly as before.
+        try {
+            ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(connectorUuid);
             ResponseEntity<CertificateDataResponseDto> issueResponse = connectorApiFactory.getCertificateApiClientV2(connectorDto).issueCertificate(
                     connectorDto,
-                    certificate.getRaProfile().getAuthorityInstanceReference().getAuthorityInstanceUuid(),
+                    authorityInstanceUuid,
                     caRequest);
 
             if (issueResponse.getStatusCode().value() == 202) {
@@ -588,21 +623,34 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
             certificateService.issueRequestedCertificate(certificateUuid, issueCaResponse.getCertificateData(), issueCaResponse.getMeta());
         } catch (Exception e) {
-            handleFailedOrRejectedEvent(certificate, null, CertificateState.FAILED, CertificateEvent.ISSUE, new HashMap<>(), e.getMessage());
+            // The certificate is detached here — the claim transaction committed (to release the row
+            // lock) before the connector call, so handleFailedOrRejectedEvent cannot lazy-load the
+            // collections it needs (locations, predecessor relations). Run the failure handling against
+            // a managed entity re-read inside a short transaction.
+            TransactionStatus failTx = transactionManager.getTransaction(new DefaultTransactionDefinition());
+            try {
+                Certificate managed = certificateRepository.findWithAssociationsByUuid(certificateUuid)
+                        .orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
+                handleFailedOrRejectedEvent(managed, null, CertificateState.FAILED, CertificateEvent.ISSUE, new HashMap<>(), e.getMessage());
+                transactionManager.commit(failTx);
+            } catch (Exception failEx) {
+                transactionManager.rollback(failTx);
+                logger.error("Failed to record issuance failure for certificate {}: {}", certificateUuid, failEx.getMessage());
+            }
             throw new CertificateOperationException("Failed to issue certificate with UUID %s: ".formatted(certificateUuid) + e.getMessage());
         }
 
         // push certificate to locations
-        for (CertificateLocation cl : certificate.getLocations()) {
+        for (CertificateLocationId locationId : locationIds) {
             try {
-                locationInternalService.pushRequestedCertificateToLocationAction(cl.getId(), false);
+                locationInternalService.pushRequestedCertificateToLocationAction(locationId, false);
             } catch (Exception e) {
                 logger.error("Failed to push issued certificate to location: {}", e.getMessage());
             }
         }
 
         // raise event
-        eventProducer.produceMessage(CertificateActionPerformedEventHandler.constructEventMessage(certificate.getUuid(), ResourceAction.ISSUE));
+        eventProducer.produceMessage(CertificateActionPerformedEventHandler.constructEventMessage(certificateUuid, ResourceAction.ISSUE));
 
         logger.debug("Certificate issued: {}", certificate);
     }
@@ -1973,26 +2021,44 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         List<MetadataAttribute> identifyMeta = identifyResponse != null && identifyResponse.getMeta() != null
                 ? identifyResponse.getMeta()
                 : List.of();
+
+        // The PENDING_ISSUE -> ISSUED finalize runs in a short transaction under a pessimistic row lock
+        // so two concurrent uploads of the same certificate cannot both finalize it. The connector
+        // identify above ran before this lock; the location pushes and best-effort async cancel below run
+        // after it commits — the lock is never held across a connector call. PENDING_ISSUE is re-asserted
+        // under the lock: the losing upload blocks here, re-reads ISSUED, and is rejected rather than
+        // driving a second finalize (duplicate location pushes / events). Mirrors issueCertificateAction /
+        // manuallyConfirmRevoke.
+        UUID certUuid = certificate.getUuid();
+        TransactionStatus tx = transactionManager.getTransaction(new DefaultTransactionDefinition());
         try {
-            certificateService.issueRequestedCertificate(certificate.getUuid(), request.getCertificate(), identifyMeta);
+            Certificate locked = certificateRepository.findAndLockWithAssociationsByUuid(certUuid)
+                    .orElseThrow(() -> new NotFoundException(Certificate.class, certUuid));
+            assertCertificateInPendingIssueWithCsr(locked);
+            certificateService.issueRequestedCertificate(certUuid, request.getCertificate(), identifyMeta);
+            transactionManager.commit(tx);
         } catch (NoSuchAlgorithmException e) {
+            transactionManager.rollback(tx);
             throw new CertificateException(e);
+        } catch (NotFoundException | CertificateException | AlreadyExistException | AttributeException | RuntimeException e) {
+            transactionManager.rollback(tx);
+            throw e;
         }
 
         if (request.getCustomAttributes() != null && !request.getCustomAttributes().isEmpty()) {
             attributeEngine.updateObjectCustomAttributesContent(Resource.CERTIFICATE,
-                    certificate.getUuid(), request.getCustomAttributes());
+                    certUuid, request.getCustomAttributes());
         }
 
         pushFinalizedCertificateToAllLocations(certificate);
 
         eventProducer.produceMessage(
-                CertificateActionPerformedEventHandler.constructEventMessage(certificate.getUuid(), ResourceAction.ISSUE));
+                CertificateActionPerformedEventHandler.constructEventMessage(certUuid, ResourceAction.ISSUE));
 
-        cancelInFlightAsyncIssueBestEffort(certificate.getUuid());
+        cancelInFlightAsyncIssueBestEffort(certUuid);
 
-        Certificate refreshed = certificateRepository.findByUuid(certificate.getUuid())
-                .orElseThrow(() -> new NotFoundException(Certificate.class, certificate.getUuid()));
+        Certificate refreshed = certificateRepository.findByUuid(certUuid)
+                .orElseThrow(() -> new NotFoundException(Certificate.class, certUuid));
         return refreshed.mapToDto();
     }
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -635,7 +635,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
                 transactionManager.commit(failTx);
             } catch (Exception failEx) {
                 transactionManager.rollback(failTx);
-                logger.error("Failed to record issuance failure for certificate {}: {}", certificateUuid, failEx.getMessage());
+                logger.error("Failed to record issuance failure for certificate {}: {}", certificateUuid, failEx.getMessage(), failEx);
             }
             throw new CertificateOperationException("Failed to issue certificate with UUID %s: ".formatted(certificateUuid) + e.getMessage());
         }

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -623,13 +623,14 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
             certificateService.issueRequestedCertificate(certificateUuid, issueCaResponse.getCertificateData(), issueCaResponse.getMeta());
         } catch (Exception e) {
-            // The certificate is detached here — the claim transaction committed (to release the row
-            // lock) before the connector call, so handleFailedOrRejectedEvent cannot lazy-load the
-            // collections it needs (locations, predecessor relations). Run the failure handling against
-            // a managed entity re-read inside a short transaction.
+            // Re-read under a row lock in a short transaction: the claim tx committed (releasing the lock)
+            // before the connector call, so the entity is detached and its collections cannot lazy-load; the
+            // lock also makes the FAILED transition authoritative — if another actor finalized this
+            // certificate meanwhile, handleFailedOrRejectedEvent sees the fresh state and its canTransition
+            // guard skips it, so a concurrent finalize is not clobbered.
             TransactionStatus failTx = transactionManager.getTransaction(new DefaultTransactionDefinition());
             try {
-                Certificate managed = certificateRepository.findWithAssociationsByUuid(certificateUuid)
+                Certificate managed = certificateRepository.findAndLockWithAssociationsByUuid(certificateUuid)
                         .orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
                 handleFailedOrRejectedEvent(managed, null, CertificateState.FAILED, CertificateEvent.ISSUE, new HashMap<>(), e.getMessage());
                 transactionManager.commit(failTx);

--- a/src/test/java/com/otilm/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateServiceTest.java
@@ -31,6 +31,7 @@ import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.core.connector.FunctionGroupCode;
 import com.otilm.api.model.core.enums.CertificateProtocol;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
+import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.dao.entity.*;
@@ -1927,6 +1928,26 @@ class CertificateServiceTest extends BaseSpringBootTest {
             certificateRepository.save(notIssued);
             certificateRepository.save(certificate);
             return notIssued;
+        }
+    }
+
+    // ── CSR attach (addCertificateRequestToExisting) ────────────────────────
+    @Nested
+    class CsrAttach {
+
+        @Test
+        void rejectsNonRegisteredCertificate() {
+            // given — a certificate that is not REGISTERED (e.g. still PENDING_ISSUE)
+            Certificate pendingIssue = certificateRepository.save(
+                    aCertificate().withRaProfile(raProfile).withState(CertificateState.PENDING_ISSUE).build());
+            UUID uuid = pendingIssue.getUuid();
+            ClientCertificateSignRequestDto signRequest = new ClientCertificateSignRequestDto();
+            signRequest.setRequest(SAMPLE_PKCS10);
+            signRequest.setFormat(CertificateRequestFormat.PKCS10);
+
+            // when / then — the locked read re-asserts state under the lock; only REGISTERED may accept a CSR
+            assertThatThrownBy(() -> certificateService.addCertificateRequestToExisting(uuid, signRequest))
+                    .isInstanceOf(ValidationException.class);
         }
     }
 

--- a/src/test/java/com/otilm/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateServiceTest.java
@@ -101,6 +101,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class CertificateServiceTest extends BaseSpringBootTest {
 
@@ -416,7 +419,7 @@ class CertificateServiceTest extends BaseSpringBootTest {
             objectAccessDenied.setAllowedObjects(List.of());
             objectAccessDenied.setForbiddenObjects(List.of());
 
-            Mockito.when(
+            when(
                     opaClient.checkObjectAccess(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())
             ).thenReturn(objectAccessDenied);
 
@@ -862,7 +865,7 @@ class CertificateServiceTest extends BaseSpringBootTest {
 
             // then
             assertThatThrownBy(() -> certificateService.getCertificate(certificate.getSecuredUuid())).isInstanceOf(NotFoundException.class);
-            Mockito.verify(notificationProducer, Mockito.times(1)).produceInternalNotificationMessage(
+            verify(notificationProducer, times(1)).produceInternalNotificationMessage(
                     Mockito.eq(Resource.CERTIFICATE),
                     Mockito.eq(nonExistentUuid),
                     Mockito.any(),
@@ -885,7 +888,7 @@ class CertificateServiceTest extends BaseSpringBootTest {
             OpaObjectAccessResult objectAccessResult = new OpaObjectAccessResult();
             objectAccessResult.setAllowedObjects(List.of(certificate.getUuid().toString()));
             objectAccessResult.setForbiddenObjects(List.of(forbiddenUuid.toString()));
-            Mockito.when(
+            when(
                     opaClient.checkObjectAccess(
                             Mockito.any(),
                             Mockito.argThat(resource ->
@@ -907,7 +910,7 @@ class CertificateServiceTest extends BaseSpringBootTest {
             // then
             assertThatThrownBy(() -> certificateService.getCertificate(certificate.getSecuredUuid())).isInstanceOf(NotFoundException.class);
             assertThatCode(() -> certificateService.getCertificate(SecuredUUID.fromUUID(forbiddenUuid))).doesNotThrowAnyException();
-            Mockito.verify(notificationProducer, Mockito.times(1)).produceInternalNotificationMessage(
+            verify(notificationProducer, times(1)).produceInternalNotificationMessage(
                     Mockito.eq(Resource.CERTIFICATE),
                     Mockito.eq(forbiddenUuid),
                     Mockito.any(),

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -1769,12 +1769,12 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
         req.setCertificate(certBase64);
         req.setCustomAttributes(List.of());
 
+        // Build args outside the lambda so only manuallyIssueCertificate can throw inside assertThrows.
+        SecuredParentUUID authorityUuid = SecuredParentUUID.fromUUID(raProfile.getAuthorityInstanceReferenceUuid());
+        SecuredUUID raProfileSecuredUuid = raProfile.getSecuredUuid();
+        String certUuidString = certificate.getUuid().toString();
         ValidationException ex = Assertions.assertThrows(ValidationException.class, () ->
-                clientOperationService.manuallyIssueCertificate(
-                        SecuredParentUUID.fromUUID(raProfile.getAuthorityInstanceReferenceUuid()),
-                        raProfile.getSecuredUuid(),
-                        certificate.getUuid().toString(),
-                        req));
+                clientOperationService.manuallyIssueCertificate(authorityUuid, raProfileSecuredUuid, certUuidString, req));
         Assertions.assertTrue(ex.getMessage().toLowerCase().contains("pending_issue"),
                 "expected the re-assert under the lock to reject with a PENDING_ISSUE message, got: " + ex.getMessage());
 

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -55,7 +55,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -76,6 +75,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class ClientOperationServiceV2Test extends BaseSpringBootTest {
@@ -395,7 +396,7 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
         request.setAltKeyUuid(altKey.getUuid());
         request.setAltTokenProfileUuid(altKey.getTokenProfileUuid());
         request.setAltSignatureAttributes(List.of());
-        Mockito.when(cryptographicOperationService.generateCsr(eq(key.getUuid()), eq(key.getTokenProfileUuid()), any(), any(), anyList(), any(), eq(altKey.getTokenProfileUuid()), anyList())).thenReturn("MIIBUjCBvAIBADATMREwDwYDVQQDDAhuZXdfY2VydDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA52WsWllsOi/XtK8VcKHN63Mhk6awMboP9iuwgtPXzkFLV/wILHH+YPAJcS8dP037SZQlAng9dF+IoLHn7WFYmQqqgkObWoH1+5LxHjkPRRNPJLKPtxfM/V+IafsddK7a5TiVD+PiKjoWQaGHVEieozV1fK2BfqVbenKbYMupGVkCAwEAAaAAMA0GCSqGSIb3DQEBBAUAA4GBALtgmv31dFCSO+KnXWeaGEVr2H8g6O0D/RS8xoTRF4yHIgU84EXL5ZWUxhLF6mAXP1de0IfeEf95gGrU9FQ7tdUnwfsBZCIhHOQ/PdzVhRRhaVaPK8N+/g1GyXM/mC074u8y+VoyhHTqAlnbGwzyJkLnVwJ0/jLiRaTdvn7zFDWr");
+        when(cryptographicOperationService.generateCsr(eq(key.getUuid()), eq(key.getTokenProfileUuid()), any(), any(), anyList(), any(), eq(altKey.getTokenProfileUuid()), anyList())).thenReturn("MIIBUjCBvAIBADATMREwDwYDVQQDDAhuZXdfY2VydDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA52WsWllsOi/XtK8VcKHN63Mhk6awMboP9iuwgtPXzkFLV/wILHH+YPAJcS8dP037SZQlAng9dF+IoLHn7WFYmQqqgkObWoH1+5LxHjkPRRNPJLKPtxfM/V+IafsddK7a5TiVD+PiKjoWQaGHVEieozV1fK2BfqVbenKbYMupGVkCAwEAAaAAMA0GCSqGSIb3DQEBBAUAA4GBALtgmv31dFCSO+KnXWeaGEVr2H8g6O0D/RS8xoTRF4yHIgU84EXL5ZWUxhLF6mAXP1de0IfeEf95gGrU9FQ7tdUnwfsBZCIhHOQ/PdzVhRRhaVaPK8N+/g1GyXM/mC074u8y+VoyhHTqAlnbGwzyJkLnVwJ0/jLiRaTdvn7zFDWr");
         SecuredParentUUID authorityUuid = authorityInstanceReference.getSecuredParentUuid();
         SecuredUUID raProfileUuid = raProfile.getSecuredUuid();
         String certificateUuid = String.valueOf(certificate.getUuid());
@@ -1762,7 +1763,7 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
         // the lock is ISSUED — as if a concurrent upload committed the finalize just before we locked.
         Certificate alreadyIssued = new Certificate();
         alreadyIssued.setState(CertificateState.ISSUED);
-        Mockito.doReturn(Optional.of(alreadyIssued))
+        doReturn(Optional.of(alreadyIssued))
                 .when(certificateRepository).findAndLockWithAssociationsByUuid(certificate.getUuid());
 
         UploadCertificateRequestDto req = new UploadCertificateRequestDto();
@@ -1798,7 +1799,7 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
     void addCertificateRequestToExisting_reassertUnderLock_rejectsWhenRaProfileChangedDuringAuthorization() throws Exception {
         Certificate switchedAway = new Certificate();
         switchedAway.setState(CertificateState.REGISTERED);   // raProfileUuid left null: profile changed away
-        Mockito.doReturn(Optional.of(switchedAway))
+        doReturn(Optional.of(switchedAway))
                 .when(certificateRepository).findAndLockWithAssociationsByUuid(certificate.getUuid());
 
         ClientCertificateSignRequestDto signRequest = new ClientCertificateSignRequestDto();

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -59,6 +59,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -71,6 +72,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -133,7 +135,7 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
     private Connector2FunctionGroupRepository connector2FunctionGroupRepository;
     @Autowired
     private ConnectorInterfaceRepository connectorInterfaceRepository;
-    @Autowired
+    @MockitoSpyBean
     private CertificateRepository certificateRepository;
     @Autowired
     private CertificateEventHistoryRepository certificateEventHistoryRepository;
@@ -1215,6 +1217,36 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
                 "an ISSUE/FAILED audit row must be written after a sync connector error");
     }
 
+    /**
+     * Concurrency guard (core#1687): the claim of a certificate for issuance now happens under a
+     * pessimistic row lock, and the state is re-asserted under that lock. A second ISSUE action for
+     * a certificate already claimed to PENDING_ISSUE (the state a concurrent winner leaves behind)
+     * must be a benign no-op — it must NOT call the connector again and must NOT drive the cert to
+     * FAILED (PENDING_ISSUE -> FAILED is a legal transition, so a wrong path here would fail the
+     * winner's in-flight issuance).
+     */
+    @Test
+    void issueCertificateAction_benignSkip_whenAlreadyPendingIssue_doesNotCallConnectorOrFail() throws Exception {
+        UUID certUuid = prepareCertificateForIssuance();
+        certificate.setState(CertificateState.PENDING_ISSUE);
+        certificateRepository.save(certificate);
+
+        // Stub the issue endpoint so that, were the skip broken and the connector called, the call
+        // would still succeed — leaving the verify(0) below as the decisive proof it was not called.
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue"))
+                .willReturn(WireMock.aResponse().withStatus(202)));
+
+        Assertions.assertDoesNotThrow(() -> clientOperationInternalService.issueCertificateAction(certUuid, true));
+
+        Certificate fetched = certificateRepository.findByUuid(certUuid).orElseThrow();
+        Assertions.assertEquals(CertificateState.PENDING_ISSUE, fetched.getState(),
+                "a duplicate ISSUE for a cert already claimed to PENDING_ISSUE must leave it in PENDING_ISSUE, not FAILED");
+
+        mockServer.verify(0, WireMock.postRequestedFor(
+                WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue")));
+    }
+
     @Test
     void revokeCertificateAction_transitionsToPendingRevoke_when202FromConnector() throws Exception {
         mockServer.stubFor(WireMock
@@ -1707,6 +1739,50 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
                         req));
         Assertions.assertTrue(ex.getMessage().toLowerCase().contains("pending_issue"),
                 "expected error mentioning PENDING_ISSUE state, got: " + ex.getMessage());
+    }
+
+    /**
+     * Concurrency guard (core#1687): the PENDING_ISSUE -> ISSUED finalize now runs under a pessimistic
+     * row lock and re-asserts PENDING_ISSUE after acquiring it. This models the losing side of a race —
+     * the outer (unlocked) checks and the connector identify all saw PENDING_ISSUE, but by the time the
+     * lock is acquired a concurrent upload has already finalized the certificate to ISSUED. Only the
+     * re-assert under the lock can catch this; it must reject the duplicate rather than finalizing twice.
+     * The locked read is stubbed to return an already-ISSUED row so the scenario is deterministic.
+     */
+    @Test
+    void manuallyIssueCertificate_reassertUnderLock_blocksWhenConcurrentUploadAlreadyFinalized() throws Exception {
+        KeyPair kp = setupPendingIssueCertWithRealCsr();
+        String certBase64 = buildSelfSignedCertBase64(kp, "test-pending-issue");
+
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/identify"))
+                .willReturn(WireMock.okJson("{\"meta\":[]}")));
+
+        // The real row stays PENDING_ISSUE (so the outer read + identify pass), but the row observed under
+        // the lock is ISSUED — as if a concurrent upload committed the finalize just before we locked.
+        Certificate alreadyIssued = new Certificate();
+        alreadyIssued.setState(CertificateState.ISSUED);
+        Mockito.doReturn(Optional.of(alreadyIssued))
+                .when(certificateRepository).findAndLockWithAssociationsByUuid(certificate.getUuid());
+
+        UploadCertificateRequestDto req = new UploadCertificateRequestDto();
+        req.setCertificate(certBase64);
+        req.setCustomAttributes(List.of());
+
+        ValidationException ex = Assertions.assertThrows(ValidationException.class, () ->
+                clientOperationService.manuallyIssueCertificate(
+                        SecuredParentUUID.fromUUID(raProfile.getAuthorityInstanceReferenceUuid()),
+                        raProfile.getSecuredUuid(),
+                        certificate.getUuid().toString(),
+                        req));
+        Assertions.assertTrue(ex.getMessage().toLowerCase().contains("pending_issue"),
+                "expected the re-assert under the lock to reject with a PENDING_ISSUE message, got: " + ex.getMessage());
+
+        // The losing upload must not have finalized: the real row is untouched, still PENDING_ISSUE.
+        // (findByUuid is unstubbed, so the spy delegates to the real repository here.)
+        Certificate afterAttempt = certificateRepository.findByUuid(certificate.getUuid()).orElseThrow();
+        Assertions.assertEquals(CertificateState.PENDING_ISSUE, afterAttempt.getState(),
+                "the losing concurrent upload must not finalize the certificate");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -1218,7 +1218,7 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
     }
 
     /**
-     * Concurrency guard (core#1687): the claim of a certificate for issuance now happens under a
+     * Concurrency guard: the claim of a certificate for issuance now happens under a
      * pessimistic row lock, and the state is re-asserted under that lock. A second ISSUE action for
      * a certificate already claimed to PENDING_ISSUE (the state a concurrent winner leaves behind)
      * must be a benign no-op — it must NOT call the connector again and must NOT drive the cert to
@@ -1742,7 +1742,7 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
     }
 
     /**
-     * Concurrency guard (core#1687): the PENDING_ISSUE -> ISSUED finalize now runs under a pessimistic
+     * Concurrency guard: the PENDING_ISSUE -> ISSUED finalize now runs under a pessimistic
      * row lock and re-asserts PENDING_ISSUE after acquiring it. This models the losing side of a race —
      * the outer (unlocked) checks and the connector identify all saw PENDING_ISSUE, but by the time the
      * lock is acquired a concurrent upload has already finalized the certificate to ISSUED. Only the

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -1785,6 +1785,33 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
                 "the losing concurrent upload must not finalize the certificate");
     }
 
+    /**
+     * Concurrency guard on the CSR-attach path: addCertificateRequestToExisting authorizes against the RA
+     * profile read before the lock, then attaches the CSR to the row read under the lock. switchRaProfile
+     * is allowed on REGISTERED certificates and takes no row lock, so a concurrent switch can move the
+     * certificate between those two reads. The re-assert under the lock must reject when the locked row no
+     * longer belongs to the authorized profile — otherwise a caller authorized on the old profile could
+     * attach a CSR to a certificate under one they do not control. The locked read is stubbed to return a
+     * row under a different (here, removed) profile so the scenario is deterministic.
+     */
+    @Test
+    void addCertificateRequestToExisting_reassertUnderLock_rejectsWhenRaProfileChangedDuringAuthorization() throws Exception {
+        Certificate switchedAway = new Certificate();
+        switchedAway.setState(CertificateState.REGISTERED);   // raProfileUuid left null: profile changed away
+        Mockito.doReturn(Optional.of(switchedAway))
+                .when(certificateRepository).findAndLockWithAssociationsByUuid(certificate.getUuid());
+
+        ClientCertificateSignRequestDto signRequest = new ClientCertificateSignRequestDto();
+        signRequest.setRequest(SAMPLE_PKCS10);
+        signRequest.setFormat(CertificateRequestFormat.PKCS10);
+
+        UUID certUuid = certificate.getUuid();
+        ValidationException ex = Assertions.assertThrows(ValidationException.class, () ->
+                certificateService.addCertificateRequestToExisting(certUuid, signRequest));
+        Assertions.assertTrue(ex.getMessage().contains("RA profile changed"),
+                "expected the re-assert under the lock to reject on RA-profile change, got: " + ex.getMessage());
+    }
+
     @Test
     void manuallyIssueCertificate_blocksOnPublicKeyMismatch() throws Exception {
         setupPendingIssueCertWithRealCsr();


### PR DESCRIPTION
## What

Under concurrency (operator double-click / retry / two admins), one certificate could reach an **ISSUED outcome more than once**. `Certificate` has no `@Version` and no `@DynamicUpdate`, and the issue-completion paths read unlocked and `save` full-column, so two racing paths could both reach the connector, or a stale write could clobber a committed claim.

Closes #1687 (sub-issue of the authority-provider-v3 epic ilm#110).

## How

Serialize the three issue-completion paths with the shipped **pessimistic-lock + re-assert in a short transaction, connector call outside the lock** pattern (`manuallyConfirmRevoke`, `PendingIssueReaper`). The lock (`findAndLockWithAssociationsByUuid`, `SELECT … FOR UPDATE`) is always released before any connector HTTP call.

1. **`issueCertificateAction`** (async ISSUE consumer, queue concurrency 10) — read + guards + `REGISTERED→PENDING_ISSUE` claim now run under the row lock, committed before the connector call. A second concurrent action blocks, re-reads `PENDING_ISSUE`, and **benign-skips**. The skip is deliberately **outside** the connector-failure catch: `PENDING_ISSUE→FAILED` is a *legal* transition, so failing there would mark the concurrent winner's in-flight issuance FAILED. Data needed after the claim (connector ids, sign request, location ids) is captured inside the lock since the entity detaches on commit; the failure path re-reads a managed entity for its collection cleanup.
2. **`addCertificateRequestToExisting`** — its read is now the locking finder (authorization preserved). The existing `state == REGISTERED` re-assert becomes authoritative: a racing CSR attach blocks, re-reads a changed state, and throws — closing the full-column write-back that would otherwise reset `state=REGISTERED` over a committed claim.
3. **`manuallyIssueCertificate`** (operator upload-finalize) — the `PENDING_ISSUE→ISSUED` finalize runs under the lock with a re-assert; the connector identify runs before, the location push/cancel after.

### Scope / determinations
- **renew/rekey are out of scope** — each call creates a *new successor* (a two-certs shape), not one cert issued twice.
- **No `@Version` needed** — with these locks every issue-completion state write is lock-guarded and re-asserts; `@Version` would only guard unrelated incidental edits (a separate, repo-wide concern).

## Testing

227 tests green (`ClientOperationServiceV2Test` + `CertificateServiceTest`), including new deterministic guards for each path:
- `issueCertificateAction` benign-skip on an already-`PENDING_ISSUE` cert — asserts the connector is **not** called (`verify(0)`) and the cert is not driven to FAILED.
- `addCertificateRequestToExisting` rejects a non-`REGISTERED` cert (the authoritative re-assert).
- `manuallyIssueCertificate` locked re-assert — stubs only the locked read to return `ISSUED` (simulating a concurrent winner the outer guard can't observe) and asserts rejection + the real row stays `PENDING_ISSUE`.

The existing happy-path issue/renew/upload tests are the regression net for the transaction/lazy-loading restructure.