### PR TITLE
Keep extensible-list options in the connector attribute response

### DIFF
--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -651,7 +651,10 @@ public class AttributeEngine {
         } else if (dataAttribute instanceof DataAttributeV2 v2) {
             copy = new DataAttributeV2(v2);
         } else {
-            copy = dataAttribute; // legacy models without a copy constructor: unchanged behavior
+            // Force a future DataAttribute subtype to add a copy constructor rather than silently
+            // regressing to in-place mutation of the caller's object.
+            throw new IllegalStateException("Unsupported DataAttribute type for content-free copy: "
+                    + dataAttribute.getClass().getName());
         }
         copy.setContent(null);
         return copy;

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -16,6 +16,7 @@ import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.v2.content.BaseAttributeContentV2;
 import com.otilm.api.model.common.attribute.common.content.data.AttributeContentData;
 import com.otilm.api.model.common.attribute.v3.CustomAttributeV3;
+import com.otilm.api.model.common.attribute.v2.DataAttributeV2;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
 import com.otilm.api.model.common.attribute.v3.mapping.ExtensionMappedField;
@@ -631,13 +632,29 @@ public class AttributeEngine {
         encryptOrDecryptExistingContent(attributeDefinition, dataAttribute.getProperties().getProtectionLevel());
         attributeDefinition.setProtectionLevel(dataAttribute.getProperties().getProtectionLevel());
 
-        // we need content only for readonly attribute
+        // Persist the definition without extensible-list options, but do NOT strip them from the
+        // caller's attribute: a listing endpoint returns that same object and the UI needs the
+        // options as suggestions. (Secret containment on callback responses is handled separately.)
         if (!Boolean.TRUE.equals(attributeDefinition.isReadOnly()) && dataAttribute.getProperties().isExtensibleList()) {
-            dataAttribute.setContent(null);
-        } else
+            attributeDefinition.setDefinition(copyWithoutContent(dataAttribute));
+        } else {
             dataAttribute.setContent(encryptDefaultAttributeContent(dataAttribute, attributeDefinition, dataAttribute.getProperties().getProtectionLevel()));
-        attributeDefinition.setDefinition(dataAttribute);
+            attributeDefinition.setDefinition(dataAttribute);
+        }
         attributeDefinitionRepository.save(attributeDefinition);
