### PR TITLE
Bump parent version to 1.4.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.otilm</groupId>
         <artifactId>dependencies</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>


### PR DESCRIPTION
Update the parent POM dependency version to 1.4.2-SNAPSHOT to begin development for the next release.