### PR TITLE
Add registration-authorization entity and challenge store

### DIFF
--- a/src/main/java/com/otilm/core/dao/entity/CertificateRegistrationAuthorization.java
+++ b/src/main/java/com/otilm/core/dao/entity/CertificateRegistrationAuthorization.java
@@ -15,10 +15,10 @@ import java.util.UUID;
 
 /**
  * Durable authorization for a pre-registered certificate: the challenge, issuance window, failed-attempt lockout,
- * and lifecycle state that let a later renew or rekey prove it is the registered subject. It coexists with the
- * transient {@link CertificateRegistration} register->issue binding but, unlike that binding, survives issuance —
- * the binding is cleared when the certificate is first issued, while this record remains to authorize follow-up
- * operations.
+ * and lifecycle state used to authorize a later renew or rekey.
+ *
+ * <p>Unlike the transient {@link CertificateRegistration} register-to-issue binding, which is cleared once the
+ * certificate is first issued, this record survives issuance so it can authorize follow-up operations.
  */
 @Getter
 @Setter

--- a/src/main/java/com/otilm/core/dao/entity/CertificateRegistrationAuthorization.java
+++ b/src/main/java/com/otilm/core/dao/entity/CertificateRegistrationAuthorization.java
@@ -1,0 +1,62 @@
+package com.otilm.core.dao.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * Durable authorization for a pre-registered certificate: the challenge, issuance window, failed-attempt lockout,
+ * and lifecycle state that let a later renew or rekey prove it is the registered subject. It coexists with the
+ * transient {@link CertificateRegistration} register->issue binding but, unlike that binding, survives issuance —
+ * the binding is cleared when the certificate is first issued, while this record remains to authorize follow-up
+ * operations.
+ */
+@Getter
+@Setter
+@ToString
+@Entity
+// A certificate has at most one durable authorization record.
+@Table(name = "certificate_registration_authorization",
+        uniqueConstraints = @UniqueConstraint(name = "uq_certificate_registration_authorization_certificate",
+                columnNames = "certificate_uuid"))
+public class CertificateRegistrationAuthorization extends UniquelyIdentifiedAndAudited {
+
+    @Column(name = "certificate_uuid", nullable = false)
+    private UUID certificateUuid;
+
+    // Ciphertext only; the plaintext challenge never touches the entity (see RegistrationChallengeStore).
+    // Excluded from toString because a tracing aspect records entity toString into spans.
+    @ToString.Exclude
+    @Column(name = "challenge", nullable = false, length = Integer.MAX_VALUE)
+    private String challenge;
+
+    // Null means no issuance deadline.
+    @Column(name = "expires_at")
+    private OffsetDateTime expiresAt;
+
+    @Column(name = "failed_attempts", nullable = false)
+    private int failedAttempts;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "state", nullable = false)
+    private RegistrationState state;
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/src/main/java/com/otilm/core/dao/entity/RegistrationState.java
+++ b/src/main/java/com/otilm/core/dao/entity/RegistrationState.java
@@ -1,0 +1,13 @@
+package com.otilm.core.dao.entity;
+
+/**
+ * Lifecycle of a {@link CertificateRegistrationAuthorization}: {@code ACTIVE} while it can still authorize an
+ * operation, {@code EXPIRED} once its issuance window has passed, {@code LOCKED} after too many failed challenge
+ * attempts, and {@code CLOSED} once it has been retired.
+ */
+public enum RegistrationState {
+    ACTIVE,
+    EXPIRED,
+    LOCKED,
+    CLOSED
+}

