### PR TITLE
Move signing/ tests into integration root - part 7

### DIFF
--- a/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
+++ b/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
@@ -126,7 +126,7 @@ class CiTestSplitTest {
      * fragments — a substring match would wrongly exempt e.g. any path merely containing "api".
      */
     private static final Set<String> MIGRATION_ALLOWLIST = Set.of(
-            "service", "util", "signing", "messaging");
+            "service", "util", "messaging");
 
     /**
      * Root-level test files live directly in com/otilm/core (no sub-package) — e.g. ApplicationTests,

--- a/src/test/java/com/otilm/core/integration/signing/record/BestEffortSigningRecordStrategyITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/record/BestEffortSigningRecordStrategyITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.signing.record;
+package com.otilm.core.integration.signing.record;
 
 import com.otilm.api.model.client.signing.profile.scheme.SigningScheme;
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
@@ -9,6 +9,9 @@ import com.otilm.core.dao.repository.signing.SigningProfileRepository;
 import com.otilm.core.dao.repository.signing.SigningProfileVersionRepository;
 import com.otilm.core.dao.repository.signing.SigningRecordRepository;
 import com.otilm.core.model.signing.SigningProfileModel;
+import com.otilm.core.signing.record.BestEffortSigningRecordStrategy;
+import com.otilm.core.signing.record.SigningRecordBestEffortFlusher;
+import com.otilm.core.signing.record.SigningRecordInputSources;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * foreign key) and reads back field-for-field — through the jsonb and {@code byte[]} columns a mocked repository
  * would only echo.
  */
