### PR TITLE
Move security/ api/ tests into integration root - part 6

### DIFF
--- a/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
+++ b/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
@@ -126,7 +126,7 @@ class CiTestSplitTest {
      * fragments — a substring match would wrongly exempt e.g. any path merely containing "api".
      */
     private static final Set<String> MIGRATION_ALLOWLIST = Set.of(
-            "service", "util", "signing", "messaging", "security", "api");
+            "service", "util", "signing", "messaging");
 
     /**
      * Root-level test files live directly in com/otilm/core (no sub-package) — e.g. ApplicationTests,

--- a/src/test/java/com/otilm/core/integration/api/web/ProxyControllerITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/ProxyControllerITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.api.web;
+package com.otilm.core.integration.api.web;
 
 import com.otilm.api.model.core.proxy.ProxyStatus;
 import com.otilm.core.dao.entity.Proxy;
@@ -20,7 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
-class ProxyControllerTest extends BaseSpringBootTest {
+class ProxyControllerITest extends BaseSpringBootTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/otilm/core/integration/api/web/SigningRecordStatisticsControllerITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/SigningRecordStatisticsControllerITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.api.web;
+package com.otilm.core.integration.api.web;
 
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.Test;
@@ -11,7 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
-class SigningRecordStatisticsControllerTest extends BaseSpringBootTest {
+class SigningRecordStatisticsControllerITest extends BaseSpringBootTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/otilm/core/integration/security/authn/client/CredentialVerificationCacheITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authn/client/CredentialVerificationCacheITest.java
@@ -1,6 +1,8 @@
-package com.otilm.core.security.authn.client;
+package com.otilm.core.integration.security.authn.client;
 
 import com.otilm.core.config.cache.CacheConfig;
+import com.otilm.core.security.authn.client.CredentialVerificationCache;
+import com.otilm.core.security.authn.client.SecretRefIndex;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,7 +15,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class CredentialVerificationCacheTest extends BaseSpringBootTest {
+class CredentialVerificationCacheITest extends BaseSpringBootTest {
 
     @Autowired
     private CredentialVerificationCache cache;

--- a/src/test/java/com/otilm/core/integration/security/authn/client/PlatformAuthenticationCacheITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authn/client/PlatformAuthenticationCacheITest.java
@@ -1,6 +1,8 @@
-package com.otilm.core.security.authn.client;
+package com.otilm.core.integration.security.authn.client;
 
 import com.otilm.api.model.core.logging.enums.AuthMethod;
+import com.otilm.core.security.authn.client.AuthenticationCache;
+import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,7 +16,7 @@ import java.util.function.Supplier;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
-class PlatformAuthenticationCacheTest extends BaseSpringBootTest {
+class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
 
     @Autowired
     private AuthenticationCache authenticationCache;

--- a/src/test/java/com/otilm/core/integration/security/authn/client/PlatformAuthenticationClientITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authn/client/PlatformAuthenticationClientITest.java
@@ -1,10 +1,13 @@
-package com.otilm.core.security.authn.client;
+package com.otilm.core.integration.security.authn.client;
 
 import com.otilm.api.model.core.logging.enums.ActorType;
 import com.otilm.api.model.core.logging.enums.AuthMethod;
 import com.otilm.api.model.core.logging.records.ActorRecord;
 import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.security.authn.PlatformAuthenticationException;
+import com.otilm.core.security.authn.client.AuthenticationCache;
+import com.otilm.core.security.authn.client.AuthenticationInfo;
+import com.otilm.core.security.authn.client.PlatformAuthenticationClient;
 import com.otilm.core.service.AuditLogInternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -28,7 +31,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class PlatformAuthenticationClientTest extends BaseSpringBootTest {
+class PlatformAuthenticationClientITest extends BaseSpringBootTest {
     private static MockWebServer authServiceMock;
 
     private PlatformAuthenticationClient authenticationClient;

--- a/src/test/java/com/otilm/core/integration/security/authn/tsp/TspProfileSecretEvictionITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authn/tsp/TspProfileSecretEvictionITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.security.authn.tsp;
+package com.otilm.core.integration.security.authn.tsp;
 
 import com.otilm.core.config.cache.CacheConfig;
 import com.otilm.core.dao.entity.signing.TspProfile;
@@ -7,6 +7,7 @@ import com.otilm.core.dao.repository.signing.TspProfileBasicCredentialRepository
 import com.otilm.core.dao.repository.signing.TspProfileRepository;
 import com.otilm.core.events.SecretContentUpdatedEvent;
 import com.otilm.core.security.authn.client.CredentialVerificationCache;
+import com.otilm.core.security.authn.tsp.TspProfileSecretEvictionListener;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * caches. This is the path a password rotation relies on, since {@code update()} intentionally does not
  * evict the verification cache eagerly on rotation.
  */