+    }
+
+    private static DataAttribute copyWithoutContent(DataAttribute dataAttribute) {
+        DataAttribute copy;
+        if (dataAttribute instanceof DataAttributeV3 v3) {
+            copy = new DataAttributeV3(v3);
+        } else if (dataAttribute instanceof DataAttributeV2 v2) {
+            copy = new DataAttributeV2(v2);
+        } else {
+            copy = dataAttribute; // legacy models without a copy constructor: unchanged behavior
+        }
+        copy.setContent(null);
+        return copy;
     }
 
     public AttributeDefinition updateMetadataAttributeDefinition(MetadataAttribute metadataAttribute, UUID connectorUuid) throws AttributeException {

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -16,7 +16,6 @@ import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.v2.content.BaseAttributeContentV2;
 import com.otilm.api.model.common.attribute.common.content.data.AttributeContentData;
 import com.otilm.api.model.common.attribute.v3.CustomAttributeV3;
-import com.otilm.api.model.common.attribute.v2.DataAttributeV2;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
 import com.otilm.api.model.common.attribute.v3.mapping.ExtensionMappedField;
@@ -645,16 +644,12 @@ public class AttributeEngine {
     }
 
     private static DataAttribute copyWithoutContent(DataAttribute dataAttribute) {
-        DataAttribute copy;
-        if (dataAttribute instanceof DataAttributeV3 v3) {
-            copy = new DataAttributeV3(v3);
-        } else if (dataAttribute instanceof DataAttributeV2 v2) {
-            copy = new DataAttributeV2(v2);
-        } else {
-            // Force a future DataAttribute subtype to add a copy constructor rather than silently
-            // regressing to in-place mutation of the caller's object.
-            throw new IllegalStateException("Unsupported DataAttribute type for content-free copy: "
-                    + dataAttribute.getClass().getName());
+        // Reuse the version-aware copy; fail loud (rather than mutate the caller in place) if a future
+        // DataAttribute version has no copy support, so the regression can't slip in silently.
+        DataAttribute copy = AttributeVersionHelper.copyDataAttribute(dataAttribute);
+        if (copy == null) {
+            throw new IllegalStateException("Unsupported DataAttribute version for content-free copy: "
+                    + dataAttribute.getVersion());
         }
         copy.setContent(null);
         return copy;

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
@@ -349,6 +349,30 @@ class AttributeEngineITest extends BaseSpringBootTest {
     }
 
     @Test
+    void updateDataAttributeDefinitionsKeepsExtensibleListOptionsOnResponse() throws AttributeException {
+        // Registering the definition must not strip the connector-provided options from the returned
+        // attribute: a listing endpoint returns that same object and the UI needs the options as
+        // suggestions for the extensible list (the definition itself is still stored without them).
+        DataAttributeV3 extensible = new DataAttributeV3();
+        extensible.setUuid(UUID.randomUUID().toString());
+        extensible.setName("extensibleListWithOptions");
+        extensible.setContentType(AttributeContentType.STRING);
+        extensible.setContent(List.of(new StringAttributeContentV3("team-a")));
+        DataAttributeProperties props = new DataAttributeProperties();
+        props.setLabel("Extensible list with options");
+        props.setList(true);
+        props.setExtensibleList(true);
+        props.setReadOnly(false);
+        extensible.setProperties(props);
+
+        attributeEngine.updateDataAttributeDefinitions(null, null, List.of(extensible));
+
+        Assertions.assertNotNull(extensible.getContent(), "extensible-list options must survive for the response");
+        Assertions.assertEquals(1, extensible.getContent().size());
+        Assertions.assertEquals("team-a", ((StringAttributeContentV3) extensible.getContent().get(0)).getData());
+    }
+
+    @Test
     void updateObjectDataAttributesContentAcceptsNullContentForNonRequiredAttribute() throws AttributeException {
         // Regression: a connector legitimately returning content=null for an optional attribute
         // used to NPE deep in createObjectAttributeContent (attributeContentItems.size() on null),

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
@@ -394,6 +394,27 @@ class AttributeEngineITest extends BaseSpringBootTest {
     }
 
     @Test
+    void updateDataAttributeDefinitionsFailsLoudOnUnsupportedVersionExtensibleList() {
+        // Guard: an extensible-list attribute whose version has no copy support must fail loudly
+        // rather than silently mutating the caller's attribute in place.
+        DataAttributeV2 unsupported = new DataAttributeV2();
+        unsupported.setUuid(UUID.randomUUID().toString());
+        unsupported.setName("unsupportedVersionExtensible");
+        unsupported.setContentType(AttributeContentType.STRING);
+        unsupported.setContent(List.of(new StringAttributeContentV2("x")));
+        unsupported.setVersion(99);
+        DataAttributeProperties props = new DataAttributeProperties();
+        props.setLabel("Unsupported version");
+        props.setList(true);
+        props.setExtensibleList(true);
+        props.setReadOnly(false);
+        unsupported.setProperties(props);
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> attributeEngine.updateDataAttributeDefinitions(null, null, List.of(unsupported)));
+    }
+
+    @Test
     void updateObjectDataAttributesContentAcceptsNullContentForNonRequiredAttribute() throws AttributeException {
         // Regression: a connector legitimately returning content=null for an optional attribute
         // used to NPE deep in createObjectAttributeContent (attributeContentItems.size() on null),

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
@@ -350,27 +350,47 @@ class AttributeEngineITest extends BaseSpringBootTest {
     }
 
     @Test
-    void updateDataAttributeDefinitionsKeepsExtensibleListOptionsOnResponse() throws AttributeException {
-        // Registering the definition must not strip the connector-provided options from the returned
-        // attribute: a listing endpoint returns that same object and the UI needs the options as
-        // suggestions for the extensible list (the definition itself is still stored without them).
-        DataAttributeV3 extensible = new DataAttributeV3();
-        extensible.setUuid(UUID.randomUUID().toString());
-        extensible.setName("extensibleListWithOptions");
-        extensible.setContentType(AttributeContentType.STRING);
-        extensible.setContent(List.of(new StringAttributeContentV3("team-a")));
-        DataAttributeProperties props = new DataAttributeProperties();
-        props.setLabel("Extensible list with options");
-        props.setList(true);
-        props.setExtensibleList(true);
-        props.setReadOnly(false);
-        extensible.setProperties(props);
+    void updateDataAttributeDefinitionsKeepsExtensibleListOptionsOnResponseButNotInStorage() throws AttributeException {
+        // The connector-provided options must survive on the returned attribute (a listing endpoint
+        // returns that same object and the UI needs them as suggestions), while the persisted
+        // definition is stored without them. Covers both copyWithoutContent branches (v3 and v2).
+        DataAttributeV3 v3 = new DataAttributeV3();
+        v3.setUuid(UUID.randomUUID().toString());
+        v3.setName("extensibleListV3");
+        v3.setContentType(AttributeContentType.STRING);
+        v3.setContent(List.of(new StringAttributeContentV3("team-a")));
+        DataAttributeProperties p3 = new DataAttributeProperties();
+        p3.setLabel("Extensible list v3");
+        p3.setList(true);
+        p3.setExtensibleList(true);
+        p3.setReadOnly(false);
+        v3.setProperties(p3);
 
-        attributeEngine.updateDataAttributeDefinitions(null, null, List.of(extensible));
+        attributeEngine.updateDataAttributeDefinitions(null, null, List.of(v3));
 
-        Assertions.assertNotNull(extensible.getContent(), "extensible-list options must survive for the response");
-        Assertions.assertEquals(1, extensible.getContent().size());
-        Assertions.assertEquals("team-a", ((StringAttributeContentV3) extensible.getContent().get(0)).getData());
+        Assertions.assertNotNull(v3.getContent(), "v3 options must survive for the response");
+        Assertions.assertEquals("team-a", ((StringAttributeContentV3) v3.getContent().get(0)).getData());
+        AttributeDefinition def3 = attributeDefinitionRepository.findByConnectorUuidAndAttributeUuid(null, UUID.fromString(v3.getUuid())).orElseThrow();
+        Assertions.assertNull(def3.getDefinition().getContent(), "v3 definition must be stored without options");
+
+        DataAttributeV2 v2 = new DataAttributeV2();
+        v2.setUuid(UUID.randomUUID().toString());
+        v2.setName("extensibleListV2");
+        v2.setContentType(AttributeContentType.STRING);
+        v2.setContent(List.of(new StringAttributeContentV2("team-b")));
+        DataAttributeProperties p2 = new DataAttributeProperties();
+        p2.setLabel("Extensible list v2");
+        p2.setList(true);
+        p2.setExtensibleList(true);
+        p2.setReadOnly(false);
+        v2.setProperties(p2);
+
+        attributeEngine.updateDataAttributeDefinitions(null, null, List.of(v2));
+
+        Assertions.assertNotNull(v2.getContent(), "v2 options must survive for the response");
+        Assertions.assertEquals("team-b", ((StringAttributeContentV2) v2.getContent().get(0)).getData());
+        AttributeDefinition def2 = attributeDefinitionRepository.findByConnectorUuidAndAttributeUuid(null, UUID.fromString(v2.getUuid())).orElseThrow();
+        Assertions.assertNull(def2.getDefinition().getContent(), "v2 definition must be stored without options");
     }
 
     @Test


### PR DESCRIPTION
## Summary

When a connector returns a **non-readonly extensible-list** data attribute with predefined options in its `content`, Core strips those options before the client ever sees them, so the UI shows an extensible field with **no suggestions**.

Root cause is a side-effect mutation in `AttributeEngine.updateDataAttributeDefinition`: for `extensibleList` (and not `readOnly`) it calls `dataAttribute.setContent(null)` **on the caller's object**, and listing endpoints such as `VaultInstanceServiceImpl.listVaultInstanceAttributes` return that same object. The definition-registration side effect leaks into the response.

## Change

Persist the definition without the options exactly as before, but do it from a **content-stripped copy** and leave the caller's attribute (and its `content`) intact for the response:

```java
if (!Boolean.TRUE.equals(attributeDefinition.isReadOnly()) && dataAttribute.getProperties().isExtensibleList()) {
    attributeDefinition.setDefinition(copyWithoutContent(dataAttribute));   // stored: no options
} else {
    dataAttribute.setContent(encryptDefaultAttributeContent(dataAttribute, attributeDefinition, ...));
    attributeDefinition.setDefinition(dataAttribute);
}
attributeDefinitionRepository.save(attributeDefinition);
```

`copyWithoutContent` uses the existing `DataAttributeV2` / `DataAttributeV3` copy constructors (shallow copy; nulling the copy's content doesn't touch the original).

**Storage is unchanged** — the persisted definition still carries no options. Only the in-flight response object is no longer clobbered.

## Safety / scope

- **Callback-path secret containment (`OutboundSecretContainment`) is untouched** — it guards NG callback *dispatch responses*, a different flow; this change is in definition registration and neither removes nor bypasses it.
- **NG attribute resolution/registry is untouched** — separate path.
- No new secret-exposure on the listing path: `ProtectionLevel` is at-rest DB encryption (not a client-exposure gate), and the listing path already returns option content for closed lists; the content preserved here is the connector's option list (for the motivating case, plain namespace strings), not secret values.
- Behavior change is confined to the non-readonly `extensibleList` branch; closed lists / defaults / `encryptDefaultAttributeContent` are unchanged.

## Motivation

Unblocks OmniTrustILM/common-credential-provider#92, where the secret provider exposes an optional `data_namespace` extensible-list vault attribute that offers already-used namespaces as suggestions while still allowing a new one.

## Testing

- New regression test in `AttributeEngineITest` (`updateDataAttributeDefinitionsKeepsExtensibleListOptionsOnResponse`): an extensible-list attribute retains its options after `updateDataAttributeDefinitions`.
- `mvn -P test-integration test -Dtest=AttributeEngineITest#updateDataAttributeDefinitionsKeepsExtensibleListOptionsOnResponse` → **1 test, BUILD SUCCESS**; `mvn test-compile` clean.

@vyskocilm — flagging you since this is adjacent to the Attributes v2 NG callback/containment work (#1679); would appreciate your eyes on the secret-containment reasoning above.
