### PR TITLE
Adopt ClientCertificateIssueRequestDto rename

### DIFF
--- a/src/main/java/com/otilm/core/api/v2/client/ClientOperationControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/v2/client/ClientOperationControllerImpl.java
@@ -38,7 +38,7 @@ public class ClientOperationControllerImpl implements ClientOperationController 
             String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid,
             @LogResource(uuid = true) String certificateUuid,
-            ClientCertificateSignRequestDto request) throws ConnectorException, CertificateException, NoSuchAlgorithmException, AlreadyExistException, NotFoundException {
+            ClientCertificateIssueRequestDto request) throws ConnectorException, CertificateException, NoSuchAlgorithmException, AlreadyExistException, NotFoundException {
         return clientOperationService.issueExistingCertificate(SecuredParentUUID.fromString(authorityUuid), SecuredUUID.fromString(raProfileUuid), certificateUuid, request);
     }
 
@@ -47,7 +47,7 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     public ClientCertificateDataResponseDto issueCertificate(
             String authorityUuid,
             @LogResource(uuid = true, affiliated = true) String raProfileUuid,
-            ClientCertificateSignRequestDto request) throws NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException, CertificateOperationException, CertificateRequestException {
+            ClientCertificateIssueRequestDto request) throws NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException, CertificateOperationException, CertificateRequestException {
         return clientOperationService.issueCertificate(SecuredParentUUID.fromString(authorityUuid), SecuredUUID.fromString(raProfileUuid), request, null);
     }
 

--- a/src/main/java/com/otilm/core/service/CertificateInternalService.java
+++ b/src/main/java/com/otilm/core/service/CertificateInternalService.java
@@ -55,7 +55,7 @@ public interface CertificateInternalService extends ResourceExtensionService {
      * for issuance. The registration identity already on the row (subject DN / SAN) is preserved; the issued
      * certificate's identity is written from the CA response at issuance.
      */
-    void addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateIssueRequestDto signRequest)
+    void addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateIssueRequestDto issueRequest)
             throws CertificateRequestException, NoSuchAlgorithmException, NotFoundException;
 
     CertificateChainResponseDto getCertificateChain(SecuredUUID uuid, boolean withEndCertificate) throws NotFoundException;

--- a/src/main/java/com/otilm/core/service/CertificateInternalService.java
+++ b/src/main/java/com/otilm/core/service/CertificateInternalService.java
@@ -8,7 +8,7 @@ import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.core.certificate.*;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateContent;
 import com.otilm.core.dao.entity.RaProfile;
@@ -55,7 +55,7 @@ public interface CertificateInternalService extends ResourceExtensionService {
      * for issuance. The registration identity already on the row (subject DN / SAN) is preserved; the issued
      * certificate's identity is written from the CA response at issuance.
      */
-    void addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateSignRequestDto signRequest)
+    void addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateIssueRequestDto signRequest)
             throws CertificateRequestException, NoSuchAlgorithmException, NotFoundException;
 
     CertificateChainResponseDto getCertificateChain(SecuredUUID uuid, boolean withEndCertificate) throws NotFoundException;

--- a/src/main/java/com/otilm/core/service/acme/impl/AcmeServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/acme/impl/AcmeServiceImpl.java
@@ -608,13 +608,13 @@ public class AcmeServiceImpl implements AcmeExternalService {
         }
 
         logger.debug("Initiating issue Certificate for Order with ID: {}", order.getOrderId());
-        ClientCertificateIssueRequestDto certificateSignRequestDto = new ClientCertificateIssueRequestDto();
-        certificateSignRequestDto.setAttributes(getClientOperationAttributes(false, order.getAcmeAccount(), isRaProfileBased));
-        certificateSignRequestDto.setRequest(decodedCsr);
-        certificateSignRequestDto.setFormat(CertificateRequestFormat.PKCS10);
+        ClientCertificateIssueRequestDto certificateIssueRequestDto = new ClientCertificateIssueRequestDto();
+        certificateIssueRequestDto.setAttributes(getClientOperationAttributes(false, order.getAcmeAccount(), isRaProfileBased));
+        certificateIssueRequestDto.setRequest(decodedCsr);
+        certificateIssueRequestDto.setFormat(CertificateRequestFormat.PKCS10);
         order.setStatus(OrderStatus.PROCESSING);
         acmeOrderRepository.save(order);
-        createCert(order, certificateSignRequestDto);
+        createCert(order, certificateIssueRequestDto);
     }
 
     @Override
@@ -1195,16 +1195,16 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     }
 
