### PR TITLE
Clear pre-existing SonarQube test smells from Round B2 migration (#1764)

### DIFF
--- a/src/test/java/com/otilm/core/integration/service/LocationServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/LocationServiceITest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -52,6 +51,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 class LocationServiceITest extends BaseSpringBootTest {
 
@@ -313,7 +313,8 @@ class LocationServiceITest extends BaseSpringBootTest {
     @Test
     void testAddLocation_validationFail() {
         AddLocationRequestDto request = new AddLocationRequestDto();
-        Assertions.assertThrows(ValidationException.class, () -> locationService.addLocation(entityInstanceReference.getSecuredParentUuid(), request));
+        var securedParentUuid = entityInstanceReference.getSecuredParentUuid();
+        Assertions.assertThrows(ValidationException.class, () -> locationService.addLocation(securedParentUuid, request));
     }
 
     @Test
@@ -384,7 +385,6 @@ class LocationServiceITest extends BaseSpringBootTest {
         Assertions.assertThrows(NotFoundException.class, () -> locationService.disableLocation(entityInstanceReference.getSecuredParentUuid(), SecuredUUID.fromString("abfbc322-29e1-11ed-a261-0242ac120002")));
     }
 
-    // TODO: testing the location push, remove, issue, sync
     @Test
     void testPushCertificateToLocation_MultiNotSupported() {
         PushToLocationRequestDto request = new PushToLocationRequestDto();
@@ -593,7 +593,7 @@ class LocationServiceITest extends BaseSpringBootTest {
         ClientCertificateDataResponseDto responseDto = new ClientCertificateDataResponseDto();
 
         responseDto.setUuid(certificate.getUuid().toString());
-        Mockito.when(clientOperationService.issueCertificate(any(), any(), any(), any())).thenReturn(responseDto);
+        when(clientOperationService.issueCertificate(any(), any(), any(), any())).thenReturn(responseDto);
         mockServer.stubFor(WireMock.get(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/push/attributes")).willReturn(WireMock.okJson("[]")));
         mockServer.stubFor(WireMock.get(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/csr/attributes")).willReturn(WireMock.okJson("[]")));
         mockServer.stubFor(WireMock.post(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/csr")).willReturn(WireMock.okJson("{}")));
@@ -659,7 +659,7 @@ class LocationServiceITest extends BaseSpringBootTest {
 
         ClientCertificateDataResponseDto responseDto = new ClientCertificateDataResponseDto();
         responseDto.setUuid(renewedCertificate.getUuid().toString());
-        Mockito.when(clientOperationService.renewCertificate(any(), any(), any(), any())).thenReturn(responseDto);
+        when(clientOperationService.renewCertificate(any(), any(), any(), any())).thenReturn(responseDto);
 
         mockServer.stubFor(WireMock.post(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/csr")).willReturn(WireMock.okJson("{}")));
         mockServer.stubFor(WireMock.get(WireMock.urlPathMatching("/v1/entityProvider/entities/[^/]+/locations/push/attributes")).willReturn(WireMock.okJson("[]")));

--- a/src/test/java/com/otilm/core/integration/service/ProxyServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ProxyServiceITest.java
@@ -221,7 +221,8 @@ class ProxyServiceITest extends BaseSpringBootTest {
         connectorRepository.save(connector);
 
         Proxy finalProxyWithConnector = proxyRepository.save(proxyWithConnector);
-        Assertions.assertThrows(ValidationException.class, () -> proxyService.deleteProxy(finalProxyWithConnector.getSecuredUuid()));
+        var securedUuid = finalProxyWithConnector.getSecuredUuid();
+        Assertions.assertThrows(ValidationException.class, () -> proxyService.deleteProxy(securedUuid));
     }
 
     @Test
@@ -293,7 +294,8 @@ class ProxyServiceITest extends BaseSpringBootTest {
                 .withStatus(500)
                 .withBody("Internal Server Error")));
 
+        var securedUuid = proxy.getSecuredUuid();
         Assertions.assertThrows(ProvisioningException.class,
-            () -> proxyService.getInstallationInstructions(proxy.getSecuredUuid()));
+            () -> proxyService.getInstallationInstructions(securedUuid));
     }
 }

--- a/src/test/java/com/otilm/core/integration/service/RaProfileCertificateRequestAttributeServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/RaProfileCertificateRequestAttributeServiceITest.java
@@ -22,7 +22,6 @@ import com.otilm.core.service.writer.RaProfileCertificateRequestAttributeWriter;
 import com.otilm.core.util.AttributeDefinitionUtils;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -31,6 +30,10 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class RaProfileCertificateRequestAttributeServiceITest extends BaseSpringBootTest {
 
@@ -116,7 +119,7 @@ class RaProfileCertificateRequestAttributeServiceITest extends BaseSpringBootTes
         // given: a connector set with c1, and a static set with c1 (conflict) + s2 (static-only)
         RaProfile raProfile = newRaProfile();
         attachConnector(raProfile);
-        Mockito.when(extendedAttributeService.listIssueCertificateAttributes(Mockito.any()))
+        when(extendedAttributeService.listIssueCertificateAttributes(any()))
                 .thenReturn(List.of(def("c1", "connector-name")));
         writer.saveStaticSet(raProfile, AttributeDefinitionUtils.serialize(List.of(def("c1", "static-conflict"), def("s2", "static-only"))),
                 AttributeSetMergeMode.MERGE, null);
@@ -142,7 +145,7 @@ class RaProfileCertificateRequestAttributeServiceITest extends BaseSpringBootTes
         List<BaseAttribute> resolved = service.resolveIssueAttributeSet(raProfile, AttributeSetMergeMode.MERGE);
 
         // then: the connector fetch is skipped gracefully (no NotFoundException) and only the static set resolves
-        Mockito.verify(extendedAttributeService, Mockito.never()).listIssueCertificateAttributes(Mockito.any());
+        verify(extendedAttributeService, never()).listIssueCertificateAttributes(any());
         assertThat(resolved).extracting(BaseAttribute::getName).containsExactly("static-only");
     }
 
@@ -151,7 +154,7 @@ class RaProfileCertificateRequestAttributeServiceITest extends BaseSpringBootTes
         // given: a stored static set whose persisted merge mode is STATIC_ONLY, plus a (would-be-winning) connector set
         RaProfile raProfile = newRaProfile();
         attachConnector(raProfile);
-        Mockito.when(extendedAttributeService.listIssueCertificateAttributes(Mockito.any()))
+        when(extendedAttributeService.listIssueCertificateAttributes(any()))
                 .thenReturn(List.of(def("c1", "connector-name")));
         writer.saveStaticSet(raProfile, AttributeDefinitionUtils.serialize(List.of(def("s1", "static-only"))),
                 AttributeSetMergeMode.STATIC_ONLY, null);

--- a/src/test/java/com/otilm/core/integration/service/ResourceServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ResourceServiceITest.java
@@ -49,7 +49,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -60,6 +59,10 @@ import java.util.*;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.when;
 
 class ResourceServiceITest extends BaseSpringBootTest {
 
@@ -260,12 +263,12 @@ class ResourceServiceITest extends BaseSpringBootTest {
         scopedAccess.setActionAllowedForGroupOfObjects(false);
         scopedAccess.setAllowedObjects(List.of(inScopeUuid.toString()));
         scopedAccess.setForbiddenObjects(List.of());
-        Mockito.when(
+        when(
                 opaClient.checkObjectAccess(
-                        Mockito.any(),
-                        Mockito.argThat(req -> isObjectAccessRequestForResource(req, Resource.RA_PROFILE, ResourceAction.LIST)),
-                        Mockito.any(),
-                        Mockito.any()
+                        any(),
+                        argThat(req -> isObjectAccessRequestForResource(req, Resource.RA_PROFILE, ResourceAction.LIST)),
+                        any(),
+                        any()
                 )
         ).thenReturn(scopedAccess);
 
@@ -504,15 +507,15 @@ class ResourceServiceITest extends BaseSpringBootTest {
     void forbidGetResourceWithAuthorization() {
         OpaResourceAccessResult resourceAccessNotAllowed = new OpaResourceAccessResult(false, List.of());
 
-        Mockito.when(
-                opaClient.checkResourceAccess(Mockito.any(),
-                        Mockito.argThat(req -> isRequestForResourceAction(req, Resource.RA_PROFILE)), Mockito.any(), Mockito.any())
+        when(
+                opaClient.checkResourceAccess(any(),
+                        argThat(req -> isRequestForResourceAction(req, Resource.RA_PROFILE)), any(), any())
         ).thenReturn(resourceAccessNotAllowed);
 
-        Mockito.when(
-                opaClient.checkResourceAccess(Mockito.any(),  Mockito.argThat(req ->
+        when(
+                opaClient.checkResourceAccess(any(),  argThat(req ->
                         isRequestForResourceAction(req, Resource.SECRET)
-                ), Mockito.any(), Mockito.any())
+                ), any(), any())
         ).thenReturn(resourceAccessNotAllowed);
 
     }

--- a/src/test/java/com/otilm/core/integration/service/RoleManagementServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/RoleManagementServiceITest.java
@@ -7,12 +7,16 @@ import com.otilm.core.security.authn.client.RoleManagementApiClient;
 import com.otilm.core.service.RoleManagementExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
 import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class RoleManagementServiceITest extends BaseSpringBootTest {
 
@@ -30,7 +34,7 @@ class RoleManagementServiceITest extends BaseSpringBootTest {
         // given
         String roleUuid = UUID.randomUUID().toString();
         RoleDetailDto roleDetailDto = roleDetailDto(roleUuid, false);
-        Mockito.when(roleManagementApiClient.updateRole(Mockito.eq(roleUuid), Mockito.any())).thenReturn(roleDetailDto);
+        when(roleManagementApiClient.updateRole(eq(roleUuid), any())).thenReturn(roleDetailDto);
 
         RoleRequestDto request = new RoleRequestDto();
         request.setName("test-role");
@@ -40,7 +44,7 @@ class RoleManagementServiceITest extends BaseSpringBootTest {
         roleManagementService.updateRole(roleUuid, request);
 
         // then
-        Mockito.verify(authenticationCache).evictAll();
+        verify(authenticationCache).evictAll();
     }
 
     @Test
@@ -52,22 +56,22 @@ class RoleManagementServiceITest extends BaseSpringBootTest {
         roleManagementService.deleteRole(roleUuid);
 
         // then
-        Mockito.verify(authenticationCache).evictAll();
+        verify(authenticationCache).evictAll();
     }
 
     @Test
     void addPermissions_evictsEntireCache() {
         // given
         String roleUuid = UUID.randomUUID().toString();
-        Mockito.when(roleManagementApiClient.getRoleDetail(roleUuid)).thenReturn(roleDetailDto(roleUuid, false));
-        Mockito.when(roleManagementApiClient.savePermissions(Mockito.eq(roleUuid), Mockito.any()))
+        when(roleManagementApiClient.getRoleDetail(roleUuid)).thenReturn(roleDetailDto(roleUuid, false));
+        when(roleManagementApiClient.savePermissions(eq(roleUuid), any()))
                 .thenReturn(new SubjectPermissionsDto());
 
         // when
         roleManagementService.addPermissions(roleUuid, new RolePermissionsRequestDto());
 
         // then
-        Mockito.verify(authenticationCache).evictAll();
+        verify(authenticationCache).evictAll();
     }
 
     @Test
@@ -75,13 +79,13 @@ class RoleManagementServiceITest extends BaseSpringBootTest {
         // given
         String roleUuid = UUID.randomUUID().toString();
         String resourceUuid = UUID.randomUUID().toString();
-        Mockito.when(roleManagementApiClient.getRoleDetail(roleUuid)).thenReturn(roleDetailDto(roleUuid, false));
+        when(roleManagementApiClient.getRoleDetail(roleUuid)).thenReturn(roleDetailDto(roleUuid, false));
 
         // when
         roleManagementService.addResourcePermissionObjects(roleUuid, resourceUuid, List.of());
 
         // then
-        Mockito.verify(authenticationCache).evictAll();
+        verify(authenticationCache).evictAll();
     }
 
     @Test
@@ -90,13 +94,13 @@ class RoleManagementServiceITest extends BaseSpringBootTest {
         String roleUuid = UUID.randomUUID().toString();
         String resourceUuid = UUID.randomUUID().toString();
         String objectUuid = UUID.randomUUID().toString();
-        Mockito.when(roleManagementApiClient.getRoleDetail(roleUuid)).thenReturn(roleDetailDto(roleUuid, false));
+        when(roleManagementApiClient.getRoleDetail(roleUuid)).thenReturn(roleDetailDto(roleUuid, false));
 
         // when
         roleManagementService.updateResourcePermissionObjects(roleUuid, resourceUuid, objectUuid, new ObjectPermissionsRequestDto());
 
         // then
-        Mockito.verify(authenticationCache).evictAll();
+        verify(authenticationCache).evictAll();
     }
 
     @Test
@@ -105,27 +109,27 @@ class RoleManagementServiceITest extends BaseSpringBootTest {
         String roleUuid = UUID.randomUUID().toString();
         String resourceUuid = UUID.randomUUID().toString();
         String objectUuid = UUID.randomUUID().toString();
-        Mockito.when(roleManagementApiClient.getRoleDetail(roleUuid)).thenReturn(roleDetailDto(roleUuid, false));
+        when(roleManagementApiClient.getRoleDetail(roleUuid)).thenReturn(roleDetailDto(roleUuid, false));
 
         // when
         roleManagementService.removeResourcePermissionObjects(roleUuid, resourceUuid, objectUuid);
 
         // then
-        Mockito.verify(authenticationCache).evictAll();
+        verify(authenticationCache).evictAll();
     }
 
     @Test
     void updateUsers_evictsEntireCache() {
         // given
         String roleUuid = UUID.randomUUID().toString();
-        Mockito.when(roleManagementApiClient.updateUsers(Mockito.eq(roleUuid), Mockito.any()))
+        when(roleManagementApiClient.updateUsers(eq(roleUuid), any()))
                 .thenReturn(roleDetailDto(roleUuid, false));
 
         // when
         roleManagementService.updateUsers(roleUuid, List.of());
 
         // then
-        Mockito.verify(authenticationCache).evictAll();
+        verify(authenticationCache).evictAll();
     }
 
     private static RoleDetailDto roleDetailDto(String uuid, boolean systemRole) {

--- a/src/test/java/com/otilm/core/integration/service/ScepProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ScepProfileServiceITest.java
@@ -45,11 +45,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -681,7 +681,8 @@ class ScepProfileServiceITest extends BaseSpringBootTest {
     @Test
     void testEditScepProfile_validationFail() {
         ScepProfileEditRequestDto request = new ScepProfileEditRequestDto();
-        Assertions.assertThrows(ValidationException.class, () -> scepProfileService.editScepProfile(SecuredUUID.fromString("abfbc322-29e1-11ed-a261-0242ac120002"), request));
+        var securedUuid = SecuredUUID.fromString("abfbc322-29e1-11ed-a261-0242ac120002");
+        Assertions.assertThrows(ValidationException.class, () -> scepProfileService.editScepProfile(securedUuid, request));
     }
 
     @Test
@@ -783,7 +784,7 @@ class ScepProfileServiceITest extends BaseSpringBootTest {
         RaProfile linkedRaProfile = new RaProfile();
         linkedRaProfile.setName("linkedRaProfile");
         SecuredList<RaProfile> nonEmptyList = new SecuredList<>(List.of(new SecuredItem<>(linkedRaProfile, true)));
-        Mockito.doReturn(nonEmptyList)
+        doReturn(nonEmptyList)
                 .when(raProfileService)
                 .listRaProfilesAssociatedWithScepProfile(scepProfile.getUuid().toString(), SecurityFilter.create());
 

--- a/src/test/java/com/otilm/core/integration/service/SigningCertificateCacheITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SigningCertificateCacheITest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -48,6 +47,10 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * Verifies that {@code getSigningCertificate} maps the entity graph correctly, is cached (second call
@@ -188,13 +191,13 @@ class SigningCertificateCacheITest extends BaseSpringBootTest {
         Certificate cert = persistSigningCertificate();
         UUID uuid = cert.getUuid();
 
-        Mockito.clearInvocations(certificateRepository);
+        clearInvocations(certificateRepository);
 
         SigningCertificate first = certificateService.getSigningCertificate(uuid);
         SigningCertificate second = certificateService.getSigningCertificate(uuid);
 
         Assertions.assertEquals(first, second);
-        Mockito.verify(certificateRepository, Mockito.times(1))
+        verify(certificateRepository, times(1))
                 .findForSigningByUuid(uuid);
     }
 

--- a/src/test/java/com/otilm/core/integration/service/StatisticsServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/StatisticsServiceITest.java
@@ -17,7 +17,6 @@ import com.otilm.core.util.CertificateUtil;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Rollback;
@@ -28,6 +27,9 @@ import org.springframework.util.SerializationUtils;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @Transactional
@@ -101,15 +103,15 @@ class StatisticsServiceITest extends BaseSpringBootTest {
     private void mockOpaResponses(List<String> forbiddenObjects) {
         OpaResourceAccessResult resourceAccessNotAllowed = new OpaResourceAccessResult(false, List.of());
         // By default, reject all
-        Mockito.when(
-                opaClient.checkResourceAccess(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())
+        when(
+                opaClient.checkResourceAccess(any(), any(), any(), any())
         ).thenReturn(resourceAccessNotAllowed);
         OpaObjectAccessResult opaObjectAccessResult = new OpaObjectAccessResult();
         opaObjectAccessResult.setAllowedObjects(List.of());
         // OPA denies both, but ownership grants access to certificateOwned — this is the low-privilege path being verified
         opaObjectAccessResult.setForbiddenObjects(forbiddenObjects);
-        Mockito.when(
-                        opaClient.checkObjectAccess(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        when(
+                        opaClient.checkObjectAccess(any(), any(), any(), any()))
                 .thenReturn(opaObjectAccessResult);
     }
 

--- a/src/test/java/com/otilm/core/integration/service/TimeQualityConfigurationServiceImplITest.java
+++ b/src/test/java/com/otilm/core/integration/service/TimeQualityConfigurationServiceImplITest.java
@@ -37,12 +37,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
 
 import java.time.Duration;
 import java.util.List;
@@ -79,7 +81,7 @@ class TimeQualityConfigurationServiceImplITest extends BaseSpringBootTest {
 
     @AfterEach
     void resetSpies() {
-        Mockito.reset(timeQualityConfigurationRepository, attributeEngine);
+        reset(timeQualityConfigurationRepository, attributeEngine);
     }
 
     @BeforeEach
@@ -350,8 +352,8 @@ class TimeQualityConfigurationServiceImplITest extends BaseSpringBootTest {
 
     @Test
     void create_translatesDbUniqueViolationToAlreadyExist() {
-        Mockito.doReturn(Optional.empty()).when(timeQualityConfigurationRepository).findByName("race-name");
-        Mockito.doThrow(new DataIntegrityViolationException("unique constraint violation"))
+        doReturn(Optional.empty()).when(timeQualityConfigurationRepository).findByName("race-name");
+        doThrow(new DataIntegrityViolationException("unique constraint violation"))
                .when(timeQualityConfigurationRepository).saveAndFlush(any(TimeQualityConfiguration.class));
 
         TimeQualityConfigurationRequestDto createRequest = buildCreateRequest("race-name");
@@ -362,8 +364,8 @@ class TimeQualityConfigurationServiceImplITest extends BaseSpringBootTest {
 
     @Test
     void update_translatesDbUniqueViolationToAlreadyExist() {
-        Mockito.doReturn(Optional.empty()).when(timeQualityConfigurationRepository).findByName("race-name");
-        Mockito.doThrow(new DataIntegrityViolationException("unique constraint violation"))
+        doReturn(Optional.empty()).when(timeQualityConfigurationRepository).findByName("race-name");
+        doThrow(new DataIntegrityViolationException("unique constraint violation"))
                .when(timeQualityConfigurationRepository).saveAndFlush(any(TimeQualityConfiguration.class));
 
         SecuredUUID uuid = savedConfiguration.getSecuredUuid();
@@ -594,7 +596,7 @@ class TimeQualityConfigurationServiceImplITest extends BaseSpringBootTest {
 
         // Throw a RuntimeException for the first item only, keyed by its UUID.
         // AttributeEngine is a concrete class so doCallRealMethod() works for the second item.
-        Mockito.doThrow(new DataIntegrityViolationException("simulated FK violation"))
+        doThrow(new DataIntegrityViolationException("simulated FK violation"))
                .when(attributeEngine).deleteObjectAttributeContent(Resource.TIME_QUALITY_CONFIGURATION, savedConfiguration.getUuid());
 
         List<BulkActionMessageDto> messages = timeQualityConfigurationService.bulkDeleteTimeQualityConfigurations(

--- a/src/test/java/com/otilm/core/integration/service/TokenInstanceServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/TokenInstanceServiceITest.java
@@ -238,7 +238,8 @@ class TokenInstanceServiceITest extends BaseSpringBootTest {
                 .get(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/tokenProfile/attributes"))
                 .willReturn(WireMock.ok()));
 
-        tokenInstanceService.listTokenProfileAttributes(tokenInstanceReference.getSecuredUuid());
+        var attributes = tokenInstanceService.listTokenProfileAttributes(tokenInstanceReference.getSecuredUuid());
+        Assertions.assertNotNull(attributes);
     }
 
     @Test
@@ -247,11 +248,12 @@ class TokenInstanceServiceITest extends BaseSpringBootTest {
                 .get(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/activate/attributes"))
                 .willReturn(WireMock.ok()));
 
-        tokenInstanceService.listTokenInstanceActivationAttributes(tokenInstanceReference.getSecuredUuid());
+        var attributes = tokenInstanceService.listTokenInstanceActivationAttributes(tokenInstanceReference.getSecuredUuid());
+        Assertions.assertNotNull(attributes);
     }
 
     @Test
-    void testActivateTokenInstance() throws ConnectorException, NotFoundException {
+    void testActivateTokenInstance() {
         mockServer.stubFor(WireMock
                 .get(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/activate/attributes"))
                 .willReturn(WireMock.ok()));
@@ -264,16 +266,18 @@ class TokenInstanceServiceITest extends BaseSpringBootTest {
                 .patch(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/activate"))
                 .willReturn(WireMock.ok()));
 
-        tokenInstanceService.activateTokenInstance(tokenInstanceReference.getSecuredUuid(), List.of());
+        var securedUuid = tokenInstanceReference.getSecuredUuid();
+        Assertions.assertDoesNotThrow(() -> tokenInstanceService.activateTokenInstance(securedUuid, List.of()));
     }
 
     @Test
-    void testDeactivateTokenInstance() throws ConnectorException, NotFoundException {
+    void testDeactivateTokenInstance() {
         mockServer.stubFor(WireMock
                 .patch(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/deactivate"))
                 .willReturn(WireMock.ok()));
 
-        tokenInstanceService.deactivateTokenInstance(tokenInstanceReference.getSecuredUuid());
+        var securedUuid = tokenInstanceReference.getSecuredUuid();
+        Assertions.assertDoesNotThrow(() -> tokenInstanceService.deactivateTokenInstance(securedUuid));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/TokenInstanceServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/TokenInstanceServiceITest.java
@@ -239,7 +239,7 @@ class TokenInstanceServiceITest extends BaseSpringBootTest {
                 .willReturn(WireMock.ok()));
 
         var attributes = tokenInstanceService.listTokenProfileAttributes(tokenInstanceReference.getSecuredUuid());
-        Assertions.assertNotNull(attributes);
+        Assertions.assertTrue(attributes.isEmpty());
     }
 
     @Test
@@ -249,7 +249,7 @@ class TokenInstanceServiceITest extends BaseSpringBootTest {
                 .willReturn(WireMock.ok()));
 
         var attributes = tokenInstanceService.listTokenInstanceActivationAttributes(tokenInstanceReference.getSecuredUuid());
-        Assertions.assertNotNull(attributes);
+        Assertions.assertTrue(attributes.isEmpty());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/TokenProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/TokenProfileServiceITest.java
@@ -146,10 +146,11 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
     @Test
     void testAddTokenProfile_validationFail() {
         AddTokenProfileRequestDto request = new AddTokenProfileRequestDto();
+        var securedParentUuid = tokenInstanceReference.getSecuredParentUuid();
         Assertions.assertThrows(
                 ValidationException.class,
                 () -> tokenProfileService.createTokenProfile(
-                        tokenInstanceReference.getSecuredParentUuid(),
+                        securedParentUuid,
                         request
                 )
         );

--- a/src/test/java/com/otilm/core/integration/service/TrustedCertificateServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/TrustedCertificateServiceITest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.Base64;
 import java.util.List;
 
@@ -140,8 +141,9 @@ class TrustedCertificateServiceITest extends BaseSpringBootTest {
                 .withStatus(500)
                 .withBody("Internal Server Error")));
 
+        var securedUuid = SecuredUUID.fromString(TEST_UUID);
         ProvisioningException exception = assertThrows(ProvisioningException.class,
-            () -> trustedCertificateService.getTrustedCertificate(SecuredUUID.fromString(TEST_UUID)));
+            () -> trustedCertificateService.getTrustedCertificate(securedUuid));
 
         assertTrue(exception.getMessage().contains("Failed to get trusted certificate"));
     }
@@ -213,8 +215,9 @@ class TrustedCertificateServiceITest extends BaseSpringBootTest {
                 .withStatus(500)
                 .withBody("Internal Server Error")));
 
+        var securedUuid = SecuredUUID.fromString(TEST_UUID);
         ProvisioningException exception = assertThrows(ProvisioningException.class,
-            () -> trustedCertificateService.deleteTrustedCertificate(SecuredUUID.fromString(TEST_UUID)));
+            () -> trustedCertificateService.deleteTrustedCertificate(securedUuid));
 
         assertTrue(exception.getMessage().contains("Failed to delete trusted certificate"));
     }
@@ -230,8 +233,8 @@ class TrustedCertificateServiceITest extends BaseSpringBootTest {
         byte[] contentA1 = "cert-A".getBytes();
         byte[] contentA2 = "cert-A".getBytes(); // distinct array instance, same content
         byte[] contentB = "cert-B".getBytes();
-        LocalDateTime notBefore = LocalDateTime.of(2024, 1, 1, 0, 0);
-        LocalDateTime notAfter = LocalDateTime.of(2025, 12, 31, 23, 59);
+        LocalDateTime notBefore = LocalDateTime.of(2024, Month.JANUARY, 1, 0, 0);
+        LocalDateTime notAfter = LocalDateTime.of(2025, Month.DECEMBER, 31, 23, 59);
 
         TrustedCertificateProvisioningDTO a1 = new TrustedCertificateProvisioningDTO(
                 TEST_UUID, contentA1, "CN=CA", "DNS:x", "1", "CN=x", "AB:CD", notBefore, notAfter);

--- a/src/test/java/com/otilm/core/integration/service/UserManagementServiceCacheEvictionITest.java
+++ b/src/test/java/com/otilm/core/integration/service/UserManagementServiceCacheEvictionITest.java
@@ -11,13 +11,17 @@ import com.otilm.core.util.SessionTableHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
 import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class UserManagementServiceCacheEvictionITest extends BaseSpringBootTest {
 
@@ -50,7 +54,7 @@ class UserManagementServiceCacheEvictionITest extends BaseSpringBootTest {
     void updateUser_evictsUserCache() throws Exception {
         // given
         UUID userUuid = UUID.randomUUID();
-        Mockito.when(userManagementApiClient.updateUser(Mockito.eq(userUuid.toString()), Mockito.any()))
+        when(userManagementApiClient.updateUser(eq(userUuid.toString()), any()))
                 .thenReturn(userDetailDto(userUuid.toString()));
 
         UpdateUserRequestDto request = new UpdateUserRequestDto();
@@ -60,21 +64,21 @@ class UserManagementServiceCacheEvictionITest extends BaseSpringBootTest {
         userManagementService.updateUser(userUuid.toString(), request);
 
         // then
-        Mockito.verify(authenticationCache).evictByUserUuid(userUuid);
+        verify(authenticationCache).evictByUserUuid(userUuid);
     }
 
     @Test
     void updateUserInternal_evictsUserCache() throws Exception {
         // given
         UUID userUuid = UUID.randomUUID();
-        Mockito.when(userManagementApiClient.updateUser(Mockito.eq(userUuid.toString()), Mockito.any()))
+        when(userManagementApiClient.updateUser(eq(userUuid.toString()), any()))
                 .thenReturn(userDetailDto(userUuid.toString()));
 
         // when
         userManagementInternalService.updateUserInternal(userUuid.toString(), new UpdateUserRequestDto(), "", "");
 
         // then
-        Mockito.verify(authenticationCache).evictByUserUuid(userUuid);
+        verify(authenticationCache).evictByUserUuid(userUuid);
     }
 
     @Test
@@ -86,34 +90,34 @@ class UserManagementServiceCacheEvictionITest extends BaseSpringBootTest {
         userManagementService.deleteUser(userUuid.toString());
 
         // then
-        Mockito.verify(authenticationCache).evictByUserUuid(userUuid);
+        verify(authenticationCache).evictByUserUuid(userUuid);
     }
 
     @Test
     void disableUser_evictsUserCache() {
         // given
         UUID userUuid = UUID.randomUUID();
-        Mockito.when(userManagementApiClient.disableUser(userUuid.toString())).thenReturn(userDetailDto(userUuid.toString()));
+        when(userManagementApiClient.disableUser(userUuid.toString())).thenReturn(userDetailDto(userUuid.toString()));
 
         // when
         userManagementService.disableUser(userUuid.toString());
 
         // then
-        Mockito.verify(authenticationCache).evictByUserUuid(userUuid);
+        verify(authenticationCache).evictByUserUuid(userUuid);
     }
 
     @Test
     void updateRoles_evictsUserCache() {
         // given
         UUID userUuid = UUID.randomUUID();
-        Mockito.when(userManagementApiClient.updateRoles(Mockito.eq(userUuid.toString()), Mockito.any()))
+        when(userManagementApiClient.updateRoles(eq(userUuid.toString()), any()))
                 .thenReturn(userDetailDto(userUuid.toString()));
 
         // when
         userManagementService.updateRoles(userUuid.toString(), List.of());
 
         // then
-        Mockito.verify(authenticationCache).evictByUserUuid(userUuid);
+        verify(authenticationCache).evictByUserUuid(userUuid);
     }
 
     @Test
@@ -121,13 +125,13 @@ class UserManagementServiceCacheEvictionITest extends BaseSpringBootTest {
         // given
         UUID userUuid = UUID.randomUUID();
         UUID roleUuid = UUID.randomUUID();
-        Mockito.when(userManagementApiClient.updateRole(userUuid.toString(), roleUuid.toString())).thenReturn(userDetailDto(userUuid.toString()));
+        when(userManagementApiClient.updateRole(userUuid.toString(), roleUuid.toString())).thenReturn(userDetailDto(userUuid.toString()));
 
         // when
         userManagementService.updateRole(userUuid.toString(), roleUuid.toString());
 
         // then
-        Mockito.verify(authenticationCache).evictByUserUuid(userUuid);
+        verify(authenticationCache).evictByUserUuid(userUuid);
     }
 
     @Test
@@ -135,13 +139,13 @@ class UserManagementServiceCacheEvictionITest extends BaseSpringBootTest {
         // given
         UUID userUuid = UUID.randomUUID();
         UUID roleUuid = UUID.randomUUID();
-        Mockito.when(userManagementApiClient.removeRole(userUuid.toString(), roleUuid.toString())).thenReturn(userDetailDto(userUuid.toString()));
+        when(userManagementApiClient.removeRole(userUuid.toString(), roleUuid.toString())).thenReturn(userDetailDto(userUuid.toString()));
 
         // when
         userManagementService.removeRole(userUuid.toString(), roleUuid.toString());
 
         // then
-        Mockito.verify(authenticationCache).evictByUserUuid(userUuid);
+        verify(authenticationCache).evictByUserUuid(userUuid);
     }
 
     private static UserDetailDto userDetailDto(String uuid) {

--- a/src/test/java/com/otilm/core/integration/service/VaultProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/VaultProfileServiceITest.java
@@ -128,7 +128,8 @@ class VaultProfileServiceITest extends BaseSpringBootTest {
         attribute.setContent(List.of(new StringAttributeContentV3("ref", "data")));
         requestDto.setCustomAttributes(List.of(attribute));
         Assertions.assertThrows(NotFoundException.class, () -> vaultProfileService.createVaultProfile(SecuredParentUUID.fromUUID(UUID.randomUUID()), requestDto));
-        Assertions.assertThrows(ValidationException.class, () -> vaultProfileService.createVaultProfile(SecuredParentUUID.fromUUID(vaultInstance.getUuid()), requestDto));
+        var parentUuid = SecuredParentUUID.fromUUID(vaultInstance.getUuid());
+        Assertions.assertThrows(ValidationException.class, () -> vaultProfileService.createVaultProfile(parentUuid, requestDto));
 
         vaultInstance.setConnector(connector);
         vaultInstance.setConnectorUuid(connector.getUuid());
@@ -156,7 +157,9 @@ class VaultProfileServiceITest extends BaseSpringBootTest {
         attribute.setContent(List.of(new StringAttributeContentV3("ref", "data")));
         requestDto.setCustomAttributes(List.of(attribute));
 
-        Assertions.assertThrows(ValidationException.class, () -> vaultProfileService.updateVaultProfile(SecuredParentUUID.fromUUID(vaultInstance.getUuid()), SecuredUUID.fromUUID(vaultProfile.getUuid()), requestDto));
+        var parentUuid = SecuredParentUUID.fromUUID(vaultInstance.getUuid());
+        var securedUuid = SecuredUUID.fromUUID(vaultProfile.getUuid());
+        Assertions.assertThrows(ValidationException.class, () -> vaultProfileService.updateVaultProfile(parentUuid, securedUuid, requestDto));
 
         vaultInstance.setConnector(connector);
         vaultInstance.setConnectorUuid(connector.getUuid());
@@ -301,7 +304,9 @@ class VaultProfileServiceITest extends BaseSpringBootTest {
         vaultInstance.setConnectorUuid(null);
         vaultInstanceRepository.save(vaultInstance);
 
-        Assertions.assertThrows(ValidationException.class, () -> vaultProfileService.listSecretAttributes(SecuredParentUUID.fromUUID(vaultInstance.getUuid()), SecuredUUID.fromUUID(vaultProfile.getUuid()), SecretType.GENERIC));
+        var parentUuid = SecuredParentUUID.fromUUID(vaultInstance.getUuid());
+        var securedUuid = SecuredUUID.fromUUID(vaultProfile.getUuid());
+        Assertions.assertThrows(ValidationException.class, () -> vaultProfileService.listSecretAttributes(parentUuid, securedUuid, SecretType.GENERIC));
     }
 
     @Test


### PR DESCRIPTION
**Clears all 63 pre-existing SonarQube smells that PR #1773 surfaced — behavior-preserving test cleanup, zero production code touched.**

## Why this PR exists

PR #1773 relocated 38 integration tests into the integration root. SonarCloud's leak period treats a renamed file as new code, so it re-dated each file's **pre-existing** smells onto #1773 — 63 of them.

I verified all 63 are pre-existing: for each flagged line I checked its content was **not** among the lines #1773 added. **0 of 63 were authored by #1773** — every one carried over verbatim by the renames.

Per the plan on #1764, these are cleared here rather than inside the relocation PR.

## What changed (14 files, all `*ITest`)

| Rule | Count | Fix |
|------|-------|-----|
| S8924 (use static import) | 46 | `Mockito.x(...)` qualified calls → static imports |
| S5778 (one throwing call per `assertThrows` lambda) | 10 | Hoist the non-asserted call out into a local |
| S2699 (no assertion) | 4 | Add assertions to `TokenInstanceServiceITest` |
| S8694 (use `java.time.Month`) | 2 | `Month.JANUARY` / `Month.DECEMBER` in `TrustedCertificate` date literals |
| S1135 (complete the TODO) | 1 | Drop a stale TODO in `LocationServiceITest` |

Matcher statics (`any`/`eq`/`argThat`) import from `org.mockito.ArgumentMatchers` and the static-import blocks sit at the bottom, matching the sibling test convention.

## Stacked on #1773

The flagged files exist at their integration paths only on #1773's branch, so this PR is **based on `test/integration-migration-pkg-pr12`**, not `main`. It should merge after #1773; retarget to `main` if #1773 lands first.

## Verification

- Full tree test-compiles clean (`-Dmaven.compiler.proc=full`).
- All 14 affected `*ITest` classes pass: **245 methods, 0 failures**.
- Behavior-preserving: hoisted calls are side-effect-free getters/factories, static-import conversions are semantically inert, added assertions strengthen rather than change what each test verifies.
- Independent multi-lens review run on the branch: the only real finding (an orphaned `import org.mockito.Mockito;` that S1128 would flag) is fixed; the rest were consistency nits, also addressed.

Closes #1784 · Tracking: #1764 · Series: #1710 · Epic: OmniTrustILM/ilm#252

🤖 Generated with [Claude Code](https://claude.com/claude-code)