-class BestEffortSigningRecordStrategyTest extends BaseSpringBootTest {
+class BestEffortSigningRecordStrategyITest extends BaseSpringBootTest {
 
     private static final Duration FLUSH_DEADLINE = Duration.ofSeconds(10);
 

--- a/src/test/java/com/otilm/core/integration/signing/record/DeferredDurableSigningRecordStrategyITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/record/DeferredDurableSigningRecordStrategyITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.signing.record;
+package com.otilm.core.integration.signing.record;
 
 import com.otilm.api.model.client.signing.profile.scheme.SigningScheme;
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
@@ -8,6 +8,9 @@ import com.otilm.core.dao.repository.signing.SigningProfileRepository;
 import com.otilm.core.dao.repository.signing.SigningRecordOutboxRepository;
 import com.otilm.core.dao.repository.signing.SigningRecordRepository;
 import com.otilm.core.model.signing.SigningProfileModel;
+import com.otilm.core.signing.record.DeferredDurableSigningRecordStrategy;
+import com.otilm.core.signing.record.SigningRecordInputSources;
+import com.otilm.core.signing.record.SigningRecordOutboxDrainer;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * back field-for-field through the jsonb and {@code byte[]} columns a mocked writer would only echo, and a
  * constraint violation propagates to the caller leaving nothing staged.
  */
-class DeferredDurableSigningRecordStrategyTest extends BaseSpringBootTest {
+class DeferredDurableSigningRecordStrategyITest extends BaseSpringBootTest {
 
     @Autowired
     private DeferredDurableSigningRecordStrategy strategy;

--- a/src/test/java/com/otilm/core/integration/signing/record/ImmediateSigningRecordStrategyITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/record/ImmediateSigningRecordStrategyITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.signing.record;
+package com.otilm.core.integration.signing.record;
 
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.client.signing.profile.scheme.SigningScheme;
@@ -13,6 +13,9 @@ import com.otilm.core.model.signing.SigningProfileModel;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.SigningRecordExternalService;
+import com.otilm.core.signing.record.ImmediateSigningRecordStrategy;
+import com.otilm.core.signing.record.SigningRecordInput;
+import com.otilm.core.signing.record.SigningRecordInputSources;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * a real database can prove lives here: a recorded input lands directly in {@code signing_record} and reads
  * back field-for-field through the jsonb and {@code byte[]} columns a mocked writer would only echo.
  */
-class ImmediateSigningRecordStrategyTest extends BaseSpringBootTest {
+class ImmediateSigningRecordStrategyITest extends BaseSpringBootTest {
 
     @Autowired
     private ImmediateSigningRecordStrategy strategy;

--- a/src/test/java/com/otilm/core/integration/signing/record/SigningRecordEndToEndITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/record/SigningRecordEndToEndITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.signing.record;
+package com.otilm.core.integration.signing.record;
 
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.client.signing.profile.record.SigningRecordPersistenceMode;
@@ -17,6 +17,10 @@ import com.otilm.core.model.signing.SigningProfileModel;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.SigningRecordExternalService;
+import com.otilm.core.signing.record.SigningRecordBestEffortFlusher;
+import com.otilm.core.signing.record.SigningRecordInputSources;
+import com.otilm.core.signing.record.SigningRecordOutboxDrainer;
+import com.otilm.core.signing.record.SigningRecordStrategyFactory;
 import com.otilm.core.util.BaseSpringBootTest;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -38,8 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * {@link SigningRecordPersistenceMode}: a write goes through the {@link SigningRecordStrategyFactory}-selected
  * strategy and ends up as a {@code signing_record} row, by whichever route the mode dictates. Each strategy, the
  * outbox drainer and the best-effort flusher are pinned in isolation elsewhere
- * ({@code ImmediateSigningRecordStrategyTest}, {@code DeferredDurableSigningRecordStrategyTest},
- * {@code SigningRecordOutboxDrainerTest}, {@code BestEffortSigningRecordStrategyTest}); what these tests alone
+ * ({@code ImmediateSigningRecordStrategyITest}, {@code DeferredDurableSigningRecordStrategyITest},
+ * {@code SigningRecordOutboxDrainerITest}, {@code BestEffortSigningRecordStrategyITest}); what these tests alone
  * prove is that the factory routes each mode to the right strategy, the mode's stages chain into one persisted
  * record, and the mode's lifecycle counters advance:
  *
@@ -51,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *         {@link SigningRecordBestEffortFlusher} thread.</li>
  * </ul>
  */
-class SigningRecordEndToEndTest extends BaseSpringBootTest {
+class SigningRecordEndToEndITest extends BaseSpringBootTest {
 
     private static final Duration FLUSH_DEADLINE = Duration.ofSeconds(10);
 

--- a/src/test/java/com/otilm/core/integration/signing/record/SigningRecordOutboxDrainerITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/record/SigningRecordOutboxDrainerITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.signing.record;
+package com.otilm.core.integration.signing.record;
 
 import com.otilm.api.model.client.signing.profile.scheme.SigningScheme;
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
@@ -12,6 +12,9 @@ import com.otilm.core.dao.repository.signing.SigningProfileVersionRepository;
 import com.otilm.core.dao.repository.signing.SigningRecordOutboxRepository;
 import com.otilm.core.dao.repository.signing.SigningRecordRepository;
 import com.otilm.core.service.writer.signingrecord.SigningRecordWriter;
+import com.otilm.core.signing.record.SigningRecordOutboxBuilder;
+import com.otilm.core.signing.record.SigningRecordOutboxDrainScheduler;
+import com.otilm.core.signing.record.SigningRecordOutboxDrainer;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         "signing-record.outbox.max-batch-size=2",
         "signing-record.outbox.poison-threshold=3"
 })
-class SigningRecordOutboxDrainerTest extends BaseSpringBootTest {
+class SigningRecordOutboxDrainerITest extends BaseSpringBootTest {
 
     private static final int MAX_BATCH_SIZE = 2;
     private static final int POISON_THRESHOLD = 3;

--- a/src/test/java/com/otilm/core/integration/signing/record/SigningRecordRetentionSweeperITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/record/SigningRecordRetentionSweeperITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.signing.record;
+package com.otilm.core.integration.signing.record;
 
 import com.otilm.api.model.client.signing.profile.scheme.SigningScheme;
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
@@ -9,6 +9,7 @@ import com.otilm.core.dao.entity.signing.SigningRecord;
 import com.otilm.core.dao.repository.signing.SigningProfileRepository;
 import com.otilm.core.dao.repository.signing.SigningProfileVersionRepository;
 import com.otilm.core.dao.repository.signing.SigningRecordRepository;
+import com.otilm.core.signing.record.SigningRecordRetentionSweeper;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +21,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class SigningRecordRetentionSweeperTest extends BaseSpringBootTest {
+class SigningRecordRetentionSweeperITest extends BaseSpringBootTest {
 
     @Autowired
     private SigningRecordRetentionSweeper sweeper;

--- a/src/test/java/com/otilm/core/integration/signing/record/SigningRecordRetrievalHookITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/record/SigningRecordRetrievalHookITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.signing.record;
+package com.otilm.core.integration.signing.record;
 
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.client.signing.profile.scheme.SigningScheme;
@@ -10,6 +10,7 @@ import com.otilm.core.dao.entity.signing.SigningRecord;
 import com.otilm.core.dao.repository.signing.SigningProfileRepository;
 import com.otilm.core.dao.repository.signing.SigningProfileVersionRepository;
 import com.otilm.core.dao.repository.signing.SigningRecordRepository;
+import com.otilm.core.signing.record.SigningRecordRetrievalHook;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -26,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class SigningRecordRetrievalHookTest extends BaseSpringBootTest {
+class SigningRecordRetrievalHookITest extends BaseSpringBootTest {
 
     @Autowired
     private SigningRecordRetrievalHook hook;

--- a/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceAuthzITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceAuthzITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.signing.tsa;
+package com.otilm.core.integration.signing.tsa;
 
 import com.otilm.api.interfaces.core.tsp.error.TspException;
 import com.otilm.api.interfaces.core.tsp.error.TspFailureInfo;
@@ -21,6 +21,8 @@ import com.otilm.core.model.signing.resolved.ResolvedStaticKeyManagedSigning;
 import com.otilm.core.model.signing.timequality.LocalClockTimeQualityConfiguration;
 import com.otilm.core.security.authz.opa.dto.OpaRequestedResource;
 import com.otilm.core.security.authz.opa.dto.OpaResourceAccessResult;
+import com.otilm.core.signing.tsa.ManagedTimestampEngine;
+import com.otilm.core.signing.tsa.TsaExternalService;
 import com.otilm.core.signing.tsa.messages.TspResponse;
 import com.otilm.core.signing.tsa.resolver.SigningProfileResolverFactory;
 import com.otilm.core.util.BaseSpringBootTest;
@@ -44,7 +46,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class TsaServiceAuthzTest extends BaseSpringBootTest {
+class TsaServiceAuthzITest extends BaseSpringBootTest {
 
     @Autowired
     private TsaExternalService tsaService;

--- a/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceImplITest.java
+++ b/src/test/java/com/otilm/core/integration/signing/tsa/TsaServiceImplITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.signing.tsa;
+package com.otilm.core.integration.signing.tsa;
 
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.interfaces.core.tsp.error.TspFailureInfo;
@@ -25,6 +25,9 @@ import com.otilm.core.service.TokenInstanceExternalService;
 import com.otilm.core.service.TokenProfileExternalService;
 import com.otilm.core.service.TspProfileExternalService;
 import com.otilm.core.service.v2.ConnectorExternalService;
+import com.otilm.core.signing.tsa.ManagedTimestampEngine;
+import com.otilm.core.signing.tsa.TimestampTokenTestUtil;
+import com.otilm.core.signing.tsa.TsaExternalService;
 import com.otilm.core.signing.tsa.messages.TspRequest;
 import com.otilm.core.signing.tsa.messages.TspResponse;
 import com.otilm.core.signing.tsa.validator.TspRequestValidationException;
@@ -67,7 +70,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * <p>The formatting returns a pre-built, structurally valid timestamp token; the profiles disable
  * token-signature validation, so the token need not cryptographically verify against the signing certificate.
  */
-class TsaServiceImplTest extends BaseSpringBootTest {
+class TsaServiceImplITest extends BaseSpringBootTest {
 
     @Autowired
     private TsaExternalService tsaService;

--- a/src/test/java/com/otilm/core/service/writer/signingrecord/SigningRecordWriterTest.java
+++ b/src/test/java/com/otilm/core/service/writer/signingrecord/SigningRecordWriterTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * caller. For {@code deleteExpiredBatch} the {@code limit} bounds a single batch, which is the signal the
  * sweeper uses to detect a full batch and keep looping; {@code deleteByUuid} removes the single
  * operator-selected row. The writer's inbound and drain paths are covered through the strategy integration
- * tests and {@code SigningRecordOutboxDrainerTest}.
+ * tests and {@code SigningRecordOutboxDrainerITest}.
  */
 class SigningRecordWriterTest extends BaseSpringBootTest {
 

--- a/src/test/java/com/otilm/core/signing/record/DeferredDurableSigningRecordStrategyUnitTest.java
+++ b/src/test/java/com/otilm/core/signing/record/DeferredDurableSigningRecordStrategyUnitTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
  * stage-2 persist is the drainer's job, so no {@code persist} meter is touched here. Like the immediate
  * strategy it does not swallow failures: a staging failure ticks {@code intake.failed{save_error}} and
  * propagates. Persistence wiring (the row landing in {@code signing_record_outbox}, field fidelity through
- * jsonb/byte[] columns) is covered against the real context in {@link DeferredDurableSigningRecordStrategyTest}.
+ * jsonb/byte[] columns) is covered against the real context in {@link com.otilm.core.integration.signing.record.DeferredDurableSigningRecordStrategyITest}.
  */
 class DeferredDurableSigningRecordStrategyUnitTest {
 

--- a/src/test/java/com/otilm/core/signing/record/ImmediateSigningRecordStrategyUnitTest.java
+++ b/src/test/java/com/otilm/core/signing/record/ImmediateSigningRecordStrategyUnitTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
  * strategy it has no queue and does not swallow persistence failures — they propagate to the caller, and the
  * failure ticks both the stage-2 {@code persist.failed} and the stage-1 {@code intake.failed{persist_error}}.
  * Persistence wiring (mapper output, columns, transaction) is covered against the real context in
- * {@link ImmediateSigningRecordStrategyTest}.
+ * {@link com.otilm.core.integration.signing.record.ImmediateSigningRecordStrategyITest}.
  */
 class ImmediateSigningRecordStrategyUnitTest {
 

--- a/src/test/java/com/otilm/core/signing/record/SigningRecordOutboxDrainerUnitTest.java
+++ b/src/test/java/com/otilm/core/signing/record/SigningRecordOutboxDrainerUnitTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
  * {@link SigningRecordWriter#recordFailure(java.util.UUID, String)} while healthy rows are still drained. A batch
  * whose bulk load returns empty (all rows already gone) is skipped without touching the writer. Poison exclusion
  * lives in the claim query; per-row transaction isolation, idempotent copy, and field fidelity are covered
- * against a real database in {@link SigningRecordOutboxDrainerTest}.
+ * against a real database in {@link com.otilm.core.integration.signing.record.SigningRecordOutboxDrainerITest}.
  */
 class SigningRecordOutboxDrainerUnitTest {
 

--- a/src/test/java/com/otilm/core/signing/record/SigningRecordRetentionSweeperUnitTest.java
+++ b/src/test/java/com/otilm/core/signing/record/SigningRecordRetentionSweeperUnitTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.*;
  * Pure unit test for {@link SigningRecordRetentionSweeper} over a mocked per-batch writer and cluster
  * synchronizer. Covers the lock gate, the per-sweep batch cap (which bounds how long the advisory lock and
  * its enclosing transaction stay open), the empty backlog, and the failure path with its metrics. The actual
- * retention SQL is covered against a real database in {@link SigningRecordRetentionSweeperTest}.
+ * retention SQL is covered against a real database in {@link com.otilm.core.integration.signing.record.SigningRecordRetentionSweeperITest}.
  */
 class SigningRecordRetentionSweeperUnitTest {
 


### PR DESCRIPTION
## What

PR 7 of the per-package integration-test migration series (#1710). Moves the **9 context-loading test classes of the `signing/` package** into the single integration root `com.otilm.core.integration.**`, renames them `*ITest`, and drops the `signing` entry from the `CiTestSplitTest` `MIGRATION_ALLOWLIST`.

| From | To |
|---|---|
| `signing/record/BestEffortSigningRecordStrategyTest` | `integration/signing/record/BestEffortSigningRecordStrategyITest` |
| `signing/record/DeferredDurableSigningRecordStrategyTest` | `integration/signing/record/DeferredDurableSigningRecordStrategyITest` |
| `signing/record/ImmediateSigningRecordStrategyTest` | `integration/signing/record/ImmediateSigningRecordStrategyITest` |
| `signing/record/SigningRecordEndToEndTest` | `integration/signing/record/SigningRecordEndToEndITest` |
| `signing/record/SigningRecordOutboxDrainerTest` | `integration/signing/record/SigningRecordOutboxDrainerITest` |
| `signing/record/SigningRecordRetentionSweeperTest` | `integration/signing/record/SigningRecordRetentionSweeperITest` |
| `signing/record/SigningRecordRetrievalHookTest` | `integration/signing/record/SigningRecordRetrievalHookITest` |
| `signing/tsa/TsaServiceAuthzTest` | `integration/signing/tsa/TsaServiceAuthzITest` |
| `signing/tsa/TsaServiceImplTest` | `integration/signing/tsa/TsaServiceImplITest` |

## Why

Establishes each context-loading test under the integration root so the three-way CI split (`test-services` / `test-non-services` / `test-integration`, #1693) routes it into the integration leg and its coverage lands in the right JaCoCo artifact. Follows #1709 (`migration/`), #1715 (`search/`), #1719 (`tasks/`, `events/`, `dao/`, `repository/`), #1722 (`config/` et al.), #1726 (`attribute/`, `model/`, `cryptography/`) and #1731 (`security/`, `api/`).

## Classification

All 9 classes `extend BaseSpringBootTest` → **pure integration (9/9)**. No pure-unit methods, so a straight move + rename with no class splitting. The `signing/` package's remaining 27 pure-unit tests (`*UnitTest`, `BestEffortSigningRecordQueueTest`, the `tsa/**` unit tests, etc.) and 6 test helpers (`SigningRecordInputBuilder`, `SigningRecordInputSources`, `SigningRecordOutboxBuilder`, `tsa/messages/TspRequestBuilder`, `tsa/TimestampTokenTestUtil`, `tsa/timequality/builders/TimeQualityResultBuilder`) stay in place.

Same-package production/helper references that no longer resolved after the move gained explicit imports (the signing strategies, drainer/scheduler/sweeper/retrieval-hook, `SigningRecordInput`/`SigningRecordInputSources`/`SigningRecordOutboxBuilder`; and `ManagedTimestampEngine`/`TsaExternalService`/`TimestampTokenTestUtil`). All referenced siblings are `public`, so no visibility widening was needed.

## Review follow-ups folded in

- Repointed the four `record/*UnitTest` `{@link ...Test}` companion references and the intra-class `{@code ...Test}` references in `SigningRecordEndToEndITest` to the moved, renamed `*ITest` classes.
- Repointed the `{@code SigningRecordOutboxDrainerTest}` reference in `service/writer/signingrecord/SigningRecordWriterTest` to `SigningRecordOutboxDrainerITest`.

## Verification

- Baseline full suite green before the change (3758 tests, 0 failures, 0 errors, 2 skipped).
- Full suite green after the change: **3758 tests, 0 failures, 0 errors, 2 skipped** — identical (move+rename preserves count).
- `mvn test-compile` clean; all 9 moved classes + the 5 touched sibling files + `CiTestSplitTest` + `TestClassTaxonomyTest` green.
- `CiTestSplitTest` guards pass with `signing` removed — including the self-prune guard that fails if an allowlist entry has no remaining pending context test, and the guard that fails if a context-loading test class remains outside `com.otilm.core.integration.**` for an already-migrated package.
- All 9 moves are git-tracked renames (94–98% similarity) — `git log`/`git blame` history preserved.

## Scope note

Redundant-test triage (#1645), test-style modernization (the `record/` package still uses JUnit `Assertions.*` rather than AssertJ), `decompose-eager-tests`, and context-cache consolidation (#1704) are deliberately **out of scope** here.

Part of #1710 · Epic OmniTrustILM/ilm#252