--- a/src/main/java/com/otilm/core/dao/repository/CertificateRegistrationAuthorizationRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CertificateRegistrationAuthorizationRepository.java
@@ -1,0 +1,30 @@
+package com.otilm.core.dao.repository;
+
+import com.otilm.core.dao.entity.CertificateRegistrationAuthorization;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface CertificateRegistrationAuthorizationRepository extends JpaRepository<CertificateRegistrationAuthorization, UUID> {
+
+    Optional<CertificateRegistrationAuthorization> findByCertificateUuid(UUID certificateUuid);
+
+    /**
+     * Pessimistic-write finder ({@code SELECT ... FOR UPDATE}) so a concurrent verify / failed-attempt update
+     * serializes on the authorization row. Must run in a transaction; the lock must not span an external call.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<CertificateRegistrationAuthorization> findAndLockByCertificateUuid(UUID certificateUuid);
+
+    @Modifying
+    @Query("DELETE FROM CertificateRegistrationAuthorization r WHERE r.certificateUuid = :certificateUuid")
+    void deleteByCertificateUuid(@Param("certificateUuid") UUID certificateUuid);
+}

--- a/src/main/java/com/otilm/core/service/registration/RegistrationChallengeStore.java
+++ b/src/main/java/com/otilm/core/service/registration/RegistrationChallengeStore.java
@@ -21,6 +21,11 @@ public class RegistrationChallengeStore {
      * the row within its own transaction.
      */
     public void store(CertificateRegistrationAuthorization row, String plaintext) {
+        // Fail fast: a null/blank challenge would encode to null and only surface as an opaque NOT NULL
+        // violation when the row is saved.
+        if (plaintext == null || plaintext.isBlank()) {
+            throw new IllegalArgumentException("A registration challenge is required");
+        }
         row.setChallenge(SecretsUtil.encryptAndEncodeSecretString(plaintext, SecretEncodingVersion.V1));
     }
 

--- a/src/main/java/com/otilm/core/service/registration/RegistrationChallengeStore.java
+++ b/src/main/java/com/otilm/core/service/registration/RegistrationChallengeStore.java
@@ -1,0 +1,48 @@
+package com.otilm.core.service.registration;
+
+import com.otilm.core.dao.entity.CertificateRegistrationAuthorization;
+import com.otilm.core.util.SecretEncodingVersion;
+import com.otilm.core.util.SecretsUtil;
+import org.springframework.stereotype.Service;
+
+import java.security.MessageDigest;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Encrypts, verifies, and reveals the registration challenge of a {@link CertificateRegistrationAuthorization}.
+ * It is the only collaborator that touches the plaintext challenge: the entity stores ciphertext, and the
+ * plaintext is confined to this service so it cannot leak through entity accessors or {@code toString}.
+ */
+@Service
+public class RegistrationChallengeStore {
+
+    /**
+     * Encrypts {@code plaintext} and writes the ciphertext onto {@code row}. Does not persist — the caller saves
+     * the row within its own transaction.
+     */
+    public void store(CertificateRegistrationAuthorization row, String plaintext) {
+        row.setChallenge(SecretsUtil.encryptAndEncodeSecretString(plaintext, SecretEncodingVersion.V1));
+    }
+
+    /**
+     * Returns whether {@code presented} matches the stored challenge, or false when either side is null.
+     */
+    public boolean verify(CertificateRegistrationAuthorization row, String presented) {
+        if (presented == null || row.getChallenge() == null) {
+            return false;
+        }
+        String stored = SecretsUtil.decodeAndDecryptSecretString(row.getChallenge(), SecretEncodingVersion.V1);
+        // Constant-time comparison so a timing side channel cannot leak how much of the challenge matched.
+        return MessageDigest.isEqual(
+                presented.getBytes(StandardCharsets.UTF_8),
+                stored.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Decrypts and returns the plaintext challenge. Internal-only — for building the future registration event
+     * payload (SCEP / CMP); never exposed by any API.
+     */
+    public String resolvePlaintext(CertificateRegistrationAuthorization row) {
+        return SecretsUtil.decodeAndDecryptSecretString(row.getChallenge(), SecretEncodingVersion.V1);
+    }
+}

--- a/src/main/java/com/otilm/core/service/registration/RegistrationChallengeStore.java
+++ b/src/main/java/com/otilm/core/service/registration/RegistrationChallengeStore.java
@@ -5,8 +5,8 @@ import com.otilm.core.util.SecretEncodingVersion;
 import com.otilm.core.util.SecretsUtil;
 import org.springframework.stereotype.Service;
 
-import java.security.MessageDigest;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 
 /**
  * Encrypts, verifies, and reveals the registration challenge of a {@link CertificateRegistrationAuthorization}.
@@ -48,6 +48,11 @@ public class RegistrationChallengeStore {
      * payload (SCEP / CMP); never exposed by any API.
      */
     public String resolvePlaintext(CertificateRegistrationAuthorization row) {
+        // Consistent with verify()'s guard: a clear domain error beats an NPE inside SecretsUtil if this is ever
+        // called on an unpopulated row. The NOT NULL challenge column keeps it unreachable for a persisted row.
+        if (row.getChallenge() == null) {
+            throw new IllegalStateException("Registration authorization has no stored challenge to resolve");
+        }
         return SecretsUtil.decodeAndDecryptSecretString(row.getChallenge(), SecretEncodingVersion.V1);
     }
 }

--- a/src/main/resources/db/migration/V202607071200__certificate_registration_authorization.sql
+++ b/src/main/resources/db/migration/V202607071200__certificate_registration_authorization.sql
@@ -1,0 +1,19 @@
+-- Durable authorization record for a pre-registered certificate: the encrypted challenge, issuance window,
+-- failed-attempt count, and lifecycle state that let a later renew or rekey prove the registered subject.
+-- One row per certificate. Distinct from the transient certificate_registration binding, which is cleared at
+-- issuance; this record survives issuance to authorize follow-up operations.
+CREATE TABLE "certificate_registration_authorization"
+(
+    "uuid"             UUID        NOT NULL PRIMARY KEY,
+    "certificate_uuid" UUID        NOT NULL,
+    "challenge"        TEXT        NOT NULL,
+    "expires_at"       TIMESTAMPTZ NULL,
+    "failed_attempts"  INT         NOT NULL DEFAULT 0,
+    "state"            VARCHAR     NOT NULL,
+    "i_author"         VARCHAR,
+    "i_cre"            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "i_upd"            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT "uq_certificate_registration_authorization_certificate" UNIQUE ("certificate_uuid"),
+    CONSTRAINT "fk_certificate_registration_authorization_certificate" FOREIGN KEY ("certificate_uuid")
+        REFERENCES "certificate" ("uuid") ON DELETE CASCADE
+);

--- a/src/test/java/com/otilm/core/dao/repository/CertificateRegistrationAuthorizationRepositoryTest.java
+++ b/src/test/java/com/otilm/core/dao/repository/CertificateRegistrationAuthorizationRepositoryTest.java
@@ -1,0 +1,100 @@
+package com.otilm.core.dao.repository;
+
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.CertificateRegistrationAuthorization;
+import com.otilm.core.dao.entity.RegistrationState;
+import com.otilm.core.util.BaseSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static com.otilm.core.util.builders.CertificateBuilder.aCertificate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration coverage for the durable registration-authorization persistence against a real PostgreSQL.
+ */
+class CertificateRegistrationAuthorizationRepositoryTest extends BaseSpringBootTest {
+
+    @Autowired
+    private CertificateRegistrationAuthorizationRepository authorizationRepository;
+    @Autowired
+    private CertificateRepository certificateRepository;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private UUID certificateUuid;
+
+    @BeforeEach
+    void createCertificate() {
+        certificateUuid = certificateRepository.save(aCertificate().build()).getUuid();
+    }
+
+    private CertificateRegistrationAuthorization persistAuthorization() {
+        CertificateRegistrationAuthorization authorization = new CertificateRegistrationAuthorization();
+        authorization.setCertificateUuid(certificateUuid);
+        authorization.setChallenge("v1|ciphertext|salt|1000");
+        authorization.setExpiresAt(OffsetDateTime.now().plusDays(1));
+        authorization.setState(RegistrationState.ACTIVE);
+        return authorizationRepository.save(authorization);
+    }
+
+    @Test
+    void findByCertificateUuidReturnsThePersistedRow() {
+        UUID persistedUuid = persistAuthorization().getUuid();
+
+        CertificateRegistrationAuthorization found =
+                authorizationRepository.findByCertificateUuid(certificateUuid).orElseThrow();
+
+        assertThat(found.getUuid()).isEqualTo(persistedUuid);
+        assertThat(found.getCertificateUuid()).isEqualTo(certificateUuid);
+        assertThat(found.getState()).isEqualTo(RegistrationState.ACTIVE);
+    }
+
+    @Test
+    void lockedFinderReturnsRowInsideTransaction() {
+        persistAuthorization();
+
+        // SELECT ... FOR UPDATE requires an active transaction.
+        CertificateRegistrationAuthorization locked = new TransactionTemplate(transactionManager).execute(
+                status -> authorizationRepository.findAndLockByCertificateUuid(certificateUuid).orElseThrow());
+
+        assertThat(locked).isNotNull();
+        assertThat(locked.getCertificateUuid()).isEqualTo(certificateUuid);
+    }
+
+    @Test
+    void deleteByCertificateUuidRemovesRow() {
+        persistAuthorization();
+
+        // The @Modifying delete needs an ambient transaction; the repository carries none by convention.
+        new TransactionTemplate(transactionManager).executeWithoutResult(
+                status -> authorizationRepository.deleteByCertificateUuid(certificateUuid));
+
+        assertThat(authorizationRepository.findByCertificateUuid(certificateUuid)).isEmpty();
+    }
+
+    @Test
+    void deletingParentCertificateCascadesTheAuthorization() {
+        // The certificate_uuid association is intentionally unmapped, so Hibernate's create-drop test schema omits
+        // the ON DELETE CASCADE foreign key that the migration ships. Recreate it here to exercise the cascade.
+        jdbcTemplate.execute("ALTER TABLE core.certificate_registration_authorization "
+                + "DROP CONSTRAINT IF EXISTS fk_certificate_registration_authorization_certificate");
+        jdbcTemplate.execute("ALTER TABLE core.certificate_registration_authorization "
+                + "ADD CONSTRAINT fk_certificate_registration_authorization_certificate "
+                + "FOREIGN KEY (certificate_uuid) REFERENCES core.certificate (uuid) ON DELETE CASCADE");
+        persistAuthorization();
+
+        certificateRepository.deleteById(certificateUuid);
+
+        assertThat(authorizationRepository.findByCertificateUuid(certificateUuid)).isEmpty();
+    }
+}

--- a/src/test/java/com/otilm/core/integration/dao/repository/CertificateRegistrationAuthorizationRepositoryITest.java
+++ b/src/test/java/com/otilm/core/integration/dao/repository/CertificateRegistrationAuthorizationRepositoryITest.java
@@ -1,13 +1,13 @@
-package com.otilm.core.dao.repository;
+package com.otilm.core.integration.dao.repository;
 
-import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateRegistrationAuthorization;
 import com.otilm.core.dao.entity.RegistrationState;
+import com.otilm.core.dao.repository.CertificateRegistrationAuthorizationRepository;
+import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Integration coverage for the durable registration-authorization persistence against a real PostgreSQL.
  */
-class CertificateRegistrationAuthorizationRepositoryTest extends BaseSpringBootTest {
+class CertificateRegistrationAuthorizationRepositoryITest extends BaseSpringBootTest {
 
     @Autowired
     private CertificateRegistrationAuthorizationRepository authorizationRepository;
@@ -28,8 +28,6 @@ class CertificateRegistrationAuthorizationRepositoryTest extends BaseSpringBootT
     private CertificateRepository certificateRepository;
     @Autowired
     private PlatformTransactionManager transactionManager;
-    @Autowired
-    private JdbcTemplate jdbcTemplate;
 
     private UUID certificateUuid;
 
@@ -78,22 +76,6 @@ class CertificateRegistrationAuthorizationRepositoryTest extends BaseSpringBootT
         // The @Modifying delete needs an ambient transaction; the repository carries none by convention.
         new TransactionTemplate(transactionManager).executeWithoutResult(
                 status -> authorizationRepository.deleteByCertificateUuid(certificateUuid));
-
-        assertThat(authorizationRepository.findByCertificateUuid(certificateUuid)).isEmpty();
-    }
-
-    @Test
-    void deletingParentCertificateCascadesTheAuthorization() {
-        // The certificate_uuid association is intentionally unmapped, so Hibernate's create-drop test schema omits
-        // the ON DELETE CASCADE foreign key that the migration ships. Recreate it here to exercise the cascade.
-        jdbcTemplate.execute("ALTER TABLE core.certificate_registration_authorization "
-                + "DROP CONSTRAINT IF EXISTS fk_certificate_registration_authorization_certificate");
-        jdbcTemplate.execute("ALTER TABLE core.certificate_registration_authorization "
-                + "ADD CONSTRAINT fk_certificate_registration_authorization_certificate "
-                + "FOREIGN KEY (certificate_uuid) REFERENCES core.certificate (uuid) ON DELETE CASCADE");
-        persistAuthorization();
-
-        certificateRepository.deleteById(certificateUuid);
 
         assertThat(authorizationRepository.findByCertificateUuid(certificateUuid)).isEmpty();
     }

--- a/src/test/java/com/otilm/core/service/registration/RegistrationChallengeStoreTest.java
+++ b/src/test/java/com/otilm/core/service/registration/RegistrationChallengeStoreTest.java
@@ -60,7 +60,8 @@ class RegistrationChallengeStoreTest extends BaseSpringBootTest {
 
     @Test
     void resolvePlaintextRejectsUnpopulatedRow() {
-        assertThatThrownBy(() -> challengeStore.resolvePlaintext(new CertificateRegistrationAuthorization()))
+        CertificateRegistrationAuthorization row = new CertificateRegistrationAuthorization();
+        assertThatThrownBy(() -> challengeStore.resolvePlaintext(row))
                 .isInstanceOf(IllegalStateException.class);
     }
 }

--- a/src/test/java/com/otilm/core/service/registration/RegistrationChallengeStoreTest.java
+++ b/src/test/java/com/otilm/core/service/registration/RegistrationChallengeStoreTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Boots the full context so {@code SecretsUtil}'s static encryption key is injected from
@@ -48,5 +49,12 @@ class RegistrationChallengeStoreTest extends BaseSpringBootTest {
     @Test
     void verifyRejectsWhenNoStoredChallenge() {
         assertThat(challengeStore.verify(new CertificateRegistrationAuthorization(), PLAINTEXT)).isFalse();
+    }
+
+    @Test
+    void storeRejectsMissingChallenge() {
+        CertificateRegistrationAuthorization row = new CertificateRegistrationAuthorization();
+        assertThatThrownBy(() -> challengeStore.store(row, null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> challengeStore.store(row, "   ")).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/otilm/core/service/registration/RegistrationChallengeStoreTest.java
+++ b/src/test/java/com/otilm/core/service/registration/RegistrationChallengeStoreTest.java
@@ -1,0 +1,52 @@
+package com.otilm.core.service.registration;
+
+import com.otilm.core.dao.entity.CertificateRegistrationAuthorization;
+import com.otilm.core.util.BaseSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Boots the full context so {@code SecretsUtil}'s static encryption key is injected from
+ * {@code secrets.encryption.key} in the test {@code application.yml}.
+ */
+class RegistrationChallengeStoreTest extends BaseSpringBootTest {
+
+    private static final String PLAINTEXT = "s3cr3t-challenge-value";
+
+    @Autowired
+    private RegistrationChallengeStore challengeStore;
+
+    @Test
+    void storeEncryptsThenVerifyAndResolveRoundTrip() {
+        CertificateRegistrationAuthorization row = new CertificateRegistrationAuthorization();
+
+        challengeStore.store(row, PLAINTEXT);
+
+        assertThat(row.getChallenge()).isNotNull().isNotEqualTo(PLAINTEXT);
+        assertThat(challengeStore.verify(row, PLAINTEXT)).isTrue();
+        assertThat(challengeStore.resolvePlaintext(row)).isEqualTo(PLAINTEXT);
+    }
+
+    @Test
+    void verifyRejectsWrongValue() {
+        CertificateRegistrationAuthorization row = new CertificateRegistrationAuthorization();
+        challengeStore.store(row, PLAINTEXT);
+
+        assertThat(challengeStore.verify(row, "not-the-challenge")).isFalse();
+    }
+
+    @Test
+    void verifyRejectsNullPresentedValue() {
+        CertificateRegistrationAuthorization row = new CertificateRegistrationAuthorization();
+        challengeStore.store(row, PLAINTEXT);
+
+        assertThat(challengeStore.verify(row, null)).isFalse();
+    }
+
+    @Test
+    void verifyRejectsWhenNoStoredChallenge() {
+        assertThat(challengeStore.verify(new CertificateRegistrationAuthorization(), PLAINTEXT)).isFalse();
+    }
+}

--- a/src/test/java/com/otilm/core/service/registration/RegistrationChallengeStoreTest.java
+++ b/src/test/java/com/otilm/core/service/registration/RegistrationChallengeStoreTest.java
@@ -57,4 +57,10 @@ class RegistrationChallengeStoreTest extends BaseSpringBootTest {
         assertThatThrownBy(() -> challengeStore.store(row, null)).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> challengeStore.store(row, "   ")).isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void resolvePlaintextRejectsUnpopulatedRow() {
+        assertThatThrownBy(() -> challengeStore.resolvePlaintext(new CertificateRegistrationAuthorization()))
+                .isInstanceOf(IllegalStateException.class);
+    }
 }


### PR DESCRIPTION
## What

Adds the durable **registration-authorization** foundation for the external self-service issuance flow (ilm#130): a per-certificate record holding the encrypted challenge, issuance window, failed-attempt lockout, and lifecycle state, plus the service that manages the challenge secret.

New:
- `CertificateRegistrationAuthorization` entity + `RegistrationState` enum — table `certificate_registration_authorization`, 1:1 with the certificate (FK `ON DELETE CASCADE`).
- `CertificateRegistrationAuthorizationRepository` — lookup + a `PESSIMISTIC_WRITE` finder (for the future verify / failed-attempt transaction) + delete.
- `RegistrationChallengeStore` — encrypts (via `SecretsUtil`), verifies **constant-time** (`MessageDigest.isEqual`, not `String.equals`), and resolves the plaintext (internal-only). The plaintext never touches the entity.
- Flyway migration `V202607071200__certificate_registration_authorization.sql`.

## Why a separate record

It coexists with the existing transient `CertificateRegistration` register→issue binding (#1720), which is cleared at issuance. This authorization record **survives** issuance, so a later renew/rekey can be authorized against the same challenge.

## Scope

**Dark / inert** — nothing wires this into the register/issue flow yet (verification is R1b, gated on interfaces#699). No existing files changed.

## Tests

- `RegistrationChallengeStoreTest` — encrypt→verify/resolve round-trip; wrong / null / absent-challenge rejection.
- `CertificateRegistrationAuthorizationRepositoryTest` — persistence, `findByCertificateUuid`, pessimistic finder, delete, and cascade on certificate delete.

8 tests green locally.

Part of #1570.