-    private void createCert(AcmeOrder order, ClientCertificateIssueRequestDto certificateSignRequestDto) {
+    private void createCert(AcmeOrder order, ClientCertificateIssueRequestDto certificateIssueRequestDto) {
         // check if certificate is not already requested (prevent calling finalize multiple times issuing more certificates)
         // not sure if it is necessary
         if (order.getCertificateReference() == null) {
             try {
                 // keep state as PROCESSING since issuing is async process
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Requesting Certificate for the Order: {} and certificate signing request: {}", order, certificateSignRequestDto);
+                    logger.debug("Requesting Certificate for the Order: {} and certificate signing request: {}", order, certificateIssueRequestDto);
                 }
-                ClientCertificateDataResponseDto certificateOutput = clientOperationService.issueCertificate(SecuredParentUUID.fromUUID(order.getAcmeAccount().getRaProfile().getAuthorityInstanceReferenceUuid()), order.getAcmeAccount().getRaProfile().getSecuredUuid(), certificateSignRequestDto,
+                ClientCertificateDataResponseDto certificateOutput = clientOperationService.issueCertificate(SecuredParentUUID.fromUUID(order.getAcmeAccount().getRaProfile().getAuthorityInstanceReferenceUuid()), order.getAcmeAccount().getRaProfile().getSecuredUuid(), certificateIssueRequestDto,
                         CertificateProtocolInfo.Acme(order.getAcmeAccount().getAcmeProfileUuid(), order.getAcmeAccountUuid()));
                 order.setCertificateId(AcmeRandomGeneratorAndValidator.generateRandomId());
                 order.setCertificateReference(certificateService.getCertificateEntity(SecuredUUID.fromString(certificateOutput.getUuid())));

--- a/src/main/java/com/otilm/core/service/acme/impl/AcmeServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/acme/impl/AcmeServiceImpl.java
@@ -1202,7 +1202,7 @@ public class AcmeServiceImpl implements AcmeExternalService {
             try {
                 // keep state as PROCESSING since issuing is async process
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Requesting Certificate for the Order: {} and certificate signing request: {}", order, certificateIssueRequestDto);
+                    logger.debug("Requesting Certificate for the Order: {} and issue request: {}", order, certificateIssueRequestDto);
                 }
                 ClientCertificateDataResponseDto certificateOutput = clientOperationService.issueCertificate(SecuredParentUUID.fromUUID(order.getAcmeAccount().getRaProfile().getAuthorityInstanceReferenceUuid()), order.getAcmeAccount().getRaProfile().getSecuredUuid(), certificateIssueRequestDto,
                         CertificateProtocolInfo.Acme(order.getAcmeAccount().getAcmeProfileUuid(), order.getAcmeAccountUuid()));

--- a/src/main/java/com/otilm/core/service/acme/impl/AcmeServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/acme/impl/AcmeServiceImpl.java
@@ -16,7 +16,7 @@ import com.otilm.api.model.core.enums.CertificateProtocol;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import com.otilm.api.model.core.v2.ClientCertificateDataResponseDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeOperation;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
@@ -608,7 +608,7 @@ public class AcmeServiceImpl implements AcmeExternalService {
         }
 
         logger.debug("Initiating issue Certificate for Order with ID: {}", order.getOrderId());
-        ClientCertificateSignRequestDto certificateSignRequestDto = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto certificateSignRequestDto = new ClientCertificateIssueRequestDto();
         certificateSignRequestDto.setAttributes(getClientOperationAttributes(false, order.getAcmeAccount(), isRaProfileBased));
         certificateSignRequestDto.setRequest(decodedCsr);
         certificateSignRequestDto.setFormat(CertificateRequestFormat.PKCS10);
@@ -1195,7 +1195,7 @@ public class AcmeServiceImpl implements AcmeExternalService {
 
     }
 
-    private void createCert(AcmeOrder order, ClientCertificateSignRequestDto certificateSignRequestDto) {
+    private void createCert(AcmeOrder order, ClientCertificateIssueRequestDto certificateSignRequestDto) {
         // check if certificate is not already requested (prevent calling finalize multiple times issuing more certificates)
         // not sure if it is necessary
         if (order.getCertificateReference() == null) {

--- a/src/main/java/com/otilm/core/service/cmp/message/handler/CrmfIrCrMessageHandler.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/handler/CrmfIrCrMessageHandler.java
@@ -9,7 +9,7 @@ import com.otilm.api.interfaces.core.cmp.error.CmpProcessingException;
 import com.otilm.api.model.core.cmp.CmpTransactionState;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import com.otilm.api.model.core.v2.ClientCertificateDataResponseDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.certificate.request.RequestAttributePolicyViolationException;
 import com.otilm.core.dao.entity.RaProfile;
 import com.otilm.core.model.auth.CertificateProtocolInfo;
@@ -78,7 +78,7 @@ public class CrmfIrCrMessageHandler implements MessageHandler<ClientCertificateD
         // -- process issue (asynchronous) operation
         CertReqMessages crmf = (CertReqMessages) request.getBody().getContent();
         try {
-            ClientCertificateSignRequestDto dto = new ClientCertificateSignRequestDto();
+            ClientCertificateIssueRequestDto dto = new ClientCertificateIssueRequestDto();
             dto.setRequest(Base64.getEncoder().encodeToString(crmf.getEncoded()));
             dto.setFormat(CertificateRequestFormat.CRMF);
             RaProfile raProfile = configuration.getRaProfile();

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
@@ -24,7 +24,7 @@ public interface AuthorityProviderAdapter {
      *
      * @param cert the certificate to issue — provides the CSR ({@code getCertificateRequest()}) and
      *             the RA-profile association used to resolve connector attributes.
-     * @param req  the operator-level sign request DTO. Currently informational at the adapter layer:
+     * @param req  the operator-level issue request DTO. Currently informational at the adapter layer:
      *             the wire body is reconstructed from the persisted certificate plus the attribute
      *             engine (Core persists the operator's CSR + request attributes before the adapter
      *             runs, then the adapter re-reads them). Kept for contract symmetry with

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
@@ -6,7 +6,7 @@ import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.RaProfile;
@@ -30,7 +30,7 @@ public interface AuthorityProviderAdapter {
      *             runs, then the adapter re-reads them). Kept for contract symmetry with
      *             {@code renew}/{@code revoke}/{@code register}, which do consume their DTOs.
      */
-    AdapterOperationResult issue(Certificate cert, ClientCertificateSignRequestDto req) throws ConnectorException;
+    AdapterOperationResult issue(Certificate cert, ClientCertificateIssueRequestDto req) throws ConnectorException;
 
     /**
      * Renews (or rekeys) a certificate through the authority provider.

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV2Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV2Adapter.java
@@ -14,7 +14,7 @@ import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeOperation;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
@@ -50,7 +50,7 @@ public class AuthorityProviderV2Adapter extends AbstractAuthorityProviderAdapter
     }
 
     @Override
-    public AdapterOperationResult issue(Certificate cert, ClientCertificateSignRequestDto req) throws ConnectorException {
+    public AdapterOperationResult issue(Certificate cert, ClientCertificateIssueRequestDto req) throws ConnectorException {
         RaProfile raProfile = cert.getRaProfile();
         AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
 

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -27,7 +27,7 @@ import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeOperation;
 import com.otilm.core.attribute.engine.OutboundSecretContainment;
@@ -88,7 +88,7 @@ public class AuthorityProviderV3Adapter
     // ---- AuthorityProviderAdapter ----
 
     @Override
-    public AdapterOperationResult issue(Certificate cert, ClientCertificateSignRequestDto req) throws ConnectorException {
+    public AdapterOperationResult issue(Certificate cert, ClientCertificateIssueRequestDto req) throws ConnectorException {
         RaProfile raProfile = cert.getRaProfile();
         AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
         ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -24,7 +24,7 @@ import com.otilm.api.model.core.certificate.*;
 import com.otilm.api.model.core.certificate.group.GroupDto;
 import com.otilm.api.model.core.compliance.ComplianceStatus;
 import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.api.model.core.compliance.v2.ComplianceCheckResultDto;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import com.otilm.api.model.core.location.LocationDto;
@@ -1122,7 +1122,7 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
 
     @Override
     @Transactional
-    public void addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateSignRequestDto signRequest)
+    public void addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateIssueRequestDto signRequest)
             throws CertificateRequestException, NoSuchAlgorithmException, NotFoundException {
         if (signRequest == null || signRequest.getRequest() == null || signRequest.getRequest().isBlank()) {
             throw new CertificateRequestException("A certificate signing request is required to complete a registered certificate");

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -1122,12 +1122,12 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
 
     @Override
     @Transactional
-    public void addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateIssueRequestDto signRequest)
+    public void addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateIssueRequestDto issueRequest)
             throws CertificateRequestException, NoSuchAlgorithmException, NotFoundException {
-        if (signRequest == null || signRequest.getRequest() == null || signRequest.getRequest().isBlank()) {
+        if (issueRequest == null || issueRequest.getRequest() == null || issueRequest.getRequest().isBlank()) {
             throw new CertificateRequestException("A certificate signing request is required to complete a registered certificate");
         }
-        if (signRequest.getFormat() == null) {
+        if (issueRequest.getFormat() == null) {
             throw new CertificateRequestException("A certificate signing request format (PKCS10 or CRMF) is required");
         }
         // Authorize before locking WITHOUT managing the entity: the RA-profile check makes an external OPA
@@ -1157,11 +1157,11 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
 
         byte[] decodedCsr;
         try {
-            decodedCsr = Base64.getDecoder().decode(signRequest.getRequest());
+            decodedCsr = Base64.getDecoder().decode(issueRequest.getRequest());
         } catch (IllegalArgumentException e) {
             throw new CertificateRequestException("Certificate signing request is not valid Base64", e);
         }
-        CertificateRequest request = CertificateRequestUtils.createCertificateRequest(decodedCsr, signRequest.getFormat());
+        CertificateRequest request = CertificateRequestUtils.createCertificateRequest(decodedCsr, issueRequest.getFormat());
 
         // Attach the operator-supplied CSR to the placeholder; the registration identity already on the row
         // (subject DN / SAN) is intentionally left untouched here — the issued certificate's identity is
@@ -1170,9 +1170,9 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
         final String fingerprint = CertificateUtil.getThumbprint(decodedCsr);
         CertificateRequestEntity certificateRequestEntity = certificateRequestRepository.findByFingerprint(fingerprint).orElse(null);
         if (certificateRequestEntity == null) {
-            certificateRequestEntity = certificate.prepareCertificateRequest(signRequest.getFormat());
+            certificateRequestEntity = certificate.prepareCertificateRequest(issueRequest.getFormat());
             certificateRequestEntity.setFingerprint(fingerprint);
-            certificateRequestEntity.setContent(signRequest.getRequest());
+            certificateRequestEntity.setContent(issueRequest.getRequest());
             setCertificateRequestEntitySignatureAlgorithms(request, certificateRequestEntity);
             certificateRequestRepository.save(certificateRequestEntity);
         }

--- a/src/main/java/com/otilm/core/service/impl/LocationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/LocationServiceImpl.java
@@ -32,7 +32,7 @@ import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.api.model.core.v2.ClientCertificateDataResponseDto;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.comparator.SearchFieldDataComparator;
@@ -814,7 +814,7 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     private ClientCertificateDataResponseDto issueCertificateForLocation(Location location, String csr, List<RequestAttribute> issueAttributes, String raProfileUuid, List<RequestAttribute> certificateCustomAttributes) throws LocationException {
-        ClientCertificateSignRequestDto clientCertificateSignRequestDto = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto clientCertificateSignRequestDto = new ClientCertificateIssueRequestDto();
         clientCertificateSignRequestDto.setAttributes(issueAttributes);
         // TODO: support for different types of certificate
         clientCertificateSignRequestDto.setRequest(csr);

--- a/src/main/java/com/otilm/core/service/impl/LocationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/LocationServiceImpl.java
@@ -814,12 +814,12 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
     }
 
     private ClientCertificateDataResponseDto issueCertificateForLocation(Location location, String csr, List<RequestAttribute> issueAttributes, String raProfileUuid, List<RequestAttribute> certificateCustomAttributes) throws LocationException {
-        ClientCertificateIssueRequestDto clientCertificateSignRequestDto = new ClientCertificateIssueRequestDto();
-        clientCertificateSignRequestDto.setAttributes(issueAttributes);
+        ClientCertificateIssueRequestDto clientCertificateIssueRequestDto = new ClientCertificateIssueRequestDto();
+        clientCertificateIssueRequestDto.setAttributes(issueAttributes);
         // TODO: support for different types of certificate
-        clientCertificateSignRequestDto.setRequest(csr);
-        clientCertificateSignRequestDto.setFormat(CertificateRequestFormat.PKCS10);
-        clientCertificateSignRequestDto.setCustomAttributes(certificateCustomAttributes);
+        clientCertificateIssueRequestDto.setRequest(csr);
+        clientCertificateIssueRequestDto.setFormat(CertificateRequestFormat.PKCS10);
+        clientCertificateIssueRequestDto.setCustomAttributes(certificateCustomAttributes);
         ClientCertificateDataResponseDto clientCertificateDataResponseDto;
         try {
             // TODO : introduces raProfileRepository, services probably need to be reorganized
@@ -828,7 +828,7 @@ public class LocationServiceImpl implements LocationExternalService, LocationInt
                 logger.debug("Failed to issue Certificate for Location {}, {}. RA profile is not existing or does not have set authority", location.getName(), location.getUuid());
                 throw new LocationException("Failed to issue Certificate for Location " + location.getName() + ". RA profile is not existing or does not have set authority");
             }
-            clientCertificateDataResponseDto = clientOperationService.issueCertificate(SecuredParentUUID.fromUUID(raProfile.get().getAuthorityInstanceReferenceUuid()), raProfile.get().getSecuredUuid(), clientCertificateSignRequestDto, null);
+            clientCertificateDataResponseDto = clientOperationService.issueCertificate(SecuredParentUUID.fromUUID(raProfile.get().getAuthorityInstanceReferenceUuid()), raProfile.get().getSecuredUuid(), clientCertificateIssueRequestDto, null);
         } catch (NotFoundException | java.security.cert.CertificateException | CertificateOperationException |
                  InvalidKeyException | IOException | NoSuchAlgorithmException | CertificateRequestException e) {
             logger.debug("Failed to issue Certificate for Location {}, {}: {}", location.getName(), location.getUuid(), e.getMessage());

--- a/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
@@ -16,7 +16,7 @@ import com.otilm.api.model.core.scep.MessageType;
 import com.otilm.api.model.core.scep.PkiStatus;
 import com.otilm.api.model.core.v2.ClientCertificateDataResponseDto;
 import com.otilm.api.model.core.v2.ClientCertificateRequestDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeOperation;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
@@ -472,7 +472,7 @@ public class ScepServiceImpl implements ScepExternalService {
                     scepRequest
             );
         }
-        ClientCertificateSignRequestDto requestDto = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto requestDto = new ClientCertificateIssueRequestDto();
         try {
             requestDto.setRequest(new String(Base64.getEncoder().encode(scepRequest.getPkcs10Request().getEncoded())));
             requestDto.setFormat(CertificateRequestFormat.PKCS10);

--- a/src/main/java/com/otilm/core/service/v2/ClientOperationExternalService.java
+++ b/src/main/java/com/otilm/core/service/v2/ClientOperationExternalService.java
@@ -38,13 +38,13 @@ public interface ClientOperationExternalService {
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid,
             String certificateUuid,
-            ClientCertificateSignRequestDto request
+            ClientCertificateIssueRequestDto request
     ) throws NotFoundException;
 
     ClientCertificateDataResponseDto issueCertificate(
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid,
-            ClientCertificateSignRequestDto request,
+            ClientCertificateIssueRequestDto request,
             CertificateProtocolInfo protocolInfo
     ) throws NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException, CertificateOperationException, CertificateRequestException;
 

--- a/src/main/java/com/otilm/core/service/v2/ClientOperationInternalService.java
+++ b/src/main/java/com/otilm/core/service/v2/ClientOperationInternalService.java
@@ -22,7 +22,7 @@ public interface ClientOperationInternalService {
     ClientCertificateDataResponseDto issueCertificate(
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid,
-            ClientCertificateSignRequestDto request,
+            ClientCertificateIssueRequestDto request,
             CertificateProtocolInfo protocolInfo
     ) throws NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException, CertificateOperationException, CertificateRequestException;
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -336,7 +336,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
-    public ClientCertificateDataResponseDto issueCertificate(final SecuredParentUUID authorityUuid, final SecuredUUID raProfileUuid, final ClientCertificateSignRequestDto request, final CertificateProtocolInfo protocolInfo) throws NotFoundException, CertificateException, NoSuchAlgorithmException, CertificateOperationException, CertificateRequestException {
+    public ClientCertificateDataResponseDto issueCertificate(final SecuredParentUUID authorityUuid, final SecuredUUID raProfileUuid, final ClientCertificateIssueRequestDto request, final CertificateProtocolInfo protocolInfo) throws NotFoundException, CertificateException, NoSuchAlgorithmException, CertificateOperationException, CertificateRequestException {
         // validate RA profile
         RaProfile raProfile = raProfileRepository.findByUuid(raProfileUuid.getValue())
                 .orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
@@ -1025,7 +1025,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
-    public ClientCertificateDataResponseDto issueExistingCertificate(final SecuredParentUUID authorityUuid, final SecuredUUID raProfileUuid, final String certificateUuid, final ClientCertificateSignRequestDto request) throws NotFoundException {
+    public ClientCertificateDataResponseDto issueExistingCertificate(final SecuredParentUUID authorityUuid, final SecuredUUID raProfileUuid, final String certificateUuid, final ClientCertificateIssueRequestDto request) throws NotFoundException {
         // NOT_SUPPORTED so the CSR attach below commits in its own transaction before the ISSUE action is
         // enqueued; otherwise the async consumer could read the placeholder before the CSR is visible and fail it.
         RaProfile raProfile = raProfileRepository.findByUuid(raProfileUuid.getValue())

--- a/src/test/java/com/otilm/core/integration/service/v3/V3RegisterLifecycleITest.java
+++ b/src/test/java/com/otilm/core/integration/service/v3/V3RegisterLifecycleITest.java
@@ -7,7 +7,7 @@ import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import com.otilm.api.model.core.v2.ClientCertificateDataResponseDto;
 import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
@@ -246,7 +246,7 @@ public class V3RegisterLifecycleITest extends BaseSpringBootTest {
         String base64Csr = Base64.getEncoder().encodeToString(csr.getEncoded());
 
         // Step 3: issue the registered certificate
-        ClientCertificateSignRequestDto signRequest = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
         signRequest.setRequest(base64Csr);
         signRequest.setFormat(CertificateRequestFormat.PKCS10);
         signRequest.setAttributes(List.of());
@@ -298,7 +298,7 @@ public class V3RegisterLifecycleITest extends BaseSpringBootTest {
         String base64Csr = Base64.getEncoder().encodeToString(csr.getEncoded());
         V3ConnectorStubs.stubV3IssueAsync(wireMockServer);
 
-        ClientCertificateSignRequestDto signRequest = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
         signRequest.setRequest(base64Csr);
         signRequest.setFormat(CertificateRequestFormat.PKCS10);
         signRequest.setAttributes(List.of());

--- a/src/test/java/com/otilm/core/integration/service/v3/V3RegisterLifecycleITest.java
+++ b/src/test/java/com/otilm/core/integration/service/v3/V3RegisterLifecycleITest.java
@@ -246,17 +246,17 @@ public class V3RegisterLifecycleITest extends BaseSpringBootTest {
         String base64Csr = Base64.getEncoder().encodeToString(csr.getEncoded());
 
         // Step 3: issue the registered certificate
-        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
-        signRequest.setRequest(base64Csr);
-        signRequest.setFormat(CertificateRequestFormat.PKCS10);
-        signRequest.setAttributes(List.of());
-        signRequest.setCustomAttributes(List.of());
+        ClientCertificateIssueRequestDto issueRequest = new ClientCertificateIssueRequestDto();
+        issueRequest.setRequest(base64Csr);
+        issueRequest.setFormat(CertificateRequestFormat.PKCS10);
+        issueRequest.setAttributes(List.of());
+        issueRequest.setCustomAttributes(List.of());
 
         clientOperationService.issueExistingCertificate(
                 SecuredParentUUID.fromUUID(fixture.authority().getUuid()),
                 fixture.raProfile().getSecuredUuid(),
                 registerResponse.getUuid(),
-                signRequest);
+                issueRequest);
 
         // Step 4: assert final state
         Certificate certAfterIssue = reloadCert(registerResponse.getUuid());
@@ -298,18 +298,18 @@ public class V3RegisterLifecycleITest extends BaseSpringBootTest {
         String base64Csr = Base64.getEncoder().encodeToString(csr.getEncoded());
         V3ConnectorStubs.stubV3IssueAsync(wireMockServer);
 
-        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
-        signRequest.setRequest(base64Csr);
-        signRequest.setFormat(CertificateRequestFormat.PKCS10);
-        signRequest.setAttributes(List.of());
-        signRequest.setCustomAttributes(List.of());
+        ClientCertificateIssueRequestDto issueRequest = new ClientCertificateIssueRequestDto();
+        issueRequest.setRequest(base64Csr);
+        issueRequest.setFormat(CertificateRequestFormat.PKCS10);
+        issueRequest.setAttributes(List.of());
+        issueRequest.setCustomAttributes(List.of());
 
         // Step 3: issue → the register-bound v3 issue returns 202 (async)
         clientOperationService.issueExistingCertificate(
                 SecuredParentUUID.fromUUID(fixture.authority().getUuid()),
                 fixture.raProfile().getSecuredUuid(),
                 registerResponse.getUuid(),
-                signRequest);
+                issueRequest);
 
         // Step 4: accepted-but-async → PENDING_ISSUE + exactly one ISSUE status-poll row scheduled
         Assertions.assertEquals(CertificateState.PENDING_ISSUE, reloadCert(registerResponse.getUuid()).getState(),

--- a/src/test/java/com/otilm/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateServiceTest.java
@@ -31,7 +31,7 @@ import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.core.connector.FunctionGroupCode;
 import com.otilm.api.model.core.enums.CertificateProtocol;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.dao.entity.*;
@@ -1955,7 +1955,7 @@ class CertificateServiceTest extends BaseSpringBootTest {
             Certificate pendingIssue = certificateRepository.save(
                     aCertificate().withRaProfile(raProfile).withState(CertificateState.PENDING_ISSUE).build());
             UUID uuid = pendingIssue.getUuid();
-            ClientCertificateSignRequestDto signRequest = new ClientCertificateSignRequestDto();
+            ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
             signRequest.setRequest(SAMPLE_PKCS10);
             signRequest.setFormat(CertificateRequestFormat.PKCS10);
 

--- a/src/test/java/com/otilm/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/otilm/core/service/CertificateServiceTest.java
@@ -1955,12 +1955,12 @@ class CertificateServiceTest extends BaseSpringBootTest {
             Certificate pendingIssue = certificateRepository.save(
                     aCertificate().withRaProfile(raProfile).withState(CertificateState.PENDING_ISSUE).build());
             UUID uuid = pendingIssue.getUuid();
-            ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
-            signRequest.setRequest(SAMPLE_PKCS10);
-            signRequest.setFormat(CertificateRequestFormat.PKCS10);
+            ClientCertificateIssueRequestDto issueRequest = new ClientCertificateIssueRequestDto();
+            issueRequest.setRequest(SAMPLE_PKCS10);
+            issueRequest.setFormat(CertificateRequestFormat.PKCS10);
 
             // when / then — the locked read re-asserts state under the lock; only REGISTERED may accept a CSR
-            assertThatThrownBy(() -> certificateService.addCertificateRequestToExisting(uuid, signRequest))
+            assertThatThrownBy(() -> certificateService.addCertificateRequestToExisting(uuid, issueRequest))
                     .isInstanceOf(ValidationException.class);
         }
     }

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceRegisterTest.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceRegisterTest.java
@@ -16,7 +16,7 @@ import com.otilm.api.model.core.v2.AvailableOperationsDto;
 import com.otilm.api.model.core.v2.CertificateOperationKind;
 import com.otilm.api.model.core.v2.ClientCertificateDataResponseDto;
 import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.api.model.core.v2.OperationSupport;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
@@ -327,7 +327,7 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
     @Test
     void issueRegisteredCertificateWithoutCsrIsRejected() throws Exception {
         String certUuid = registerSyncRegistered();
-        ClientCertificateSignRequestDto noCsr = new ClientCertificateSignRequestDto(); // request == null
+        ClientCertificateIssueRequestDto noCsr = new ClientCertificateIssueRequestDto(); // request == null
 
         Assertions.assertThrows(ValidationException.class, () -> clientOperationService.issueExistingCertificate(
                 authorityParent,
@@ -339,7 +339,7 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
         // An explicit null format must surface a clear validation error rather than an NPE inside the
         // CSR parser's format-selection logic.
         String certUuid = registerSyncRegistered();
-        ClientCertificateSignRequestDto noFormat = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto noFormat = new ClientCertificateIssueRequestDto();
         noFormat.setRequest(generateCsrBase64());
         noFormat.setFormat(null);
 
@@ -356,7 +356,7 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
         requested = certificateRepository.save(requested);
         String certUuid = requested.getUuid().toString();
 
-        ClientCertificateSignRequestDto withCsr = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto withCsr = new ClientCertificateIssueRequestDto();
         withCsr.setRequest("a-csr-body"); // validation rejects before any parsing
 
         Assertions.assertThrows(ValidationException.class, () -> clientOperationService.issueExistingCertificate(
@@ -375,7 +375,7 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
         requested = certificateRepository.save(requested);
         String certUuid = requested.getUuid().toString();
 
-        ClientCertificateSignRequestDto blank = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto blank = new ClientCertificateIssueRequestDto();
         blank.setRequest("   ");
 
         clientOperationService.issueExistingCertificate(authorityParent, securedRaProfile, certUuid, blank);
@@ -386,7 +386,7 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
     @Test
     void issueRegisteredCertificateAttachesOperatorCsr() throws Exception {
         String certUuid = registerSyncRegistered();
-        ClientCertificateSignRequestDto signRequest = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
         signRequest.setRequest(generateCsrBase64());
 
         clientOperationService.issueExistingCertificate(
@@ -406,10 +406,10 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
         UUID first = UUID.fromString(registerSyncRegistered());
         UUID second = UUID.fromString(registerSyncRegistered());
 
-        ClientCertificateSignRequestDto req1 = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto req1 = new ClientCertificateIssueRequestDto();
         req1.setRequest(csr);
         clientOperationService.issueExistingCertificate(authorityParent, securedRaProfile, first.toString(), req1);
-        ClientCertificateSignRequestDto req2 = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto req2 = new ClientCertificateIssueRequestDto();
         req2.setRequest(csr);
         clientOperationService.issueExistingCertificate(authorityParent, securedRaProfile, second.toString(), req2);
 
@@ -427,7 +427,7 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
         requested.setRaProfile(raProfile);
         requested = certificateRepository.save(requested);
         UUID uuid = requested.getUuid();
-        ClientCertificateSignRequestDto req = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto req = new ClientCertificateIssueRequestDto();
         req.setRequest(generateCsrBase64());
 
         Assertions.assertThrows(ValidationException.class, () -> certificateService.addCertificateRequestToExisting(uuid, req));
@@ -488,7 +488,7 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
         otherRaProfile.setEnabled(true);
         otherRaProfile = raProfileRepository.save(otherRaProfile);
 
-        ClientCertificateSignRequestDto signRequest = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
         signRequest.setRequest("ignored-rejected-before-parse");
         SecuredParentUUID otherAuthority = SecuredParentUUID.fromUUID(otherRaProfile.getAuthorityInstanceReferenceUuid());
         SecuredUUID otherRa = otherRaProfile.getSecuredUuid();
@@ -532,7 +532,7 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
     @Test
     void issueRegisteredCertificateRejectsMalformedCsr() throws Exception {
         String certUuid = registerSyncRegistered();
-        ClientCertificateSignRequestDto signRequest = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
         signRequest.setRequest("!!!not-valid-base64!!!");
         Assertions.assertThrows(ValidationException.class, () -> clientOperationService.issueExistingCertificate(
                 authorityParent,
@@ -570,7 +570,7 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
         String certUuid = registerSyncRegistered();
         raProfile.setEnabled(false);
         raProfileRepository.save(raProfile);
-        ClientCertificateSignRequestDto signRequest = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
         signRequest.setRequest("x");
         Assertions.assertThrows(ValidationException.class, () -> clientOperationService.issueExistingCertificate(
                 authorityParent,

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceRegisterTest.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceRegisterTest.java
@@ -386,12 +386,12 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
     @Test
     void issueRegisteredCertificateAttachesOperatorCsr() throws Exception {
         String certUuid = registerSyncRegistered();
-        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
-        signRequest.setRequest(generateCsrBase64());
+        ClientCertificateIssueRequestDto issueRequest = new ClientCertificateIssueRequestDto();
+        issueRequest.setRequest(generateCsrBase64());
 
         clientOperationService.issueExistingCertificate(
                 authorityParent,
-                securedRaProfile, certUuid, signRequest);
+                securedRaProfile, certUuid, issueRequest);
 
         Certificate cert = certificateRepository.findByUuid(UUID.fromString(certUuid)).orElseThrow();
         Assertions.assertNotNull(cert.getCertificateRequest(), "operator CSR should be attached to the registered placeholder");
@@ -488,12 +488,12 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
         otherRaProfile.setEnabled(true);
         otherRaProfile = raProfileRepository.save(otherRaProfile);
 
-        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
-        signRequest.setRequest("ignored-rejected-before-parse");
+        ClientCertificateIssueRequestDto issueRequest = new ClientCertificateIssueRequestDto();
+        issueRequest.setRequest("ignored-rejected-before-parse");
         SecuredParentUUID otherAuthority = SecuredParentUUID.fromUUID(otherRaProfile.getAuthorityInstanceReferenceUuid());
         SecuredUUID otherRa = otherRaProfile.getSecuredUuid();
         Assertions.assertThrows(ValidationException.class, () -> clientOperationService.issueExistingCertificate(
-                otherAuthority, otherRa, certUuid, signRequest));
+                otherAuthority, otherRa, certUuid, issueRequest));
     }
 
     @Test
@@ -532,11 +532,11 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
     @Test
     void issueRegisteredCertificateRejectsMalformedCsr() throws Exception {
         String certUuid = registerSyncRegistered();
-        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
-        signRequest.setRequest("!!!not-valid-base64!!!");
+        ClientCertificateIssueRequestDto issueRequest = new ClientCertificateIssueRequestDto();
+        issueRequest.setRequest("!!!not-valid-base64!!!");
         Assertions.assertThrows(ValidationException.class, () -> clientOperationService.issueExistingCertificate(
                 authorityParent,
-                securedRaProfile, certUuid, signRequest));
+                securedRaProfile, certUuid, issueRequest));
     }
 
     @Test
@@ -570,11 +570,11 @@ class ClientOperationServiceRegisterTest extends BaseSpringBootTest {
         String certUuid = registerSyncRegistered();
         raProfile.setEnabled(false);
         raProfileRepository.save(raProfile);
-        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
-        signRequest.setRequest("x");
+        ClientCertificateIssueRequestDto issueRequest = new ClientCertificateIssueRequestDto();
+        issueRequest.setRequest("x");
         Assertions.assertThrows(ValidationException.class, () -> clientOperationService.issueExistingCertificate(
                 authorityParent,
-                securedRaProfile, certUuid, signRequest));
+                securedRaProfile, certUuid, issueRequest));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -26,7 +26,7 @@ import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import com.otilm.api.model.core.v2.ClientCertificateRekeyRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.dao.entity.*;
@@ -276,7 +276,7 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
                 .post(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue/attributes/validate"))
                 .willReturn(WireMock.okJson("true")));
 
-        ClientCertificateSignRequestDto request = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto request = new ClientCertificateIssueRequestDto();
         request.setRequest(SAMPLE_PKCS10);
         request.setAttributes(List.of());
         Assertions.assertDoesNotThrow(() -> clientOperationService.issueCertificate(authorityInstanceReference.getSecuredParentUuid(), raProfile.getSecuredUuid(), request, null));
@@ -1802,7 +1802,7 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
         doReturn(Optional.of(switchedAway))
                 .when(certificateRepository).findAndLockWithAssociationsByUuid(certificate.getUuid());
 
-        ClientCertificateSignRequestDto signRequest = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
         signRequest.setRequest(SAMPLE_PKCS10);
         signRequest.setFormat(CertificateRequestFormat.PKCS10);
 

--- a/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
+++ b/src/test/java/com/otilm/core/service/ClientOperationServiceV2Test.java
@@ -1802,13 +1802,13 @@ class ClientOperationServiceV2Test extends BaseSpringBootTest {
         doReturn(Optional.of(switchedAway))
                 .when(certificateRepository).findAndLockWithAssociationsByUuid(certificate.getUuid());
 
-        ClientCertificateIssueRequestDto signRequest = new ClientCertificateIssueRequestDto();
-        signRequest.setRequest(SAMPLE_PKCS10);
-        signRequest.setFormat(CertificateRequestFormat.PKCS10);
+        ClientCertificateIssueRequestDto issueRequest = new ClientCertificateIssueRequestDto();
+        issueRequest.setRequest(SAMPLE_PKCS10);
+        issueRequest.setFormat(CertificateRequestFormat.PKCS10);
 
         UUID certUuid = certificate.getUuid();
         ValidationException ex = Assertions.assertThrows(ValidationException.class, () ->
-                certificateService.addCertificateRequestToExisting(certUuid, signRequest));
+                certificateService.addCertificateRequestToExisting(certUuid, issueRequest));
         Assertions.assertTrue(ex.getMessage().contains("RA profile changed"),
                 "expected the re-assert under the lock to reject on RA-profile change, got: " + ex.getMessage());
     }

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV2AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV2AdapterTest.java
@@ -14,7 +14,7 @@ import com.otilm.api.model.connector.v2.CertificateSignRequestDto;
 import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
@@ -118,7 +118,7 @@ class AuthorityProviderV2AdapterTest {
         when(certClient.issueCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateSignRequestDto.class)))
                 .thenReturn(ResponseEntity.ok(responseBody));
 
-        AdapterOperationResult result = adapter.issue(cert, new ClientCertificateSignRequestDto());
+        AdapterOperationResult result = adapter.issue(cert, new ClientCertificateIssueRequestDto());
 
         assertEquals(AdapterOperationOutcome.SYNC_OK, result.outcome());
         assertEquals("issuedCertData==", result.certificateData());
@@ -132,7 +132,7 @@ class AuthorityProviderV2AdapterTest {
         when(certClient.issueCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateSignRequestDto.class)))
                 .thenReturn(ResponseEntity.ok(responseBody));
 
-        adapter.issue(cert, new ClientCertificateSignRequestDto());
+        adapter.issue(cert, new ClientCertificateIssueRequestDto());
 
         ArgumentCaptor<CertificateSignRequestDto> captor = ArgumentCaptor.forClass(CertificateSignRequestDto.class);
         verify(certClient).issueCertificate(eq(connectorInfo), eq("auth-instance-uuid"), captor.capture());
@@ -148,7 +148,7 @@ class AuthorityProviderV2AdapterTest {
         when(certClient.issueCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateSignRequestDto.class)))
                 .thenReturn(ResponseEntity.ok(new CertificateDataResponseDto()));
 
-        adapter.issue(cert, new ClientCertificateSignRequestDto());
+        adapter.issue(cert, new ClientCertificateIssueRequestDto());
 
         ArgumentCaptor<CertificateSignRequestDto> captor = ArgumentCaptor.forClass(CertificateSignRequestDto.class);
         verify(certClient).issueCertificate(eq(connectorInfo), eq("auth-instance-uuid"), captor.capture());
@@ -216,7 +216,7 @@ class AuthorityProviderV2AdapterTest {
         when(certClient.issueCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateSignRequestDto.class)))
                 .thenReturn(ResponseEntity.status(202).body(responseBody));
 
-        AdapterOperationResult result = adapter.issue(cert, new ClientCertificateSignRequestDto());
+        AdapterOperationResult result = adapter.issue(cert, new ClientCertificateIssueRequestDto());
 
         assertEquals(AdapterOperationOutcome.ASYNC_ACCEPTED, result.outcome());
         assertTrue(result.isAsync());

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -23,7 +23,7 @@ import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.authority.CertificateRevocationReason;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.attribute.RequestAttributeV3;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
@@ -192,7 +192,7 @@ class AuthorityProviderV3AdapterTest {
         when(certClientV3.issue(eq(connectorInfo), any(CertificateSignRequestDtoV3.class)))
                 .thenReturn(ResponseEntity.ok(body));
 
-        AdapterOperationResult result = adapter.issue(cert, new ClientCertificateSignRequestDto());
+        AdapterOperationResult result = adapter.issue(cert, new ClientCertificateIssueRequestDto());
 
         assertEquals(AdapterOperationOutcome.SYNC_OK, result.outcome());
         assertEquals("issuedCert==", result.certificateData());
@@ -208,7 +208,7 @@ class AuthorityProviderV3AdapterTest {
         when(certClientV3.issue(eq(connectorInfo), any(CertificateSignRequestDtoV3.class)))
                 .thenReturn(ResponseEntity.ok(body));
 
-        adapter.issue(cert, new ClientCertificateSignRequestDto());
+        adapter.issue(cert, new ClientCertificateIssueRequestDto());
 
         // The certificate-scoped attribute load must carry operation=CERTIFICATE_ISSUE, otherwise the
         // engine returns unscoped attributes. (Other captured calls are AUTHORITY/RA_PROFILE-scoped.)
@@ -245,7 +245,7 @@ class AuthorityProviderV3AdapterTest {
         when(certClientV3.issue(eq(connectorInfo), any(CertificateSignRequestDtoV3.class)))
                 .thenReturn(ResponseEntity.ok(new CertificateDataResponseDto()));
 
-        adapter.issue(cert, new ClientCertificateSignRequestDto());
+        adapter.issue(cert, new ClientCertificateIssueRequestDto());
 
         ArgumentCaptor<CertificateSignRequestDtoV3> wireCaptor = ArgumentCaptor.forClass(CertificateSignRequestDtoV3.class);
         verify(certClientV3).issue(eq(connectorInfo), wireCaptor.capture());
@@ -317,7 +317,7 @@ class AuthorityProviderV3AdapterTest {
         when(certClientV3.issue(eq(connectorInfo), any(CertificateSignRequestDtoV3.class)))
                 .thenReturn(ResponseEntity.status(202).body(body));
 
-        AdapterOperationResult result = adapter.issue(cert, new ClientCertificateSignRequestDto());
+        AdapterOperationResult result = adapter.issue(cert, new ClientCertificateIssueRequestDto());
 
         assertEquals(AdapterOperationOutcome.ASYNC_ACCEPTED, result.outcome());
         assertTrue(result.isAsync());
@@ -341,7 +341,7 @@ class AuthorityProviderV3AdapterTest {
                 .thenReturn(faultyResponse);
 
         assertThrows(ConnectorAcceptedButLocalFailureException.class,
-                () -> adapter.issue(cert, new ClientCertificateSignRequestDto()));
+                () -> adapter.issue(cert, new ClientCertificateIssueRequestDto()));
     }
 
     // ---- issue: pre-acceptance connector failure propagates raw (no acceptance guard wrap) ----
@@ -353,7 +353,7 @@ class AuthorityProviderV3AdapterTest {
         when(certClientV3.issue(eq(connectorInfo), any(CertificateSignRequestDtoV3.class)))
                 .thenThrow(connectorFailure);
 
-        ClientCertificateSignRequestDto request = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto request = new ClientCertificateIssueRequestDto();
         RuntimeException thrown = assertThrows(RuntimeException.class, () -> adapter.issue(cert, request));
         assertSame(connectorFailure, thrown);
     }

--- a/src/test/java/com/otilm/core/service/v2/impl/ClientOperationRequestAttributePropagationTest.java
+++ b/src/test/java/com/otilm/core/service/v2/impl/ClientOperationRequestAttributePropagationTest.java
@@ -2,7 +2,7 @@ package com.otilm.core.service.v2.impl;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
-import com.otilm.api.model.core.v2.ClientCertificateSignRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.attribute.CsrAttributes;
 import com.otilm.core.certificate.request.RequestAttributePolicyViolationException;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
@@ -93,7 +93,7 @@ class ClientOperationRequestAttributePropagationTest extends BaseSpringBootTest 
         // a genuine policy violation (a client fault), distinct from an availability failure
         when(requestAttributeService.resolveIssueAttributeSet(any())).thenReturn(List.of(CsrAttributes.commonNameAttribute()));
         when(requestAttributeService.resolveExternalCsrValidationStrict(any())).thenReturn(true);
-        ClientCertificateSignRequestDto request = new ClientCertificateSignRequestDto();
+        ClientCertificateIssueRequestDto request = new ClientCertificateIssueRequestDto();
         request.setRequest(pemEncodedCsrWithSubject("O=Acme,C=US"));
         request.setFormat(CertificateRequestFormat.PKCS10);
         request.setAttributes(List.of());


### PR DESCRIPTION
## What

Adopt the DTO rename shipped by **interfaces#699 / #758**: `ClientCertificateSignRequestDto` → `ClientCertificateIssueRequestDto`, across core's client-operations path (20 files: the v2 controller impl, `ClientOperationServiceImpl`, `CertificateServiceImpl`, ACME/SCEP/CMP/Location services, the V2/V3 authority adapters, the v2 service interfaces, and 3 test classes).

Pure mechanical rename — symmetric diff, no logic change. The separate v1 `LegacyClientCertificateSignRequestDto` is untouched.

## ⚠️ Blocked on interfaces#758 — draft until it merges

Core consumes `com.otilm:interfaces:2.18.1-SNAPSHOT`. The renamed class only exists in that SNAPSHOT **after #758 merges** to interfaces `main`. Until then this branch does not compile and **CI will be red** — that's expected. This PR is the "keep core `main` green through the SNAPSHOT rename" step: it's staged so it can be **un-drafted and merged immediately once #758 lands**, minimizing the window where core `main` is broken against the updated SNAPSHOT.

Sequence: #758 merges → un-draft this → merge → then R1b (core#1570) builds on green `main`.

Part of #1570 (ilm#130).
