### PR TITLE
Accept structured csrAttributes on the register path

### DIFF
--- a/src/main/java/com/otilm/core/certificate/request/IssuanceDefinitionResolver.java
+++ b/src/main/java/com/otilm/core/certificate/request/IssuanceDefinitionResolver.java
@@ -1,0 +1,114 @@
+package com.otilm.core.certificate.request;
+
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
+import com.otilm.api.model.common.attribute.v3.mapping.FieldMapping;
+import com.otilm.api.model.common.attribute.v3.mapping.FieldType;
+import com.otilm.api.model.common.attribute.v3.mapping.RdnMappedField;
+import com.otilm.core.attribute.CsrAttributes;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.oid.OidHandler;
+import com.otilm.core.service.v2.ExtendedAttributeService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Resolves the issuance attribute definitions for a certificate request: the connector-supplied v3
+ * definitions (which carry {@link FieldMapping}) merged over the static {@link CsrAttributes} default set.
+ *
+ * <p>Shared by the platform-built issue path ({@code ClientOperationServiceImpl}) and the register path
+ * ({@code AuthorityProviderV3Adapter}) so both project structured attribute values against an identical
+ * definition set.
+ */
+@Component
+public class IssuanceDefinitionResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(IssuanceDefinitionResolver.class);
+
+    private final ExtendedAttributeService extendedAttributeService;
+
+    /**
+     * {@code ExtendedAttributeService} is injected {@link Lazy}: {@code AuthorityProviderV3Adapter} depends on
+     * this resolver, and the service transitively depends back on that adapter (through
+     * {@code AuthorityProviderAdapterFactory}). A lazy proxy breaks the construction-time cycle — the real
+     * service is resolved on first use, long after the context is built.
+     */
+    public IssuanceDefinitionResolver(@Lazy ExtendedAttributeService extendedAttributeService) {
+        this.extendedAttributeService = extendedAttributeService;
+    }
+
+    /**
+     * Prefers connector-supplied v3 definitions (which carry {@code fieldMapping}) and falls back to the static
+     * CSR default set. Returns the defaults unchanged when {@code raProfile} is null.
+     */
+    public List<DataAttributeV3> resolve(RaProfile raProfile) throws ConnectorException, NotFoundException {
+        List<DataAttributeV3> defaults = CsrAttributes.csrAttributesAsDataAttributesV3();
+        if (raProfile == null) {
+            return defaults;
+        }
+        List<BaseAttribute> connectorAttrs = extendedAttributeService.listIssueCertificateAttributes(raProfile);
+        List<DataAttributeV3> connectorDefs = connectorAttrs.stream()
+                .filter(DataAttributeV3.class::isInstance)
+                .map(DataAttributeV3.class::cast)
+                .toList();
+        int droppedNonV3 = connectorAttrs.size() - connectorDefs.size();
+        if (droppedNonV3 > 0) {
+            logger.debug("Ignoring {} non-v3 connector issue attribute(s) for RA profile {}; structured CSR enrichment requires a v3 authority connector",
+                    droppedNonV3, raProfile.getName());
+        }
+        return mergeIssuanceDefinitions(defaults, connectorDefs, OidHandler.getCodeToOidMap());
+    }
+
+    /**
+     * Merges connector-supplied v3 definitions with the static default set. Connector definitions take
+     * precedence: any default whose RDN field mapping is also claimed by a connector definition is dropped.
+     * Connector definitions without a {@code fieldMapping} (connector-specific fields) carry no RDN claim
+     * and are always retained.
+     */
+    static List<DataAttributeV3> mergeIssuanceDefinitions(List<DataAttributeV3> defaults,
+                                                          List<DataAttributeV3> connectorDefs,
+                                                          Map<String, String> codeToOid) {
+        Set<String> claimedRdns = connectorDefs.stream()
+                .flatMap(d -> rdnFields(d).map(f -> normalizeRdn(f.getRdn(), codeToOid)))
+                .collect(Collectors.toSet());
+
+        List<DataAttributeV3> filteredDefaults = defaults.stream()
+                .filter(d -> rdnFields(d)
+                        .map(f -> normalizeRdn(f.getRdn(), codeToOid))
+                        .noneMatch(claimedRdns::contains))
+                .toList();
+
+        List<DataAttributeV3> merged = new ArrayList<>(connectorDefs);
+        merged.addAll(filteredDefaults);
+        return merged;
+    }
+
+    /**
+     * Streams the RDN-typed mapped fields of a definition, tolerating connector payloads that carry a
+     * null {@code fieldMapping} or a mapping with null {@code fields}.
+     */
+    private static Stream<RdnMappedField> rdnFields(DataAttributeV3 def) {
+        FieldMapping fm = def.getFieldMapping();
+        if (fm == null || fm.getFields() == null) {
+            return Stream.empty();
+        }
+        return fm.getFields().stream()
+                .filter(f -> f.getFieldType() == FieldType.RDN)
+                .map(RdnMappedField.class::cast);
+    }
+
+    private static String normalizeRdn(String rdn, Map<String, String> codeToOid) {
+        return codeToOid == null ? rdn : codeToOid.getOrDefault(rdn, rdn);
+    }
+}

--- a/src/main/java/com/otilm/core/certificate/request/IssuanceDefinitionResolver.java
+++ b/src/main/java/com/otilm/core/certificate/request/IssuanceDefinitionResolver.java
@@ -13,7 +13,6 @@ import com.otilm.core.oid.OidHandler;
 import com.otilm.core.service.v2.ExtendedAttributeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -27,8 +26,8 @@ import java.util.stream.Stream;
  * Resolves the issuance attribute definitions for a certificate request: the connector-supplied v3
  * definitions (which carry {@link FieldMapping}) merged over the static {@link CsrAttributes} default set.
  *
- * <p>Shared by the platform-built issue path ({@code ClientOperationServiceImpl}) and the register path
- * ({@code AuthorityProviderV3Adapter}) so both project structured attribute values against an identical
+ * <p>Shared by the platform-built issue path and the register path — both orchestrated in
+ * {@code ClientOperationServiceImpl} — so both project structured attribute values against an identical
  * definition set.
  */
 @Component
