### PR TITLE
Split services into internal and external interfaces - part 19

### DIFF
--- a/src/main/java/com/otilm/core/api/web/CertificateControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CertificateControllerImpl.java
@@ -20,7 +20,7 @@ import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.ApprovalExternalService;
 import com.otilm.core.service.CertificateEventHistoryExternalService;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateExternalService;
 import com.otilm.core.service.v2.ClientOperationExternalService;
 import com.otilm.core.util.converter.CertificateFormatConverter;
 import com.otilm.core.util.converter.CertificateFormatEncodingConverter;
@@ -44,7 +44,7 @@ import java.util.UUID;
 @RestController
 public class CertificateControllerImpl implements CertificateController {
 
-    private CertificateService certificateService;
+    private CertificateExternalService certificateService;
 
     private CertificateEventHistoryExternalService certificateEventHistoryService;
 
@@ -244,7 +244,7 @@ public class CertificateControllerImpl implements CertificateController {
     // SETTERs
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateExternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/evaluator/CertificateTriggerEvaluator.java
+++ b/src/main/java/com/otilm/core/evaluator/CertificateTriggerEvaluator.java
@@ -9,7 +9,7 @@ import com.otilm.api.model.core.search.FilterFieldSource;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,10 +20,10 @@ import java.util.*;
 @Transactional
 public class CertificateTriggerEvaluator extends TriggerEvaluator<Certificate> {
 
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -25,7 +25,7 @@ import com.otilm.core.events.transaction.TransactionHandler;
 import com.otilm.core.messaging.jms.producers.ValidationProducer;
 import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.messaging.model.ValidationMessage;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.handler.CertificateHandler;
 import com.otilm.core.tasks.ScheduledJobInfo;
 import com.otilm.core.util.CertificateUtil;
@@ -69,7 +69,7 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
     private TransactionHandler transactionHandler;
     private ValidationProducer validationProducer;
 
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private DiscoveryRepository discoveryRepository;
     private DiscoveryCertificateRepository discoveryCertificateRepository;
 
@@ -94,7 +94,7 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/events/handlers/CertificateUploadedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateUploadedEventHandler.java
@@ -25,7 +25,7 @@ import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
 import com.otilm.core.service.CertificateEventHistoryInternalService;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.util.CertificateUtil;
 import com.otilm.core.util.X509ObjectToString;
 import org.bouncycastle.asn1.x509.Extension;
@@ -46,7 +46,7 @@ public class CertificateUploadedEventHandler extends EventHandler<Certificate> {
     private static final Logger logger = LoggerFactory.getLogger(CertificateUploadedEventHandler.class);
 
     private final CertificateRepository certificateRepository;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private CertificateEventHistoryInternalService certificateEventHistoryService;
     private AttributeEngine attributeEngine;
     private TriggerHistoryRepository triggerHistoryRepository;
@@ -63,7 +63,7 @@ public class CertificateUploadedEventHandler extends EventHandler<Certificate> {
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
@@ -16,7 +16,7 @@ import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.events.transaction.TransactionHandler;
 import com.otilm.core.messaging.jms.configuration.StatusPollProperties;
 import com.otilm.core.messaging.model.CertificateStatusPollMessage;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.handler.authority.AsyncOperationCapability;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapter;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
@@ -68,7 +68,7 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
     private StatusPollProperties statusPollProperties;
     private AttributeEngine attributeEngine;
     private TransactionHandler transactionHandler;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private CertificateRevocationFinalizer revocationFinalizer;
 
     @Override
@@ -405,7 +405,7 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/CertificateExternalService.java
+++ b/src/main/java/com/otilm/core/service/CertificateExternalService.java
@@ -1,0 +1,147 @@
+package com.otilm.core.service;
+
+import com.otilm.api.exception.*;
+import com.otilm.api.model.client.certificate.*;
+import com.otilm.api.model.common.UuidDto;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.core.certificate.*;
+import com.otilm.api.model.core.location.LocationDto;
+import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
+import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.security.authz.SecurityFilter;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.util.List;
+import java.util.UUID;
+
+public interface CertificateExternalService {
+
+    CertificateResponseDto listCertificates(SecurityFilter filter, CertificateSearchRequestDto request);
+
+    CertificateDetailDto getCertificate(SecuredUUID uuid) throws NotFoundException, CertificateException, IOException;
+
+    void deleteCertificate(SecuredUUID uuid) throws NotFoundException;
+
+    CertificateChainResponseDto getCertificateChain(SecuredUUID uuid, boolean withEndCertificate) throws NotFoundException;
+
+    CertificateChainDownloadResponseDto downloadCertificateChain(SecuredUUID uuid, CertificateFormat certificateFormat, boolean withEndCertificate, CertificateFormatEncoding encoding) throws NotFoundException, CertificateException;
+
+    CertificateDownloadResponseDto downloadCertificate(UUID uuid, CertificateFormat certificateFormat, CertificateFormatEncoding encoding) throws CertificateException, NotFoundException, IOException;
+
+    /**
+     * Function to get the validation result of the certificate
+     *
+     * @param uuid UUID of the certificate
+     * @return Certificate Validation result
+     * @throws NotFoundException
+     */
+    CertificateValidationResultDto getCertificateValidationResult(SecuredUUID uuid) throws NotFoundException, CertificateException;
+
+    FingerprintDto uploadAsync(UploadCertificateRequestDto request) throws CertificateException, AlreadyExistException;
+
+    UuidDto uploadSync(UploadCertificateRequestDto request) throws CertificateException, AlreadyExistException;
+
+    List<SearchFieldDataByGroupDto> getSearchableFieldInformationByGroup();
+
+    void bulkDeleteCertificate(SecurityFilter filter, RemoveCertificateDto request) throws NotFoundException, NotSupportedException;
+
+    /**
+     * List all locations associated with the certificate
+     *
+     * @param certificateUuid
+     * @return List of locations
+     * @throws NotFoundException
+     */
+    List<LocationDto> listLocations(SecuredUUID certificateUuid) throws NotFoundException;
+
+    /**
+     * Initiates the compliance check for the certificates in the request
+     *
+     * @param request List of uuids of the certificate
+     */
+    void checkCompliance(CertificateComplianceCheckDto request) throws NotFoundException;
+
+    /**
+     * Update the Certificate Objects contents
+     *
+     * @param uuid    UUID of the certificate
+     * @param request Request for the certificate objects update
+     */
+    void updateCertificateObjects(SecuredUUID uuid, CertificateUpdateObjectsDto request) throws NotFoundException, CertificateOperationException, AttributeException;
+
+    /**
+     * Method to update the Objects of multiple certificates
+     *
+     * @param request Request to update multiple objects
+     */
+    void bulkUpdateCertificatesObjects(SecurityFilter filter, MultipleCertificateObjectUpdateDto request) throws NotFoundException, NotSupportedException;
+
+    /**
+     * Get the list of attributes to generate the CSR
+     *
+     * @return List of attributes to generate the CSR in core
+     */
+    List<BaseAttribute> getCsrGenerationAttributes();
+
+    /**
+     * Get the list of the certificate contents for the provided certificate UUIDs
+     *
+     * @param uuids UUIDs of the certificate
+     * @return List of certificate contents
+     */
+    List<CertificateContentDto> getCertificateContent(List<UUID> uuids);
+
+    /**
+     * Archives a single certificate by its UUID.
+     *
+     * @param uuid the UUID of the certificate to archive
+     */
+    void archiveCertificate(UUID uuid) throws NotFoundException;
+
+    /**
+     * Unarchives a single certificate by its UUID.
+     *
+     * @param uuid the UUID of the certificate to unarchive
+     */
+    void unarchiveCertificate(UUID uuid) throws NotFoundException;
+
+    /**
+     * Archives a list of certificates by their UUIDs.
+     *
+     * @param uuids the list of UUIDs of certificates to archive
+     */
+    void bulkArchiveCertificates(List<UUID> uuids);
+
+    /**
+     * Unarchives a list of certificates by their UUIDs.
+     *
+     * @param uuids the list of UUIDs of certificates to unarchive
+     */
+    void bulkUnarchiveCertificates(List<UUID> uuids);
+
+    /**
+     * Retrieves the relations for the given certificate.
+     *
+     * @param uuid UUID of the certificate whose relations should be retrieved.
+     * @return {@link CertificateRelationsDto} containing related certificates.
+     */
+    CertificateRelationsDto getCertificateRelations(UUID uuid) throws NotFoundException;
+
+    /**
+     * Associates the given certificate with the subject certificate.
+     *
+     * @param uuid            UUID of the subject certificate.
+     * @param certificateUuid UUID of the certificate to associate.
+     */
+    void associateCertificates(UUID uuid, UUID certificateUuid) throws NotFoundException;
+
+    /**
+     * Removes the association between the given certificates
+     *
+     * @param uuid            UUID of the subject certificate.
+     * @param certificateUuid UUID of the certificate
+     */
+    void removeCertificateAssociation(UUID uuid, UUID certificateUuid) throws NotFoundException;
+
+}

--- a/src/main/java/com/otilm/core/service/CertificateInternalService.java
+++ b/src/main/java/com/otilm/core/service/CertificateInternalService.java
@@ -2,16 +2,11 @@ package com.otilm.core.service;
 
 import com.otilm.api.exception.*;
 import com.otilm.api.model.client.attribute.RequestAttribute;
-import com.otilm.api.model.client.certificate.*;
 import com.otilm.api.model.client.dashboard.StatisticsDto;
-import com.otilm.api.model.common.UuidDto;
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
-import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.core.certificate.*;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
-import com.otilm.api.model.core.location.LocationDto;
-import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
 import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
 import com.otilm.core.dao.entity.Certificate;
@@ -23,7 +18,6 @@ import com.otilm.core.model.signing.SigningCertificate;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 
-import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
@@ -33,11 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-public interface CertificateService extends ResourceExtensionService {
-
-    CertificateResponseDto listCertificates(SecurityFilter filter, CertificateSearchRequestDto request);
-
-    CertificateDetailDto getCertificate(SecuredUUID uuid) throws NotFoundException, CertificateException, IOException;
+public interface CertificateInternalService extends ResourceExtensionService {
 
     Certificate getCertificateEntity(SecuredUUID uuid) throws NotFoundException;
 
@@ -50,8 +40,6 @@ public interface CertificateService extends ResourceExtensionService {
     Optional<Certificate> findCertificateEntityByUserUuid(UUID userUuid);
 
     boolean checkCertificateExistsByFingerprint(String fingerprint);
-
-    void deleteCertificate(SecuredUUID uuid) throws NotFoundException;
 
     Certificate createCertificateEntity(X509Certificate certificate);
 
@@ -91,19 +79,6 @@ public interface CertificateService extends ResourceExtensionService {
      */
     SigningCertificate getSigningCertificate(UUID certificateUuid) throws NotFoundException;
 
-    CertificateChainDownloadResponseDto downloadCertificateChain(SecuredUUID uuid, CertificateFormat certificateFormat, boolean withEndCertificate, CertificateFormatEncoding encoding) throws NotFoundException, CertificateException;
-
-    CertificateDownloadResponseDto downloadCertificate(UUID uuid, CertificateFormat certificateFormat, CertificateFormatEncoding encoding) throws CertificateException, NotFoundException, IOException;
-
-    /**
-     * Function to get the validation result of the certificate
-     *
-     * @param uuid UUID of the certificate
-     * @return Certificate Validation result
-     * @throws NotFoundException
-     */
-    CertificateValidationResultDto getCertificateValidationResult(SecuredUUID uuid) throws NotFoundException, CertificateException;
-
     void validate(Certificate certificate);
 
     /**
@@ -115,10 +90,6 @@ public interface CertificateService extends ResourceExtensionService {
      */
     Certificate createCertificate(String certificateData, CertificateType certificateType) throws com.otilm.api.exception.CertificateException;
 
-    FingerprintDto uploadAsync(UploadCertificateRequestDto request) throws CertificateException, AlreadyExistException;
-
-    UuidDto uploadSync(UploadCertificateRequestDto request) throws CertificateException, AlreadyExistException;
-
     Certificate checkCreateCertificate(String certificate) throws AlreadyExistException, CertificateException, NoSuchAlgorithmException;
 
     void uploadCertificateKey(PublicKey publicKey, Certificate certificate, byte[] altPublicKeyEncoded);
@@ -129,19 +100,6 @@ public interface CertificateService extends ResourceExtensionService {
 
     // TODO AUTH - unable to check access based on certificate serial number. Make private? Special permission? Call opa in method?
     void revokeCertificate(String serialNumber);
-
-    List<SearchFieldDataByGroupDto> getSearchableFieldInformationByGroup();
-
-    void bulkDeleteCertificate(SecurityFilter filter, RemoveCertificateDto request) throws NotFoundException, NotSupportedException;
-
-    /**
-     * List all locations associated with the certificate
-     *
-     * @param certificateUuid
-     * @return List of locations
-     * @throws NotFoundException
-     */
-    List<LocationDto> listLocations(SecuredUUID certificateUuid) throws NotFoundException;
 
     /**
      * List the available certificates that are associated with the RA Profile
@@ -160,27 +118,11 @@ public interface CertificateService extends ResourceExtensionService {
     List<Certificate> listCertificatesForRaProfileAndNonNullComplianceStatus(RaProfile raProfile);
 
     /**
-     * Initiates the compliance check for the certificates in the request
-     *
-     * @param request List of uuids of the certificate
-     */
-    void checkCompliance(CertificateComplianceCheckDto request) throws NotFoundException;
-
-    /**
      * Update the Certificate Entity
      *
      * @param certificate Certificate entity to be updated
      */
     void updateCertificateEntity(Certificate certificate);
-
-    /**
-     * Update the Certificate Objects contents
-     *
-     * @param uuid    UUID of the certificate
-     * @param request Request for the certificate objects update
-     */
-    void updateCertificateObjects(SecuredUUID uuid, CertificateUpdateObjectsDto request) throws NotFoundException, CertificateOperationException, AttributeException;
-
 
     /**
      * Method to switch RA profile of a Certificate
@@ -198,7 +140,6 @@ public interface CertificateService extends ResourceExtensionService {
      */
     void updateCertificateGroups(SecuredUUID uuid, Set<UUID> groupUuids) throws NotFoundException;
 
-
     /**
      * Method to change Owner for a Certificate
      *
@@ -206,14 +147,6 @@ public interface CertificateService extends ResourceExtensionService {
      * @param ownerUuid UUID of the certificate owner
      */
     void updateOwner(SecuredUUID uuid, String ownerUuid) throws NotFoundException;
-
-
-    /**
-     * Method to update the Objects of multiple certificates
-     *
-     * @param request Request to update multiple objects
-     */
-    void bulkUpdateCertificatesObjects(SecurityFilter filter, MultipleCertificateObjectUpdateDto request) throws NotFoundException, NotSupportedException;
 
     /**
      * Function to update status of certificates by scheduled event
@@ -274,13 +207,6 @@ public interface CertificateService extends ResourceExtensionService {
     void checkRevokePermissions();
 
     /**
-     * Get the list of attributes to generate the CSR
-     *
-     * @return List of attributes to generate the CSR in core
-     */
-    List<BaseAttribute> getCsrGenerationAttributes();
-
-    /**
      * Unassociate the given key from all the certificates.
      *
      * @param keyUuid UUID of the key object or alternative key object to be unassociated
@@ -302,14 +228,6 @@ public interface CertificateService extends ResourceExtensionService {
      * @throws NotFoundException
      */
     void updateCertificateKeys(UUID keyUuid, String publicKeyFingerprint);
-
-    /**
-     * Get the list of the certificate contents for the provided certificate UUIDs
-     *
-     * @param uuids UUIDs of the certificate
-     * @return List of certificate contents
-     */
-    List<CertificateContentDto> getCertificateContent(List<UUID> uuids);
 
     /**
      * Create certificate request entity and certificate in status New, store it in the database ready for issuing
@@ -373,35 +291,6 @@ public interface CertificateService extends ResourceExtensionService {
      */
     int handleExpiringCertificates();
 
-    /**
-     * Archives a single certificate by its UUID.
-     *
-     * @param uuid the UUID of the certificate to archive
-     */
-    void archiveCertificate(UUID uuid) throws NotFoundException;
-
-    /**
-     * Unarchives a single certificate by its UUID.
-     *
-     * @param uuid the UUID of the certificate to unarchive
-     */
-    void unarchiveCertificate(UUID uuid) throws NotFoundException;
-
-    /**
-     * Archives a list of certificates by their UUIDs.
-     *
-     * @param uuids the list of UUIDs of certificates to archive
-     */
-    void bulkArchiveCertificates(List<UUID> uuids);
-
-    /**
-     * Unarchives a list of certificates by their UUIDs.
-     *
-     * @param uuids the list of UUIDs of certificates to unarchive
-     */
-    void bulkUnarchiveCertificates(List<UUID> uuids);
-
-
     /***
      * Update Subject DN and Issuer DN in certificates when there is a change in code
      * @param oid of RDN to change
@@ -410,28 +299,4 @@ public interface CertificateService extends ResourceExtensionService {
      */
     void updateCertificateDNs(String oid, String newCode, String oldCode);
 
-
-    /**
-     * Retrieves the relations for the given certificate.
-     *
-     * @param uuid UUID of the certificate whose relations should be retrieved.
-     * @return {@link CertificateRelationsDto} containing related certificates.
-     */
-    CertificateRelationsDto getCertificateRelations(UUID uuid) throws NotFoundException;
-
-    /**
-     * Associates the given certificate with the subject certificate.
-     *
-     * @param uuid            UUID of the subject certificate.
-     * @param certificateUuid UUID of the certificate to associate.
-     */
-    void associateCertificates(UUID uuid, UUID certificateUuid) throws NotFoundException;
-
-    /**
-     * Removes the association between the given certificates
-     *
-     * @param uuid            UUID of the subject certificate.
-     * @param certificateUuid UUID of the certificate
-     */
-    void removeCertificateAssociation(UUID uuid, UUID certificateUuid) throws NotFoundException;
 }

--- a/src/main/java/com/otilm/core/service/acme/impl/AcmeServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/acme/impl/AcmeServiceImpl.java
@@ -29,7 +29,7 @@ import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.model.auth.CertificateProtocolInfo;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.security.authz.ProtocolEndpoint;
 import com.otilm.core.service.acme.AcmeConstants;
 import com.otilm.core.service.acme.AcmeExternalService;
@@ -102,7 +102,7 @@ public class AcmeServiceImpl implements AcmeExternalService {
     private AcmeAuthorizationRepository acmeAuthorizationRepository;
     private AcmeChallengeRepository acmeChallengeRepository;
     private ClientOperationInternalService clientOperationService;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private AttributeEngine attributeEngine;
 
     @Autowired
@@ -151,7 +151,7 @@ public class AcmeServiceImpl implements AcmeExternalService {
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/cmp/impl/CmpServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/cmp/impl/CmpServiceImpl.java
@@ -13,7 +13,7 @@ import com.otilm.api.model.core.cmp.ProtectionMethod;
 import com.otilm.api.model.core.logging.enums.Operation;
 import com.otilm.core.dao.entity.cmp.CmpTransaction;
 import com.otilm.core.logging.LoggingHelper;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.cmp.message.CertificateKeyServiceImpl;
 import com.otilm.core.service.cmp.configurations.ConfigurationContext;
 import com.otilm.core.service.cmp.message.CmpTransactionService;
@@ -163,10 +163,10 @@ public class CmpServiceImpl implements CmpExternalService {
 
     // -- OTHERS
     private AttributeEngine attributeEngine;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
 
     @Autowired
-    private void setCertificateService(CertificateService certificateService) {
+    private void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/cmp/message/handler/CrmfMessageHandler.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/handler/CrmfMessageHandler.java
@@ -12,7 +12,7 @@ import com.otilm.api.interfaces.core.cmp.error.CmpProcessingException;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateContent;
 import com.otilm.core.dao.entity.cmp.CmpTransaction;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.cmp.configurations.ConfigurationContext;
 import com.otilm.core.service.cmp.message.CmpTransactionService;
 import com.otilm.core.service.cmp.message.PkiMessageDumper;
@@ -64,10 +64,10 @@ public class CrmfMessageHandler implements MessageHandler<PKIMessage> {
             PKIBody.TYPE_KEY_RECOVERY_REQ,  // krr      [9]  CertReqMessages,       --Key Recovery Req     (not implemented)
             PKIBody.TYPE_CROSS_CERT_REQ);   // ccr      [13] CertReqMessages,       --Cross-Cert.  Request (not implemented)
 
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/cmp/message/handler/PollFeature.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/handler/PollFeature.java
@@ -5,7 +5,7 @@ import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.interfaces.core.cmp.error.CmpProcessingException;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.extern.slf4j.Slf4j;
@@ -31,10 +31,10 @@ public class PollFeature {
     @Value("${cmp.protocol.poll.feature.timeout}")
     private Integer pollFeatureTimeout;
 
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/handler/CertificateHandler.java
+++ b/src/main/java/com/otilm/core/service/handler/CertificateHandler.java
@@ -23,7 +23,7 @@ import com.otilm.core.messaging.model.ValidationMessage;
 import com.otilm.core.service.*;
 import com.otilm.core.util.*;
 import com.otilm.core.service.CertificateEventHistoryInternalService;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.ComplianceInternalService;
 import com.otilm.core.service.CryptographicKeyInternalService;
 import com.otilm.core.util.CertificateUtil;
@@ -58,7 +58,7 @@ public class CertificateHandler {
     private ValidationProducer validationProducer;
 
     private ComplianceInternalService complianceService;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private CertificateEventHistoryInternalService certificateEventHistoryService;
     private CryptographicKeyInternalService cryptographicKeyService;
 
@@ -88,7 +88,7 @@ public class CertificateHandler {
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/impl/CertificateChainServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateChainServiceImpl.java
@@ -4,7 +4,7 @@ import com.otilm.api.exception.NotFoundException;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.service.CertificateChainService;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.writer.CertificateChainWriter;
 import com.otilm.core.util.CertificateUtil;
 import com.otilm.core.util.LdapUtils;
@@ -49,13 +49,13 @@ public class CertificateChainServiceImpl implements CertificateChainService {
 
     private final CertificateRepository certificateRepository;
     private final CertificateChainWriter chainWriter;
-    private final CertificateService certificateService;
+    private final CertificateInternalService certificateService;
 
     @Autowired
     public CertificateChainServiceImpl(
             CertificateRepository certificateRepository,
             CertificateChainWriter chainWriter,
-            @Lazy CertificateService certificateService) {
+            @Lazy CertificateInternalService certificateService) {
         this.certificateRepository = certificateRepository;
         this.chainWriter = chainWriter;
         this.certificateService = certificateService;

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -71,6 +71,7 @@ import com.otilm.core.oid.OidRecord;
 import com.otilm.core.security.authn.client.AuthenticationCache;
 import com.otilm.core.security.authn.client.UserManagementApiClient;
 import com.otilm.core.security.authz.ExternalAuthorization;
+import com.otilm.core.security.authz.ExternalAuthorizationMissing;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
@@ -130,7 +131,7 @@ import java.util.stream.Collectors;
 @Service(Resource.Codes.CERTIFICATE)
 @Transactional
 @Slf4j
-public class CertificateServiceImpl implements CertificateService, AttributeResourceService {
+public class CertificateServiceImpl implements CertificateExternalService, CertificateInternalService, AttributeResourceService {
 
     private static final String UNDEFINED_CERTIFICATE_OBJECT_NAME = "undefined";
 
@@ -790,6 +791,7 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
     }
 
     @Override
+    @ExternalAuthorizationMissing
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformationByGroup() {
         final List<SearchFieldDataByGroupDto> searchFieldDataByGroupDtos = attributeEngine.getResourceSearchableFields(Resource.CERTIFICATE, false);
 
@@ -1368,6 +1370,7 @@ public class CertificateServiceImpl implements CertificateService, AttributeReso
 
     @Override
     @Async
+    @ExternalAuthorizationMissing
     public void checkCompliance(CertificateComplianceCheckDto request) throws NotFoundException {
         for (String uuid : request.getCertificateUuids()) {
             try {

--- a/src/main/java/com/otilm/core/service/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ClientOperationServiceImpl.java
@@ -31,7 +31,7 @@ import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.ClientOperationExternalService;
 import com.otilm.core.service.v2.ConnectorInternalService;
 import com.otilm.core.util.AttributeDefinitionUtils;
@@ -54,7 +54,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
     private RaProfileRepository raProfileRepository;
     private ConnectorApiFactory connectorApiFactory;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private AttributeEngine attributeEngine;
     private ConnectorInternalService connectorService;
 
@@ -69,7 +69,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/impl/CmpProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CmpProfileServiceImpl.java
@@ -28,7 +28,7 @@ import com.otilm.core.security.authz.AnyPrincipalEndpoint;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.CmpProfileExternalService;
 import com.otilm.core.service.CmpProfileInternalService;
 import com.otilm.core.service.RaProfileInternalService;
@@ -61,7 +61,7 @@ public class CmpProfileServiceImpl implements CmpProfileExternalService, CmpProf
     private CmpProfileRepository cmpProfileRepository;
     private RaProfileInternalService raProfileService;
     private ExtendedAttributeService extendedAttributeService;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private AttributeEngine attributeEngine;
     private ProtocolCertificateAssociationsRepository certificateAssociationRepository;
 
@@ -91,7 +91,7 @@ public class CmpProfileServiceImpl implements CmpProfileExternalService, CmpProf
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
@@ -114,7 +114,7 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     private TokenInstanceInternalService tokenInstanceService;
     private CryptographicKeyEventHistoryService keyEventHistoryService;
     private PermissionEvaluator permissionEvaluator;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private ResourceObjectAssociationService objectAssociationService;
     private NotificationProducer notificationProducer;
 
@@ -175,7 +175,7 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -24,7 +24,7 @@ import com.otilm.core.oid.OidHandler;
 import com.otilm.core.oid.OidRecord;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.CustomOidEntryExternalService;
 import com.otilm.core.util.FilterPredicatesBuilder;
 import com.otilm.core.util.RequestValidatorHelper;
@@ -51,10 +51,10 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
 
     public static final String OID_ENTRY = "OID Entry";
     private final CustomOidEntryRepository customOidEntryRepository;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/impl/LocationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/LocationServiceImpl.java
@@ -46,7 +46,7 @@ import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CertificateEventHistoryInternalService;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.LocationExternalService;
 import com.otilm.core.service.LocationInternalService;
 import com.otilm.core.service.PermissionEvaluator;
@@ -89,7 +89,7 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     private RaProfileRepository raProfileRepository;
     private ConnectorApiFactory connectorApiFactory;
     private ConnectorInternalService connectorService;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private ClientOperationInternalService clientOperationService;
     private CertificateEventHistoryInternalService certificateEventHistoryService;
     private AttributeEngine attributeEngine;
@@ -132,7 +132,7 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ScepProfileServiceImpl.java
@@ -51,7 +51,7 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
     private final ScepProfileRepository scepProfileRepository;
     private RaProfileInternalService raProfileService;
     private ExtendedAttributeService extendedAttributeService;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private AttributeEngine attributeEngine;
     private ProtocolCertificateAssociationsRepository certificateAssociationRepository;
 
@@ -81,7 +81,7 @@ public class ScepProfileServiceImpl implements ScepProfileExternalService, ScepP
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SigningProfileServiceImpl.java
@@ -80,7 +80,7 @@ import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.ExternalAuthorizationMissing;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.ConnectorInternalService;
 import com.otilm.core.service.CryptographicOperationInternalService;
 import com.otilm.core.service.RaProfileInternalService;
@@ -126,7 +126,7 @@ public class SigningProfileServiceImpl implements SigningProfileExternalService,
 
     private SigningProfileServiceImpl self;
     private CryptographicOperationInternalService cryptographicOperationService;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private ConnectorInternalService connectorService;
     private TokenProfileInternalService tokenProfileService;
     private RaProfileInternalService raProfileService;
@@ -981,7 +981,7 @@ public class SigningProfileServiceImpl implements SigningProfileExternalService,
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/impl/StatisticsServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/StatisticsServiceImpl.java
@@ -3,7 +3,7 @@ package com.otilm.core.service.impl;
 import com.otilm.api.model.client.dashboard.StatisticsDto;
 import com.otilm.core.security.authz.AnyPrincipalEndpoint;
 import com.otilm.core.security.authz.SecurityFilter;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.DiscoveryInternalService;
 import com.otilm.core.service.GroupInternalService;
 import com.otilm.core.service.RaProfileInternalService;
@@ -25,7 +25,7 @@ public class StatisticsServiceImpl implements StatisticsExternalService {
 
     private static final Logger logger = LoggerFactory.getLogger(StatisticsServiceImpl.class);
 
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private DiscoveryInternalService discoveryService;
     private GroupInternalService groupService;
     private RaProfileInternalService raProfileService;
@@ -80,7 +80,7 @@ public class StatisticsServiceImpl implements StatisticsExternalService {
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/impl/UserManagementServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/UserManagementServiceImpl.java
@@ -62,7 +62,7 @@ public class UserManagementServiceImpl implements UserManagementExternalService,
 
     private UserManagementApiClient userManagementApiClient;
 
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private CertificateUploadService certificateUploadService;
     private GroupExternalService groupService;
     private ResourceObjectAssociationService objectAssociationService;
@@ -100,7 +100,7 @@ public class UserManagementServiceImpl implements UserManagementExternalService,
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
@@ -37,7 +37,7 @@ import com.otilm.core.model.auth.CertificateProtocolInfo;
 import com.otilm.core.provider.PlatformProvider;
 import com.otilm.core.provider.key.PlatformPrivateKey;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.CryptographicKeyInternalService;
 import com.otilm.core.security.authz.ProtocolEndpoint;
 import com.otilm.core.service.scep.ScepExternalService;
@@ -109,7 +109,7 @@ public class ScepServiceImpl implements ScepExternalService {
     private ScepProfileRepository scepProfileRepository;
     private ScepTransactionRepository scepTransactionRepository;
     private ClientOperationInternalService clientOperationService;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private CryptographicKeyInternalService cryptographicKeyService;
     private ConnectorApiFactory connectorApiFactory;
     private AttributeEngine attributeEngine;
@@ -145,7 +145,7 @@ public class ScepServiceImpl implements ScepExternalService {
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -143,7 +143,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     private CertificateRepository certificateRepository;
     private LocationExternalService locationService;
     private LocationInternalService locationInternalService;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private ComplianceInternalService complianceService;
     private CertificateEventHistoryInternalService certificateEventHistoryService;
     private ExtendedAttributeService extendedAttributeService;
@@ -249,7 +249,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/service/writer/CertificateValidationWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/CertificateValidationWriter.java
@@ -3,7 +3,7 @@ package com.otilm.core.service.writer;
 import com.otilm.api.model.core.certificate.CertificateValidationStatus;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.repository.CertificateRepository;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.validation.certificate.X509CertificateValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -18,7 +18,7 @@ import java.util.UUID;
  * <p>Methods use the default propagation ({@code REQUIRED}) — they join an ambient transaction if one is active,
  * or open a new one if no ambient transaction exists.
  *
- * @see CertificateService#validate(Certificate)
+ * @see CertificateInternalService#validate(Certificate)
  * @see X509CertificateValidator
  */
 @Service

--- a/src/main/java/com/otilm/core/signing/tsa/resolver/StaticKeyManagedTimestampingResolver.java
+++ b/src/main/java/com/otilm/core/signing/tsa/resolver/StaticKeyManagedTimestampingResolver.java
@@ -16,7 +16,7 @@ import com.otilm.core.model.signing.scheme.StaticKeyManagedSigning;
 import com.otilm.core.model.signing.timequality.LocalClockTimeQualityConfiguration;
 import com.otilm.core.model.signing.timequality.TimeQualityConfigurationModel;
 import com.otilm.core.model.signing.workflow.ManagedTimestampingWorkflow;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.CryptographicKeyInternalService;
 import com.otilm.core.service.TimeQualityConfigurationInternalService;
 import com.otilm.core.service.v2.ConnectorInternalService;
@@ -40,12 +40,12 @@ import java.util.UUID;
 @Component
 public class StaticKeyManagedTimestampingResolver implements SigningProfileResolver {
 
-    private final CertificateService certificateService;
+    private final CertificateInternalService certificateService;
     private final CryptographicKeyInternalService cryptographicKeyService;
     private final TimeQualityConfigurationInternalService timeQualityConfigurationService;
     private final ConnectorInternalService connectorService;
 
-    public StaticKeyManagedTimestampingResolver(CertificateService certificateService,
+    public StaticKeyManagedTimestampingResolver(CertificateInternalService certificateService,
                                                 CryptographicKeyInternalService cryptographicKeyService,
                                                 TimeQualityConfigurationInternalService timeQualityConfigurationService,
                                                 ConnectorInternalService connectorService) {

--- a/src/main/java/com/otilm/core/tasks/UpdateCertificateStatusTask.java
+++ b/src/main/java/com/otilm/core/tasks/UpdateCertificateStatusTask.java
@@ -4,7 +4,7 @@ import com.otilm.api.model.scheduler.SchedulerJobExecutionStatus;
 import com.otilm.core.dao.repository.acme.AcmeNonceRepository;
 import com.otilm.core.model.ScheduledTaskResult;
 import com.otilm.core.service.ApprovalInternalService;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import jakarta.transaction.Transactional;
 import lombok.NoArgsConstructor;
 import org.slf4j.Logger;
@@ -24,7 +24,7 @@ public class UpdateCertificateStatusTask implements ScheduledJobTask {
     private static final Logger logger = LoggerFactory.getLogger(UpdateCertificateStatusTask.class);
 
     private ApprovalInternalService approvalService;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private AcmeNonceRepository acmeNonceRepository;
 
     public String getDefaultJobName() {
@@ -74,7 +74,7 @@ public class UpdateCertificateStatusTask implements ScheduledJobTask {
     // SETTERs
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/main/java/com/otilm/core/tasks/UpdateIntuneRevocationRequestsTask.java
+++ b/src/main/java/com/otilm/core/tasks/UpdateIntuneRevocationRequestsTask.java
@@ -18,7 +18,7 @@ import com.otilm.core.model.ScheduledTaskResult;
 import com.otilm.core.oid.OidHandler;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.v2.ClientOperationInternalService;
 import com.otilm.core.util.AuthHelper;
 import com.otilm.core.util.PlatformX500NameStyle;
@@ -55,7 +55,7 @@ public class UpdateIntuneRevocationRequestsTask implements ScheduledJobTask {
 
     private ScepProfileRepository scepProfileRepository;
 
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
 
     private ClientOperationInternalService clientOperationService;
 
@@ -77,7 +77,7 @@ public class UpdateIntuneRevocationRequestsTask implements ScheduledJobTask {
     }
 
     @Autowired
-    public void setCertificateService(CertificateService certificateService) {
+    public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/test/java/com/otilm/core/helpers/CertificateUploader.java
+++ b/src/test/java/com/otilm/core/helpers/CertificateUploader.java
@@ -7,7 +7,7 @@ import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.common.UuidDto;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.impl.CertificateServiceImpl;
 import org.springframework.stereotype.Component;
 
 import java.security.cert.CertificateException;
@@ -17,17 +17,21 @@ import static com.otilm.core.util.builders.CertificateUpdateObjectsDtoBuilder.aC
 import static com.otilm.core.util.builders.UploadCertificateRequestDtoBuilder.anUploadCertificateRequest;
 
 /**
- * Uploads X.509 certificates into the platform through {@link CertificateService} and exposes the
+ * Uploads X.509 certificates into the platform through {@link CertificateServiceImpl} and exposes the
  * follow-up actions a test typically needs (marking a CA trusted, running validation). Generation of
  * the certificate is the caller's concern (see {@code CertificateGeneratorHelper}); this class owns the
  * persistence boundary only.
+ *
+ * <p>Depends on the concrete {@code CertificateServiceImpl} rather than either split interface because
+ * it calls methods from both the external face ({@code uploadSync}, {@code updateCertificateObjects},
+ * {@code getCertificateValidationResult}) and the internal face ({@code getCertificateEntity}).</p>
  */
 @Component
 public class CertificateUploader {
 
-    private final CertificateService certificateService;
+    private final CertificateServiceImpl certificateService;
 
-    public CertificateUploader(CertificateService certificateService) {
+    public CertificateUploader(CertificateServiceImpl certificateService) {
         this.certificateService = certificateService;
     }
 

--- a/src/test/java/com/otilm/core/helpers/CertificateUploader.java
+++ b/src/test/java/com/otilm/core/helpers/CertificateUploader.java
@@ -44,7 +44,7 @@ public class CertificateUploader {
         certificateService.updateCertificateObjects(certificate.getSecuredUuid(), aCertificateUpdateObjectsRequest().withTrustedCa(true).build());
     }
 
-    public void validate(Certificate certificate) throws NotFoundException, CertificateException {
+    public void validate(Certificate certificate) throws NotFoundException {
         certificateService.getCertificateValidationResult(certificate.getSecuredUuid());
     }
 }

--- a/src/test/java/com/otilm/core/helpers/TestCertificateAuthority.java
+++ b/src/test/java/com/otilm/core/helpers/TestCertificateAuthority.java
@@ -12,7 +12,7 @@ import java.security.cert.X509Certificate;
 /**
  * Test fixture that establishes a trusted certificate authority inside the platform and issues leaf
  * certificates from it. Certificate material is produced by {@code CertificateGeneratorHelper} (pure
- * crypto) and persisted by {@link CertificateUploader} (the {@code CertificateService} boundary); this
+ * crypto) and persisted by {@link CertificateUploader} (the {@code CertificateServiceImpl} boundary); this
  * class only wires the two together so a test can obtain an uploaded, trusted chain in one call.
  */
 @Component

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
@@ -45,7 +45,7 @@ import com.otilm.core.oid.OidHandler;
 import com.otilm.core.oid.OidRecord;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityResourceFilter;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.*;
@@ -74,7 +74,7 @@ class AttributeEngineITest extends BaseSpringBootTest {
     @Autowired
     private AttributeEngine attributeEngine;
     @Autowired
-    private CertificateService certificateService;
+    private CertificateExternalService certificateService;
     @Autowired
     private CertificateRepository certificateRepository;
     @Autowired

--- a/src/test/java/com/otilm/core/integration/evaluator/TriggerEvaluatorITest.java
+++ b/src/test/java/com/otilm/core/integration/evaluator/TriggerEvaluatorITest.java
@@ -86,7 +86,7 @@ class TriggerEvaluatorITest extends BaseSpringBootTest {
     private CertificateRepository certificateRepository;
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateExternalService certificateService;
 
     @Autowired
     private AttributeExternalService attributeService;

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -59,6 +59,7 @@ import com.otilm.core.messaging.model.NotificationRecipient;
 import com.otilm.core.model.ScheduledTaskResult;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.service.*;
+import com.otilm.core.service.impl.CertificateServiceImpl;
 import com.otilm.core.tasks.DiscoveryCertificateTask;
 import com.otilm.core.util.AuthHelper;
 import com.otilm.core.util.BaseSpringBootTest;
@@ -89,7 +90,7 @@ class EventHandlersITest extends BaseSpringBootTest {
     }
 
     @Autowired
-    private com.otilm.core.service.impl.CertificateServiceImpl certificateService;
+    private CertificateServiceImpl certificateService;
     @Autowired
     private CertificateEventHistoryExternalService certificateEventHistoryService;
     @Autowired

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -89,7 +89,7 @@ class EventHandlersITest extends BaseSpringBootTest {
     }
 
     @Autowired
-    private CertificateService certificateService;
+    private com.otilm.core.service.impl.CertificateServiceImpl certificateService;
     @Autowired
     private CertificateEventHistoryExternalService certificateEventHistoryService;
     @Autowired

--- a/src/test/java/com/otilm/core/integration/tasks/UpdateCertificateStatusTaskITest.java
+++ b/src/test/java/com/otilm/core/integration/tasks/UpdateCertificateStatusTaskITest.java
@@ -19,7 +19,7 @@ import com.otilm.core.messaging.jms.listeners.ValidationListener;
 import com.otilm.core.messaging.jms.producers.ValidationProducer;
 import com.otilm.core.messaging.model.ValidationMessage;
 import com.otilm.core.model.ScheduledTaskResult;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.SettingExternalService;
 import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.tasks.ScheduledJobInfo;
@@ -71,7 +71,7 @@ class UpdateCertificateStatusTaskITest extends BaseSpringBootTest {
     private ValidationListener validationListener;
 
     @MockitoSpyBean
-    private CertificateService mockedCertificateService;
+    private CertificateInternalService mockedCertificateService;
 
     private ScheduledJobInfo scheduledJobInfo;
 

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
@@ -56,7 +56,7 @@ class CertificateStatusPollListenerTest {
     @Mock private StatusPollProperties statusPollProperties;
     @Mock private AttributeEngine attributeEngine;
     @Mock private com.otilm.core.events.transaction.TransactionHandler transactionHandler;
-    @Mock private com.otilm.core.service.CertificateService certificateService;
+    @Mock private com.otilm.core.service.CertificateInternalService certificateService;
     @Mock private com.otilm.core.service.handler.authority.lifecycle.CertificateRevocationFinalizer revocationFinalizer;
     @Mock private com.otilm.core.service.writer.registration.CertificateRegistrationWriter registrationWriter;
 

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateUploadMessagingIntTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateUploadMessagingIntTest.java
@@ -3,7 +3,7 @@ package com.otilm.core.messaging.jms.listeners;
 import com.otilm.api.model.client.certificate.UploadCertificateRequestDto;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.helpers.CertificateGeneratorHelper;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateExternalService;
 import com.otilm.core.util.BaseMessagingIntTest;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +19,7 @@ import static org.awaitility.Awaitility.await;
 /**
  * End-to-end integration test for the certificate upload async flow using a real RabbitMQ container.
  *
- * <p>Flow: {@link CertificateService#uploadAsync} → EventProducer → RabbitMQ exchange/queue →
+ * <p>Flow: {@link CertificateExternalService#uploadAsync} → EventProducer → RabbitMQ exchange/queue →
  * EventListener → CertificateUploadedEventHandler → certificate persisted in DB.</p>
  *
  * <p>Kept separate from {@link JmsListenerIntegrationTest} because that class mocks
@@ -29,7 +29,7 @@ import static org.awaitility.Awaitility.await;
 class CertificateUploadMessagingIntTest extends BaseMessagingIntTest {
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateExternalService certificateService;
 
     @Autowired
     private CertificateRepository certificateRepository;

--- a/src/test/java/com/otilm/core/service/CertificateChainCacheTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateChainCacheTest.java
@@ -39,7 +39,7 @@ import java.util.UUID;
 class CertificateChainCacheTest extends BaseSpringBootTest {
 
     @Autowired
-    private CertificateService certificateService;
+    private com.otilm.core.service.impl.CertificateServiceImpl certificateService;
 
     @MockitoSpyBean
     private CertificateRepository certificateRepository;

--- a/src/test/java/com/otilm/core/service/CertificateChainCacheTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateChainCacheTest.java
@@ -9,6 +9,7 @@ import com.otilm.core.events.handlers.CertificateUploadedEventHandler;
 import com.otilm.core.helpers.CertificateGeneratorHelper;
 import com.otilm.core.messaging.model.CertificateUploadEventMessageData;
 import com.otilm.core.security.authz.SecurityFilter;
+import com.otilm.core.service.impl.CertificateServiceImpl;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.CertificateUtil;
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -39,7 +40,7 @@ import java.util.UUID;
 class CertificateChainCacheTest extends BaseSpringBootTest {
 
     @Autowired
-    private com.otilm.core.service.impl.CertificateServiceImpl certificateService;
+    private CertificateServiceImpl certificateService;
 
     @MockitoSpyBean
     private CertificateRepository certificateRepository;

--- a/src/test/java/com/otilm/core/service/CertificateChainParityTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateChainParityTest.java
@@ -38,8 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Parity tests ensuring that {@link CertificateService#getCertificateChain(SecuredUUID, boolean)}
- * (DTO path) and {@link CertificateService#getCertificateChainForSigning(UUID, boolean)}
+ * Parity tests ensuring that {@link CertificateInternalService#getCertificateChain(SecuredUUID, boolean)}
+ * (DTO path) and {@link CertificateInternalService#getCertificateChainForSigning(UUID, boolean)}
  * (signing hot path) return the same certificate bytes in the same order for every scenario
  * where parity is expected.
  *
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CertificateChainParityTest extends BaseSpringBootTest {
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
 
     @Autowired
     private CertificateRepository certificateRepository;

--- a/src/test/java/com/otilm/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateServiceTest.java
@@ -126,7 +126,7 @@ class CertificateServiceTest extends BaseSpringBootTest {
     private CrlRepository crlRepository;
 
     @Autowired
-    private CertificateService certificateService;
+    private com.otilm.core.service.impl.CertificateServiceImpl certificateService;
 
     @Autowired
     private CertificateRepository certificateRepository;

--- a/src/test/java/com/otilm/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateServiceTest.java
@@ -823,7 +823,7 @@ class CertificateServiceTest extends BaseSpringBootTest {
         }
 
         @Test
-        void deletesAllCertificates_whenBulkRemoving() throws NotFoundException {
+        void deletesAllCertificates_whenBulkRemoving() {
             // given
             List<String> uuids = new ArrayList<>();
             uuids.add(certificate.getUuid().toString());
@@ -852,7 +852,7 @@ class CertificateServiceTest extends BaseSpringBootTest {
         }
 
         @Test
-        void notifiesAndContinues_whenBulkRemoveHasMissingUuid() throws NotFoundException {
+        void notifiesAndContinues_whenBulkRemoveHasMissingUuid() {
             // given
             UUID nonExistentUuid = UUID.randomUUID();
             RemoveCertificateDto request = new RemoveCertificateDto();
@@ -1410,7 +1410,7 @@ class CertificateServiceTest extends BaseSpringBootTest {
     class EventHistory {
 
         @Test
-        void recordsFailedHistory_whenBulkRaProfileUpdateFails() throws NotFoundException, NotSupportedException {
+        void recordsFailedHistory_whenBulkRaProfileUpdateFails() throws NotSupportedException {
             // given
             // The authority of the new RA profile does not identify the certificate,
             // so switching the RA profile fails for every selected certificate.

--- a/src/test/java/com/otilm/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateServiceTest.java
@@ -41,6 +41,7 @@ import com.otilm.core.messaging.jms.producers.NotificationProducer;
 import com.otilm.core.model.auth.CertificateProtocolInfo;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.service.handler.authority.lifecycle.InvalidTransitionException;
+import com.otilm.core.service.impl.CertificateServiceImpl;
 import com.otilm.api.model.core.logging.enums.AuthMethod;
 import com.otilm.core.security.authn.client.AuthenticationCache;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
@@ -126,7 +127,7 @@ class CertificateServiceTest extends BaseSpringBootTest {
     private CrlRepository crlRepository;
 
     @Autowired
-    private com.otilm.core.service.impl.CertificateServiceImpl certificateService;
+    private CertificateServiceImpl certificateService;
 
     @Autowired
     private CertificateRepository certificateRepository;

--- a/src/test/java/com/otilm/core/service/CertificateValidationTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateValidationTest.java
@@ -18,6 +18,7 @@ import com.otilm.api.model.core.settings.PlatformSettingsUpdateDto;
 import com.otilm.core.helpers.CertificateGeneratorHelper;
 import com.otilm.core.messaging.model.CertificateUploadEventMessageData;
 import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.service.impl.CertificateServiceImpl;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.CertificateTestUtil;
 import com.otilm.core.util.CertificateUtil;
@@ -70,7 +71,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 public class CertificateValidationTest extends BaseSpringBootTest {
 
     @Autowired
-    private com.otilm.core.service.impl.CertificateServiceImpl certificateService;
+    private CertificateServiceImpl certificateService;
 
     @Autowired
     private CrlService crlService;

--- a/src/test/java/com/otilm/core/service/CertificateValidationTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateValidationTest.java
@@ -70,7 +70,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 public class CertificateValidationTest extends BaseSpringBootTest {
 
     @Autowired
-    private CertificateService certificateService;
+    private com.otilm.core.service.impl.CertificateServiceImpl certificateService;
 
     @Autowired
     private CrlService crlService;

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceRegisterTest.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceRegisterTest.java
@@ -86,7 +86,7 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
     @Autowired
     private ClientOperationInternalService clientOperationInternalService;
     @Autowired
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     @Autowired
     private CertificateRepository certificateRepository;
     @Autowired

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -110,7 +110,7 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
     private ClientOperationInternalService clientOperationInternalService;
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
 
     @MockitoBean
     private CryptographicOperationInternalService cryptographicOperationService;

--- a/src/test/java/com/otilm/core/service/CmpProfileServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CmpProfileServiceTest.java
@@ -51,7 +51,7 @@ class CmpProfileServiceTest extends BaseSpringBootTest {
     private AttributeEngine attributeEngine;
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateExternalService certificateService;
 
     @Autowired
     private CmpProfileExternalService cmpProfileService;

--- a/src/test/java/com/otilm/core/service/ResourceServiceTest.java
+++ b/src/test/java/com/otilm/core/service/ResourceServiceTest.java
@@ -95,7 +95,7 @@ class ResourceServiceTest extends BaseSpringBootTest {
     private AttributeRelationRepository attributeRelationRepository;
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
 
     private WireMockServer mockServer;
 

--- a/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
+++ b/src/test/java/com/otilm/core/service/ScepProfileServiceTest.java
@@ -57,7 +57,7 @@ class ScepProfileServiceTest extends BaseSpringBootTest {
     private AttributeEngine attributeEngine;
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateExternalService certificateService;
 
     @Autowired
     private ScepProfileExternalService scepProfileService;

--- a/src/test/java/com/otilm/core/service/SchedulerServiceTest.java
+++ b/src/test/java/com/otilm/core/service/SchedulerServiceTest.java
@@ -93,7 +93,7 @@ class SchedulerServiceTest extends BaseSpringBootTest {
     private TriggerAssociationRepository triggerAssociationRepository;
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateExternalService certificateService;
     @Autowired
     private CertificateRepository certificateRepository;
     @Autowired

--- a/src/test/java/com/otilm/core/service/SigningCertificateCacheTest.java
+++ b/src/test/java/com/otilm/core/service/SigningCertificateCacheTest.java
@@ -26,6 +26,7 @@ import com.otilm.core.dao.repository.TokenProfileRepository;
 import com.otilm.core.helpers.CertificateGeneratorHelper;
 import com.otilm.core.messaging.jms.producers.NotificationProducer;
 import com.otilm.core.model.signing.SigningCertificate;
+import com.otilm.core.service.impl.CertificateServiceImpl;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.MetaDefinitions;
 import com.otilm.api.model.core.oid.SystemOid;
@@ -57,7 +58,7 @@ import java.util.UUID;
 class SigningCertificateCacheTest extends BaseSpringBootTest {
 
     @Autowired
-    private com.otilm.core.service.impl.CertificateServiceImpl certificateService;
+    private CertificateServiceImpl certificateService;
 
     @MockitoSpyBean
     private CertificateRepository certificateRepository;

--- a/src/test/java/com/otilm/core/service/SigningCertificateCacheTest.java
+++ b/src/test/java/com/otilm/core/service/SigningCertificateCacheTest.java
@@ -57,7 +57,7 @@ import java.util.UUID;
 class SigningCertificateCacheTest extends BaseSpringBootTest {
 
     @Autowired
-    private CertificateService certificateService;
+    private com.otilm.core.service.impl.CertificateServiceImpl certificateService;
 
     @MockitoSpyBean
     private CertificateRepository certificateRepository;

--- a/src/test/java/com/otilm/core/service/SigningCertificateParityTest.java
+++ b/src/test/java/com/otilm/core/service/SigningCertificateParityTest.java
@@ -55,7 +55,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 class SigningCertificateParityTest extends BaseSpringBootTest {
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     @Autowired
     private CryptographicKeyInternalService cryptographicKeyService;
     @Autowired

--- a/src/test/java/com/otilm/core/service/cmp/message/handler/CrmfMessageHandlerITest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/handler/CrmfMessageHandlerITest.java
@@ -14,7 +14,7 @@ import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.cmp.CmpProfile;
 import com.otilm.core.dao.repository.*;
 import com.otilm.core.dao.repository.cmp.CmpProfileRepository;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.cmp.CmpEntityUtil;
 import com.otilm.core.service.cmp.CmpTestUtil;
 import com.otilm.core.service.cmp.configurations.variants.Mobile3gppProfileContext;
@@ -52,7 +52,7 @@ public class CrmfMessageHandlerITest extends BaseSpringBootTest {
     @Autowired private CmpProfileRepository cmpProfileRepository;
     @Autowired private RaProfileRepository raProfileRepository;
     @Autowired private CertificateKeyServiceImpl certificateKeyService;
-    @Autowired private CertificateService certificateService;
+    @Autowired private CertificateInternalService certificateService;
     @Autowired private CryptographicKeyRepository cryptographicKeyRepository;
     @Autowired private CryptographicKeyItemRepository cryptographicKeyItemRepository;
     @Autowired private TokenInstanceReferenceRepository tokenInstanceReferenceRepository;

--- a/src/test/java/com/otilm/core/service/cmp/message/handler/KurMessageHandlerITest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/handler/KurMessageHandlerITest.java
@@ -12,7 +12,7 @@ import com.otilm.core.dao.entity.*;
 import com.otilm.core.dao.entity.cmp.CmpProfile;
 import com.otilm.core.dao.repository.*;
 import com.otilm.core.dao.repository.cmp.CmpProfileRepository;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.cmp.CmpEntityUtil;
 import com.otilm.core.service.cmp.CmpTestUtil;
 import com.otilm.core.service.cmp.configurations.variants.Mobile3gppProfileContext;
@@ -54,7 +54,7 @@ public class KurMessageHandlerITest extends BaseSpringBootTest {
     @Autowired private CmpProfileRepository cmpProfileRepository;
     @Autowired private RaProfileRepository raProfileRepository;
     @Autowired private CertificateKeyServiceImpl certificateKeyService;
-    @Autowired private CertificateService certificateService;
+    @Autowired private CertificateInternalService certificateService;
     @Autowired private CryptographicKeyRepository cryptographicKeyRepository;
     @Autowired private CryptographicKeyItemRepository cryptographicKeyItemRepository;
     @Autowired private TokenInstanceReferenceRepository tokenInstanceReferenceRepository;

--- a/src/test/java/com/otilm/core/service/cmp/message/handler/PollFeatureTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/handler/PollFeatureTest.java
@@ -5,7 +5,7 @@ import com.otilm.api.interfaces.core.cmp.error.CmpProcessingException;
 import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import jakarta.persistence.EntityManager;
 import org.bouncycastle.asn1.DEROctetString;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,13 +36,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class PollFeatureTest {
 
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private EntityManager entityManager;
     private PollFeature pollFeature;
 
     @BeforeEach
     void setUp() throws Exception {
-        certificateService = Mockito.mock(CertificateService.class);
+        certificateService = Mockito.mock(CertificateInternalService.class);
         entityManager = Mockito.mock(EntityManager.class);
         pollFeature = new PollFeature();
         pollFeature.setCertificateService(certificateService);

--- a/src/test/java/com/otilm/core/service/compliance/CertificateHandlerValidationAndComplianceTest.java
+++ b/src/test/java/com/otilm/core/service/compliance/CertificateHandlerValidationAndComplianceTest.java
@@ -9,7 +9,7 @@ import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateEventHistory;
 import com.otilm.core.dao.repository.CertificateEventHistoryRepository;
 import com.otilm.core.helpers.CertificateGeneratorHelper;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateExternalService;
 import com.otilm.core.service.handler.CertificateHandler;
 import com.otilm.core.util.RabbitMQContainerFactory;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -67,7 +67,7 @@ class CertificateHandlerValidationAndComplianceTest extends BaseComplianceTest {
     private CertificateHandler certificateHandler;
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateExternalService certificateService;
 
     @Autowired
     private CertificateEventHistoryRepository certificateEventHistoryRepository;

--- a/src/test/java/com/otilm/core/service/compliance/ComplianceServiceTest.java
+++ b/src/test/java/com/otilm/core/service/compliance/ComplianceServiceTest.java
@@ -33,7 +33,7 @@ import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.opa.dto.OpaRequestedResource;
 import com.otilm.core.security.authz.opa.dto.OpaResourceAccessResult;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateExternalService;
 import com.otilm.core.service.ComplianceExternalService;
 import com.otilm.core.service.ComplianceInternalService;
 import com.otilm.core.service.v2.ClientOperationExternalService;
@@ -61,7 +61,7 @@ class ComplianceServiceTest extends BaseComplianceTest {
     private ComplianceExternalService complianceExternalService;
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateExternalService certificateService;
 
     @Autowired
     private CertificateUploadedEventHandler certificateUploadedEventHandler;

--- a/src/test/java/com/otilm/core/service/impl/StatisticsServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/impl/StatisticsServiceImplTest.java
@@ -18,7 +18,7 @@ class StatisticsServiceImplTest {
 
     private StatisticsServiceImpl statisticsService;
 
-    @Mock private CertificateService certificateService;
+    @Mock private CertificateInternalService certificateService;
     @Mock private DiscoveryInternalService discoveryService;
     @Mock private GroupInternalService groupService;
     @Mock private RaProfileInternalService raProfileService;

--- a/src/test/java/com/otilm/core/service/impl/UpdateTrustedCaMarkTest.java
+++ b/src/test/java/com/otilm/core/service/impl/UpdateTrustedCaMarkTest.java
@@ -18,7 +18,7 @@ import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
 import com.otilm.core.events.transaction.CertificateValidationEvent;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateExternalService;
 import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,7 +63,7 @@ class UpdateTrustedCaMarkTest extends BaseSpringBootTest {
     }
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateExternalService certificateService;
     @Autowired
     private CertificateRepository certificateRepository;
     @Autowired

--- a/src/test/java/com/otilm/core/service/signingprofile/SigningProfileTestBase.java
+++ b/src/test/java/com/otilm/core/service/signingprofile/SigningProfileTestBase.java
@@ -57,7 +57,7 @@ import com.otilm.core.dao.repository.signing.SigningProfileRepository;
 import com.otilm.core.dao.repository.signing.SigningProfileVersionRepository;
 import com.otilm.core.dao.repository.signing.TspProfileRepository;
 import com.otilm.core.security.authz.SecuredUUID;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.SigningProfileExternalService;
 import com.otilm.core.service.SigningProfileInternalService;
 import com.otilm.core.service.TimeQualityConfigurationExternalService;
@@ -120,7 +120,7 @@ abstract class SigningProfileTestBase extends BaseSpringBootTest {
     protected CertificateRepository certificateRepository;
 
     @Autowired
-    protected CertificateService certificateService;
+    protected CertificateInternalService certificateService;
 
     @Autowired
     protected SigningProfileRepository signingProfileRepository;

--- a/src/test/java/com/otilm/core/service/v2/impl/ClientOperationServiceImplRegisterBoundIssueTest.java
+++ b/src/test/java/com/otilm/core/service/v2/impl/ClientOperationServiceImplRegisterBoundIssueTest.java
@@ -26,7 +26,7 @@ import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.exception.ConnectorAcceptedButLocalFailureException;
 import com.otilm.core.messaging.jms.producers.EventProducer;
 import com.otilm.core.service.CertificateEventHistoryInternalService;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.handler.ConnectorCapabilityService;
 import com.otilm.core.service.handler.authority.AdapterOperationResult;
 import com.otilm.core.service.handler.authority.AsyncOperationCapability;
@@ -75,7 +75,7 @@ class ClientOperationServiceImplRegisterBoundIssueTest {
     private CertificateRegistrationWriter certificateRegistrationWriter;
     private AuthorityProviderAdapterFactory adapterFactory;
     private ConnectorCapabilityService capabilityService;
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     private PlatformTransactionManager transactionManager;
     private CertificateStateMachine stateMachine;
     private AttributeEngine attributeEngine;
@@ -119,7 +119,7 @@ class ClientOperationServiceImplRegisterBoundIssueTest {
         certificateRegistrationWriter = mock(CertificateRegistrationWriter.class);
         adapterFactory = mock(AuthorityProviderAdapterFactory.class);
         capabilityService = mock(ConnectorCapabilityService.class);
-        certificateService = mock(CertificateService.class);
+        certificateService = mock(CertificateInternalService.class);
         transactionManager = mock(PlatformTransactionManager.class);
         stateMachine = mock(CertificateStateMachine.class);
         attributeEngine = mock(AttributeEngine.class);

--- a/src/test/java/com/otilm/core/signing/tsa/resolver/StaticKeyManagedTimestampingResolverTest.java
+++ b/src/test/java/com/otilm/core/signing/tsa/resolver/StaticKeyManagedTimestampingResolverTest.java
@@ -24,7 +24,7 @@ import com.otilm.core.model.signing.timequality.TimeQualityConfigurationModel;
 import com.otilm.core.model.signing.workflow.DelegatedRawSigningWorkflow;
 import com.otilm.core.model.signing.workflow.ManagedTimestampingWorkflow;
 import com.otilm.core.model.signing.workflow.SigningWorkflow;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.CryptographicKeyInternalService;
 import com.otilm.core.service.TimeQualityConfigurationInternalService;
 import com.otilm.core.service.v2.ConnectorInternalService;
@@ -57,7 +57,7 @@ import static org.mockito.Mockito.when;
 class StaticKeyManagedTimestampingResolverTest {
 
     @Mock
-    private CertificateService certificateService;
+    private CertificateInternalService certificateService;
     @Mock
     private CryptographicKeyInternalService cryptographicKeyService;
     @Mock

--- a/src/test/java/com/otilm/core/util/FilterPredicatesBuilderTest.java
+++ b/src/test/java/com/otilm/core/util/FilterPredicatesBuilderTest.java
@@ -41,7 +41,7 @@ import com.otilm.core.enums.FilterField;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.AttributeExternalService;
 import com.otilm.core.service.AuditLogExternalService;
-import com.otilm.core.service.CertificateService;
+import com.otilm.core.service.impl.CertificateServiceImpl;
 import com.otilm.core.service.CryptographicKeyExternalService;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -95,7 +95,7 @@ class FilterPredicatesBuilderTest extends BaseSpringBootTest {
     private AttributeEngine attributeEngine;
 
     @Autowired
-    private CertificateService certificateService;
+    private CertificateServiceImpl certificateService;
 
     @Autowired
     private CertificateRepository certificateRepository;

--- a/src/test/resources/archunit_store/dc319b8f-4aa8-4995-960d-775b2144f2a2
+++ b/src/test/resources/archunit_store/dc319b8f-4aa8-4995-960d-775b2144f2a2
@@ -1,4 +1,6 @@
 Method <com.otilm.core.service.impl.AttributeServiceImpl.getResources()> is annotated with @ExternalAuthorizationMissing in (AttributeServiceImpl.java:316)
+Method <com.otilm.core.service.impl.CertificateServiceImpl.checkCompliance(com.otilm.api.model.client.certificate.CertificateComplianceCheckDto)> is annotated with @ExternalAuthorizationMissing in (CertificateServiceImpl.java:1375)
+Method <com.otilm.core.service.impl.CertificateServiceImpl.getSearchableFieldInformationByGroup()> is annotated with @ExternalAuthorizationMissing in (CertificateServiceImpl.java:796)
 Method <com.otilm.core.service.impl.ConnectorServiceImpl.checkHealth(com.otilm.core.security.authz.SecuredUUID)> is annotated with @ExternalAuthorizationMissing in (ConnectorServiceImpl.java:222)
 Method <com.otilm.core.service.impl.CryptographicKeyServiceImpl.compromiseKeyItems(com.otilm.api.model.client.cryptography.key.BulkCompromiseKeyItemRequestDto)> is annotated with @ExternalAuthorizationMissing in (CryptographicKeyServiceImpl.java:861)
 Method <com.otilm.core.service.impl.CryptographicKeyServiceImpl.destroyKeyItems(java.util.List)> is annotated with @ExternalAuthorizationMissing in (CryptographicKeyServiceImpl.java:746)


### PR DESCRIPTION
Split CertificateService (the last Mixed service in the series) into a flat CertificateExternalService (24 controller-callable methods) and a CertificateInternalService extends ResourceExtensionService (44 methods, incl. the dual getCertificateChain). CertificateServiceImpl now implements both faces plus AttributeResourceService; two controller-reachable but previously unannotated methods (getSearchableFieldInformationByGroup, checkCompliance) gain @ExternalAuthorizationMissing and are recorded in the ArchUnit freeze store (15 -> 17). Every consumer is repointed to the single interface it uses and the old CertificateService interface is removed. Behavior is preserved exactly; Javadoc moved verbatim.