### PR TITLE
Move util/ tests into integration root - part 9

### DIFF
--- a/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
+++ b/src/test/java/com/otilm/core/architecture/CiTestSplitTest.java
@@ -126,7 +126,7 @@ class CiTestSplitTest {
      * fragments — a substring match would wrongly exempt e.g. any path merely containing "api".
      */
     private static final Set<String> MIGRATION_ALLOWLIST = Set.of(
-            "service", "util");
+            "service");
 
     /**
      * Root-level test files live directly in com/otilm/core (no sub-package) — e.g. ApplicationTests,

--- a/src/test/java/com/otilm/core/integration/util/DigitalSigningCertQueryITest.java
+++ b/src/test/java/com/otilm/core/integration/util/DigitalSigningCertQueryITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.util;
+package com.otilm.core.integration.util;
 
 import com.otilm.api.model.client.connector.v2.ConnectorVersion;
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
@@ -16,6 +16,12 @@ import com.otilm.core.dao.repository.*;
 import com.otilm.core.helpers.CertificateGeneratorHelper;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.cmp.CmpEntityUtil;
+import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.CertificateEligibilityUtil;
+import com.otilm.core.util.CertificateTestData;
+import com.otilm.core.util.CertificateTestUtil;
+import com.otilm.core.util.CertificateUtil;
+import com.otilm.core.util.MetaDefinitions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,7 +36,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class DigitalSigningCertQueryTest extends BaseSpringBootTest {
+class DigitalSigningCertQueryITest extends BaseSpringBootTest {
 
     @Autowired private CertificateRepository certificateRepository;
     @Autowired private CertificateContentRepository certificateContentRepository;

--- a/src/test/java/com/otilm/core/integration/util/FilterPredicatesBuilderITest.java
+++ b/src/test/java/com/otilm/core/integration/util/FilterPredicatesBuilderITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.util;
+package com.otilm.core.integration.util;
 
 import com.otilm.api.exception.AlreadyExistException;
 import com.otilm.api.exception.AttributeException;
@@ -43,6 +43,8 @@ import com.otilm.core.service.AttributeExternalService;
 import com.otilm.core.service.AuditLogExternalService;
 import com.otilm.core.service.impl.CertificateServiceImpl;
 import com.otilm.core.service.CryptographicKeyExternalService;
+import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.FilterPredicatesBuilder;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import jakarta.persistence.EntityManager;
@@ -83,7 +85,7 @@ import static com.otilm.core.util.builders.SearchFilterRequestDtoBuilder.aSearch
  * Tests for class {@link FilterPredicatesBuilder}
  */
 @SpringBootTest