@@ -38,13 +37,7 @@ public class IssuanceDefinitionResolver {
 
     private final ExtendedAttributeService extendedAttributeService;
 
-    /**
-     * {@code ExtendedAttributeService} is injected {@link Lazy}: {@code AuthorityProviderV3Adapter} depends on
-     * this resolver, and the service transitively depends back on that adapter (through
-     * {@code AuthorityProviderAdapterFactory}). A lazy proxy breaks the construction-time cycle — the real
-     * service is resolved on first use, long after the context is built.
-     */
-    public IssuanceDefinitionResolver(@Lazy ExtendedAttributeService extendedAttributeService) {
+    public IssuanceDefinitionResolver(ExtendedAttributeService extendedAttributeService) {
         this.extendedAttributeService = extendedAttributeService;
     }
 

--- a/src/main/java/com/otilm/core/certificate/request/RegisterWireBuilder.java
+++ b/src/main/java/com/otilm/core/certificate/request/RegisterWireBuilder.java
@@ -239,13 +239,18 @@ public final class RegisterWireBuilder {
     }
 
     /**
-     * Fails closed when the request content carries an entry the flat register wire cannot represent — a non-DER
-     * extension value, or an otherName SAN with a non-UTF8 value encoding. Reached only for connectors without
-     * {@code CERTIFICATE_REQUEST_STRUCTURED}, where the flat renderers would otherwise drop such entries with only
-     * a warn log, reducing the registered identity below what the operator requested. Flat operator input never
-     * trips this — {@link #buildContent} forces DER extensions and UTF8 otherNames.
+     * Fails closed when projected content cannot be represented on the flat register wire.
+     *
+     * <p>Rejects a non-DER extension value, or an otherName SAN with a non-UTF8 encoding — throwing
+     * rather than dropping it.
+     *
+     * <p><b>Only reached</b> for connectors without {@code CERTIFICATE_REQUEST_STRUCTURED}, where the
+     * flat renderers would otherwise silently drop such entries (warn-log only) and register an identity
+     * weaker than the operator asked for.
+     *
+     * <p>Flat operator input never trips this — {@link #buildContent} forces DER extensions and UTF8 otherNames.
      */
-    private static void assertFlatRepresentable(X509RequestContent content) {
+    public static void assertFlatRepresentable(X509RequestContent content) {
         if (content.getExtensions() != null) {
             for (RequestedExtension ext : content.getExtensions()) {
                 if (ext.getEncoding() != null && ext.getEncoding() != ExtensionValueEncoding.DER) {

--- a/src/main/java/com/otilm/core/certificate/request/RegisterWireBuilder.java
+++ b/src/main/java/com/otilm/core/certificate/request/RegisterWireBuilder.java
@@ -87,6 +87,9 @@ public final class RegisterWireBuilder {
         if (connectorSupportsStructured) {
             dto.setRequestContent(content);
         } else {
+            // No structured wire carries the content here, so anything the flat wire cannot represent would be
+            // silently dropped — fail closed rather than register an identity reduced below the operator's request.
+            assertFlatRepresentable(content);
             dto.setExtensions(renderFlatExtensions(content.getExtensions()));
         }
         return dto;
@@ -233,6 +236,35 @@ public final class RegisterWireBuilder {
             return null;
         }
         return "otherName:" + entry.getOtherNameOid() + ";UTF8:" + entry.getValue();
+    }
+
+    /**
+     * Fails closed when the request content carries an entry the flat register wire cannot represent — a non-DER
+     * extension value, or an otherName SAN with a non-UTF8 value encoding. Reached only for connectors without
+     * {@code CERTIFICATE_REQUEST_STRUCTURED}, where the flat renderers would otherwise drop such entries with only
+     * a warn log, reducing the registered identity below what the operator requested. Flat operator input never
+     * trips this — {@link #buildContent} forces DER extensions and UTF8 otherNames.
+     */
+    private static void assertFlatRepresentable(X509RequestContent content) {
+        if (content.getExtensions() != null) {
+            for (RequestedExtension ext : content.getExtensions()) {
+                if (ext.getEncoding() != null && ext.getEncoding() != ExtensionValueEncoding.DER) {
+                    throw new ValidationException(("Extension %s has %s value encoding, which the flat register wire "
+                            + "cannot represent; the authority must advertise CERTIFICATE_REQUEST_STRUCTURED")
+                            .formatted(ext.getOid(), ext.getEncoding()));
+                }
+            }
+        }
+        if (content.getSubjectAltNames() != null) {
+            for (GeneralNameEntry san : content.getSubjectAltNames()) {
+                if (san.getType() == GeneralNameType.OTHER_NAME
+                        && san.getValueEncoding() != null && san.getValueEncoding() != ExtensionValueEncoding.UTF8_STRING) {
+                    throw new ValidationException(("otherName SAN %s has %s value encoding, which the flat register "
+                            + "wire cannot represent; the authority must advertise CERTIFICATE_REQUEST_STRUCTURED")
+                            .formatted(san.getOtherNameOid(), san.getValueEncoding()));
+                }
+            }
+        }
     }
 
     private static List<CertificateExtension> renderFlatExtensions(List<RequestedExtension> extensions) {

--- a/src/main/java/com/otilm/core/certificate/request/RegisterWireBuilder.java
+++ b/src/main/java/com/otilm/core/certificate/request/RegisterWireBuilder.java
@@ -182,7 +182,11 @@ public final class RegisterWireBuilder {
 
     // ── flat-wire rendering ─────────────────────────────────────────────────
 
-    private static String renderSubjectDn(X509RequestContent content) {
+    /**
+     * Renders the RFC 4514 subject DN string for the given content, or null when it carries no subject.
+     * Shared with the register orchestrator so the persisted placeholder DN matches the wire anchor exactly.
+     */
+    public static String renderSubjectDn(X509RequestContent content) {
         if (content.getSubject() == null || content.getSubject().isEmpty()) {
             return null;
         }

--- a/src/main/java/com/otilm/core/service/CertificateInternalService.java
+++ b/src/main/java/com/otilm/core/service/CertificateInternalService.java
@@ -7,7 +7,6 @@ import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.core.certificate.*;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
-import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
 import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateContent;
@@ -45,10 +44,14 @@ public interface CertificateInternalService extends ResourceExtensionService {
 
     /**
      * Creates a no-CSR placeholder certificate for a v3 authority registration: an identity-only
-     * record (subject taken from the registration request) in state REQUESTED, created before any
-     * CSR exists. A later CSR-driven issuance completes the certificate against this placeholder.
+     * record in state REQUESTED, created before any CSR exists. A later CSR-driven issuance completes
+     * the certificate against this placeholder.
+     *
+     * @param effectiveSubjectDn the subject DN to persist — the flat {@code subjectDn} for a flat request,
+     *                           or the DN rendered from projected {@code csrAttributes} for a structured one
+     *                           (resolved by the caller so the placeholder matches the register wire identity)
      */
-    Certificate createRegistrationPlaceholder(RaProfile raProfile, ClientCertificateRegistrationDto request);
+    Certificate createRegistrationPlaceholder(RaProfile raProfile, String effectiveSubjectDn);
 
     /**
      * Attaches an operator-supplied CSR to an existing certificate (a REGISTERED placeholder), preparing it

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -235,15 +235,20 @@ public class AuthorityProviderV3Adapter
     }
 
     @Override
-    public AdapterOperationResult register(Certificate cert, ClientCertificateRegistrationDto req) throws ConnectorException {
+    public AdapterOperationResult register(Certificate cert, ClientCertificateRegistrationDto req,
+                                           X509RequestContent identityContent) throws ConnectorException {
         RaProfile raProfile = cert.getRaProfile();
         AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
         ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
 
-        X509RequestContent content = RegisterWireBuilder.buildContent(
-                req != null ? req.getSubjectDn() : null,
-                req != null ? req.getSubjectAltName() : null,
-                req != null ? req.getExtensions() : null);
+        // Structured csrAttributes are projected once by the orchestrator (identityContent); a flat request
+        // carries no pre-built content, so build the identity here from subjectDn/subjectAltName/extensions.
+        X509RequestContent content = identityContent != null
+                ? identityContent
+                : RegisterWireBuilder.buildContent(
+                        req != null ? req.getSubjectDn() : null,
+                        req != null ? req.getSubjectAltName() : null,
+                        req != null ? req.getExtensions() : null);
         boolean structured = capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED);
         CertificateRegistrationRequestDtoV3 wire = RegisterWireBuilder.buildRegistration(content, structured);
         if (req != null) {

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -13,6 +13,7 @@ import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.common.error.ErrorCode;
 import com.otilm.api.model.connector.v3.certificate.CertificateAttributeListRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateDataResponseDto;
+import com.otilm.api.model.connector.v3.certificate.CertificateExtension;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationCancelRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatusRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatusResponseDto;
@@ -243,12 +244,15 @@ public class AuthorityProviderV3Adapter
 
         // Structured csrAttributes are projected once by the orchestrator (identityContent); a flat request
         // carries no pre-built content, so build the identity here from subjectDn/subjectAltName/extensions.
-        X509RequestContent content = identityContent != null
-                ? identityContent
-                : RegisterWireBuilder.buildContent(
-                        req != null ? req.getSubjectDn() : null,
-                        req != null ? req.getSubjectAltName() : null,
-                        req != null ? req.getExtensions() : null);
+        X509RequestContent content;
+        if (identityContent != null) {
+            content = identityContent;
+        } else {
+            String subjectDn = req != null ? req.getSubjectDn() : null;
+            String subjectAltName = req != null ? req.getSubjectAltName() : null;
+            List<CertificateExtension> extensions = req != null ? req.getExtensions() : null;
+            content = RegisterWireBuilder.buildContent(subjectDn, subjectAltName, extensions);
+        }
         boolean structured = capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED);
         CertificateRegistrationRequestDtoV3 wire = RegisterWireBuilder.buildRegistration(content, structured);
         if (req != null) {

--- a/src/main/java/com/otilm/core/service/handler/authority/RegisterCapability.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/RegisterCapability.java
@@ -4,6 +4,7 @@ import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.connector.v3.certificate.CertificateRequestContent;
+import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
 import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.Certificate;
@@ -28,9 +29,12 @@ public interface RegisterCapability {
      * {@link com.otilm.core.exception.ConnectorAcceptedButLocalFailureException}; a raw {@link RuntimeException}
      * signals a pre-acceptance failure.
      *
+     * @param identityContent the structured identity projected once by the orchestrator (from {@code csrAttributes}),
+     *                         or null for a flat request — the adapter then builds it from subjectDn/subjectAltName/extensions
      * @return SYNC_OK when the CA confirmed immediately, ASYNC_ACCEPTED when polling is needed.
      */
-    AdapterOperationResult register(Certificate cert, ClientCertificateRegistrationDto req) throws ConnectorException;
+    AdapterOperationResult register(Certificate cert, ClientCertificateRegistrationDto req,
+                                    @Nullable X509RequestContent identityContent) throws ConnectorException;
 
     /**
      * Issues a certificate against a prior registration: the client CSR is forwarded intact, the binding's CA

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -23,7 +23,6 @@ import com.otilm.api.model.core.auth.UserDto;
 import com.otilm.api.model.core.certificate.*;
 import com.otilm.api.model.core.certificate.group.GroupDto;
 import com.otilm.api.model.core.compliance.ComplianceStatus;
-import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
 import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.api.model.core.compliance.v2.ComplianceCheckResultDto;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
@@ -1107,12 +1106,12 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
 
     @Override
     @Transactional
-    public Certificate createRegistrationPlaceholder(RaProfile raProfile, ClientCertificateRegistrationDto request) {
+    public Certificate createRegistrationPlaceholder(RaProfile raProfile, String effectiveSubjectDn) {
         // Identity-only placeholder: no key/CSR/content yet. The authoritative subject, SAN and key
         // material are recorded when the follow-up CSR issuance completes against this record, so only
         // the subject DN identity from the registration request is captured here.
         Certificate certificate = new Certificate();
-        CertificateUtil.applyRegistrationSubject(certificate, request.getSubjectDn());
+        CertificateUtil.applyRegistrationSubject(certificate, effectiveSubjectDn);
         certificate.setState(CertificateState.REQUESTED);
         certificate.setComplianceStatus(ComplianceStatus.NOT_CHECKED);
         certificate.setValidationStatus(CertificateValidationStatus.NOT_CHECKED);

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -515,7 +515,16 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         } catch (AttributeException e) {
             throw new ValidationException("Invalid csrAttributes for certificate registration: " + e.getMessage());
         }
-        return CertificateRequestAttributeProjector.project(definitions, csrAttributes);
+        X509RequestContent content = CertificateRequestAttributeProjector.project(definitions, csrAttributes);
+        boolean hasSubject = content.getSubject() != null && !content.getSubject().isEmpty();
+        boolean hasSan = content.getSubjectAltNames() != null && !content.getSubjectAltNames().isEmpty();
+        if (!hasSubject && !hasSan) {
+            // Optional/unmapped/extension-only csrAttributes can project to no subject and no SAN; reject
+            // locally rather than create a placeholder and register an identity-less certificate.
+            throw new ValidationException(
+                    "csrAttributes did not yield a subject or subjectAltName for the pre-registration identity");
+        }
+        return content;
     }
 
     private static boolean hasStructuredIdentity(List<RequestAttribute> csrAttributes) {

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -524,6 +524,14 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             throw new ValidationException(
                     "csrAttributes did not yield a subject or subjectAltName for the pre-registration identity");
         }
+        // A connector without CERTIFICATE_REQUEST_STRUCTURED carries only the flat wire; content it cannot
+        // represent (a non-DER extension or non-UTF8 otherName that only structured csrAttributes can produce)
+        // is rejected here, before the placeholder, so a purely-local rejection leaves no row — uniform with the
+        // sibling rejectAmbiguousRegistrationIdentity and empty-projection validations. The adapter re-checks
+        // when it builds the flat wire, so this hoist is a consistency guard, not the sole enforcement.
+        if (!capabilityService.supports(raProfile.getAuthorityInstanceReference(), FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED)) {
+            RegisterWireBuilder.assertFlatRepresentable(content);
+        }
         return content;
     }
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -506,13 +506,16 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         if (!hasStructuredIdentity(request.getCsrAttributes())) {
             return null;
         }
+        // The gate tolerates null elements (anyMatch); drop them before validation/projection so a
+        // partially-null list projects the real attributes instead of NPE-ing in the projector.
+        List<RequestAttribute> csrAttributes = request.getCsrAttributes().stream().filter(Objects::nonNull).toList();
         List<DataAttributeV3> definitions = issuanceDefinitionResolver.resolve(raProfile);
         try {
-            attributeEngine.validateUpdateDataAttributes(null, null, definitions, request.getCsrAttributes());
+            attributeEngine.validateUpdateDataAttributes(null, null, definitions, csrAttributes);
         } catch (AttributeException e) {
             throw new ValidationException("Invalid csrAttributes for certificate registration: " + e.getMessage());
         }
-        return CertificateRequestAttributeProjector.project(definitions, request.getCsrAttributes());
+        return CertificateRequestAttributeProjector.project(definitions, csrAttributes);
     }
 
     private static boolean hasStructuredIdentity(List<RequestAttribute> csrAttributes) {

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -10,9 +10,6 @@ import com.otilm.api.model.client.certificate.UploadCertificateRequestDto;
 import com.otilm.api.model.client.location.PushToLocationRequestDto;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
-import com.otilm.api.model.common.attribute.v3.mapping.FieldMapping;
-import com.otilm.api.model.common.attribute.v3.mapping.FieldType;
-import com.otilm.api.model.common.attribute.v3.mapping.RdnMappedField;
 import com.otilm.api.model.connector.v3.certificate.CertificateRequestContent;
 import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
 import com.otilm.api.model.connector.v2.CertRevocationDto;
@@ -38,11 +35,10 @@ import com.otilm.api.model.core.logging.enums.OperationResult;
 import com.otilm.api.model.core.logging.records.ResourceObjectIdentity;
 import com.otilm.api.model.core.v2.*;
 import com.otilm.core.attribute.CertificateRequestAttributeProjector;
-import com.otilm.core.attribute.CsrAttributes;
+import com.otilm.core.certificate.request.IssuanceDefinitionResolver;
 import com.otilm.core.certificate.request.ProtocolRequestAttributeValidator;
 import com.otilm.core.certificate.request.RegisterWireBuilder;
 import com.otilm.core.certificate.request.RequestAttributePolicyViolationException;
-import com.otilm.core.oid.OidHandler;
 import com.otilm.core.util.X509RequestContentRenderer;
 import com.otilm.core.attribute.engine.AttributeContentPurpose;
 import com.otilm.core.attribute.engine.AttributeEngine;
@@ -158,10 +154,16 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     private CertificateStateMachine stateMachine;
     private ConnectorCapabilityService capabilityService;
     private ProtocolRequestAttributeValidator protocolRequestAttributeValidator;
+    private IssuanceDefinitionResolver issuanceDefinitionResolver;
 
     @Autowired
     public void setProtocolRequestAttributeValidator(ProtocolRequestAttributeValidator protocolRequestAttributeValidator) {
         this.protocolRequestAttributeValidator = protocolRequestAttributeValidator;
+    }
+
+    @Autowired
+    public void setIssuanceDefinitionResolver(IssuanceDefinitionResolver issuanceDefinitionResolver) {
+        this.issuanceDefinitionResolver = issuanceDefinitionResolver;
     }
 
     @Autowired
@@ -403,6 +405,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         if (request == null) {
             throw new ValidationException("A certificate registration request is required.");
         }
+        rejectAmbiguousRegistrationIdentity(request);
         // Connector call below holds no transaction (NOT_SUPPORTED), so load the authority graph eagerly —
         // every association the adapter dereferences must be initialized before the session closes.
         RaProfile raProfile = raProfileRepository.findWithAuthorityByUuid(raProfileUuid.getValue())
@@ -423,7 +426,13 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             throw new ValidationException("Certificate registration is not supported by the authority of RA profile %s.".formatted(raProfile.getName()));
         }
 
-        Certificate placeholder = certificateService.createRegistrationPlaceholder(raProfile, request);
+        // Project structured csrAttributes once (validated) so the placeholder DN and the connector wire derive
+        // from the same content; a flat request yields null here and the adapter builds its identity itself.
+        X509RequestContent registrationContent = buildStructuredRegistrationContent(raProfile, request);
+        String effectiveSubjectDn = registrationContent != null
+                ? RegisterWireBuilder.renderSubjectDn(registrationContent)
+                : request.getSubjectDn();
+        Certificate placeholder = certificateService.createRegistrationPlaceholder(raProfile, effectiveSubjectDn);
         // Re-load with the full adapter graph for the transaction-less connector call, as the poll listener does.
         // No pessimistic lock here (unlike the cancel/poll paths): the placeholder was just created and its UUID
         // is not yet known to any concurrent actor, so the read-modify-write below cannot race.
@@ -433,7 +442,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
         AdapterOperationResult result;
         try {
-            result = registerCapability.register(certificate, request);
+            result = registerCapability.register(certificate, request, registrationContent);
         } catch (ConnectorAcceptedButLocalFailureException e) {
             // Connector already accepted the registration (2xx/202); per the state-divergence rule local state
             // must NOT roll back — leave the cert PENDING_REGISTRATION so the poll or operator reconciles it.
@@ -473,6 +482,51 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         response.setUuid(certificate.getUuid().toString());
         response.setCertificateData(result.certificateData() != null ? result.certificateData() : "");
         return response;
+    }
+
+    /**
+     * The pre-registration identity may be supplied structured (via {@code csrAttributes}) or flat (via
+     * subjectDn/subjectAltName/extensions), never both — the register handling owns this precedence
+     * (see the {@code ClientCertificateRegistrationDto} schema).
+     */
+    private static void rejectAmbiguousRegistrationIdentity(ClientCertificateRegistrationDto request) {
+        if (hasStructuredIdentity(request.getCsrAttributes()) && hasFlatIdentity(request)) {
+            throw new ValidationException(
+                    "Provide the pre-registration identity either via csrAttributes or the flat subjectDn/subjectAltName/extensions, not both");
+        }
+    }
+
+    /**
+     * Projects a structured pre-registration request ({@code csrAttributes}) into the register identity content,
+     * once and validated, so the placeholder DN and the connector wire derive from the same projection. Returns
+     * null for a flat request, whose identity the adapter builds from subjectDn/subjectAltName/extensions.
+     */
+    private X509RequestContent buildStructuredRegistrationContent(RaProfile raProfile, ClientCertificateRegistrationDto request)
+            throws ConnectorException, NotFoundException {
+        if (!hasStructuredIdentity(request.getCsrAttributes())) {
+            return null;
+        }
+        List<DataAttributeV3> definitions = issuanceDefinitionResolver.resolve(raProfile);
+        try {
+            attributeEngine.validateUpdateDataAttributes(null, null, definitions, request.getCsrAttributes());
+        } catch (AttributeException e) {
+            throw new ValidationException("Invalid csrAttributes for certificate registration: " + e.getMessage());
+        }
+        return CertificateRequestAttributeProjector.project(definitions, request.getCsrAttributes());
+    }
+
+    private static boolean hasStructuredIdentity(List<RequestAttribute> csrAttributes) {
+        return csrAttributes != null && csrAttributes.stream().anyMatch(Objects::nonNull);
+    }
+
+    private static boolean hasFlatIdentity(ClientCertificateRegistrationDto request) {
+        return isNotBlank(request.getSubjectDn())
+                || isNotBlank(request.getSubjectAltName())
+                || (request.getExtensions() != null && !request.getExtensions().isEmpty());
+    }
+
+    private static boolean isNotBlank(String value) {
+        return value != null && !value.isBlank();
     }
 
     /**
@@ -2012,72 +2066,6 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     /**
-     * Merges connector-supplied v3 definitions with the static {@link CsrAttributes} default set.
-     * Connector definitions take precedence: any default definition whose {@code fieldMapping} targets
-     * overlap with a connector definition is dropped in favour of the connector one.
-     * Definitions without a {@code fieldMapping} (connector-specific fields) are always included.
-     */
-    private List<DataAttributeV3> resolveIssuanceDefinitions(RaProfile raProfile) throws ConnectorException, NotFoundException {
-        List<DataAttributeV3> defaults = CsrAttributes.csrAttributesAsDataAttributesV3();
-        if (raProfile == null) {
-            return defaults;
-        }
-        var connectorAttrs = extendedAttributeService.listIssueCertificateAttributes(raProfile);
-        List<DataAttributeV3> connectorDefs = connectorAttrs.stream()
-                .filter(DataAttributeV3.class::isInstance)
-                .map(DataAttributeV3.class::cast)
-                .toList();
-        int droppedNonV3 = connectorAttrs.size() - connectorDefs.size();
-        if (droppedNonV3 > 0) {
-            logger.debug("Ignoring {} non-v3 connector issue attribute(s) for RA profile {}; structured CSR enrichment requires a v3 authority connector",
-                    droppedNonV3, raProfile.getName());
-        }
-        return mergeIssuanceDefinitions(defaults, connectorDefs, OidHandler.getCodeToOidMap());
-    }
-
-    /**
-     * Merges connector-supplied v3 definitions with the static default set. Connector definitions take
-     * precedence: any default whose RDN field mapping is also claimed by a connector definition is dropped.
-     * Connector definitions without a {@code fieldMapping} (connector-specific fields) carry no RDN claim
-     * and are always retained.
-     */
-    static List<DataAttributeV3> mergeIssuanceDefinitions(List<DataAttributeV3> defaults,
-                                                          List<DataAttributeV3> connectorDefs,
-                                                          Map<String, String> codeToOid) {
-        Set<String> claimedRdns = connectorDefs.stream()
-                .flatMap(d -> rdnFields(d).map(f -> normalizeRdn(f.getRdn(), codeToOid)))
-                .collect(java.util.stream.Collectors.toSet());
-
-        List<DataAttributeV3> filteredDefaults = defaults.stream()
-                .filter(d -> rdnFields(d)
-                        .map(f -> normalizeRdn(f.getRdn(), codeToOid))
-                        .noneMatch(claimedRdns::contains))
-                .toList();
-
-        List<DataAttributeV3> merged = new ArrayList<>(connectorDefs);
-        merged.addAll(filteredDefaults);
-        return merged;
-    }
-
-    /**
-     * Streams the RDN-typed mapped fields of a definition, tolerating connector payloads that carry a
-     * null {@code fieldMapping} or a mapping with null {@code fields}.
-     */
-    private static java.util.stream.Stream<RdnMappedField> rdnFields(DataAttributeV3 def) {
-        FieldMapping fm = def.getFieldMapping();
-        if (fm == null || fm.getFields() == null) {
-            return java.util.stream.Stream.empty();
-        }
-        return fm.getFields().stream()
-                .filter(f -> f.getFieldType() == FieldType.RDN)
-                .map(RdnMappedField.class::cast);
-    }
-
-    private static String normalizeRdn(String rdn, Map<String, String> codeToOid) {
-        return codeToOid == null ? rdn : codeToOid.getOrDefault(rdn, rdn);
-    }
-
-    /**
      * Parse the uploaded CSR into typed content and delegate request-attribute policy validation to the shared
      * {@link ProtocolRequestAttributeValidator}. A policy violation propagates as {@link RequestAttributePolicyViolationException} unchanged.
      */
@@ -2112,7 +2100,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
                 throw new ValidationException("Cannot generate certificate request without specifying RA profile");
             }
             // prefer connector-supplied v3 definitions (carry fieldMapping); fall back to a static CSR default set
-            List<DataAttributeV3> definitions = resolveIssuanceDefinitions(raProfile);
+            List<DataAttributeV3> definitions = issuanceDefinitionResolver.resolve(raProfile);
 
             // validate and update definitions of certificate request attributes with the attribute engine
             attributeEngine.validateUpdateDataAttributes(null, null, definitions, csrAttributes);

--- a/src/test/java/com/otilm/core/certificate/request/IssuanceDefinitionResolverMergeTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/IssuanceDefinitionResolverMergeTest.java
@@ -1,4 +1,4 @@
-package com.otilm.core.service.v2.impl;
+package com.otilm.core.certificate.request;
 
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.common.attribute.v3.mapping.FieldMapping;
@@ -12,7 +12,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ClientOperationServiceImplMergeTest {
+class IssuanceDefinitionResolverMergeTest {
 
     @Test
     void retainsUnmappedConnectorDefinition() {
@@ -22,7 +22,7 @@ class ClientOperationServiceImplMergeTest {
 
         // when
         List<DataAttributeV3> merged =
-                ClientOperationServiceImpl.mergeIssuanceDefinitions(defaults, List.of(unmapped), Map.of());
+                IssuanceDefinitionResolver.mergeIssuanceDefinitions(defaults, List.of(unmapped), Map.of());
 
         // then the unmapped connector definition survives the merge
         assertThat(merged).extracting(DataAttributeV3::getName).contains("connector-custom");
@@ -39,7 +39,7 @@ class ClientOperationServiceImplMergeTest {
 
         // when
         List<DataAttributeV3> merged =
-                ClientOperationServiceImpl.mergeIssuanceDefinitions(defaults, List.of(connectorCommonName), Map.of());
+                IssuanceDefinitionResolver.mergeIssuanceDefinitions(defaults, List.of(connectorCommonName), Map.of());
 
         // then the connector definition replaces the overlapping default; other defaults remain
         assertThat(merged)
@@ -56,7 +56,7 @@ class ClientOperationServiceImplMergeTest {
 
         // when — must not NPE while collecting claimed RDNs
         List<DataAttributeV3> merged =
-                ClientOperationServiceImpl.mergeIssuanceDefinitions(defaults, List.of(nullFields), Map.of());
+                IssuanceDefinitionResolver.mergeIssuanceDefinitions(defaults, List.of(nullFields), Map.of());
 
         // then the connector definition survives and no default is dropped
         assertThat(merged)
@@ -74,7 +74,7 @@ class ClientOperationServiceImplMergeTest {
 
         // when — normalizeRdn must tolerate a null codeToOid map
         List<DataAttributeV3> merged =
-                ClientOperationServiceImpl.mergeIssuanceDefinitions(defaults, List.of(connectorCommonName), null);
+                IssuanceDefinitionResolver.mergeIssuanceDefinitions(defaults, List.of(connectorCommonName), null);
 
         // then the connector definition still overrides the overlapping default
         assertThat(merged)

--- a/src/test/java/com/otilm/core/certificate/request/RegisterWireBuilderTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/RegisterWireBuilderTest.java
@@ -331,8 +331,9 @@ class RegisterWireBuilderTest {
         }
 
         @Test
-        void flatSan_skipsOtherNameWithNonTextualEncoding() {
-            // given — a DER-encoded otherName value has no faithful flat-string form
+        void flatWire_rejectsOtherNameWithNonTextualEncoding() {
+            // A DER-encoded otherName has no faithful flat-string form; with no structured wire to carry it the
+            // flat register wire fails closed rather than silently dropping it.
             GeneralNameEntry derOtherName = new GeneralNameEntry();
             derOtherName.setType(GeneralNameType.OTHER_NAME);
             derOtherName.setOtherNameOid("1.3.6.1.4.1.311.20.2.3");
@@ -345,11 +346,8 @@ class RegisterWireBuilderTest {
             content.setCertificateType(CertificateType.X509);
             content.setSubjectAltNames(List.of(derOtherName, dns));
 
-            // when
-            CertificateRegistrationRequestDtoV3 dto = RegisterWireBuilder.buildRegistration(content, false);
-
-            // then — it is carried only on the structured wire; the flat string keeps the rest
-            assertThat(dto.getSubjectAltName()).isEqualTo("DNS:a.test");
+            assertThatThrownBy(() -> RegisterWireBuilder.buildRegistration(content, false))
+                    .isInstanceOf(ValidationException.class);
         }
 
         @Test
@@ -374,8 +372,9 @@ class RegisterWireBuilderTest {
         }
 
         @Test
-        void flatExtensions_skipNonDerEncodings() {
-            // given — a UTF8-encoded requested extension is not a DER blob and cannot ride the flat wire
+        void flatWire_rejectsNonDerExtension() {
+            // A UTF8-encoded requested extension is not a DER blob and cannot ride the flat wire; fail closed
+            // rather than silently drop it when the connector has no structured wire.
             RequestedExtension utf8 = new RequestedExtension();
             utf8.setOid("1.2.3.4.5");
             utf8.setCritical(false);
@@ -390,13 +389,8 @@ class RegisterWireBuilderTest {
             content.setCertificateType(CertificateType.X509);
             content.setExtensions(List.of(utf8, der));
 
-            // when
-            CertificateRegistrationRequestDtoV3 dto = RegisterWireBuilder.buildRegistration(content, false);
-
-            // then
-            assertThat(dto.getExtensions()).hasSize(1);
-            assertThat(dto.getExtensions().get(0).getOid()).isEqualTo("2.5.29.37");
-            assertThat(dto.getExtensions().get(0).isCritical()).isTrue();
+            assertThatThrownBy(() -> RegisterWireBuilder.buildRegistration(content, false))
+                    .isInstanceOf(ValidationException.class);
         }
 
         @Test

--- a/src/test/java/com/otilm/core/integration/service/CertificateRequestIntegrationITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CertificateRequestIntegrationITest.java
@@ -240,8 +240,8 @@ class CertificateRequestIntegrationITest extends BaseSpringBootTest {
 
     @Test
     void failsRequest_whenConnectorAttributeFetchFails() throws Exception {
-        // given — the v3 connector issue-attributes endpoint errors. resolveIssuanceDefinitions fails on a genuine connector
-        // failure rather than silently falling back to the default CSR set, so the request is rejected.
+        // given — the v3 connector issue-attributes endpoint errors. Issuance-definition resolution fails on a genuine
+        // connector failure rather than silently falling back to the default CSR set, so the request is rejected.
         stubIssueAttributes("[]");
         mockServer.stubFor(WireMock
                 .post(WireMock.urlPathMatching("/v3/authorityProvider/certificates/issue/attributes"))

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -618,6 +618,20 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     }
 
     @Test
+    void registerRejectsStructuredCsrAttributesThatProjectNoIdentity() throws Exception {
+        // Unmapped/extension-only csrAttributes project to no subject and no SAN — reject before placeholder creation.
+        when(issuanceDefinitionResolver.resolve(Mockito.any())).thenReturn(List.of());
+        ClientCertificateRegistrationDto request = new ClientCertificateRegistrationDto();
+        request.setCsrAttributes(List.of(new RequestAttributeV3(UUID.randomUUID(), "unmapped",
+                AttributeContentType.STRING, List.<BaseAttributeContentV3<?>>of(new StringAttributeContentV3("x")))));
+
+        Assertions.assertThrows(ValidationException.class, () -> clientOperationService.registerCertificate(
+                authorityParent, securedRaProfile, request));
+        Assertions.assertEquals(0, certificateRepository.count(),
+                "no placeholder should be persisted when structured identity projects empty");
+    }
+
+    @Test
     void registerRejectsInvalidSubjectDn() {
         registeringAdapter();
         ClientCertificateRegistrationDto request = new ClientCertificateRegistrationDto();

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -1,5 +1,6 @@
 package com.otilm.core.integration.service;
 
+import com.otilm.api.exception.AttributeException;
 import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.attribute.RequestAttribute;
@@ -620,15 +621,40 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     @Test
     void registerRejectsStructuredCsrAttributesThatProjectNoIdentity() throws Exception {
         // Unmapped/extension-only csrAttributes project to no subject and no SAN — reject before placeholder creation.
+        // The adapter must be register-capable so the flow passes the capability gate and actually reaches the
+        // empty-projection check (otherwise the gate's ValidationException would satisfy the assertion by accident).
+        registeringAdapter();
         when(issuanceDefinitionResolver.resolve(Mockito.any())).thenReturn(List.of());
         ClientCertificateRegistrationDto request = new ClientCertificateRegistrationDto();
         request.setCsrAttributes(List.of(new RequestAttributeV3(UUID.randomUUID(), "unmapped",
                 AttributeContentType.STRING, List.<BaseAttributeContentV3<?>>of(new StringAttributeContentV3("x")))));
 
-        Assertions.assertThrows(ValidationException.class, () -> clientOperationService.registerCertificate(
-                authorityParent, securedRaProfile, request));
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
+                () -> clientOperationService.registerCertificate(authorityParent, securedRaProfile, request));
+        Assertions.assertTrue(ex.getMessage().contains("did not yield a subject or subjectAltName"),
+                "must fail on the empty-projection check, not the upstream capability gate");
         Assertions.assertEquals(0, certificateRepository.count(),
                 "no placeholder should be persisted when structured identity projects empty");
+    }
+
+    @Test
+    void registerWrapsCsrAttributeValidationFailure() throws Exception {
+        // An AttributeException from the attribute engine's validation must surface as a client-facing
+        // ValidationException ("Invalid csrAttributes...") and leave no placeholder behind.
+        registeringAdapter();
+        when(issuanceDefinitionResolver.resolve(Mockito.any())).thenReturn(List.of());
+        doThrow(new AttributeException("content item is not part of predefined list")).when(attributeEngine)
+                .validateUpdateDataAttributes(Mockito.any(), Mockito.any(), Mockito.anyList(), Mockito.anyList());
+        ClientCertificateRegistrationDto request = new ClientCertificateRegistrationDto();
+        request.setCsrAttributes(List.of(new RequestAttributeV3(UUID.randomUUID(), "commonName",
+                AttributeContentType.STRING, List.<BaseAttributeContentV3<?>>of(new StringAttributeContentV3("device-9")))));
+
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
+                () -> clientOperationService.registerCertificate(authorityParent, securedRaProfile, request));
+        Assertions.assertTrue(ex.getMessage().startsWith("Invalid csrAttributes for certificate registration"),
+                "the AttributeException must be wrapped as a csrAttributes validation error");
+        Assertions.assertEquals(0, certificateRepository.count(),
+                "no placeholder should be persisted when csrAttributes validation fails");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -3,6 +3,7 @@ package com.otilm.core.integration.service;
 import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.attribute.RequestAttribute;
+import com.otilm.api.model.client.attribute.RequestAttributeV3;
 import com.otilm.api.model.client.connector.v2.ConnectorVersion;
 import com.otilm.api.model.client.connector.v2.FeatureFlag;
 import com.otilm.api.model.core.certificate.CertificateState;
@@ -13,6 +14,13 @@ import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.v2.MetadataAttributeV2;
 import com.otilm.api.model.common.attribute.v2.content.StringAttributeContentV2;
+import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
+import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
+import com.otilm.api.model.common.attribute.v3.content.StringAttributeContentV3;
+import com.otilm.api.model.common.attribute.v3.mapping.FieldMapping;
+import com.otilm.api.model.common.attribute.v3.mapping.FieldType;
+import com.otilm.api.model.common.attribute.v3.mapping.RdnMappedField;
+import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
 import com.otilm.api.model.core.v2.AvailableOperationsDto;
 import com.otilm.api.model.core.v2.CertificateOperationKind;
 import com.otilm.api.model.core.v2.ClientCertificateDataResponseDto;
@@ -20,6 +28,7 @@ import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
 import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.api.model.core.v2.OperationSupport;
 import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.certificate.request.IssuanceDefinitionResolver;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.Connector;
@@ -55,6 +64,7 @@ import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -125,6 +135,11 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     // so the other register tests are unaffected.
     @MockitoBean
     private AttributeEngine attributeEngine;
+
+    // Mocked so the structured-register test supplies canned issuance definitions without a connector round-trip;
+    // the flat register tests never call resolve(), so the default no-op mock is inert for them.
+    @MockitoBean
+    private IssuanceDefinitionResolver issuanceDefinitionResolver;
 
     private RaProfile raProfile;
     // Pre-computed secured UUIDs so each assertThrows lambda contains only the call under test.
@@ -567,6 +582,39 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
         Assertions.assertThrows(ValidationException.class, () -> clientOperationService.registerCertificate(
                 authorityParent, securedRaProfile, request));
         Assertions.assertEquals(0, certificateRepository.count(), "no placeholder should be persisted on an ambiguous request");
+    }
+
+    @Test
+    void registerProjectsStructuredCsrAttributesAndForwardsContent() throws Exception {
+        // Structured identity: a csrAttribute mapping the CN RDN. The orchestrator resolves definitions, projects
+        // the attributes once, derives the placeholder DN from that content, and forwards the content to register().
+        UUID cnUuid = UUID.randomUUID();
+        DataAttributeV3 cnDef = new DataAttributeV3();
+        cnDef.setUuid(cnUuid.toString());
+        cnDef.setName("commonName");
+        RdnMappedField rdn = new RdnMappedField();
+        rdn.setFieldType(FieldType.RDN);
+        rdn.setRdn("2.5.4.3");
+        FieldMapping fieldMapping = new FieldMapping();
+        fieldMapping.setFields(List.of(rdn));
+        cnDef.setFieldMapping(fieldMapping);
+        when(issuanceDefinitionResolver.resolve(Mockito.any())).thenReturn(List.of(cnDef));
+
+        ArgumentCaptor<X509RequestContent> contentCaptor = ArgumentCaptor.forClass(X509RequestContent.class);
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), contentCaptor.capture()))
+                .thenReturn(AdapterOperationResult.syncOk(null, List.of(), CertificateType.X509));
+
+        ClientCertificateRegistrationDto request = new ClientCertificateRegistrationDto();
+        request.setCsrAttributes(List.of(new RequestAttributeV3(cnUuid, "commonName",
+                AttributeContentType.STRING, List.<BaseAttributeContentV3<?>>of(new StringAttributeContentV3("device-9")))));
+
+        ClientCertificateDataResponseDto response = clientOperationService.registerCertificate(
+                authorityParent, securedRaProfile, request);
+
+        // The projected structured content (subject from the attribute, not a flat DN) is forwarded to register().
+        Assertions.assertEquals("device-9", contentCaptor.getValue().getSubject().get(0).getValue());
+        Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
+        Assertions.assertEquals(CertificateState.REGISTERED, cert.getState());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -2,6 +2,7 @@ package com.otilm.core.integration.service;
 
 import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.connector.v2.ConnectorVersion;
 import com.otilm.api.model.client.connector.v2.FeatureFlag;
 import com.otilm.api.model.core.certificate.CertificateState;
@@ -182,7 +183,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
 
     @Test
     void syncRegistrationTransitionsToRegistered() throws Exception {
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
 
         ClientCertificateDataResponseDto response = register();
@@ -193,7 +194,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
 
     @Test
     void asyncRegistrationStaysPendingAndSchedulesRegisterPoll() throws Exception {
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(AdapterOperationResult.asyncAccepted(null));
 
         ClientCertificateDataResponseDto response = register();
@@ -216,7 +217,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
 
     @Test
     void connectorFailureLeavesPlaceholderFailed() throws Exception {
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenThrow(new ConnectorException("upstream refused"));
 
         Assertions.assertThrows(ConnectorException.class, this::register);
@@ -230,7 +231,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     void registerRuntimeFailureLeavesPlaceholderFailed() throws Exception {
         // A raw RuntimeException from register() is pre-acceptance per the RegisterCapability contract, so
         // the placeholder must be FAILED — not orphaned in PENDING_REGISTRATION with no transition.
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenThrow(new IllegalStateException("pre-acceptance failure"));
 
         Assertions.assertThrows(IllegalStateException.class, this::register);
@@ -285,7 +286,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     void asyncRegistrationSkipsPollWhenStatusPollingNotAdvertised() throws Exception {
         // Registration is advertised (proceeds), but status polling is not — the cert is left PENDING
         // with no poll scheduled (manual / out-of-band completion).
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(AdapterOperationResult.asyncAccepted(null));
         when(capabilityService.supports(
                         Mockito.any(AuthorityInstanceReference.class), Mockito.eq(FeatureFlag.CERTIFICATE_STATUS_POLLING)))
@@ -452,7 +453,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
 
     @Test
     void registerStaysPendingWhenConnectorAcceptedButLocalFailureRaised() throws Exception {
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenThrow(new ConnectorAcceptedButLocalFailureException("accepted upstream, local step failed", new RuntimeException("boom")));
 
         Assertions.assertThrows(ConnectorAcceptedButLocalFailureException.class, this::register);
@@ -466,7 +467,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
 
     @Test
     void sanOnlyRegistrationReachesRegistered() throws Exception {
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
         ClientCertificateRegistrationDto request = new ClientCertificateRegistrationDto();
         request.setSubjectAltName("DNS:device-1.example.com"); // subject carried entirely in the SAN, no subjectDn
@@ -503,7 +504,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
         AuthorityProviderAdapter adapter = mock(AuthorityProviderAdapter.class,
                 Mockito.withSettings().extraInterfaces(RegisterCapability.class));
         when(adapterFactory.forAuthority(Mockito.any())).thenReturn(adapter);
-        when(((RegisterCapability) adapter).register(Mockito.any(), Mockito.any()))
+        when(((RegisterCapability) adapter).register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(AdapterOperationResult.asyncAccepted(null));
 
         ClientCertificateDataResponseDto response = register();
@@ -542,7 +543,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
 
     @Test
     void registerPersistsConnectorMetadata() throws Exception {
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(AdapterOperationResult.syncOk(null, List.of(caHandle("endEntityName", "device-1")), CertificateType.X509));
 
         ClientCertificateDataResponseDto response = clientOperationService.registerCertificate(
@@ -554,6 +555,18 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
         Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
         Assertions.assertEquals(CertificateState.REGISTERED, cert.getState());
         verify(attributeEngine).updateMetadataAttributes(Mockito.anyList(), Mockito.any());
+    }
+
+    @Test
+    void registerRejectsBothFlatAndStructuredIdentity() {
+        // Precedence: the pre-registration identity is either structured (csrAttributes) or flat, never both.
+        ClientCertificateRegistrationDto request = new ClientCertificateRegistrationDto();
+        request.setSubjectDn("CN=device-1,O=Acme");
+        request.setCsrAttributes(List.of(mock(RequestAttribute.class)));
+
+        Assertions.assertThrows(ValidationException.class, () -> clientOperationService.registerCertificate(
+                authorityParent, securedRaProfile, request));
+        Assertions.assertEquals(0, certificateRepository.count(), "no placeholder should be persisted on an ambiguous request");
     }
 
     @Test
@@ -604,7 +617,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
 
     @Test
     void syncRegistrationPersistsRegisterIssueBinding() throws Exception {
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(AdapterOperationResult.syncOk(null, List.of(caHandle("endEntityName", "device-1")), CertificateType.X509));
 
         ClientCertificateDataResponseDto response = register();
@@ -617,7 +630,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
 
     @Test
     void asyncRegistrationPersistsBindingWithTrackingHandle() throws Exception {
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(AdapterOperationResult.asyncAccepted(List.of(caHandle("trackingId", "t-1"))));
 
         ClientCertificateDataResponseDto response = register();
@@ -631,7 +644,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     void registrationWithoutMetaStillCreatesBinding() throws Exception {
         // The binding row's presence is the register-bound discriminator for the later issue,
         // independent of whether the connector returned a CA handle.
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
 
         ClientCertificateDataResponseDto response = register();
@@ -646,7 +659,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
         // Post-acceptance divergence: the connector accepted the registration, so a failed binding
         // write must NOT roll certificate state back — it surfaces a clear error and leaves the cert
         // PENDING_REGISTRATION for reconciliation (the sync REGISTERED transition never runs).
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
         doThrow(new IllegalStateException("db down")).when(registrationWriter)
                 .upsert(Mockito.any(), Mockito.any());
@@ -660,7 +673,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
 
     @Test
     void rejectedRegistrationLeavesNoBinding() throws Exception {
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenThrow(new ConnectorException("upstream refused"));
 
         Assertions.assertThrows(ConnectorException.class, this::register);
@@ -670,7 +683,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     }
 
     private String registerSyncRegistered() throws Exception {
-        when(registeringAdapter().register(Mockito.any(), Mockito.any()))
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
         return register().getUuid();
     }

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -534,9 +534,9 @@ class AuthorityProviderV3AdapterTest {
         when(capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED)).thenReturn(false);
         X509RequestContent content = new X509RequestContent();
         content.setExtensions(List.of(new RequestedExtension("1.2.3.4", false, ExtensionValueEncoding.UTF8_STRING, "Zm9v")));
+        ClientCertificateRegistrationDto req = new ClientCertificateRegistrationDto();
 
-        assertThrows(ValidationException.class,
-                () -> adapter.register(cert, new ClientCertificateRegistrationDto(), content));
+        assertThrows(ValidationException.class, () -> adapter.register(cert, req, content));
     }
 
     // ---- issueRegistered: register-bound issue ----

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -420,7 +420,7 @@ class AuthorityProviderV3AdapterTest {
         when(certClientV3.register(eq(connectorInfo), any()))
                 .thenReturn(ResponseEntity.ok(body));
 
-        AdapterOperationResult result = adapter.register(cert, new ClientCertificateRegistrationDto());
+        AdapterOperationResult result = adapter.register(cert, new ClientCertificateRegistrationDto(), null);
 
         assertEquals(AdapterOperationOutcome.SYNC_OK, result.outcome());
         verify(certClientV3).register(eq(connectorInfo), any());
@@ -446,7 +446,7 @@ class AuthorityProviderV3AdapterTest {
         body.setMeta(List.of());
         when(certClientV3.register(eq(connectorInfo), any())).thenReturn(ResponseEntity.ok(body));
 
-        adapter.register(cert, req);
+        adapter.register(cert, req, null);
 
         ArgumentCaptor<CertificateRegistrationRequestDtoV3> captor =
                 ArgumentCaptor.forClass(CertificateRegistrationRequestDtoV3.class);
@@ -501,6 +501,27 @@ class AuthorityProviderV3AdapterTest {
         assertNotNull(wire.getAttributes());
         assertNotNull(wire.getAuthorityAttributes());
         assertNotNull(wire.getRaProfileAttributes());
+    }
+
+    // ---- register: forwards the orchestrator's pre-built identity content ----
+
+    @Test
+    void registerForwardsPreBuiltIdentityContentVerbatim() throws ConnectorException {
+        // Structured csrAttributes are projected by the orchestrator and handed in as identityContent; the adapter
+        // must forward it onto the structured wire without re-projecting.
+        when(capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED)).thenReturn(true);
+        X509RequestContent projected = new X509RequestContent();
+
+        CertificateDataResponseDto body = new CertificateDataResponseDto();
+        body.setMeta(List.of());
+        when(certClientV3.register(eq(connectorInfo), any())).thenReturn(ResponseEntity.ok(body));
+
+        adapter.register(cert, new ClientCertificateRegistrationDto(), projected);
+
+        ArgumentCaptor<CertificateRegistrationRequestDtoV3> captor =
+                ArgumentCaptor.forClass(CertificateRegistrationRequestDtoV3.class);
+        verify(certClientV3).register(eq(connectorInfo), captor.capture());
+        assertSame(projected, captor.getValue().getRequestContent());
     }
 
     // ---- issueRegistered: register-bound issue ----

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -46,10 +46,13 @@ import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateContent;
 import com.otilm.core.dao.entity.CertificateRequestEntity;
 import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.connector.v2.FeatureFlag;
 import com.otilm.api.model.connector.v3.certificate.CertificateExtension;
 import com.otilm.api.model.connector.v3.certificate.CertificateRegistrationRequestDtoV3;
+import com.otilm.api.model.connector.v3.certificate.RequestedExtension;
 import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
+import com.otilm.api.model.core.oid.ExtensionValueEncoding;
 import com.otilm.api.model.core.oid.OidCategory;
 import com.otilm.core.exception.ConnectorAcceptedButLocalFailureException;
 import com.otilm.core.oid.OidHandler;
@@ -522,6 +525,18 @@ class AuthorityProviderV3AdapterTest {
                 ArgumentCaptor.forClass(CertificateRegistrationRequestDtoV3.class);
         verify(certClientV3).register(eq(connectorInfo), captor.capture());
         assertSame(projected, captor.getValue().getRequestContent());
+    }
+
+    @Test
+    void registerFailsClosedWhenStructuredContentCannotRideFlatWire() {
+        // A connector without CERTIFICATE_REQUEST_STRUCTURED carries only the flat wire; content it cannot
+        // represent (here a non-DER extension) must be rejected, not silently dropped.
+        when(capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REQUEST_STRUCTURED)).thenReturn(false);
+        X509RequestContent content = new X509RequestContent();
+        content.setExtensions(List.of(new RequestedExtension("1.2.3.4", false, ExtensionValueEncoding.UTF8_STRING, "Zm9v")));
+
+        assertThrows(ValidationException.class,
+                () -> adapter.register(cert, new ClientCertificateRegistrationDto(), content));
     }
 
     // ---- issueRegistered: register-bound issue ----


### PR DESCRIPTION
Closes #1788.

Accept structured `csrAttributes` on the certificate register path, mirroring the issue path; the flat `subjectDn`/`subjectAltName`/`extensions` stay as the simple shape.

- Orchestrator (`registerCertificate`) projects `csrAttributes` **once** (resolve definitions → `validateUpdateDataAttributes` → `CertificateRequestAttributeProjector.project`), derives the placeholder DN from that same content, rejects a request supplying both flat and structured identity, and threads the content to `register()`.
- `AuthorityProviderV3Adapter.register` uses the pre-built content when present, else builds flat identity itself. Signature gains a `@Nullable X509RequestContent` (mirrors `issueRegistered`).
- Shared `IssuanceDefinitionResolver` extracted from the issue path (single projection, one definition set).
- Fails closed when structured content cannot ride a non-structured connector's flat wire (non-DER extension / non-UTF8 `otherName`), instead of silently dropping.

Depends on interfaces#769 (`csrAttributes` on `ClientCertificateRegistrationDto`) — merged.

Reviewed branch-only via multi-reviewer pass before push; four findings applied. Targeted register/issue tests green (95/95); full verify runs in CI.