-class TspProfileSecretEvictionIntegrationTest extends BaseSpringBootTest {
+class TspProfileSecretEvictionITest extends BaseSpringBootTest {
 
     @Autowired
     private CredentialVerificationCache credentialVerificationCache;

--- a/src/test/java/com/otilm/core/integration/security/authz/ExternalAuthorizationDynamicITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authz/ExternalAuthorizationDynamicITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.security.authz;
+package com.otilm.core.integration.security.authz;
 
 import com.otilm.api.exception.AttributeException;
 import com.otilm.api.exception.NotFoundException;
@@ -23,6 +23,10 @@ import com.otilm.core.dao.repository.AttributeRelationRepository;
 import com.otilm.core.dao.repository.CertificateContentRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.security.authz.ExternalAuthorizationDynamic;
+import com.otilm.core.security.authz.ExternalMethodAuthorizationManager;
+import com.otilm.core.security.authz.SecuredResource;
+import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.opa.dto.OpaRequestedResource;
 import com.otilm.core.security.authz.opa.dto.OpaResourceAccessResult;
 import com.otilm.core.service.ComplianceExternalService;
@@ -42,7 +46,7 @@ import java.util.UUID;
  * AOP stack: the {@code dynamicAuthorizationManagerBeforeMethodInterception} advisor wired in {@code MethodSecurityConfig},
  * the {@link ExternalMethodAuthorizationManager}, and {@link OpaSecuredAnnotationMetadataExtractor}.
  */
-class ExternalAuthorizationDynamicIntegrationTest extends BaseSpringBootTest {
+class ExternalAuthorizationDynamicITest extends BaseSpringBootTest {
 
     @Autowired
     private ResourceExternalService resourceService;

--- a/src/test/java/com/otilm/core/integration/security/oauth2/JwtDecoderITest.java
+++ b/src/test/java/com/otilm/core/integration/security/oauth2/JwtDecoderITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.security.oauth2;
+package com.otilm.core.integration.security.oauth2;
 
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.core.settings.SettingsSection;
@@ -10,6 +10,7 @@ import com.otilm.core.dao.repository.SettingRepository;
 import com.otilm.core.security.authn.PlatformAnonymousToken;
 import com.otilm.core.security.authn.PlatformAuthenticationException;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
+import com.otilm.core.security.oauth2.OAuth2TestUtil;
 import com.otilm.core.service.SettingExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -38,7 +39,7 @@ import java.util.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 
 @SpringBootTest
-class JwtDecoderTest extends BaseSpringBootTest {
+class JwtDecoderITest extends BaseSpringBootTest {
 
     public static final String AUDIENCE = "your-audience";
     @Autowired

--- a/src/test/java/com/otilm/core/integration/security/oauth2/OAuth2AuthenticationSuccessHandlerITest.java
+++ b/src/test/java/com/otilm/core/integration/security/oauth2/OAuth2AuthenticationSuccessHandlerITest.java
@@ -1,10 +1,11 @@
-package com.otilm.core.security.oauth2;
+package com.otilm.core.integration.security.oauth2;
 
 import com.otilm.api.model.core.settings.SettingsSection;
 import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDto;
 import com.otilm.core.auth.oauth2.PlatformAuthenticationSuccessHandler;
 import com.otilm.core.auth.oauth2.PlatformClientRegistrationRepository;
 import com.otilm.core.security.authn.PlatformAuthenticationException;
+import com.otilm.core.security.oauth2.OAuth2TestUtil;
 import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.util.OAuth2Constants;
 import com.nimbusds.jose.JOSEException;
@@ -36,7 +37,7 @@ import java.util.List;
 import java.util.Map;
 
 @SpringBootTest
-class OAuth2AuthenticationSuccessHandlerTest {
+class OAuth2AuthenticationSuccessHandlerITest {
 
     @MockitoBean
     OAuth2AuthorizedClientService clientService;

--- a/src/test/java/com/otilm/core/integration/security/oauth2/PlatformClientRegistrationRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/security/oauth2/PlatformClientRegistrationRepositoryITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.security.oauth2;
+package com.otilm.core.integration.security.oauth2;
 
 import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsUpdateDto;
 import com.otilm.core.auth.oauth2.PlatformClientRegistrationRepository;
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class PlatformClientRegistrationRepositoryTest extends BaseSpringBootTest {
+class PlatformClientRegistrationRepositoryITest extends BaseSpringBootTest {
 
     @Autowired
     private PlatformClientRegistrationRepository clientRegistrationRepository;

--- a/src/test/java/com/otilm/core/integration/security/oauth2/PlatformJwtConvertorITest.java
+++ b/src/test/java/com/otilm/core/integration/security/oauth2/PlatformJwtConvertorITest.java
@@ -1,9 +1,10 @@
-package com.otilm.core.security.oauth2;
+package com.otilm.core.integration.security.oauth2;
 
 import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsUpdateDto;
 import com.otilm.core.auth.oauth2.PlatformJwtAuthenticationConverter;
 import com.otilm.core.security.authn.PlatformAuthenticationException;
 import com.otilm.core.security.authn.PlatformAuthenticationToken;
+import com.otilm.core.security.oauth2.OAuth2TestUtil;
 import com.otilm.core.service.SettingExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -22,7 +23,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 
-class PlatformJwtConvertorTest extends BaseSpringBootTest {
+class PlatformJwtConvertorITest extends BaseSpringBootTest {
 
     @DynamicPropertySource
     static void authServiceProperties(DynamicPropertyRegistry registry) {


### PR DESCRIPTION
## What

PR 6 of the per-package integration-test migration series (#1710). Moves the context-loading test classes of **two packages** — `security/` and `api/` — into the single integration root `com.otilm.core.integration.**`, renames them `*ITest`, and drops those two entries from the `CiTestSplitTest` `MIGRATION_ALLOWLIST`.

| From | To |
|---|---|
| `security/oauth2/OAuth2AuthenticationSuccessHandlerTest` | `integration/security/oauth2/OAuth2AuthenticationSuccessHandlerITest` |
| `security/oauth2/PlatformJwtConvertorTest` | `integration/security/oauth2/PlatformJwtConvertorITest` |
| `security/oauth2/JwtDecoderTest` | `integration/security/oauth2/JwtDecoderITest` |
| `security/oauth2/PlatformClientRegistrationRepositoryTest` | `integration/security/oauth2/PlatformClientRegistrationRepositoryITest` |
| `security/authz/ExternalAuthorizationDynamicIntegrationTest` | `integration/security/authz/ExternalAuthorizationDynamicITest` |
| `security/authn/tsp/TspProfileSecretEvictionIntegrationTest` | `integration/security/authn/tsp/TspProfileSecretEvictionITest` |
| `security/authn/client/CredentialVerificationCacheTest` | `integration/security/authn/client/CredentialVerificationCacheITest` |
| `security/authn/client/PlatformAuthenticationClientTest` | `integration/security/authn/client/PlatformAuthenticationClientITest` |
| `security/authn/client/PlatformAuthenticationCacheTest` | `integration/security/authn/client/PlatformAuthenticationCacheITest` |
| `api/web/ProxyControllerTest` | `integration/api/web/ProxyControllerITest` |
| `api/web/SigningRecordStatisticsControllerTest` | `integration/api/web/SigningRecordStatisticsControllerITest` |

## Why

Establishes each context-loading test under the integration root so the three-way CI split (`test-services` / `test-non-services` / `test-integration`, #1693) routes it into the integration leg and its coverage lands in the right JaCoCo artifact. Follows #1709 (PR 1, `migration/`), #1715 (PR 2, `search/`), #1719 (PR 3), #1722 (PR 4) and #1726 (PR 5, in flight). Combines the plan's PR 6 (`security/`, 9 context classes) with PR 7 (`api/`, 2 context classes) since both are straight move+rename with no mixed classes to split.

## Classification

**security/** — 9 of 22 classes are context-loading (`extends BaseSpringBootTest` or `@SpringBootTest`); the 13 pure-unit siblings (`OAuth2UtilTest`, `SecuredUUIDTest`, `TspRouteResolverTest`, `SecretRefIndexTest`, the `opa/OpaClientTest`, etc.) and the `OAuth2TestUtil` helper stay in place. **api/** — 2 of the remaining context-loading classes move; `integration/api/tsp/*ITest` was migrated earlier, which is why `api/` was still allowlisted. All 11 moved classes are pure integration → straight move + rename, no class splitting.

Retired `*IntegrationTest` suffixes normalized to `*ITest` (`ExternalAuthorizationDynamicIntegrationTest`, `TspProfileSecretEvictionIntegrationTest`).

Same-package references that no longer resolve after the move gained explicit imports: the `OAuth2TestUtil` helper (three oauth2 tests), the `SecuredResource`/`SecuredUUID` annotations, and the `authn/client` production types (`CredentialVerificationCache`, `SecretRefIndex`, `AuthenticationCache`, `AuthenticationInfo`, `PlatformAuthenticationClient`).

## Review follow-ups folded in

Repointed move-induced dangling Javadoc `{@link}`s by importing their targets: `ExternalAuthorizationDynamic` / `ExternalMethodAuthorizationManager` in the authz ITest, and `TspProfileSecretEvictionListener` in the tsp ITest. Placed the added `OAuth2TestUtil` imports in alphabetical position.

## Verification

- Baseline full suite green before the change (3657 tests; one unrelated flaky WireMock read-timeout in `ComplianceProfileServiceV2Test` that passes on isolated rerun).
- Clean `test-compile` green; all 11 moved classes + `CiTestSplitTest` + `TestClassTaxonomyTest` green (96 tests).
- `CiTestSplitTest` guards pass — including the self-prune guard (fails if an allowlist entry has no remaining pending context test) and the guard that fails if a context-loading test class remains outside `com.otilm.core.integration.**` for an already-migrated package. All remaining tests under `security/` and `api/` are pure unit tests, so removing both from the allowlist keeps the guards green.

## Scope note

Redundant-test triage (#1645), test-style modernization (AssertJ, naming), and context-cache consolidation (#1704) are deliberately **out of scope** here.

Part of #1710 · Epic OmniTrustILM/ilm#252