-class FilterPredicatesBuilderTest extends BaseSpringBootTest {
+class FilterPredicatesBuilderITest extends BaseSpringBootTest {
 
     @Autowired
     private EntityManager entityManager;

--- a/src/test/java/com/otilm/core/integration/util/PlatformX500NameStyleITest.java
+++ b/src/test/java/com/otilm/core/integration/util/PlatformX500NameStyleITest.java
@@ -1,12 +1,14 @@
-package com.otilm.core.util;
+package com.otilm.core.integration.util;
 
 import com.otilm.api.model.core.oid.OidCategory;
 import com.otilm.api.model.core.oid.SystemOid;
 import com.otilm.core.oid.OidHandler;
 import com.otilm.core.oid.OidRecord;
+import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.CertificateUtil;
+import com.otilm.core.util.PlatformX500NameStyle;
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.security.auth.x500.X500Principal;
@@ -15,23 +17,25 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Map;
 
-class PlatformX500NameStyleTest extends BaseSpringBootTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlatformX500NameStyleITest extends BaseSpringBootTest {
 
 
     @Test
     void testCustomNameStyle() throws CertificateException {
-        Assertions.assertEquals("CN=Certificate Authority, L=Location, ST=State, C=US, O=Organization", getDnWithCustomStyle("CN=Certificate Authority; L=Location,ST=State, C=US;O=Organization"));
-        Assertions.assertEquals("2.5.4.10=Organization,2.5.4.3=Certificate Authority,2.5.4.6=US,2.5.4.7=Location,2.5.4.8=State", getDnWithCustomStyleNormalized("CN=Certificate Authority; L=Location,ST=State, C=US;O=Organization"));
-        Assertions.assertEquals("CN=Example Root CA, O=Example Corp, EMAIL=admin@example.com, C=US", getDnWithCustomStyle("CN=Example Root CA; O=Example Corp; EMAILADDRESS=admin@example.com,C=US"));
-        Assertions.assertEquals("1.2.840.113549.1.9.1=admin@example.com,2.5.4.10=Example Corp,2.5.4.3=Example Root CA,2.5.4.6=US", getDnWithCustomStyleNormalized("CN=Example Root CA; O=Example Corp; EMAILADDRESS=admin@example.com,C=US"));
-        Assertions.assertEquals("OU=IT Security, O=SecureCorp, L=City, ST=State, C=US, 2.5.4.77=SSL Issuer", getDnWithCustomStyle("OU=IT Security; O=SecureCorp; L=City; ST=State; C=US, 2.5.4.77=SSL Issuer"));
-        Assertions.assertEquals("2.5.4.10=SecureCorp,2.5.4.11=IT Security,2.5.4.6=US,2.5.4.7=City,2.5.4.77=SSL Issuer,2.5.4.8=State", getDnWithCustomStyleNormalized("OU=IT Security; O=SecureCorp; L=City; ST=State; C=US, 2.5.4.77=SSL Issuer"));
+        assertThat(getDnWithCustomStyle("CN=Certificate Authority; L=Location,ST=State, C=US;O=Organization")).isEqualTo("CN=Certificate Authority, L=Location, ST=State, C=US, O=Organization");
+        assertThat(getDnWithCustomStyleNormalized("CN=Certificate Authority; L=Location,ST=State, C=US;O=Organization")).isEqualTo("2.5.4.10=Organization,2.5.4.3=Certificate Authority,2.5.4.6=US,2.5.4.7=Location,2.5.4.8=State");
+        assertThat(getDnWithCustomStyle("CN=Example Root CA; O=Example Corp; EMAILADDRESS=admin@example.com,C=US")).isEqualTo("CN=Example Root CA, O=Example Corp, EMAIL=admin@example.com, C=US");
+        assertThat(getDnWithCustomStyleNormalized("CN=Example Root CA; O=Example Corp; EMAILADDRESS=admin@example.com,C=US")).isEqualTo("1.2.840.113549.1.9.1=admin@example.com,2.5.4.10=Example Corp,2.5.4.3=Example Root CA,2.5.4.6=US");
+        assertThat(getDnWithCustomStyle("OU=IT Security; O=SecureCorp; L=City; ST=State; C=US, 2.5.4.77=SSL Issuer")).isEqualTo("OU=IT Security, O=SecureCorp, L=City, ST=State, C=US, 2.5.4.77=SSL Issuer");
+        assertThat(getDnWithCustomStyleNormalized("OU=IT Security; O=SecureCorp; L=City; ST=State; C=US, 2.5.4.77=SSL Issuer")).isEqualTo("2.5.4.10=SecureCorp,2.5.4.11=IT Security,2.5.4.6=US,2.5.4.7=City,2.5.4.77=SSL Issuer,2.5.4.8=State");
         X509Certificate certificateAVA = CertificateUtil.getX509Certificate(("MIIEBjCCAu6gAwIBAgIUb2wDIxFx4Ma6mtoWuFPoPFULDR8wDQYJKoZIhvcNAQELBQAwgYExDDAKBgNVBAMMA0FiYzEMMAoGA1UEAwwDQmNkMQ4wDAYDVQQDDAVYeXp6eTELMAkGA1UEBhMCQ1oxDzANBgNVBAgMBlByYWd1ZTEPMA0GA1UEBwwGUHJhZ3VlMQ8wDQYDVQQHDAZMb25kb24xEzARBgNVBAcMCkJyYXRpc2xhdmEwHhcNMjMxMTEwMTEwNDUzWhcNMjQxMTA5MTEwNDUzWjCBgTEMMAoGA1UEAwwDQWJjMQwwCgYDVQQDDANCY2QxDjAMBgNVBAMMBVh5enp5MQswCQYDVQQGEwJDWjEPMA0GA1UECAwGUHJhZ3VlMQ8wDQYDVQQHDAZQcmFndWUxDzANBgNVBAcMBkxvbmRvbjETMBEGA1UEBwwKQnJhdGlzbGF2YTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALa3Th//z2GeyFFtlUmBdwYIww5dTZqHihaBLhfkUtS+fhetHRDlWXcBaCFYT/SB44+rXh3F6iADWW4oB2KQLEaqUG7cP651Ni2e2hag2pny36P5lrSi0uhRcGbDikixCAXauif9iJRwcNCZQYGgq0/FrROikyFMxVx5BxWOVjmD0M36tR+kCE0pKdqRfwKGZ1gb0rLmH6XQhz26Whb0+BFT5WnUxFUMvtm8GpwN8RufP/YvSyTGQNnODm2+VMctJ/fk5tYQowciTnhZvcFCBui50XRJPN1kjSKgoJkNongbmi0nWqy24Hv3fLC01dVND0vnNcqmcrFpmCeYE4cHRxECAwEAAaN0MHIwHQYDVR0OBBYEFEPtLZm3Uxd9hVEAw0mmlc4uEmwcMB8GA1UdIwQYMBaAFEPtLZm3Uxd9hVEAw0mmlc4uEmwcMA4GA1UdDwEB/wQEAwIFoDAgBgNVHSUBAf8EFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADggEBAC/3uvlM3hbHtk9FOAfj7tmjWqXk1at8mNyOY/0SDauSWQk1VGgf66pPjccq72dfYcpfh17cswyTX/ZF5Kj2nZ9uv09tBL+yZL+FJBJ6e/1s53bY3XKlbB6qJUG+cebpUiYqOf+yuPYGDokBa6/aA1XtgkgaIMq06N/Wvl0/dvXnMz+EDPQsApbM96yl23QGhezdebYh7VM7qiDl5CNuGnidZkm4tUNq3F1aBnVPPADmxOfdVkdDwJbfjluozBDZIRW14lixbzBWx2WVz/m090r/zPERhCcghVvYEnKUIp683UT+SrJNKZhCrqWL45KzMheLbB5GRQWTo1euXJT0Vec="));
         X509Certificate certificateO = CertificateUtil.getX509Certificate("MIIEDjCCAvagAwIBAgIUZ0CT63uIZ4fMvIqM5k8lGT+nZOAwDQYJKoZIhvcNAQELBQAwgYUxEDAOBgNVBAMMB2NvbXAuZXUxCzAJBgNVBAYTAkNaMQ8wDQYDVQQIDAZQcmFndWUxDzANBgNVBAcMBlByYWd1ZTEUMBIGA1UECgwLT3JnLCBzLnIuby4xHTAbBgNVBA8MFFByaXZhdGUgT3JnYW5pemF0aW9uMQ0wCwYDVQQFEwQxMjM0MB4XDTIzMTExMDExMTQwM1oXDTI0MTEwOTExMTQwM1owgYUxEDAOBgNVBAMMB2NvbXAuZXUxCzAJBgNVBAYTAkNaMQ8wDQYDVQQIDAZQcmFndWUxDzANBgNVBAcMBlByYWd1ZTEUMBIGA1UECgwLT3JnLCBzLnIuby4xHTAbBgNVBA8MFFByaXZhdGUgT3JnYW5pemF0aW9uMQ0wCwYDVQQFEwQxMjM0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzLQ+JnQEQVQH1ygGaVfmR+SfrowGcNfCDZ+rg97eCzFBzkeCPiFHa8A6f/Zc8vZeKUTvepAFQ7fd2rh5kjQMgAb4fIOtFL7+SfEH+Hn0g7Te+4UuxZKRQax5nsTEo1s8XFrE3cNRhB3bxKj+b8cOndoGaDVsLXy9X9UGMwfdYbtkSgdzHOeGVsPsc7ppn2xo8vm+CDi5rEIQlvopeshrAKPXa8cgM9HgwxhdIpj5/7CvswxOvlEzeDT7MbUoPKiVQKO/RDixa50Eov4wENlQS3OxwvkBYa2STnBO7iooQGmtbnyQsHnbW4RxyhYgyTPXK1K+ssSsNW5KTdjp2VZkcQIDAQABo3QwcjAdBgNVHQ4EFgQUinfVgYajVU8ySmBRcLzgU/M4IX8wHwYDVR0jBBgwFoAUinfVgYajVU8ySmBRcLzgU/M4IX8wDgYDVR0PAQH/BAQDAgWgMCAGA1UdJQEB/wQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjANBgkqhkiG9w0BAQsFAAOCAQEACAQLiLbysA9kCL0Di5Rfp/cg/qfBr0udWr1EwrO5p4MsgNgTAMpD15DbtSefw9FPralH9hmkxdNH5OmMtHuoBc+6S63iIZ4zq4/V5mJTmd675UPu7N3SQNXAN5A8klFv0rW0E/O5uZaPEv/CaM+zO3fHpJvrGn+dVHWPU2Q2yCMCy6ikuzshb0yjw5FH7TEPjgkobygd2gGWMVk2ZOKAKImBDf7f6PMi/AXKkucaTf5XV+SucN9DXUx3ukCDEdEoqzjW+s2xx7TRATm6j1PFfGKNNBOxQnAYQAYOSp38TKo9EsTqAt+YvlTrlVuKJQBOHJ2/rqCiQfZ1Vid7/9nuKA==");
-        Assertions.assertEquals("L=Bratislava, L=London, L=Prague, ST=Prague, C=CZ, CN=Xyzzy, CN=Bcd, CN=Abc", X500Name.getInstance(new PlatformX500NameStyle(false), certificateAVA.getSubjectX500Principal().getEncoded()).toString());
-        Assertions.assertEquals("2.5.4.3=Abc,2.5.4.3=Bcd,2.5.4.3=Xyzzy,2.5.4.6=CZ,2.5.4.7=Bratislava,2.5.4.7=London,2.5.4.7=Prague,2.5.4.8=Prague", X500Name.getInstance(new PlatformX500NameStyle(true), certificateAVA.getSubjectX500Principal().getEncoded()).toString());
-        Assertions.assertEquals("SERIALNUMBER=1234, BusinessCategory=Private Organization, O=Org, s.r.o., L=Prague, ST=Prague, C=CZ, CN=comp.eu", X500Name.getInstance(new PlatformX500NameStyle(false), certificateO.getSubjectX500Principal().getEncoded()).toString());
-        Assertions.assertEquals("2.5.4.10=Org, s.r.o.,2.5.4.15=Private Organization,2.5.4.3=comp.eu,2.5.4.5=1234,2.5.4.6=CZ,2.5.4.7=Prague,2.5.4.8=Prague", X500Name.getInstance(new PlatformX500NameStyle(true), certificateO.getSubjectX500Principal().getEncoded()).toString());
+        assertThat(X500Name.getInstance(new PlatformX500NameStyle(false), certificateAVA.getSubjectX500Principal().getEncoded()).toString()).isEqualTo("L=Bratislava, L=London, L=Prague, ST=Prague, C=CZ, CN=Xyzzy, CN=Bcd, CN=Abc");
+        assertThat(X500Name.getInstance(new PlatformX500NameStyle(true), certificateAVA.getSubjectX500Principal().getEncoded()).toString()).isEqualTo("2.5.4.3=Abc,2.5.4.3=Bcd,2.5.4.3=Xyzzy,2.5.4.6=CZ,2.5.4.7=Bratislava,2.5.4.7=London,2.5.4.7=Prague,2.5.4.8=Prague");
+        assertThat(X500Name.getInstance(new PlatformX500NameStyle(false), certificateO.getSubjectX500Principal().getEncoded()).toString()).isEqualTo("SERIALNUMBER=1234, BusinessCategory=Private Organization, O=Org, s.r.o., L=Prague, ST=Prague, C=CZ, CN=comp.eu");
+        assertThat(X500Name.getInstance(new PlatformX500NameStyle(true), certificateO.getSubjectX500Principal().getEncoded()).toString()).isEqualTo("2.5.4.10=Org, s.r.o.,2.5.4.15=Private Organization,2.5.4.3=comp.eu,2.5.4.5=1234,2.5.4.6=CZ,2.5.4.7=Prague,2.5.4.8=Prague");
     }
 
     private String getDnWithCustomStyle(String dn) {
@@ -57,10 +61,10 @@ class PlatformX500NameStyleTest extends BaseSpringBootTest {
         String originalX500 = "CN=Certificate Authority, X=Location, XX=State, UID=US, O=Organization, IP=1.2.3";
         X500Principal x500Principal = new X500Principal(originalX500, codeToOid);
         X500Name normalizedX500Name = X500Name.getInstance(new PlatformX500NameStyle(true), x500Principal.getEncoded());
-        Assertions.assertEquals(SystemOid.COMMON_NAME.getOid(), getOidByValueFromRDNs(normalizedX500Name, "Certificate Authority"));
-        Assertions.assertEquals(oid, getOidByValueFromRDNs(normalizedX500Name, "Location"));
-        Assertions.assertEquals(oid, getOidByValueFromRDNs(normalizedX500Name, "State"));
-        Assertions.assertEquals(oid2, getOidByValueFromRDNs(normalizedX500Name, "US"));
+        assertThat(getOidByValueFromRDNs(normalizedX500Name, "Certificate Authority")).isEqualTo(SystemOid.COMMON_NAME.getOid());
+        assertThat(getOidByValueFromRDNs(normalizedX500Name, "Location")).isEqualTo(oid);
+        assertThat(getOidByValueFromRDNs(normalizedX500Name, "State")).isEqualTo(oid);
+        assertThat(getOidByValueFromRDNs(normalizedX500Name, "US")).isEqualTo(oid2);
     }
 
     @Test
@@ -82,8 +86,8 @@ class PlatformX500NameStyleTest extends BaseSpringBootTest {
         // use non-normalized custom style which maps OID -> code for toString()
         String rendered = X500Name.getInstance(new PlatformX500NameStyle(false), x500Principal.getEncoded()).toString();
 
-        Assertions.assertTrue(rendered.contains(code + "=Location"), "OID should be rendered as code for Location");
-        Assertions.assertTrue(rendered.contains(code2 + "=US"), "OID should be rendered as code for US");
+        assertThat(rendered).as("OID should be rendered as code for Location").contains(code + "=Location");
+        assertThat(rendered).as("OID should be rendered as code for US").contains(code2 + "=US");
     }
 
     private static String getOidByValueFromRDNs(X500Name normalizedX500Name, String value) {

--- a/src/test/java/com/otilm/core/integration/util/SearchHelperITest.java
+++ b/src/test/java/com/otilm/core/integration/util/SearchHelperITest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.util;
+package com.otilm.core.integration.util;
 
 import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
@@ -13,7 +13,8 @@ import com.otilm.api.model.core.search.FilterConditionOperator;
 import com.otilm.api.model.core.search.SearchFieldDataDto;
 import com.otilm.core.enums.FilterField;
 import com.otilm.core.model.SearchFieldObject;
-import org.junit.jupiter.api.Assertions;
+import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.SearchHelper;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -21,19 +22,21 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-class SearchHelperTest extends BaseSpringBootTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SearchHelperITest extends BaseSpringBootTest {
 
     @Test
     void testPrepareSearchForJSON() {
         SearchFieldObject attributeSearchInfo = new SearchFieldObject(AttributeContentType.TIME);
         SearchFieldDataDto searchFieldDataDto = SearchHelper.prepareSearchForJSON(attributeSearchInfo, false);
-        Assertions.assertFalse(searchFieldDataDto.getConditions().isEmpty());
-        Assertions.assertFalse(searchFieldDataDto.getConditions().contains(FilterConditionOperator.IN_NEXT), "Condition should not contain IN_NEXT operator");
-        Assertions.assertFalse(searchFieldDataDto.getConditions().contains(FilterConditionOperator.IN_PAST), "Condition should not contain IN_PAST operator");
+        assertThat(searchFieldDataDto.getConditions()).isNotEmpty();
+        assertThat(searchFieldDataDto.getConditions()).as("Condition should not contain IN_NEXT operator").doesNotContain(FilterConditionOperator.IN_NEXT);
+        assertThat(searchFieldDataDto.getConditions()).as("Condition should not contain IN_PAST operator").doesNotContain(FilterConditionOperator.IN_PAST);
 
         attributeSearchInfo.setProtectionLevel(ProtectionLevel.ENCRYPTED);
         searchFieldDataDto = SearchHelper.prepareSearchForJSON(attributeSearchInfo, false);
-        Assertions.assertEquals(List.of(FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY), searchFieldDataDto.getConditions());
+        assertThat(searchFieldDataDto.getConditions()).isEqualTo(List.of(FilterConditionOperator.EMPTY, FilterConditionOperator.NOT_EMPTY));
     }
 
     @Test
@@ -47,18 +50,18 @@ class SearchHelperTest extends BaseSpringBootTest {
         attributeV3.setContentType(AttributeContentType.DATE);
         attributeV3.setProperties(dataAttributeProperties);
         SearchFieldObject searchFieldObject = new SearchFieldObject(attributeV3.getName(), attributeV3.getContentType(), AttributeType.DATA, "label", attributeV3);
-        Assertions.assertEquals(List.of(now.toString()), searchFieldObject.getContentItems());
+        assertThat(searchFieldObject.getContentItems()).isEqualTo(List.of(now.toString()));
 
         dataAttributeProperties.setList(false);
         attributeV3.setProperties(dataAttributeProperties);
         searchFieldObject = new SearchFieldObject(attributeV3.getName(), attributeV3.getContentType(), AttributeType.DATA, "label", attributeV3);
-        Assertions.assertNull(searchFieldObject.getContentItems());
+        assertThat(searchFieldObject.getContentItems()).isNull();
 
         dataAttributeProperties.setList(true);
         dataAttributeProperties.setProtectionLevel(ProtectionLevel.ENCRYPTED);
         attributeV3.setProperties(dataAttributeProperties);
         searchFieldObject = new SearchFieldObject(attributeV3.getName(), attributeV3.getContentType(), AttributeType.DATA, "label", attributeV3);
-        Assertions.assertNull(searchFieldObject.getContentItems());
+        assertThat(searchFieldObject.getContentItems()).isNull();
 
         CustomAttributeV3 customAttributeV3 = new CustomAttributeV3();
         customAttributeV3.setName("name");
@@ -68,17 +71,17 @@ class SearchHelperTest extends BaseSpringBootTest {
         customAttributeV3.setContentType(AttributeContentType.DATE);
         customAttributeV3.setProperties(customAttributeProperties);
         searchFieldObject = new SearchFieldObject(customAttributeV3.getName(), customAttributeV3.getContentType(), AttributeType.CUSTOM, "label", customAttributeV3);
-        Assertions.assertEquals(List.of("string"), searchFieldObject.getContentItems());
+        assertThat(searchFieldObject.getContentItems()).isEqualTo(List.of("string"));
 
         customAttributeProperties.setList(false);
         customAttributeV3.setProperties(customAttributeProperties);
         searchFieldObject = new SearchFieldObject(customAttributeV3.getName(), customAttributeV3.getContentType(), AttributeType.CUSTOM, "label", customAttributeV3);
-        Assertions.assertNull(searchFieldObject.getContentItems());
+        assertThat(searchFieldObject.getContentItems()).isNull();
         customAttributeProperties.setList(true);
         customAttributeProperties.setProtectionLevel(ProtectionLevel.ENCRYPTED);
         customAttributeV3.setProperties(customAttributeProperties);
         searchFieldObject = new SearchFieldObject(customAttributeV3.getName(), customAttributeV3.getContentType(), AttributeType.CUSTOM, "label", customAttributeV3);
-        Assertions.assertNull(searchFieldObject.getContentItems());
+        assertThat(searchFieldObject.getContentItems()).isNull();
 
     }
 
@@ -91,7 +94,7 @@ class SearchHelperTest extends BaseSpringBootTest {
             if (searchFieldDataDto.getConditions().containsAll(Set.of(FilterConditionOperator.COUNT_EQUAL, FilterConditionOperator.COUNT_NOT_EQUAL, FilterConditionOperator.COUNT_GREATER_THAN, FilterConditionOperator.COUNT_LESS_THAN)))
                 withCountOperator.add(filterField);
             }
-        Assertions.assertEquals(shouldHaveCountOperator, withCountOperator);
+        assertThat(withCountOperator).isEqualTo(shouldHaveCountOperator);
     }
 
     @Test
@@ -99,8 +102,8 @@ class SearchHelperTest extends BaseSpringBootTest {
         Set<FilterField> jsonArrays = Set.of(FilterField.AUDIT_LOG_RESOURCE_NAME, FilterField.AUDIT_LOG_RESOURCE_UUID);
         for (FilterField filterField : jsonArrays) {
             SearchFieldDataDto searchFieldDataDto = SearchHelper.prepareSearch(filterField);
-            Assertions.assertEquals(Set.of(FilterConditionOperator.EQUALS, FilterConditionOperator.NOT_EQUALS, FilterConditionOperator.NOT_EMPTY, FilterConditionOperator.EMPTY),
-                    new HashSet<>(searchFieldDataDto.getConditions()));
+            assertThat(new HashSet<>(searchFieldDataDto.getConditions()))
+                    .isEqualTo(Set.of(FilterConditionOperator.EQUALS, FilterConditionOperator.NOT_EQUALS, FilterConditionOperator.NOT_EMPTY, FilterConditionOperator.EMPTY));
         }
     }
 }


### PR DESCRIPTION
Part of the per-package integration-test migration series (**#1710**, PR 10; epic OmniTrustILM/ilm#252).

Migrates the 4 runnable context-loading tests under `com.otilm.core.util` into `com.otilm.core.integration.util`, renamed `*ITest`:

| From | To |
|---|---|
| `util/DigitalSigningCertQueryTest` | `integration/util/DigitalSigningCertQueryITest` |
| `util/FilterPredicatesBuilderTest` | `integration/util/FilterPredicatesBuilderITest` |
| `util/PlatformX500NameStyleTest` | `integration/util/PlatformX500NameStyleITest` |
| `util/SearchHelperTest` | `integration/util/SearchHelperITest` |

### Notes
- The shared context-root base classes (`BaseSpringBootTest`, `BaseSpringBootTestNoAuth`, `BaseMessagingIntTest`) are **non-runnable** infrastructure extended repo-wide (163 files) and intentionally **stay** in `com.otilm.core.util` — the guard exempts them (`isRunnableTest = false`). Moved tests already extend them cross-package.
- Added imports for the same-package `com.otilm.core.util` types the moved tests now reference cross-package (all `public`).
- While moving, aligned `PlatformX500NameStyleITest` and `SearchHelperITest` assertions to the codebase-standard AssertJ `assertThat(...)` (were JUnit `Assertions.*`).
- Drops `"util"` from `CiTestSplitTest.MIGRATION_ALLOWLIST` — only `"service"` now remains (plus the root-sweep flag). This is required: the allowlist-staleness guard would fail otherwise, since no pending context test remains under `util/`.

### Verification
- Guards `CiTestSplitTest` (7/7) + `TestClassTaxonomyTest` (11/11): green.
- Full-suite parity run (all profiles): **3808 tests, 0F / 0E / 2S, BUILD SUCCESS**.
- Renames tracked by git (history preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)