### PR TITLE
Route certificate renew/revoke, attribute validation, identify, and CA-chain retrieval through authority adapters

### DIFF
--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
@@ -96,17 +96,13 @@ public interface AuthorityProviderAdapter {
      * Connector-side validation of operator-supplied issue attributes. v2 calls the connector's
      * {@code /validate} endpoint; v3 is a no-op (the v3 contract dropped {@code /validate} — Core
      * validates structurally against the listed definitions instead).
-     *
-     * @return
      */
-    Boolean validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+    void validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
 
     /**
      * Connector-side validation of operator-supplied revoke attributes. See {@link #validateIssueAttributes}.
-     *
-     * @return
      */
-    Boolean validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+    void validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
 
     void checkAuthorityConnection(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
 

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
@@ -4,6 +4,7 @@ import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
 import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
@@ -50,6 +51,21 @@ public interface AuthorityProviderAdapter {
     AdapterOperationResult revoke(Certificate cert, ClientCertificateRevocationDto req) throws ConnectorException;
 
     /**
+     * Asks the authority provider whether the given certificate was issued by (and is known to)
+     * the authority behind the RA profile. Returns the connector's identification metadata,
+     * never {@code null}. A connector policy rejection (v2/v3 wire 422) surfaces as
+     * {@link ValidationException} with the connector's reason.
+     *
+     * <p>v2 posts to the instance-scoped identify endpoint with the stored RA-profile attributes;
+     * v3 is stateless and carries the authority/RA-profile attributes in the request body.</p>
+     *
+     * @param raProfile          the RA profile whose authority performs the identification —
+     *                           may differ from the certificate's current RA profile (RA profile switch)
+     * @param certificateContent Base64 certificate content to identify
+     */
+    List<MetadataAttribute> identify(RaProfile raProfile, String certificateContent) throws ValidationException, ConnectorException;
+
+    /**
      * Authority-instance attribute definitions. v2 lists via the function-group attribute endpoint
      * (`/v1/authorityProvider/{kind}/attributes`); v3 via the stateless
      * `/v3/authorityProvider/authorities/attributes`. Used by authority create/edit so the operator
@@ -93,4 +109,6 @@ public interface AuthorityProviderAdapter {
     Boolean validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
 
     void checkAuthorityConnection(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+
+
 }

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
@@ -80,11 +80,17 @@ public interface AuthorityProviderAdapter {
      * Connector-side validation of operator-supplied issue attributes. v2 calls the connector's
      * {@code /validate} endpoint; v3 is a no-op (the v3 contract dropped {@code /validate} — Core
      * validates structurally against the listed definitions instead).
+     *
+     * @return
      */
-    void validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+    Boolean validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
 
-    /** Connector-side validation of operator-supplied revoke attributes. See {@link #validateIssueAttributes}. */
-    void validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
+    /**
+     * Connector-side validation of operator-supplied revoke attributes. See {@link #validateIssueAttributes}.
+     *
+     * @return
+     */
+    Boolean validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
 
     void checkAuthorityConnection(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
 }

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapter.java
@@ -109,5 +109,5 @@ public interface AuthorityProviderAdapter {
 
     void checkAuthorityConnection(AuthorityInstanceReference authority, List<RequestAttribute> attributes) throws ValidationException, ConnectorException;
 
-
+    List<AdapterOperationResult> getCaCertificates(AuthorityInstanceReference authority, RaProfile raProfile) throws ConnectorException;
 }

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV2Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV2Adapter.java
@@ -7,6 +7,7 @@ import com.otilm.api.interfaces.client.v2.CertificateSyncApiClient;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
+import com.otilm.api.model.connector.authority.CaCertificatesRequestDto;
 import com.otilm.api.model.connector.v2.CertRevocationDto;
 import com.otilm.api.model.connector.v2.CertificateDataResponseDto;
 import com.otilm.api.model.connector.v2.CertificateIdentificationRequestDto;
@@ -197,6 +198,18 @@ public class AuthorityProviderV2Adapter extends AbstractAuthorityProviderAdapter
         ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
         connectorApiFactory.getAuthorityInstanceApiClient(connectorDto)
                 .validateRAProfileAttributes(connectorDto, authority.getAuthorityInstanceUuid(), attributes);
+    }
+
+    @Override
+    public List<AdapterOperationResult> getCaCertificates(AuthorityInstanceReference authority, RaProfile raProfile) throws ConnectorException {
+        ApiClientConnectorInfo connectorInfo = connectorForApiClient(authority);
+        List<CertificateDataResponseDto> certificates = connectorApiFactory.getAuthorityInstanceApiClient(connectorInfo)
+                .getCaCertificates(connectorInfo, authority.getAuthorityInstanceUuid(), new CaCertificatesRequestDto(raProfileAttributesFor(raProfile, authority)))
+                .getCertificates();
+        return certificates == null ? List.of() : certificates
+                .stream()
+                .map(cert -> AdapterOperationResult.syncOk(cert.getCertificateData(), cert.getMeta(), cert.getCertificateType()))
+                .toList();
     }
 
     // --- private helpers ---

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV2Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV2Adapter.java
@@ -147,18 +147,18 @@ public class AuthorityProviderV2Adapter extends AbstractAuthorityProviderAdapter
     }
 
     @Override
-    public void validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes)
+    public Boolean validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes)
             throws ValidationException, ConnectorException {
         ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
-        connectorApiFactory.getCertificateApiClientV2(connectorDto)
+        return connectorApiFactory.getCertificateApiClientV2(connectorDto)
                 .validateIssueCertificateAttributes(connectorDto, authority.getAuthorityInstanceUuid(), attributes);
     }
 
     @Override
-    public void validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes)
+    public Boolean validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes)
             throws ValidationException, ConnectorException {
         ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
-        connectorApiFactory.getCertificateApiClientV2(connectorDto)
+        return connectorApiFactory.getCertificateApiClientV2(connectorDto)
                 .validateRevokeCertificateAttributes(connectorDto, authority.getAuthorityInstanceUuid(), attributes);
     }
 

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV2Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV2Adapter.java
@@ -6,8 +6,11 @@ import com.otilm.api.exception.ValidationException;
 import com.otilm.api.interfaces.client.v2.CertificateSyncApiClient;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.connector.v2.CertRevocationDto;
 import com.otilm.api.model.connector.v2.CertificateDataResponseDto;
+import com.otilm.api.model.connector.v2.CertificateIdentificationRequestDto;
+import com.otilm.api.model.connector.v2.CertificateIdentificationResponseDto;
 import com.otilm.api.model.connector.v2.CertificateRenewRequestDto;
 import com.otilm.api.model.connector.v2.CertificateSignRequestDto;
 import com.otilm.api.model.core.auth.Resource;
@@ -110,6 +113,20 @@ public class AuthorityProviderV2Adapter extends AbstractAuthorityProviderAdapter
             return AdapterOperationResult.asyncAccepted(null);
         }
         return AdapterOperationResult.syncNoContent();
+    }
+
+    @Override
+    public List<MetadataAttribute> identify(RaProfile raProfile, String certificateContent) throws ValidationException, ConnectorException {
+        AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
+
+        CertificateIdentificationRequestDto wire = new CertificateIdentificationRequestDto();
+        wire.setCertificate(certificateContent);
+        wire.setRaProfileAttributes(raProfileAttributesFor(raProfile, authority));
+
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        CertificateIdentificationResponseDto response = connectorApiFactory.getCertificateApiClientV2(connectorDto)
+                .identifyCertificate(connectorDto, authority.getAuthorityInstanceUuid(), wire);
+        return response.getMeta() != null ? response.getMeta() : List.of();
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV2Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV2Adapter.java
@@ -164,18 +164,18 @@ public class AuthorityProviderV2Adapter extends AbstractAuthorityProviderAdapter
     }
 
     @Override
-    public Boolean validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes)
+    public void validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes)
             throws ValidationException, ConnectorException {
         ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
-        return connectorApiFactory.getCertificateApiClientV2(connectorDto)
+        connectorApiFactory.getCertificateApiClientV2(connectorDto)
                 .validateIssueCertificateAttributes(connectorDto, authority.getAuthorityInstanceUuid(), attributes);
     }
 
     @Override
-    public Boolean validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes)
+    public void validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes)
             throws ValidationException, ConnectorException {
         ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
-        return connectorApiFactory.getCertificateApiClientV2(connectorDto)
+        connectorApiFactory.getCertificateApiClientV2(connectorDto)
                 .validateRevokeCertificateAttributes(connectorDto, authority.getAuthorityInstanceUuid(), attributes);
     }
 

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -201,16 +201,14 @@ public class AuthorityProviderV3Adapter
     }
 
     @Override
-    public Boolean validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) {
+    public void validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) {
         // v3 has no connector-side /validate; the caller validates structurally against the listed
         // definitions (AttributeEngine.validateUpdateDataAttributes) — no connector round-trip.
-        return Boolean.TRUE;
     }
 
     @Override
-    public Boolean validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) {
+    public void validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) {
         // v3 has no connector-side /validate — see validateIssueAttributes.
-        return Boolean.TRUE;
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -14,6 +14,8 @@ import com.otilm.api.model.common.error.ErrorCode;
 import com.otilm.api.model.connector.v3.certificate.CertificateAttributeListRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateDataResponseDto;
 import com.otilm.api.model.connector.v3.certificate.CertificateExtension;
+import com.otilm.api.model.connector.v3.certificate.CertificateIdentificationRequestDtoV3;
+import com.otilm.api.model.connector.v3.certificate.CertificateIdentificationResponseDto;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationCancelRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatusRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatusResponseDto;
@@ -147,6 +149,21 @@ public class AuthorityProviderV3Adapter
         return executeWithAcceptanceGuard(CertificateOperation.REVOKE,
                 () -> connectorApiFactory.getCertificateApiClientV3(connectorDto).revoke(connectorDto, wire),
                 this::mapRevokeResponse);
+    }
+
+    @Override
+    public List<MetadataAttribute> identify(RaProfile raProfile, String certificateContent) throws ValidationException, ConnectorException {
+        AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+
+        CertificateIdentificationRequestDtoV3 wire = new CertificateIdentificationRequestDtoV3();
+        wire.setCertificate(certificateContent);
+        wire.setAuthorityAttributes(authorityAttributesFor(authority));
+        wire.setRaProfileAttributes(resolvedRaProfileAttributes(raProfile, authority));
+
+        CertificateIdentificationResponseDto response =
+                connectorApiFactory.getCertificateApiClientV3(connectorDto).identify(connectorDto, wire);
+        return response.getMeta() != null ? response.getMeta() : List.of();
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -230,7 +230,7 @@ public class AuthorityProviderV3Adapter
     public List<AdapterOperationResult> getCaCertificates(AuthorityInstanceReference authority, RaProfile raProfile) throws ConnectorException {
         ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
         CaCertificatesRequestDtoV3 request = new CaCertificatesRequestDtoV3();
-        request.setRaProfileAttributes(raProfileAttributesFor(raProfile, authority));
+        request.setRaProfileAttributes(resolvedRaProfileAttributes(raProfile, authority));
         request.setAuthorityAttributes(authorityAttributesFor(authority));
         List<CertificateDataResponseDto> certificates = connectorApiFactory.getAuthorityInstanceApiClientV3(connectorDto).getCaCertificates(connectorDto, request)
                 .getCertificates();

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -184,14 +184,16 @@ public class AuthorityProviderV3Adapter
     }
 
     @Override
-    public void validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) {
+    public Boolean validateIssueAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) {
         // v3 has no connector-side /validate; the caller validates structurally against the listed
         // definitions (AttributeEngine.validateUpdateDataAttributes) — no connector round-trip.
+        return Boolean.TRUE;
     }
 
     @Override
-    public void validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) {
+    public Boolean validateRevokeAttributes(AuthorityInstanceReference authority, List<RequestAttribute> attributes) {
         // v3 has no connector-side /validate — see validateIssueAttributes.
+        return Boolean.TRUE;
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -11,6 +11,7 @@ import com.otilm.api.model.client.connector.v2.FeatureFlag;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.common.error.ErrorCode;
+import com.otilm.api.model.connector.v3.authority.CaCertificatesRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateAttributeListRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateDataResponseDto;
 import com.otilm.api.model.connector.v3.certificate.CertificateExtension;
@@ -223,6 +224,20 @@ public class AuthorityProviderV3Adapter
         ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
         connectorApiFactory.getAuthorityInstanceApiClientV3(connectorDto)
                 .checkAuthorityConnection(connectorDto, attributes);
+    }
+
+    @Override
+    public List<AdapterOperationResult> getCaCertificates(AuthorityInstanceReference authority, RaProfile raProfile) throws ConnectorException {
+        ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
+        CaCertificatesRequestDtoV3 request = new CaCertificatesRequestDtoV3();
+        request.setRaProfileAttributes(raProfileAttributesFor(raProfile, authority));
+        request.setAuthorityAttributes(authorityAttributesFor(authority));
+        List<CertificateDataResponseDto> certificates = connectorApiFactory.getAuthorityInstanceApiClientV3(connectorDto).getCaCertificates(connectorDto, request)
+                .getCertificates();
+        return  certificates == null ? List.of() : certificates
+                .stream()
+                .map(cert -> AdapterOperationResult.syncOk(cert.getCertificateData(), cert.getMeta(), cert.getCertificateType()))
+                .toList();
     }
 
     // ---- RegisterCapability ----

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -1,9 +1,7 @@
 package com.otilm.core.service.impl;
 
 import com.otilm.api.model.common.UuidDto;
-import com.otilm.api.clients.ApiClientConnectorInfo;
 import com.otilm.core.attribute.CsrAttributes;
-import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.api.exception.*;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.attribute.ResponseAttribute;
@@ -16,8 +14,6 @@ import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.v3.content.data.ResourceCertificateContentData;
 import com.otilm.api.model.common.attribute.v3.content.data.ResourceObjectContentData;
-import com.otilm.api.model.connector.v2.CertificateIdentificationRequestDto;
-import com.otilm.api.model.connector.v2.CertificateIdentificationResponseDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.auth.UserDto;
 import com.otilm.api.model.core.certificate.*;
@@ -75,9 +71,10 @@ import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.*;
+import com.otilm.core.service.handler.authority.AuthorityProviderAdapter;
+import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
 import com.otilm.core.service.handler.authority.lifecycle.CertificateStateMachine;
 import com.otilm.core.service.writer.CertificateValidationWriter;
-import com.otilm.core.service.v2.ConnectorInternalService;
 import com.otilm.core.service.v2.ExtendedAttributeService;
 import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.util.*;
@@ -167,8 +164,6 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
     private AuthorizationEnforcer authorizationEnforcer;
     private EventProducer eventProducer;
     private NotificationProducer notificationProducer;
-    private ConnectorApiFactory connectorApiFactory;
-    private ConnectorInternalService connectorService;
     private UserManagementApiClient userManagementApiClient;
     private CrlService crlService;
     private ProtocolCertificateAssociationsRepository protocolCertificateAssociationsRepository;
@@ -187,11 +182,17 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
     private AuthenticationCache authenticationCache;
     private CertificateUploadService certificateUploadService;
     private CertificateStateMachine stateMachine;
+    private AuthorityProviderAdapterFactory adapterFactory;
 
     /**
      * A map that contains ICertificateValidator implementations mapped to their corresponding certificate type code
      */
     private Map<String, ICertificateValidator> certificateValidatorMap;
+
+    @Autowired
+    public void setAdapterFactory(AuthorityProviderAdapterFactory adapterFactory) {
+        this.adapterFactory = adapterFactory;
+    }
 
 
     @Autowired
@@ -341,16 +342,6 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
     @Autowired
     public void setNotificationProducer(NotificationProducer notificationProducer) {
         this.notificationProducer = notificationProducer;
-    }
-
-    @Autowired
-    public void setConnectorApiFactory(ConnectorApiFactory connectorApiFactory) {
-        this.connectorApiFactory = connectorApiFactory;
-    }
-
-    @Autowired
-    public void setConnectorService(ConnectorInternalService connectorService) {
-        this.connectorService = connectorService;
     }
 
     @Autowired
@@ -2145,18 +2136,15 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
         RaProfile currentRaProfile = certificate.getRaProfile();
         String newRaProfileName = UNDEFINED_CERTIFICATE_OBJECT_NAME;
         String currentRaProfileName = currentRaProfile != null ? currentRaProfile.getName() : UNDEFINED_CERTIFICATE_OBJECT_NAME;
-        CertificateIdentificationResponseDto response = null;
+        List<MetadataAttribute> identifiedMeta = null;
         if (raProfileUuid != null) {
             newRaProfile = raProfileRepository.findByUuid(raProfileUuid).orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
             newRaProfileName = newRaProfile.getName();
 
             // identify certificate by new authority
-            CertificateIdentificationRequestDto requestDto = new CertificateIdentificationRequestDto();
-            requestDto.setCertificate(certificate.getCertificateContent().getContent());
-            requestDto.setRaProfileAttributes(attributeEngine.getRequestObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.RA_PROFILE, newRaProfile.getUuid()).connector(newRaProfile.getAuthorityInstanceReference().getConnectorUuid()).build()));
             try {
-                ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(newRaProfile.getAuthorityInstanceReference().getConnectorUuid());
-                response = connectorApiFactory.getCertificateApiClientV2(connectorDto).identifyCertificate(connectorDto, newRaProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(), requestDto);
+                AuthorityProviderAdapter adapter = adapterFactory.forAuthority(newRaProfile.getAuthorityInstanceReference());
+                identifiedMeta = adapter.identify(newRaProfile, certificate.getCertificateContent().getContent());
             } catch (ConnectorException e) {
                 certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Certificate not identified by authority of new RA profile %s. Certificate needs to be reissued.", newRaProfile.getName()), null);
                 throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Certificate not identified by authority of new RA profile %s. Certificate: %s", newRaProfile.getName(), certificate.toStringShort()));
@@ -2181,7 +2169,7 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
         // save metadata for identified certificate and run compliance
         if (newRaProfile != null) {
             UUID connectorUuid = newRaProfile.getAuthorityInstanceReference().getConnectorUuid();
-            attributeEngine.updateMetadataAttributes(response.getMeta(), ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(connectorUuid).build());
+            attributeEngine.updateMetadataAttributes(identifiedMeta, ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(connectorUuid).build());
 
             try {
                 complianceExternalService.checkResourceObjectComplianceAsync(Resource.CERTIFICATE, certificate.getUuid());

--- a/src/main/java/com/otilm/core/service/impl/RaProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/RaProfileServiceImpl.java
@@ -1,7 +1,5 @@
 package com.otilm.core.service.impl;
 
-import com.otilm.api.clients.ApiClientConnectorInfo;
-import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.api.exception.*;
 import com.otilm.api.model.client.approvalprofile.ApprovalProfileDto;
 import com.otilm.api.model.client.approvalprofile.ApprovalProfileRelationDto;
@@ -11,9 +9,6 @@ import com.otilm.api.model.client.compliance.SimplifiedComplianceProfileDto;
 import com.otilm.api.model.client.raprofile.*;
 import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
-import com.otilm.api.model.connector.authority.CaCertificatesRequestDto;
-import com.otilm.api.model.connector.authority.CaCertificatesResponseDto;
-import com.otilm.api.model.connector.v2.CertificateDataResponseDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.certificate.CertificateDetailDto;
 import com.otilm.api.model.core.raprofile.RaProfileDto;
@@ -36,11 +31,11 @@ import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.ApprovalProfileExternalService;
+import com.otilm.core.service.handler.authority.AdapterOperationResult;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapter;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
 import com.otilm.core.service.v2.ComplianceProfileExternalService;
 import com.otilm.core.service.ComplianceInternalService;
-import com.otilm.core.service.v2.ConnectorInternalService;
 import com.otilm.core.service.RaProfileExternalService;
 import com.otilm.core.service.RaProfileInternalService;
 import com.otilm.core.service.RaProfileCertificateRequestAttributeService;
@@ -72,8 +67,6 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
 
     private RaProfileRepository raProfileRepository;
     private AuthorityInstanceReferenceRepository authorityInstanceReferenceRepository;
-    private ConnectorApiFactory connectorApiFactory;
-    private ConnectorInternalService connectorService;
     private CertificateRepository certificateRepository;
     private AcmeProfileRepository acmeProfileRepository;
     private ExtendedAttributeService extendedAttributeService;
@@ -638,17 +631,14 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
         RaProfile raProfile = getRaProfileEntity(raProfileUuid);
         AuthorityInstanceReference authorityInstanceReference = authorityInstanceReferenceRepository.findByUuid(authorityUuid)
                 .orElseThrow(() -> new NotFoundException(AuthorityInstanceReference.class, authorityUuid));
-
-        List<RequestAttribute> requestAttributes = attributeEngine.getRequestObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.RA_PROFILE, raProfile.getUuid()).connector(authorityInstanceReference.getConnectorUuid()).build());
-        ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(authorityInstanceReference.getConnectorUuid());
-        CaCertificatesResponseDto caCertificatesResponseDto = connectorApiFactory.getAuthorityInstanceApiClient(connectorDto).getCaCertificates(connectorDto, authorityInstanceReference.getAuthorityInstanceUuid(), new CaCertificatesRequestDto(requestAttributes));
-        List<CertificateDataResponseDto> certificateDataResponseDtos = caCertificatesResponseDto.getCertificates();
+        AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(authorityInstanceReference);
+        List<AdapterOperationResult> caCertificatesResponse = adapter.getCaCertificates(authorityInstanceReference, raProfile);
         List<CertificateDetailDto> certificateDetailDtos = new ArrayList<>();
-        for (CertificateDataResponseDto certificateDataResponseDto : certificateDataResponseDtos) {
+        for (AdapterOperationResult certificateDataResponse : caCertificatesResponse) {
             X509Certificate certificate;
             String fingerprint;
             try {
-                certificate = CertificateUtil.parseCertificate(certificateDataResponseDto.getCertificateData());
+                certificate = CertificateUtil.parseCertificate(certificateDataResponse.certificateData());
                 fingerprint = CertificateUtil.getThumbprint(certificate);
             } catch (java.security.cert.CertificateException | NoSuchAlgorithmException e) {
                 logger.warn("Cannot process certificate from CA certificate chain returned from authority of RA profile {}", raProfile.getName());
@@ -760,16 +750,6 @@ public class RaProfileServiceImpl implements RaProfileExternalService, RaProfile
     @Autowired
     public void setAuthorityInstanceReferenceRepository(AuthorityInstanceReferenceRepository authorityInstanceReferenceRepository) {
         this.authorityInstanceReferenceRepository = authorityInstanceReferenceRepository;
-    }
-
-    @Autowired
-    public void setConnectorApiFactory(ConnectorApiFactory connectorApiFactory) {
-        this.connectorApiFactory = connectorApiFactory;
-    }
-
-    @Autowired
-    public void setConnectorService(ConnectorInternalService connectorService) {
-        this.connectorService = connectorService;
     }
 
     @Autowired

--- a/src/main/java/com/otilm/core/service/v2/ClientOperationExternalService.java
+++ b/src/main/java/com/otilm/core/service/v2/ClientOperationExternalService.java
@@ -24,7 +24,7 @@ public interface ClientOperationExternalService {
             SecuredUUID raProfileUuid
     ) throws ConnectorException, NotFoundException;
 
-    boolean validateIssueCertificateAttributes(
+    void validateIssueCertificateAttributes(
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid,
             List<RequestAttribute> attributes
@@ -73,7 +73,7 @@ public interface ClientOperationExternalService {
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid) throws ConnectorException, NotFoundException;
 
-    boolean validateRevokeCertificateAttributes(
+    void validateRevokeCertificateAttributes(
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid,
             List<RequestAttribute> attributes

--- a/src/main/java/com/otilm/core/service/v2/ExtendedAttributeService.java
+++ b/src/main/java/com/otilm/core/service/v2/ExtendedAttributeService.java
@@ -15,14 +15,14 @@ public interface ExtendedAttributeService {
     List<BaseAttribute> listIssueCertificateAttributes(
             RaProfile raProfile) throws ConnectorException, NotFoundException;
 
-    boolean validateIssueCertificateAttributes(
+    void validateIssueCertificateAttributes(
             RaProfile raProfile,
             List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException;
 
     List<BaseAttribute> listRevokeCertificateAttributes(
             RaProfile raProfile) throws ConnectorException, NotFoundException;
 
-    boolean validateRevokeCertificateAttributes(
+    void validateRevokeCertificateAttributes(
             RaProfile raProfile,
             List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException;
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -13,7 +13,6 @@ import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateRequestContent;
 import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
 import com.otilm.api.model.connector.v2.CertRevocationDto;
-import com.otilm.api.model.connector.v2.CertificateDataResponseDto;
 import com.otilm.api.model.connector.v2.CertificateIdentificationRequestDto;
 import com.otilm.api.exception.ConnectorClientException;
 import com.otilm.api.exception.ConnectorCommunicationException;
@@ -81,6 +80,7 @@ import com.otilm.core.service.v2.ClientOperationInternalService;
 import com.otilm.core.service.v2.ConnectorInternalService;
 import com.otilm.core.service.v2.ExtendedAttributeService;
 import com.otilm.core.util.*;
+import io.micrometer.common.util.StringUtils;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.asn1.x509.Extension;
@@ -948,9 +948,9 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     /** Delegates with the metadata from the connector's {@code 202 Accepted} response body. */
-    private void onAsyncAccepted(Certificate certificate, CertificateDataResponseDto acceptedBody, ResourceAction originatingAction) {
+    private void onAsyncAccepted(Certificate certificate, AdapterOperationResult result, ResourceAction originatingAction) {
         onAsyncAccepted(certificate,
-                acceptedBody != null ? acceptedBody.getMeta() : null,
+                result != null ? result.meta() : null,
                 originatingAction);
     }
 
@@ -1248,15 +1248,6 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
         logger.debug("Renewing Certificate: {}", oldCertificate);
 
-        CertificateRenewRequestDto caRequest = new CertificateRenewRequestDto();
-        caRequest.setRequest(certificate.getCertificateRequest().getContent());
-        caRequest.setFormat(certificate.getCertificateRequest().getCertificateRequestFormat());
-        caRequest.setRaProfileAttributes(attributeEngine.getRequestObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.RA_PROFILE, raProfile.getUuid()).connector(raProfile.getAuthorityInstanceReference().getConnectorUuid()).build()));
-        caRequest.setCertificate(oldCertificate.getCertificateContent().getContent());
-        // TODO: check if retrieved correctly, just metadata with null source object
-        caRequest.setMeta(attributeEngine.getMetadataAttributesDefinitionContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, oldCertificate.getUuid()).connector(raProfile.getAuthorityInstanceReference().getConnectorUuid()).build()));
-
-        CertificateDataResponseDto renewCaResponse;
         HashMap<String, Object> additionalInformation = new HashMap<>();
         additionalInformation.put("New Certificate UUID", certificate.getUuid());
         try {
@@ -1266,30 +1257,26 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             stateMachine.transition(certificate, CertificateState.PENDING_ISSUE, CertificateEvent.ISSUE,
                     "Issuance in progress");
 
-            ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(raProfile.getAuthorityInstanceReference().getConnectorUuid());
-            ResponseEntity<CertificateDataResponseDto> renewResponse = connectorApiFactory.getCertificateApiClientV2(connectorDto).renewCertificate(
-                    connectorDto,
-                    raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(),
-                    caRequest);
+            AuthorityProviderAdapter adapter = adapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
+            AdapterOperationResult renewResult = adapter.renew(oldCertificate, certificate, request);
 
-            if (renewResponse.getStatusCode().value() == 202) {
+            if (renewResult.isAsync()) {
                 // The connector accepted the renewal but completion is asynchronous; the new
                 // certificate stays in PENDING_ISSUE while the predecessor remains ISSUED.
-                onAsyncAccepted(certificate, renewResponse.getBody(), ResourceAction.RENEW);
+                onAsyncAccepted(certificate, renewResult, ResourceAction.RENEW);
                 certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.RENEW,
                         CertificateEventStatus.SUCCESS, "Renewal accepted; awaiting asynchronous completion.",
                         MetaDefinitions.serialize(additionalInformation));
                 return;
             }
 
-            renewCaResponse = renewResponse.getBody();
-            if (renewCaResponse == null || renewCaResponse.getCertificateData() == null || renewCaResponse.getCertificateData().isEmpty()) {
+            if (StringUtils.isBlank(renewResult.certificateData())) {
                 throw new CertificateOperationException("Response from authority did not contain certificate data");
             }
 
             logger.info("Certificate {} was renewed by authority", certificateUuid);
 
-            CertificateDetailDto certificateDetailDto = certificateService.issueRequestedCertificate(certificateUuid, renewCaResponse.getCertificateData(), renewCaResponse.getMeta());
+            CertificateDetailDto certificateDetailDto = certificateService.issueRequestedCertificate(certificateUuid, renewResult.certificateData(), renewResult.meta());
 
             additionalInformation.put("New Certificate Serial Number", certificateDetailDto.getSerialNumber());
             certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.RENEW, CertificateEventStatus.SUCCESS, "Renewed using RA Profile " + raProfile.getName(), MetaDefinitions.serialize(additionalInformation));
@@ -1467,15 +1454,6 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         RaProfile raProfile = certificate.getRaProfile();
 
         logger.debug("Rekeying Certificate: {}", oldCertificate);
-        CertificateRenewRequestDto caRequest = new CertificateRenewRequestDto();
-        caRequest.setRequest(certificate.getCertificateRequest().getContent());
-        caRequest.setFormat(certificate.getCertificateRequest().getCertificateRequestFormat());
-        caRequest.setRaProfileAttributes(attributeEngine.getRequestObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.RA_PROFILE, raProfile.getUuid()).connector(raProfile.getAuthorityInstanceReference().getConnectorUuid()).build()));
-        caRequest.setCertificate(oldCertificate.getCertificateContent().getContent());
-        // TODO: check if retrieved correctly, just metadata with null source object
-        caRequest.setMeta(attributeEngine.getMetadataAttributesDefinitionContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, oldCertificate.getUuid()).connector(raProfile.getAuthorityInstanceReference().getConnectorUuid()).build()));
-
-        CertificateDataResponseDto renewCaResponse = null;
         HashMap<String, Object> additionalInformation = new HashMap<>();
         additionalInformation.put("New Certificate UUID", certificate.getUuid());
         try {
@@ -1485,30 +1463,26 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             stateMachine.transition(certificate, CertificateState.PENDING_ISSUE, CertificateEvent.ISSUE,
                     "Issuance in progress");
 
-            ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(raProfile.getAuthorityInstanceReference().getConnectorUuid());
-            ResponseEntity<CertificateDataResponseDto> rekeyResponse = connectorApiFactory.getCertificateApiClientV2(connectorDto).renewCertificate(
-                    connectorDto,
-                    raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(),
-                    caRequest);
+            AuthorityProviderAdapter adapter = adapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
+            AdapterOperationResult rekeyResult = adapter.renew(oldCertificate, certificate, null);
 
-            if (rekeyResponse.getStatusCode().value() == 202) {
+            if (rekeyResult.isAsync()) {
                 // The connector accepted the rekey but completion is asynchronous; the new
                 // certificate stays in PENDING_ISSUE while the predecessor remains ISSUED.
-                onAsyncAccepted(certificate, rekeyResponse.getBody(), ResourceAction.REKEY);
+                onAsyncAccepted(certificate, rekeyResult, ResourceAction.REKEY);
                 certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.REKEY,
                         CertificateEventStatus.SUCCESS, "Rekey accepted; awaiting asynchronous completion.",
                         MetaDefinitions.serialize(additionalInformation));
                 return;
             }
 
-            renewCaResponse = rekeyResponse.getBody();
-            if (renewCaResponse == null || renewCaResponse.getCertificateData() == null || renewCaResponse.getCertificateData().isEmpty()) {
+            if (StringUtils.isBlank(rekeyResult.certificateData())) {
                 throw new CertificateOperationException("Response from authority did not contain certificate data");
             }
 
             logger.info("Certificate {} was rekeyed by authority", certificateUuid);
 
-            CertificateDetailDto certificateDetailDto = certificateService.issueRequestedCertificate(certificateUuid, renewCaResponse.getCertificateData(), renewCaResponse.getMeta());
+            CertificateDetailDto certificateDetailDto = certificateService.issueRequestedCertificate(certificateUuid, rekeyResult.certificateData(), rekeyResult.meta());
 
             additionalInformation.put("New Certificate Serial Number", certificateDetailDto.getSerialNumber());
             certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.REKEY, CertificateEventStatus.SUCCESS, "Rekeyed using RA Profile " + raProfile.getName(), MetaDefinitions.serialize(additionalInformation));
@@ -1590,23 +1564,11 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         // that has already accepted (or completed) the revocation.
         boolean connectorAccepted = false;
         try {
-            CertRevocationDto caRequest = new CertRevocationDto();
-            caRequest.setReason(request.getReason());
-            if (request.getReason() == null) {
-                caRequest.setReason(CertificateRevocationReason.UNSPECIFIED);
-            }
-            caRequest.setAttributes(request.getAttributes());
-            caRequest.setRaProfileAttributes(attributeEngine.getRequestObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.RA_PROFILE, raProfile.getUuid()).connector(raProfile.getAuthorityInstanceReference().getConnectorUuid()).build()));
-            caRequest.setCertificate(certificate.getCertificateContent().getContent());
-
-            ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(raProfile.getAuthorityInstanceReference().getConnectorUuid());
-            ResponseEntity<Void> revokeResponse = connectorApiFactory.getCertificateApiClientV2(connectorDto).revokeCertificate(
-                    connectorDto,
-                    raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(),
-                    caRequest);
+            AuthorityProviderAdapter adapter = adapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
+            AdapterOperationResult revokeResult = adapter.revoke(certificate, request);
             connectorAccepted = true;
 
-            if (revokeResponse.getStatusCode().value() == 202) {
+            if (revokeResult.isAsync()) {
                 transitionToPendingRevoke(certificate, request);
                 return;
             }
@@ -1620,7 +1582,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             stateMachine.transitionAuditedExternally(certificate, CertificateState.REVOKED);
 
             attributeEngine.updateObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(raProfile.getAuthorityInstanceReference().getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_REVOKE).build(), request.getAttributes());
-            certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.REVOKE, CertificateEventStatus.SUCCESS, "Certificate revoked. Reason: " + caRequest.getReason().getLabel(), "");
+            certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.REVOKE, CertificateEventStatus.SUCCESS, "Certificate revoked. Reason: " + request.getReason().getLabel(), "");
         } catch (Exception e) {
             if (connectorAccepted) {
                 // Connector accepted the operation (200/202) but a subsequent local step failed.
@@ -2480,7 +2442,6 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         RaProfile raProfile = cert.getRaProfile();
         ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(raProfile.getAuthorityInstanceReference().getConnectorUuid());
         CertificateOperationCancelRequestDto cancelReq = assembleCancelRequest(cert, raProfile);
-
         try {
             if (target.isCancelIssue()) {
                 connectorApiFactory.getCertificateApiClientV2(connectorDto).cancelIssueCertificate(connectorDto,

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -294,10 +294,10 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
     @Override
     @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
-    public boolean validateIssueCertificateAttributes(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid, List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException {
+    public void validateIssueCertificateAttributes(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid, List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException {
         RaProfile raProfile = raProfileRepository.findByUuidAndEnabledIsTrue(raProfileUuid.getValue())
                 .orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
-        return extendedAttributeService.validateIssueCertificateAttributes(raProfile, attributes);
+        extendedAttributeService.validateIssueCertificateAttributes(raProfile, attributes);
     }
 
     @Override
@@ -1773,10 +1773,10 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
     @Override
     @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
-    public boolean validateRevokeCertificateAttributes(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid, List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException {
+    public void validateRevokeCertificateAttributes(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid, List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException {
         RaProfile raProfile = raProfileRepository.findByUuidAndEnabledIsTrue(raProfileUuid.getValue())
                 .orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
-        return extendedAttributeService.validateRevokeCertificateAttributes(raProfile, attributes);
+        extendedAttributeService.validateRevokeCertificateAttributes(raProfile, attributes);
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -13,12 +13,10 @@ import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateRequestContent;
 import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
 import com.otilm.api.model.connector.v2.CertRevocationDto;
-import com.otilm.api.model.connector.v2.CertificateIdentificationRequestDto;
 import com.otilm.api.exception.ConnectorClientException;
 import com.otilm.api.exception.ConnectorCommunicationException;
 import com.otilm.api.exception.ConnectorEntityNotFoundException;
 import com.otilm.api.exception.ConnectorServerException;
-import com.otilm.api.model.connector.v2.CertificateIdentificationResponseDto;
 import com.otilm.api.model.connector.v2.CertificateOperationCancelRequestDto;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.connector.v2.CertificateRenewRequestDto;
@@ -2153,12 +2151,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         CertificateRequest storedCsr = parseStoredCsr(certificate);
         validatePublicKeyForCsrAndCertificate(request.getCertificate(), storedCsr, true);
 
-        CertificateIdentificationResponseDto identifyResponse =
-                identifyUploadedCertificateOrReject(certificate, request);
-
-        List<MetadataAttribute> identifyMeta = identifyResponse != null && identifyResponse.getMeta() != null
-                ? identifyResponse.getMeta()
-                : List.of();
+        List<MetadataAttribute> identifyMeta = identifyUploadedCertificateOrReject(certificate, request);
 
         // The PENDING_ISSUE -> ISSUED finalize runs in a short transaction under a pessimistic row lock
         // so two concurrent uploads of the same certificate cannot both finalize it. The connector
@@ -2244,24 +2237,22 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
     /**
      * The connector owns the decision whether the uploaded certificate was actually issued
-     * by the configured authority — call identify and surface only the user-input failure
-     * mode (422 → {@link ValidationException}). Connector infrastructure failures (5xx,
-     * auth, network) propagate so the client sees the appropriate upstream error and can
-     * retry; the certificate stays in {@code PENDING_ISSUE} for the next attempt.
+     * by the configured authority — call identify (version-dispatched via the authority
+     * adapter) and surface only the user-input failure mode (422 → {@link ValidationException}).
+     * Connector infrastructure failures (5xx, auth, network) propagate so the client sees the
+     * appropriate upstream error and can retry; the certificate stays in {@code PENDING_ISSUE}
+     * for the next attempt. Returns the connector's identification meta, never {@code null}.
      */
-    private CertificateIdentificationResponseDto identifyUploadedCertificateOrReject(
+    private List<MetadataAttribute> identifyUploadedCertificateOrReject(
             Certificate certificate, UploadCertificateRequestDto request) throws ConnectorException, NotFoundException {
-        RaProfile raProfile = certificate.getRaProfile();
-        ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(raProfile.getAuthorityInstanceReference().getConnectorUuid());
-        CertificateIdentificationRequestDto idReq = new CertificateIdentificationRequestDto();
-        idReq.setCertificate(request.getCertificate());
-        idReq.setRaProfileAttributes(attributeEngine.getRequestObjectDataAttributesContent(
-                ObjectAttributeContentInfo.builder(Resource.RA_PROFILE, raProfile.getUuid())
-                        .connector(raProfile.getAuthorityInstanceReference().getConnectorUuid()).build()));
+        // The caller's finder omits the authority's connectorInterface (lazy) and the caller
+        // holds no session — reload with the full adapter graph for adapter dispatch.
+        Certificate certForAdapter = certificateRepository.findForPollingByUuid(certificate.getUuid())
+                .orElseThrow(() -> new NotFoundException(Certificate.class, certificate.getUuid()));
+        RaProfile raProfile = certForAdapter.getRaProfile();
         try {
-            return connectorApiFactory.getCertificateApiClientV2(connectorDto)
-                    .identifyCertificate(connectorDto,
-                            raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(), idReq);
+            return adapterFactory.forAuthority(raProfile.getAuthorityInstanceReference())
+                    .identify(raProfile, request.getCertificate());
         } catch (ValidationException e) {
             certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.ISSUE,
                     CertificateEventStatus.FAILED,

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -12,14 +12,12 @@ import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateRequestContent;
 import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
-import com.otilm.api.model.connector.v2.CertRevocationDto;
 import com.otilm.api.exception.ConnectorClientException;
 import com.otilm.api.exception.ConnectorCommunicationException;
 import com.otilm.api.exception.ConnectorEntityNotFoundException;
 import com.otilm.api.exception.ConnectorServerException;
 import com.otilm.api.model.connector.v2.CertificateOperationCancelRequestDto;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
-import com.otilm.api.model.connector.v2.CertificateRenewRequestDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.api.model.core.certificate.*;
@@ -87,7 +85,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
@@ -1581,7 +1578,8 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             stateMachine.transitionAuditedExternally(certificate, CertificateState.REVOKED);
 
             attributeEngine.updateObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(raProfile.getAuthorityInstanceReference().getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_REVOKE).build(), request.getAttributes());
-            certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.REVOKE, CertificateEventStatus.SUCCESS, "Certificate revoked. Reason: " + request.getReason().getLabel(), "");
+            String reason = request.getReason() == null ? CertificateRevocationReason.UNSPECIFIED.getLabel() : request.getReason().getLabel();
+            certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.REVOKE, CertificateEventStatus.SUCCESS, "Certificate revoked. Reason: " + reason, "");
         } catch (Exception e) {
             if (connectorAccepted) {
                 // Connector accepted the operation (200/202) but a subsequent local step failed.

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -61,6 +61,7 @@ import com.otilm.core.service.handler.ConnectorCapabilityService;
 import com.otilm.api.model.client.connector.v2.FeatureFlag;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
+import com.otilm.core.service.handler.authority.CancelOutcome;
 import com.otilm.core.service.handler.authority.CertificateOperation;
 import com.otilm.core.service.handler.authority.RegisterCapability;
 import com.otilm.core.service.handler.authority.lifecycle.CertificateStateMachine;
@@ -2416,14 +2417,20 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     /**
-     * Connector cancel contract:
+     * Connector cancel dispatch: resolves the authority's adapter and, when it exposes
+     * {@link AsyncOperationCapability} (v3), uses the outcome-mapped {@code cancel} operation —
+     * {@code CANCELLED} proceeds, {@code NOT_TRACKED} is a soft failure (proceed locally),
+     * {@code REFUSED_PAST_POINT_OF_NO_RETURN} is a hard refusal. Adapters without the
+     * capability (v2) call the dedicated v2 cancel endpoints directly.
+     *
+     * <p>Shared error contract (both paths):
      * <ul>
-     *   <li>{@code 204 No Content} — aborted upstream; proceed with local transition.</li>
-     *   <li>{@code 404 Not Found} — connector does not track this operation; soft failure,
+     *   <li>Cancelled upstream (v2 {@code 204}, v3 {@code CANCELLED}) — proceed with local transition.</li>
+     *   <li>Operation not tracked (v2 {@code 404}, v3 {@code NOT_TRACKED}) — soft failure,
      *       proceed locally.</li>
-     *   <li>{@code 422 Unprocessable Entity} → {@link ValidationException} — connector
-     *       refuses to abort; HARD refusal, surface the upstream reason and abort the local
-     *       cancel (cert stays in PENDING_*).</li>
+     *   <li>Refusal (v2 {@code 422}, v3 {@code REFUSED_PAST_POINT_OF_NO_RETURN}) →
+     *       {@link ValidationException} — HARD refusal, surface the upstream reason and abort
+     *       the local cancel (cert stays in PENDING_*).</li>
      *   <li>{@code 5xx} / network / timeout — infrastructure error, soft failure, proceed
      *       locally (the connector may recover and we can reconcile via status).</li>
      *   <li>Other {@code 4xx} (400, 401, 403) → {@link ConnectorClientException} — request
@@ -2440,15 +2447,38 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
      */
     private void invokeConnectorCancelOrThrow(Certificate cert, CancelTarget target) throws NotFoundException {
         RaProfile raProfile = cert.getRaProfile();
-        ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(raProfile.getAuthorityInstanceReference().getConnectorUuid());
-        CertificateOperationCancelRequestDto cancelReq = assembleCancelRequest(cert, raProfile);
         try {
-            if (target.isCancelIssue()) {
-                connectorApiFactory.getCertificateApiClientV2(connectorDto).cancelIssueCertificate(connectorDto,
-                        raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(), cancelReq);
+            // The caller's finder omits the authority's connectorInterface (lazy) and this method
+            // holds no session — reload with the full adapter graph for adapter dispatch,
+            // mirroring cancelInFlightAsyncIssueBestEffort.
+            Certificate certForAdapter = certificateRepository.findForPollingByUuid(cert.getUuid())
+                    .orElseThrow(() -> new NotFoundException(Certificate.class, cert.getUuid()));
+            AuthorityProviderAdapter adapter = adapterFactory.forAuthority(certForAdapter.getRaProfile().getAuthorityInstanceReference());
+            if (adapter instanceof AsyncOperationCapability asyncCapable) {
+                CancelOutcome outcome = asyncCapable.cancel(certForAdapter,
+                        target.isCancelIssue() ? CertificateOperation.ISSUE : CertificateOperation.REVOKE).outcome();
+                if (outcome == CancelOutcome.REFUSED_PAST_POINT_OF_NO_RETURN) {
+                    // Routed through the ValidationException handler below — same hard-refusal
+                    // recording and rethrow as a v2 connector 422.
+                    throw new ValidationException("operation is past the point of no return");
+                }
+                if (outcome == CancelOutcome.NOT_TRACKED) {
+                    recordCancelSoftFailure(cert, target,
+                            "Connector does not track this operation; proceeding with local cancel",
+                            "Connector did not track the operation; proceeded with local cancel",
+                            "Connector cancel reported operation not tracked for cert {} — proceeding with local cancel ({})",
+                            "adapter outcome NOT_TRACKED", null);
+                }
             } else {
-                connectorApiFactory.getCertificateApiClientV2(connectorDto).cancelRevokeCertificate(connectorDto,
-                        raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(), cancelReq);
+                ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(raProfile.getAuthorityInstanceReference().getConnectorUuid());
+                CertificateOperationCancelRequestDto cancelReq = assembleCancelRequest(cert, raProfile);
+                if (target.isCancelIssue()) {
+                    connectorApiFactory.getCertificateApiClientV2(connectorDto).cancelIssueCertificate(connectorDto,
+                            raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(), cancelReq);
+                } else {
+                    connectorApiFactory.getCertificateApiClientV2(connectorDto).cancelRevokeCertificate(connectorDto,
+                            raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(), cancelReq);
+                }
             }
         } catch (ValidationException upstreamRefused) {
             recordCancelFailure(cert, target,
@@ -2474,6 +2504,10 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
                     "Connector cancel call failed (" + infra.getClass().getSimpleName() + "); proceeded with local cancel",
                     "Connector cancel call failed for cert {} ({}: {}) — proceeding with local cancel",
                     infra.getClass().getSimpleName() + ": " + infra.getMessage(), infra);
+        } catch (NotFoundException connectorRecordMissing) {
+            // Local connector record missing (getConnectorForApiClient) — a configuration
+            // problem, not a connector response; propagate unchanged instead of softening.
+            throw connectorRecordMissing;
         } catch (Exception unexpected) {
             // Defensive catch-all. Covers any ConnectorException subtype not handled above
             // (e.g. ConnectorProblemException or future additions) plus any unchecked

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -1524,6 +1524,12 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
             additionalInformation.put("New Certificate Serial Number", certificateDetailDto.getSerialNumber());
             certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.RENEW, CertificateEventStatus.SUCCESS, "Renewed using RA Profile " + raProfile.getName(), MetaDefinitions.serialize(additionalInformation));
+        } catch (ConnectorAcceptedButLocalFailureException e) {
+            // Connector accepted the renewal (2xx) but the adapter's local mapping failed. The new certificate
+            // stays in PENDING_ISSUE — do not drive it to FAILED — so reconciliation/polling can resolve it against
+            // the authority that already accepted; record the failure against the predecessor and surface it.
+            certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.RENEW, CertificateEventStatus.FAILED, "Connector accepted renewal but local update failed: " + e.getMessage(), MetaDefinitions.serialize(additionalInformation));
+            throw new CertificateOperationException("Connector accepted renewal but local update failed for certificate %s: ".formatted(certificateUuid) + e.getMessage());
         } catch (Exception e) {
             handleFailedOrRejectedEvent(certificate, oldCertificate.getUuid(), CertificateState.FAILED, CertificateEvent.RENEW, additionalInformation, e.getMessage());
             throw new CertificateOperationException("Failed to renew certificate with UUID %s: ".formatted(certificateUuid) + e.getMessage());
@@ -1734,6 +1740,12 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
             additionalInformation.put("New Certificate Serial Number", certificateDetailDto.getSerialNumber());
             certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.REKEY, CertificateEventStatus.SUCCESS, "Rekeyed using RA Profile " + raProfile.getName(), MetaDefinitions.serialize(additionalInformation));
+        } catch (ConnectorAcceptedButLocalFailureException e) {
+            // Connector accepted the rekey (2xx) but the adapter's local mapping failed. The new certificate stays
+            // in PENDING_ISSUE — do not drive it to FAILED — so reconciliation/polling can resolve it against the
+            // authority that already accepted; record the failure against the predecessor and surface it.
+            certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.REKEY, CertificateEventStatus.FAILED, "Connector accepted rekey but local update failed: " + e.getMessage(), MetaDefinitions.serialize(additionalInformation));
+            throw new CertificateOperationException("Connector accepted rekey but local update failed for certificate %s: ".formatted(certificateUuid) + e.getMessage());
         } catch (Exception e) {
             handleFailedOrRejectedEvent(certificate, oldCertificate.getUuid(), CertificateState.FAILED, CertificateEvent.REKEY, additionalInformation, e.getMessage());
             throw new CertificateOperationException("Failed to rekey certificate with UUID %s: ".formatted(certificateUuid) + e.getMessage());
@@ -1832,6 +1844,14 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             attributeEngine.updateObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(raProfile.getAuthorityInstanceReference().getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_REVOKE).build(), request.getAttributes());
             String reason = request.getReason() == null ? CertificateRevocationReason.UNSPECIFIED.getLabel() : request.getReason().getLabel();
             certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.REVOKE, CertificateEventStatus.SUCCESS, "Certificate revoked. Reason: " + reason, "");
+        } catch (ConnectorAcceptedButLocalFailureException e) {
+            // The adapter reports the connector accepted the revoke (2xx) but its local response mapping failed,
+            // so connectorAccepted was never set. Treat it as connector-accepted: do NOT roll the certificate back
+            // to its entry state — the upstream is committed — and surface the local failure for reconciliation.
+            String msg = "Connector accepted revoke but local state update failed: " + e.getMessage();
+            certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.REVOKE, CertificateEventStatus.FAILED, msg, "");
+            logger.error("Local mapping failed after connector accepted revoke for cert {}: {}", certificate.getUuid(), e.getMessage(), e);
+            throw new CertificateOperationException(msg);
         } catch (Exception e) {
             if (connectorAccepted) {
                 // Connector accepted the operation (200/202) but a subsequent local step failed.

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -86,7 +86,7 @@ import com.otilm.core.service.v2.ClientOperationInternalService;
 import com.otilm.core.service.v2.ConnectorInternalService;
 import com.otilm.core.service.v2.ExtendedAttributeService;
 import com.otilm.core.util.*;
-import io.micrometer.common.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.asn1.x509.Extension;
@@ -1494,6 +1494,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
         HashMap<String, Object> additionalInformation = new HashMap<>();
         additionalInformation.put("New Certificate UUID", certificate.getUuid());
+        boolean connectorAccepted = false;
         try {
             // Move the new certificate to PENDING_ISSUE before calling the connector so every path
             // (sync 200 or async 202) reaches issueRequestedCertificate / the poll cycle from a
@@ -1503,6 +1504,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
             AuthorityProviderAdapter adapter = adapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
             AdapterOperationResult renewResult = adapter.renew(oldCertificate, certificate, request);
+            connectorAccepted = true;
 
             if (renewResult.isAsync()) {
                 // The connector accepted the renewal but completion is asynchronous; the new
@@ -1524,13 +1526,16 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
             additionalInformation.put("New Certificate Serial Number", certificateDetailDto.getSerialNumber());
             certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.RENEW, CertificateEventStatus.SUCCESS, "Renewed using RA Profile " + raProfile.getName(), MetaDefinitions.serialize(additionalInformation));
-        } catch (ConnectorAcceptedButLocalFailureException e) {
-            // Connector accepted the renewal (2xx) but the adapter's local mapping failed. The new certificate
-            // stays in PENDING_ISSUE — do not drive it to FAILED — so reconciliation/polling can resolve it against
-            // the authority that already accepted; record the failure against the predecessor and surface it.
-            certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.RENEW, CertificateEventStatus.FAILED, "Connector accepted renewal but local update failed: " + e.getMessage(), MetaDefinitions.serialize(additionalInformation));
-            throw new CertificateOperationException("Connector accepted renewal but local update failed for certificate %s: ".formatted(certificateUuid) + e.getMessage());
         } catch (Exception e) {
+            // Once the connector has accepted (2xx) — whether reported as a returned result or surfaced as a
+            // ConnectorAcceptedButLocalFailureException from the adapter's own response mapping — a subsequent
+            // local failure (mapping, persistence, event history) must NOT drive the successor to FAILED. Leave it
+            // in PENDING_ISSUE so reconciliation/polling can resolve it against the authority that already accepted;
+            // record the failure against the predecessor and surface it. (state-divergence rule)
+            if (connectorAccepted || e instanceof ConnectorAcceptedButLocalFailureException) {
+                certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.RENEW, CertificateEventStatus.FAILED, "Connector accepted renewal but local update failed: " + e.getMessage(), MetaDefinitions.serialize(additionalInformation));
+                throw new CertificateOperationException("Connector accepted renewal but local update failed for certificate %s: ".formatted(certificateUuid) + e.getMessage());
+            }
             handleFailedOrRejectedEvent(certificate, oldCertificate.getUuid(), CertificateState.FAILED, CertificateEvent.RENEW, additionalInformation, e.getMessage());
             throw new CertificateOperationException("Failed to renew certificate with UUID %s: ".formatted(certificateUuid) + e.getMessage());
         }
@@ -1710,6 +1715,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         logger.debug("Rekeying Certificate: {}", oldCertificate);
         HashMap<String, Object> additionalInformation = new HashMap<>();
         additionalInformation.put("New Certificate UUID", certificate.getUuid());
+        boolean connectorAccepted = false;
         try {
             // Move the new certificate to PENDING_ISSUE before calling the connector so every path
             // (sync 200 or async 202) reaches issueRequestedCertificate / the poll cycle from a
@@ -1719,6 +1725,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
             AuthorityProviderAdapter adapter = adapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
             AdapterOperationResult rekeyResult = adapter.renew(oldCertificate, certificate, null);
+            connectorAccepted = true;
 
             if (rekeyResult.isAsync()) {
                 // The connector accepted the rekey but completion is asynchronous; the new
@@ -1740,13 +1747,16 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
             additionalInformation.put("New Certificate Serial Number", certificateDetailDto.getSerialNumber());
             certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.REKEY, CertificateEventStatus.SUCCESS, "Rekeyed using RA Profile " + raProfile.getName(), MetaDefinitions.serialize(additionalInformation));
-        } catch (ConnectorAcceptedButLocalFailureException e) {
-            // Connector accepted the rekey (2xx) but the adapter's local mapping failed. The new certificate stays
-            // in PENDING_ISSUE — do not drive it to FAILED — so reconciliation/polling can resolve it against the
-            // authority that already accepted; record the failure against the predecessor and surface it.
-            certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.REKEY, CertificateEventStatus.FAILED, "Connector accepted rekey but local update failed: " + e.getMessage(), MetaDefinitions.serialize(additionalInformation));
-            throw new CertificateOperationException("Connector accepted rekey but local update failed for certificate %s: ".formatted(certificateUuid) + e.getMessage());
         } catch (Exception e) {
+            // Once the connector has accepted (2xx) — whether reported as a returned result or surfaced as a
+            // ConnectorAcceptedButLocalFailureException from the adapter's own response mapping — a subsequent
+            // local failure (mapping, persistence, event history) must NOT drive the successor to FAILED. Leave it
+            // in PENDING_ISSUE so reconciliation/polling can resolve it against the authority that already accepted;
+            // record the failure against the predecessor and surface it. (state-divergence rule)
+            if (connectorAccepted || e instanceof ConnectorAcceptedButLocalFailureException) {
+                certificateEventHistoryService.addEventHistory(oldCertificate.getUuid(), CertificateEvent.REKEY, CertificateEventStatus.FAILED, "Connector accepted rekey but local update failed: " + e.getMessage(), MetaDefinitions.serialize(additionalInformation));
+                throw new CertificateOperationException("Connector accepted rekey but local update failed for certificate %s: ".formatted(certificateUuid) + e.getMessage());
+            }
             handleFailedOrRejectedEvent(certificate, oldCertificate.getUuid(), CertificateState.FAILED, CertificateEvent.REKEY, additionalInformation, e.getMessage());
             throw new CertificateOperationException("Failed to rekey certificate with UUID %s: ".formatted(certificateUuid) + e.getMessage());
         }
@@ -2765,10 +2775,11 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
                     "Connector cancel call failed (" + infra.getClass().getSimpleName() + "); proceeded with local cancel",
                     "Connector cancel call failed for cert {} ({}: {}) — proceeding with local cancel",
                     infra.getClass().getSimpleName() + ": " + infra.getMessage(), infra);
-        } catch (NotFoundException connectorRecordMissing) {
-            // Local connector record missing (getConnectorForApiClient) — a configuration
-            // problem, not a connector response; propagate unchanged instead of softening.
-            throw connectorRecordMissing;
+        } catch (NotFoundException entityMissing) {
+            // A local lookup failed — either the certificate vanished on the adapter-graph reload, or the
+            // connector record is missing (getConnectorForApiClient). Both are local/configuration problems,
+            // not connector responses, so propagate unchanged instead of softening into a local cancel.
+            throw entityMissing;
         } catch (Exception unexpected) {
             // Defensive catch-all. Covers any ConnectorException subtype not handled above
             // (e.g. ConnectorProblemException or future additions) plus any unchecked

--- a/src/main/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImpl.java
@@ -11,6 +11,7 @@ import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.Connector2FunctionGroup;
 import com.otilm.core.dao.entity.RaProfile;
 import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.service.handler.authority.AuthorityProviderAdapter;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
 import com.otilm.core.service.v2.ConnectorInternalService;
 import com.otilm.core.service.v2.ExtendedAttributeService;
@@ -22,13 +23,6 @@ import java.util.List;
 
 @Service("extendedAcmeServiceImpl")
 public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
-
-    private ConnectorApiFactory connectorApiFactory;
-
-    @Autowired
-    public void setConnectorApiFactory(ConnectorApiFactory connectorApiFactory) {
-        this.connectorApiFactory = connectorApiFactory;
-    }
 
     private ConnectorRepository connectorRepository;
 
@@ -78,11 +72,8 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
         }
         validateLegacyConnector(connector);
 
-        ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(connector.getUuid());
-        return connectorApiFactory.getCertificateApiClientV2(connectorDto).validateIssueCertificateAttributes(
-                connectorDto,
-                authorityRef.getAuthorityInstanceUuid(),
-                attributes);
+        AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(authorityRef);
+        return adapter.validateIssueAttributes(authorityRef, attributes);
     }
 
     @Override
@@ -90,17 +81,16 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
         if (raProfile.getAuthorityInstanceReference().getConnector() == null) {
             throw new ValidationException(ValidationError.create("Connector of the Authority is not available / deleted"));
         }
-        ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(raProfile.getAuthorityInstanceReference().getConnectorUuid());
-        var certificateApiClient = connectorApiFactory.getCertificateApiClientV2(connectorDto);
+        AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
 
         // validate first by connector
         if (attributes == null) {
             attributes = new ArrayList<>();
         }
-        certificateApiClient.validateIssueCertificateAttributes(connectorDto, raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(), attributes);
+        adapter.validateIssueAttributes(raProfile.getAuthorityInstanceReference(), attributes);
 
         // get definitions from connector
-        List<BaseAttribute> definitions = certificateApiClient.listIssueCertificateAttributes(connectorDto, raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid());
+        List<BaseAttribute> definitions = adapter.listIssueAttributes(raProfile.getAuthorityInstanceReference(), raProfile);
 
         // validate and update definitions with attribute engine
         attributeEngine.validateUpdateDataAttributes(raProfile.getAuthorityInstanceReference().getConnectorUuid(), AttributeOperation.CERTIFICATE_ISSUE, definitions, attributes);
@@ -114,11 +104,8 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
             throw new NotFoundException("Connector of the Authority is not available / deleted");
         }
         validateLegacyConnector(connector);
-
-        ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(connector.getUuid());
-        return connectorApiFactory.getCertificateApiClientV2(connectorDto).listRevokeCertificateAttributes(
-                connectorDto,
-                authorityRef.getAuthorityInstanceUuid());
+        AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
+        return adapter.listRevokeAttributes(authorityRef, raProfile);
     }
 
     @Override
@@ -129,12 +116,8 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
             throw new NotFoundException("Connector of the Authority is not available / deleted");
         }
         validateLegacyConnector(connector);
-
-        ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(connector.getUuid());
-        return connectorApiFactory.getCertificateApiClientV2(connectorDto).validateRevokeCertificateAttributes(
-                connectorDto,
-                authorityRef.getAuthorityInstanceUuid(),
-                attributes);
+        AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
+        return adapter.validateRevokeAttributes(authorityRef, attributes);
     }
 
     @Override
@@ -142,18 +125,16 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
         if (raProfile.getAuthorityInstanceReference().getConnector() == null) {
             throw new ValidationException(ValidationError.create("Connector of the Authority is not available / deleted"));
         }
-
-        ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(raProfile.getAuthorityInstanceReference().getConnectorUuid());
-        var certificateApiClient = connectorApiFactory.getCertificateApiClientV2(connectorDto);
+        AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
 
         // validate first by connector
         if (attributes == null) {
             attributes = new ArrayList<>();
         }
-        certificateApiClient.validateRevokeCertificateAttributes(connectorDto, raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid(), attributes);
+        adapter.validateRevokeAttributes(raProfile.getAuthorityInstanceReference(), attributes);
 
         // get definitions from connector
-        List<BaseAttribute> definitions = certificateApiClient.listRevokeCertificateAttributes(connectorDto, raProfile.getAuthorityInstanceReference().getAuthorityInstanceUuid());
+        List<BaseAttribute> definitions = adapter.listRevokeAttributes(raProfile.getAuthorityInstanceReference(), raProfile);
 
         // validate and update definitions with attribute engine
         attributeEngine.validateUpdateDataAttributes(raProfile.getAuthorityInstanceReference().getConnectorUuid(), AttributeOperation.CERTIFICATE_REVOKE, definitions, attributes);

--- a/src/main/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImpl.java
@@ -54,7 +54,7 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
     }
 
     @Override
-    public boolean validateIssueCertificateAttributes(RaProfile raProfile, List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException {
+    public void validateIssueCertificateAttributes(RaProfile raProfile, List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException {
         var authorityRef = raProfile.getAuthorityInstanceReference();
         var connector = authorityRef.getConnector();
         if (connector == null) {
@@ -63,7 +63,7 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
         validateLegacyConnector(connector);
 
         AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(authorityRef);
-        return adapter.validateIssueAttributes(authorityRef, attributes);
+        adapter.validateIssueAttributes(authorityRef, attributes);
     }
 
     @Override
@@ -99,7 +99,7 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
     }
 
     @Override
-    public boolean validateRevokeCertificateAttributes(RaProfile raProfile, List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException {
+    public void validateRevokeCertificateAttributes(RaProfile raProfile, List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException {
         var authorityRef = raProfile.getAuthorityInstanceReference();
         var connector = authorityRef.getConnector();
         if (connector == null) {
@@ -107,7 +107,7 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
         }
         validateLegacyConnector(connector);
         AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
-        return adapter.validateRevokeAttributes(authorityRef, attributes);
+        adapter.validateRevokeAttributes(authorityRef, attributes);
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImpl.java
@@ -1,19 +1,16 @@
 package com.otilm.core.service.v2.impl;
 
-import com.otilm.api.clients.ApiClientConnectorInfo;
 import com.otilm.api.exception.*;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeOperation;
-import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.Connector2FunctionGroup;
 import com.otilm.core.dao.entity.RaProfile;
 import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapter;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
-import com.otilm.core.service.v2.ConnectorInternalService;
 import com.otilm.core.service.v2.ExtendedAttributeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -29,13 +26,6 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
     @Autowired
     public void setConnectorRepository(ConnectorRepository connectorRepository) {
         this.connectorRepository = connectorRepository;
-    }
-
-    private ConnectorInternalService connectorService;
-
-    @Autowired
-    public void setConnectorService(ConnectorInternalService connectorService) {
-        this.connectorService = connectorService;
     }
 
     private AuthorityProviderAdapterFactory authorityProviderAdapterFactory;

--- a/src/test/java/com/otilm/core/integration/service/CertificateRequestIntegrationITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CertificateRequestIntegrationITest.java
@@ -11,6 +11,8 @@ import com.otilm.api.model.core.certificate.CertificateDetailDto;
 import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.core.connector.FunctionGroupCode;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
+import com.otilm.api.model.core.oid.ExtensionValueEncoding;
+import com.otilm.api.model.core.oid.OidCategory;
 import com.otilm.api.model.core.v2.ClientCertificateRequestDto;
 import com.otilm.core.attribute.CsrAttributes;
 import com.otilm.core.attribute.RsaSignatureAttributes;
@@ -18,6 +20,8 @@ import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeOperation;
 import com.otilm.core.dao.entity.*;
 import com.otilm.core.dao.repository.*;
+import com.otilm.core.oid.OidHandler;
+import com.otilm.core.oid.OidRecord;
 import com.otilm.core.service.v2.ClientOperationExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.MetaDefinitions;
@@ -159,6 +163,22 @@ class CertificateRequestIntegrationITest extends BaseSpringBootTest {
         // listener does: connectorUuid=null, operation="sign".
         attributeEngine.updateDataAttributeDefinitions(null, AttributeOperation.SIGN,
                 RsaSignatureAttributes.getRsaSignatureAttributes());
+
+        // The extension-mapped connector attribute requires its OID in the process-wide OID
+        // registry cache: the issue-attribute definitions flow through the authority adapter
+        // into AttributeEngine.validateUpdateDataAttributes, whose validateMappedField fails
+        // closed on an unregistered extension OID. Seed per test (not @BeforeAll): on an
+        // isolated run the Spring context is created after @BeforeAll, and
+        // CustomOidEntryServiceImpl's constructor reloads every cache category from the
+        // truncated DB — wiping any earlier seed. Mirrors AttributeEngineITest.ensureOidCached.
+        if (OidHandler.getOidCache(OidCategory.CERTIFICATE_EXTENSION) == null) {
+            OidHandler.cacheOidCategory(OidCategory.CERTIFICATE_EXTENSION, new HashMap<>());
+        }
+        OidHandler.cacheOid(OidCategory.CERTIFICATE_EXTENSION, CUSTOM_EXT_OID, OidRecord.builder()
+                .displayName("Test Custom Extension")
+                .defaultCritical(false)
+                .valueEncoding(ExtensionValueEncoding.DER)
+                .build());
 
         keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
         var publicKeyData = Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded());

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceV2ITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceV2ITest.java
@@ -15,6 +15,7 @@ import com.otilm.api.model.common.attribute.common.properties.DataAttributePrope
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
 import com.otilm.api.model.common.enums.cryptography.KeyType;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.api.model.core.certificate.CertificateEvent;
 import com.otilm.api.model.core.certificate.CertificateEventStatus;
 import com.otilm.api.model.core.certificate.CertificateRelationType;
@@ -378,6 +379,7 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
 
         ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
         request.setAttributes(List.of());
+        request.setReason(CertificateRevocationReason.AA_COMPROMISE);
         Assertions.assertDoesNotThrow(() -> clientOperationInternalService.revokeCertificateAction(certificate.getUuid(), request, true));
     }
 
@@ -1317,6 +1319,7 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
 
         ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
         request.setAttributes(List.of());
+        request.setReason(CertificateRevocationReason.AA_COMPROMISE);
 
         Assertions.assertDoesNotThrow(() ->
                 clientOperationInternalService.revokeCertificateAction(certificate.getUuid(), request, true));
@@ -1338,6 +1341,7 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
 
         ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
         request.setAttributes(List.of());
+        request.setReason(CertificateRevocationReason.AA_COMPROMISE);
 
         Assertions.assertDoesNotThrow(() ->
                 clientOperationInternalService.revokeCertificateAction(certificate.getUuid(), request, true));
@@ -1358,6 +1362,7 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
 
         ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
         request.setAttributes(List.of());
+        request.setReason(CertificateRevocationReason.AA_COMPROMISE);
 
         Assertions.assertDoesNotThrow(() ->
                 clientOperationInternalService.revokeCertificateAction(certificate.getUuid(), request, true));
@@ -1383,6 +1388,7 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
 
         ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
         request.setAttributes(List.of());
+        request.setReason(CertificateRevocationReason.AA_COMPROMISE);
 
         Assertions.assertDoesNotThrow(() ->
                 clientOperationInternalService.revokeCertificateAction(certificate.getUuid(), request, true));

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceV2ITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceV2ITest.java
@@ -1319,7 +1319,6 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
 
         ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
         request.setAttributes(List.of());
-        request.setReason(CertificateRevocationReason.AA_COMPROMISE);
 
         Assertions.assertDoesNotThrow(() ->
                 clientOperationInternalService.revokeCertificateAction(certificate.getUuid(), request, true));

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceV2ITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceV2ITest.java
@@ -251,13 +251,15 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
     }
 
     @Test
-    void testValidateIssueCertificateAttributes() throws ConnectorException, NotFoundException {
+    void testValidateIssueCertificateAttributes() {
         mockServer.stubFor(WireMock
                 .post(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue/attributes/validate"))
-                .willReturn(WireMock.okJson("true")));
+                .willReturn(WireMock.ok()));
 
-        boolean result = clientOperationService.validateIssueCertificateAttributes(SecuredParentUUID.fromUUID(raProfile.getAuthorityInstanceReferenceUuid()), SecuredUUID.fromUUID(raProfile.getUuid()), List.of());
-        Assertions.assertTrue(result);
+        SecuredParentUUID authorityUuid = SecuredParentUUID.fromUUID(raProfile.getAuthorityInstanceReferenceUuid());
+        SecuredUUID raProfileUuid = SecuredUUID.fromUUID(raProfile.getUuid());
+        List<RequestAttribute> attributes = List.of();
+        Assertions.assertDoesNotThrow(() -> clientOperationService.validateIssueCertificateAttributes(authorityUuid, raProfileUuid, attributes));
     }
 
     @Test
@@ -350,13 +352,15 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
     }
 
     @Test
-    void testValidateRevokeCertificateAttributes() throws ConnectorException, NotFoundException {
+    void testValidateRevokeCertificateAttributes(){
         mockServer.stubFor(WireMock
                 .post(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/revoke/attributes/validate"))
-                .willReturn(WireMock.okJson("true")));
+                .willReturn(WireMock.ok()));
 
-        boolean result = clientOperationService.validateRevokeCertificateAttributes(SecuredParentUUID.fromUUID(raProfile.getAuthorityInstanceReferenceUuid()), SecuredUUID.fromUUID(raProfile.getUuid()), List.of());
-        Assertions.assertTrue(result);
+        SecuredParentUUID authorityUuid = SecuredParentUUID.fromUUID(raProfile.getAuthorityInstanceReferenceUuid());
+        SecuredUUID raProfileUuid = SecuredUUID.fromUUID(raProfile.getUuid());
+        List<RequestAttribute> attributes = List.of();
+        Assertions.assertDoesNotThrow(() -> clientOperationService.validateRevokeCertificateAttributes(authorityUuid, raProfileUuid, attributes));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceV2ITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceV2ITest.java
@@ -15,7 +15,6 @@ import com.otilm.api.model.common.attribute.common.properties.DataAttributePrope
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
 import com.otilm.api.model.common.enums.cryptography.KeyType;
 import com.otilm.api.model.core.auth.Resource;
-import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.api.model.core.certificate.CertificateEvent;
 import com.otilm.api.model.core.certificate.CertificateEventStatus;
 import com.otilm.api.model.core.certificate.CertificateRelationType;
@@ -383,7 +382,6 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
 
         ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
         request.setAttributes(List.of());
-        request.setReason(CertificateRevocationReason.AA_COMPROMISE);
         Assertions.assertDoesNotThrow(() -> clientOperationInternalService.revokeCertificateAction(certificate.getUuid(), request, true));
     }
 
@@ -1344,7 +1342,6 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
 
         ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
         request.setAttributes(List.of());
-        request.setReason(CertificateRevocationReason.AA_COMPROMISE);
 
         Assertions.assertDoesNotThrow(() ->
                 clientOperationInternalService.revokeCertificateAction(certificate.getUuid(), request, true));
@@ -1365,7 +1362,6 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
 
         ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
         request.setAttributes(List.of());
-        request.setReason(CertificateRevocationReason.AA_COMPROMISE);
 
         Assertions.assertDoesNotThrow(() ->
                 clientOperationInternalService.revokeCertificateAction(certificate.getUuid(), request, true));
@@ -1391,7 +1387,6 @@ class ClientOperationServiceV2ITest extends BaseSpringBootTest {
 
         ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
         request.setAttributes(List.of());
-        request.setReason(CertificateRevocationReason.AA_COMPROMISE);
 
         Assertions.assertDoesNotThrow(() ->
                 clientOperationInternalService.revokeCertificateAction(certificate.getUuid(), request, true));

--- a/src/test/java/com/otilm/core/integration/service/RaProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/RaProfileServiceITest.java
@@ -492,6 +492,43 @@ class RaProfileServiceITest extends ApprovalProfileData {
     }
 
     @Test
+    void testGetAuthorityCertificateChain_v3Authority() throws ConnectorException, AttributeException, NotFoundException {
+        // v3 adapter path: the CA chain comes from the stateless v3 endpoint (authority/RA-profile
+        // attributes in the request body); the v1/v2 instance-scoped endpoint is never called.
+        AuthorityFixtures.Fixture v3 = AuthorityFixtures.v3Authority(
+                new AuthorityFixtures.Repos(connectorRepository, functionGroupRepository,
+                        connector2FunctionGroupRepository, authorityInstanceReferenceRepository,
+                        raProfileRepository, connectorInterfaceRepository),
+                mockServer);
+        mockServer.stubFor(WireMock
+                .any(WireMock.urlPathMatching("/v3/authorityProvider(/authorities)?/raProfile/attributes"))
+                .willReturn(WireMock.okJson("[]")));
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/v3/authorityProvider/authorities/caCertificates"))
+                .willReturn(WireMock.okJson("""
+                        {
+                            "certificates": [
+                                {
+                                    "certificateData": "MIIGIzCCBAugAwIBAgIUXqFSYLp0ubziDvE6soPiV8juAyswDQYJKoZIhvcNAQELBQAwOzEbMBkGA1UEAwwSRGVtb1Jvb3RDQV8yMzA3UlNBMRwwGgYDVQQKDBMzS2V5IENvbXBhbnkgcy5yLm8uMB4XDTIzMDcxOTExMTQwMloXDTM4MDcxNTExMTQwMVowQDEgMB4GA1UEAwwXRGVtb0NsaWVudFN1YkNBXzIzMDdSU0ExHDAaBgNVBAoMEzNLZXkgQ29tcGFueSBzLnIuby4wggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDX4VT1wD0iNVPaojteRUZD5r2Dhtr9lmWggvFUcE9Pd8XAk7fQK0dI5Y1igPnyUazNqFTCHnI0UdGsHzBIY06urrUIW5VNUcRjXjX+kh86Y16LP8M0hvDl4oDK7EBW5a9gzJtsnFS71WxTurDrsJYgN3jJLBlmSi/yA8MaiY76fktI6++nB4O+uQfK7StpA9Dst+HLM6FLk7r39D/wIWfn2q/MCTF+h4OY+pEcJvNHk+1HHsuKOQOlYDeYGzN/CopK7Zmymu9DfgwpPcVXJ9dZBwx+G4dE3Ri0pnL/hfVaBEbNUkYDIgs5zRpb3ZN68JJy0XTmCcTAgiUZBYmiDhMSMBPl5mts40OpL5bewM+ekrAbFwNL4idUPS2V9XWOGy51UYtcjHUTQB9m9E+aP5ZfvDCZhu+yzenDcYT6UhENpgGfDpJ+im0jjNNgC+z58Y9uYRqN/w+HWrXermZxGQS6mkQ+iJLeEWWHDjFi4v0TjbHyhxPkQSAacJ4IWFT37eivVirQZFGuXpBEI51xvs25K24f0fxuLcAumS5APTPD90D2Xa5J1vMowsdtKgs5nZP3dKmmSr2reAsiodNtBroUpWcjznurHf43zhAlQuQvCCn12zyaXGtaF/Cl0Aj0nmuVf6fEhoCM4xiECqlmtoXKTTA7vaMRTGgXlR1iyHKaXwIDAQABo4IBGDCCARQwDwYDVR0TAQH/BAUwAwEB/zAfBgNVHSMEGDAWgBQkykIO76rGkT7RqvoTWHgqFlBGiTBTBggrBgEFBQcBAQRHMEUwQwYIKwYBBQUHMAKGN2h0dHA6Ly9wa2kuM2tleS5jb21wYW55L2Nhcy9kZW1vL2RlbW9yb290Y2FfMjMwN3JzYS5jcnQwEQYDVR0gBAowCDAGBgRVHSAAMEkGA1UdHwRCMEAwPqA8oDqGOGh0dHA6Ly9wa2kuM2tleS5jb21wYW55L2NybHMvZGVtby9kZW1vcm9vdGNhXzIzMDdyc2EuY3JsMB0GA1UdDgQWBBSVb1aJP6lv/cDXMMG3l1/mLEqvHTAOBgNVHQ8BAf8EBAMCAYYwDQYJKoZIhvcNAQELBQADggIBAGDcHP44ZO26c5p6XyMOzuc7TMkMeDdnqcPD8y+Cnj4V/r8Qq8gdpzjdozw3NMtVfnHP72P1XOcG5U3NUaRtEnP0C4SHnciPttV1WWkaQhzLNU6nnR1M7OiqHVkAmHHZ0U1R8ih8h4LvHO/UzcXFA5avn23udOfZL9tSN9/ljyLIdPAievFGGv94JB+YlykkUHzlrrlFADct4CVKiwoMjhdBMoLnFetNr6ZmTXbImnLMjVhhZHQ0cQfFdTnS7KeN2O4orSqiptkPAZ7ySsP4jEzTVxGzOZbsVna4XeGr5m2P6+ONVIj801Zp5QZh1F7IYV6M2jnIzXcE4+xrn1Nwj0SkOY4NUK5Gh16y78f/R+igjIC+L3VCs9Pr4ePepx1wJSb+180Gy0FED/4DQyAX0bAyGRv6POVsaIpRLAGWkkh6Qn4g9lAVLZydmXAJuQ05m0X4Ljq9EshPwad9tcVGIFcGvw7Wat+75ib40CarKP8OGp//cDVSqlv4JRPNwgo/0lhTXQP2tNNODOMGn3qtPy9MYHHyUjsnhbiDtUGQHL7QrZIAB00aTJFwD4YcMqjTd0b0Sdi34kPrhYLvY5ouBREsF50DhrUrz45YKbZiB5kWA8NsGgbLGiJQurxuNFwezwDYziAyWn+Xr01o8dLTEo5FZOEhWhKbEp4GGoq9BD8v",
+                                    "meta": [],
+                                    "certificateType": "X.509"
+                                }    ]
+                        }""")));
+
+        EditRaProfileRequestDto request = new EditRaProfileRequestDto();
+        request.setDescription("v3 chain");
+        request.setAttributes(List.of());
+        raProfileService.editRaProfile(v3.authority().getSecuredParentUuid(), v3.raProfile().getSecuredUuid(), request);
+
+        RaProfile refreshedRaProfile = raProfileRepository.findByUuid(v3.raProfile().getUuid()).orElse(null);
+        Assertions.assertNotNull(refreshedRaProfile);
+        Assertions.assertNotNull(refreshedRaProfile.getAuthorityCertificateUuid(),
+                "v3 authority certificate chain must be linked to the RA profile");
+        mockServer.verify(0, WireMock.postRequestedFor(
+                WireMock.urlPathMatching("/v1/authorityProvider/authorities/[^/]+/caCertificates")));
+    }
+
+    @Test
     void testListIssueCertificateAttributes() throws ConnectorException, NotFoundException {
         mockServer.stubFor(WireMock
                 .get(WireMock.urlPathMatching("/v2/authorityProvider/authorities/[^/]+/certificates/issue/attributes"))

--- a/src/test/java/com/otilm/core/integration/service/v3/V3CancelITest.java
+++ b/src/test/java/com/otilm/core/integration/service/v3/V3CancelITest.java
@@ -62,25 +62,23 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
  * <p>Two distinct cancel paths are exercised:
  * <ol>
  *   <li><b>Operator cancel</b> ({@code cancelPendingCertificateOperation}) — routes through the
- *       <em>v2 cancel client</em> regardless of adapter version. The v3 adapter's
- *       {@code cancel()} is NOT involved here. HTTP status from the connector drives the
- *       exception-type mapping: 404 is a soft success (local cancel proceeds); 422 is a hard
- *       refusal ({@link ValidationException}, cert stays {@code PENDING_*}).
- *       This path is shared with v2; the tests here are a thin v3-authority smoke.</li>
+ *       v3 adapter's {@code cancel()}, which maps the connector's problem-detail response onto
+ *       a {@code CancelOutcome}: {@code CANCELLED} and {@code NOT_TRACKED} proceed with the
+ *       local cancel; {@code REFUSED_PAST_POINT_OF_NO_RETURN} is a hard refusal
+ *       ({@link ValidationException}, cert stays {@code PENDING_*}). The v2 cancel endpoints
+ *       are never called for a v3 authority.</li>
  *   <li><b>Manual-issue cancel hook</b> ({@code manuallyIssueCertificate}) — after the operator
  *       uploads the issued certificate, the service fires a best-effort v3 adapter
  *       {@code cancel(ISSUE)} to tell the connector to abort the in-flight async operation.
  *       The {@code CancelResult} is discarded; a failure must not abort the issuance.</li>
  * </ol>
  */
-public class V3CancelITest extends BaseSpringBootTest {
+class V3CancelITest extends BaseSpringBootTest {
 
-    // v3 issue/cancel path — used by cancelInFlightAsyncIssueBestEffort via v3 adapter cancel(ISSUE)
-    private static final String V3_ISSUE_CANCEL_PATH = "/v3/authorityProvider/certificates/issue/cancel";
-
-    // v2 cancel paths used by cancelPendingCertificateOperation via the v2 cancel client
-    private static final String V2_ISSUE_CANCEL_PATTERN  = "/v2/authorityProvider/authorities/[^/]+/certificates/issue/cancel";
-    private static final String V2_REVOKE_CANCEL_PATTERN = "/v2/authorityProvider/authorities/[^/]+/certificates/revoke/cancel";
+    // v3 cancel paths — operator cancel (cancelPendingCertificateOperation) and the best-effort
+    // manual-issue hook both go through the v3 adapter cancel()
+    private static final String V3_ISSUE_CANCEL_PATH  = "/v3/authorityProvider/certificates/issue/cancel";
+    private static final String V3_REVOKE_CANCEL_PATH = "/v3/authorityProvider/certificates/revoke/cancel";
 
     // v2 identify path used by manuallyIssueCertificate
     private static final String V2_IDENTIFY_PATTERN = "/v2/authorityProvider/authorities/[^/]+/certificates/identify";
@@ -122,30 +120,32 @@ public class V3CancelITest extends BaseSpringBootTest {
     // ── Lifecycle ─────────────────────────────────────────────────────────────
 
     @BeforeEach
-    public void setUpWireMock() {
+    void setUpWireMock() {
         wireMockServer = new WireMockServer(0);
         wireMockServer.start();
         WireMock.configureFor("localhost", wireMockServer.port());
     }
 
     @AfterEach
-    public void tearDownWireMock() {
+    void tearDownWireMock() {
         wireMockServer.stop();
     }
 
     // ── Step 1: Operator-cancel scenarios ─────────────────────────────────────
 
     /**
-     * Operator cancel of a {@code PENDING_ISSUE} v3-authority cert: connector returns 404
-     * (soft — not tracked) → local cancel proceeds → cert transitions to {@code FAILED}.
+     * Operator cancel of a {@code PENDING_ISSUE} v3-authority cert: connector cancels the
+     * operation (204) → local cancel proceeds → cert transitions to {@code FAILED}. Also pins
+     * the routing: the v3 issue-cancel endpoint is hit exactly once and no v2 cancel endpoint
+     * is ever called.
      */
     @Test
-    public void operatorCancel_pendingIssue_softConnector404_transitionsToFailed() {
+    void operatorCancel_pendingIssue_connectorCancelled_transitionsToFailed() {
         AuthorityFixtures.Fixture fixture = buildV3Fixture();
         Certificate cert = seedCertificate(fixture, CertificateState.PENDING_ISSUE);
 
-        wireMockServer.stubFor(post(urlPathMatching(V2_ISSUE_CANCEL_PATTERN))
-                .willReturn(aResponse().withStatus(404).withBody("not tracked")));
+        wireMockServer.stubFor(post(urlEqualTo(V3_ISSUE_CANCEL_PATH))
+                .willReturn(aResponse().withStatus(204)));
 
         Assertions.assertDoesNotThrow(() ->
                         clientOperationService.cancelPendingCertificateOperation(
@@ -153,27 +153,33 @@ public class V3CancelITest extends BaseSpringBootTest {
                                 fixture.raProfile().getSecuredUuid(),
                                 cert.getUuid().toString(),
                                 new CancelPendingCertificateRequestDto()),
-                "Operator cancel with connector 404 must not throw (soft failure, local cancel proceeds)");
+                "Operator cancel with connector 204 must not throw");
 
         Certificate after = reloadCert(cert.getUuid());
         Assertions.assertEquals(CertificateState.FAILED, after.getState(),
-                "PENDING_ISSUE + connector 404 → cert must transition to FAILED");
+                "PENDING_ISSUE + connector 204 → cert must transition to FAILED");
+        wireMockServer.verify(1, postRequestedFor(urlEqualTo(V3_ISSUE_CANCEL_PATH)));
+        wireMockServer.verify(0, postRequestedFor(urlPathMatching("/v2/.*/cancel")));
     }
 
     /**
-     * Operator cancel of a {@code PENDING_REVOKE} v3-authority cert: connector returns 404
-     * (soft) → local cancel proceeds → cert reverts to {@code ISSUED}.
+     * Operator cancel of a {@code PENDING_REVOKE} v3-authority cert: connector reports the
+     * operation as not tracked (422 with {@code OPERATION_NOT_TRACKED}) — a soft success —
+     * → local cancel proceeds → cert reverts to {@code ISSUED}.
      */
     @Test
-    public void operatorCancel_pendingRevoke_softConnector404_revertsToIssued() {
+    void operatorCancel_pendingRevoke_notTracked_revertsToIssued() {
         AuthorityFixtures.Fixture fixture = buildV3Fixture();
         Certificate cert = seedCertificate(fixture, CertificateState.PENDING_REVOKE);
         cert.setPendingRevokeDestroyKey(true);
         cert.setPendingRevokeAttributes(List.of());
         certificateRepository.save(cert);
 
-        wireMockServer.stubFor(post(urlPathMatching(V2_REVOKE_CANCEL_PATTERN))
-                .willReturn(aResponse().withStatus(404).withBody("not tracked")));
+        wireMockServer.stubFor(post(urlEqualTo(V3_REVOKE_CANCEL_PATH))
+                .willReturn(aResponse()
+                        .withStatus(422)
+                        .withHeader("Content-Type", "application/problem+json")
+                        .withBody(problemJson("OPERATION_NOT_TRACKED", "No tracked revocation for this certificate"))));
 
         Assertions.assertDoesNotThrow(() ->
                         clientOperationService.cancelPendingCertificateOperation(
@@ -181,28 +187,28 @@ public class V3CancelITest extends BaseSpringBootTest {
                                 fixture.raProfile().getSecuredUuid(),
                                 cert.getUuid().toString(),
                                 new CancelPendingCertificateRequestDto()),
-                "Operator cancel with connector 404 on PENDING_REVOKE must not throw");
+                "Operator cancel with NOT_TRACKED outcome on PENDING_REVOKE must not throw");
 
         Certificate after = reloadCert(cert.getUuid());
         Assertions.assertEquals(CertificateState.ISSUED, after.getState(),
-                "PENDING_REVOKE + connector 404 → cert must revert to ISSUED");
+                "PENDING_REVOKE + NOT_TRACKED outcome → cert must revert to ISSUED");
     }
 
     /**
-     * Operator cancel of a {@code PENDING_ISSUE} v3-authority cert: connector returns 422
-     * (hard refusal) → {@link ValidationException} is thrown and the cert stays
-     * {@code PENDING_ISSUE}.
+     * Operator cancel of a {@code PENDING_ISSUE} v3-authority cert: connector refuses with
+     * 422 {@code OPERATION_PAST_POINT_OF_NO_RETURN} (hard refusal) → {@link ValidationException}
+     * is thrown and the cert stays {@code PENDING_ISSUE}.
      */
     @Test
-    public void operatorCancel_pendingIssue_hardConnector422_throwsAndCertUnchanged() {
+    void operatorCancel_pendingIssue_refusedPastPonr_throwsAndCertUnchanged() {
         AuthorityFixtures.Fixture fixture = buildV3Fixture();
         Certificate cert = seedCertificate(fixture, CertificateState.PENDING_ISSUE);
 
-        wireMockServer.stubFor(post(urlPathMatching(V2_ISSUE_CANCEL_PATTERN))
+        wireMockServer.stubFor(post(urlEqualTo(V3_ISSUE_CANCEL_PATH))
                 .willReturn(aResponse()
                         .withStatus(422)
-                        .withHeader("Content-Type", "application/json")
-                        .withBody("[\"Issuance is past the point of no return\"]")));
+                        .withHeader("Content-Type", "application/problem+json")
+                        .withBody(problemJson("OPERATION_PAST_POINT_OF_NO_RETURN", "Issuance is past the point of no return"))));
 
         SecuredParentUUID authorityUuid = SecuredParentUUID.fromUUID(fixture.authority().getUuid());
         SecuredUUID raProfileUuid = fixture.raProfile().getSecuredUuid();
@@ -230,7 +236,7 @@ public class V3CancelITest extends BaseSpringBootTest {
      * received exactly one request after {@code manuallyIssueCertificate} completes.</p>
      */
     @Test
-    public void manualIssueHook_firesV3CancelOnce_whenConnectorReturns204() throws Exception {
+    void manualIssueHook_firesV3CancelOnce_whenConnectorReturns204() throws Exception {
         AuthorityFixtures.Fixture fixture = buildV3Fixture();
         SeededCert seeded = seedPendingIssueCertWithCsr(fixture);
         String certBase64 = buildSelfSignedCertBase64(seeded.keyPair(), "v3-manual-cancel-hook");
@@ -266,7 +272,7 @@ public class V3CancelITest extends BaseSpringBootTest {
      * complete. The certificate ends up in {@code ISSUED} state.
      */
     @Test
-    public void manualIssueHook_doesNotBreakIssuance_whenConnectorReturns500() throws Exception {
+    void manualIssueHook_doesNotBreakIssuance_whenConnectorReturns500() throws Exception {
         AuthorityFixtures.Fixture fixture = buildV3Fixture();
         SeededCert seeded = seedPendingIssueCertWithCsr(fixture);
         String certBase64 = buildSelfSignedCertBase64(seeded.keyPair(), "v3-manual-cancel-resilience");
@@ -302,6 +308,17 @@ public class V3CancelITest extends BaseSpringBootTest {
 
     // ── Private helpers ───────────────────────────────────────────────────────
 
+    /**
+     * v3 problem-detail body as emitted by connectors; the {@code application/problem+json}
+     * content type is what makes the api client surface it as ConnectorProblemException with
+     * a parsed errorCode (which the v3 adapter maps onto a CancelOutcome).
+     */
+    private static String problemJson(String errorCode, String detail) {
+        return """
+                {"type":"about:blank","title":"Unprocessable Entity","status":422,"detail":"%s","errorCode":"%s"}
+                """.formatted(detail, errorCode);
+    }
+
     private AuthorityFixtures.Repos repos() {
         return new AuthorityFixtures.Repos(
                 connectorRepository,
@@ -314,8 +331,8 @@ public class V3CancelITest extends BaseSpringBootTest {
 
     /**
      * Builds a v3 authority fixture bound to the per-test WireMock server. No feature flags are
-     * needed for operator-cancel (the v2 cancel client path is flag-agnostic); the manual-issue
-     * hook tests do not gate on flags either. A single fixture is used for each test.
+     * needed: neither the operator-cancel path nor the manual-issue hook gates on them. A single
+     * fixture is used for each test.
      */
     private AuthorityFixtures.Fixture buildV3Fixture() {
         return AuthorityFixtures.v3Authority(repos(), wireMockServer);

--- a/src/test/java/com/otilm/core/integration/service/v3/V3CancelITest.java
+++ b/src/test/java/com/otilm/core/integration/service/v3/V3CancelITest.java
@@ -80,8 +80,8 @@ class V3CancelITest extends BaseSpringBootTest {
     private static final String V3_ISSUE_CANCEL_PATH  = "/v3/authorityProvider/certificates/issue/cancel";
     private static final String V3_REVOKE_CANCEL_PATH = "/v3/authorityProvider/certificates/revoke/cancel";
 
-    // v2 identify path used by manuallyIssueCertificate
-    private static final String V2_IDENTIFY_PATTERN = "/v2/authorityProvider/authorities/[^/]+/certificates/identify";
+    // v3 identify path used by manuallyIssueCertificate (via the v3 adapter identify())
+    private static final String V3_IDENTIFY_PATH = "/v3/authorityProvider/certificates/identify";
 
     // ── Spring beans ──────────────────────────────────────────────────────────
 
@@ -241,8 +241,8 @@ class V3CancelITest extends BaseSpringBootTest {
         SeededCert seeded = seedPendingIssueCertWithCsr(fixture);
         String certBase64 = buildSelfSignedCertBase64(seeded.keyPair(), "v3-manual-cancel-hook");
 
-        // v2 identify endpoint — required by manuallyIssueCertificate
-        wireMockServer.stubFor(post(urlPathMatching(V2_IDENTIFY_PATTERN))
+        // v3 identify endpoint — required by manuallyIssueCertificate
+        wireMockServer.stubFor(post(urlEqualTo(V3_IDENTIFY_PATH))
                 .willReturn(WireMock.okJson("{\"meta\":[]}")));
 
         // v3 issue-cancel endpoint — the best-effort hook
@@ -277,8 +277,8 @@ class V3CancelITest extends BaseSpringBootTest {
         SeededCert seeded = seedPendingIssueCertWithCsr(fixture);
         String certBase64 = buildSelfSignedCertBase64(seeded.keyPair(), "v3-manual-cancel-resilience");
 
-        // v2 identify endpoint
-        wireMockServer.stubFor(post(urlPathMatching(V2_IDENTIFY_PATTERN))
+        // v3 identify endpoint
+        wireMockServer.stubFor(post(urlEqualTo(V3_IDENTIFY_PATH))
                 .willReturn(WireMock.okJson("{\"meta\":[]}")));
 
         // v3 issue-cancel: simulate connector error — the hook must swallow this

--- a/src/test/java/com/otilm/core/integration/service/v3/V3RenewRevokeITest.java
+++ b/src/test/java/com/otilm/core/integration/service/v3/V3RenewRevokeITest.java
@@ -1,0 +1,230 @@
+package com.otilm.core.integration.service.v3;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
+import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
+import com.otilm.api.model.core.certificate.CertificateRelationType;
+import com.otilm.api.model.core.certificate.CertificateState;
+import com.otilm.api.model.core.certificate.CertificateValidationStatus;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.CertificateContent;
+import com.otilm.core.dao.entity.CertificateRelation;
+import com.otilm.core.dao.entity.CertificateRequestEntity;
+import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
+import com.otilm.core.dao.repository.CertificateContentRepository;
+import com.otilm.core.dao.repository.CertificateRelationRepository;
+import com.otilm.core.dao.repository.CertificateRepository;
+import com.otilm.core.dao.repository.CertificateRequestRepository;
+import com.otilm.core.dao.repository.Connector2FunctionGroupRepository;
+import com.otilm.core.dao.repository.ConnectorInterfaceRepository;
+import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.dao.repository.FunctionGroupRepository;
+import com.otilm.core.dao.repository.RaProfileRepository;
+import com.otilm.core.service.v2.ClientOperationInternalService;
+import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.builders.AuthorityFixtures;
+import com.otilm.core.util.builders.V3ConnectorStubs;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+
+/**
+ * Integration tests for renew and revoke against a v3 authority. These operations dispatch through
+ * {@code AuthorityProviderAdapterFactory}; a v3 authority does not serve the v2 endpoints, so the tests
+ * pin that the request lands on the v3 wire and never on the v2 endpoints.
+ */
+class V3RenewRevokeITest extends BaseSpringBootTest {
+
+    private static final String V3_RENEW_PATH  = "/v3/authorityProvider/certificates/renew";
+    private static final String V3_REVOKE_PATH = "/v3/authorityProvider/certificates/revoke";
+    private static final String V2_RENEW_PATTERN  = "/v2/authorityProvider/authorities/[^/]+/certificates/renew";
+    private static final String V2_REVOKE_PATTERN = "/v2/authorityProvider/authorities/[^/]+/certificates/revoke";
+
+    @Autowired
+    private ClientOperationInternalService clientOperationInternalService;
+    @Autowired
+    private CertificateRepository certificateRepository;
+    @Autowired
+    private CertificateContentRepository certificateContentRepository;
+    @Autowired
+    private CertificateRequestRepository certificateRequestRepository;
+    @Autowired
+    private CertificateRelationRepository certificateRelationRepository;
+
+    // Fixture builder repos
+    @Autowired
+    private ConnectorRepository connectorRepository;
+    @Autowired
+    private FunctionGroupRepository functionGroupRepository;
+    @Autowired
+    private Connector2FunctionGroupRepository connector2FunctionGroupRepository;
+    @Autowired
+    private AuthorityInstanceReferenceRepository authorityInstanceReferenceRepository;
+    @Autowired
+    private RaProfileRepository raProfileRepository;
+    @Autowired
+    private ConnectorInterfaceRepository connectorInterfaceRepository;
+
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void setUpWireMock() {
+        wireMockServer = new WireMockServer(0);
+        wireMockServer.start();
+        WireMock.configureFor("localhost", wireMockServer.port());
+    }
+
+    @AfterEach
+    void tearDownWireMock() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void renew_async202_parksSuccessorPendingIssue_viaV3_notV2() throws Exception {
+        AuthorityFixtures.Fixture fixture = buildV3Fixture();
+        V3ConnectorStubs.stubAttributesAndValidate(wireMockServer);
+        UUID predecessorUuid = seedRenewalPair(fixture);
+        UUID successorUuid = successorUuid(predecessorUuid);
+
+        wireMockServer.stubFor(post(urlEqualTo(V3_RENEW_PATH))
+                .willReturn(aResponse().withStatus(202)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"certificateData\": null, \"meta\": []}")));
+
+        Assertions.assertDoesNotThrow(() ->
+                clientOperationInternalService.renewCertificateAction(
+                        successorUuid, ClientCertificateRenewRequestDto.builder().build(), true));
+
+        Assertions.assertEquals(CertificateState.PENDING_ISSUE, reloadCert(successorUuid).getState(),
+                "an accepted async v3 renew (202) must park the successor in PENDING_ISSUE");
+        Assertions.assertEquals(CertificateState.ISSUED, reloadCert(predecessorUuid).getState(),
+                "the predecessor must stay ISSUED while the successor awaits asynchronous completion");
+        wireMockServer.verify(1, postRequestedFor(urlEqualTo(V3_RENEW_PATH)));
+        wireMockServer.verify(0, postRequestedFor(urlPathMatching(V2_RENEW_PATTERN)));
+    }
+
+    @Test
+    void revoke_sync200_transitionsToRevoked_viaV3_notV2() {
+        AuthorityFixtures.Fixture fixture = buildV3Fixture();
+        V3ConnectorStubs.stubAttributesAndValidate(wireMockServer);
+        Certificate cert = seedCertificate(fixture, CertificateState.ISSUED);
+
+        wireMockServer.stubFor(post(urlEqualTo(V3_REVOKE_PATH))
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"certificateData\": null, \"meta\": []}")));
+
+        ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
+        request.setAttributes(List.of());
+
+        Assertions.assertDoesNotThrow(() ->
+                clientOperationInternalService.revokeCertificateAction(cert.getUuid(), request, true));
+
+        Assertions.assertEquals(CertificateState.REVOKED, reloadCert(cert.getUuid()).getState(),
+                "a synchronous v3 revoke (200) must transition the certificate to REVOKED");
+        wireMockServer.verify(1, postRequestedFor(urlEqualTo(V3_REVOKE_PATH)));
+        wireMockServer.verify(0, postRequestedFor(urlPathMatching(V2_REVOKE_PATTERN)));
+    }
+
+    @Test
+    void revoke_async202_parksPendingRevoke_viaV3() {
+        AuthorityFixtures.Fixture fixture = buildV3Fixture();
+        V3ConnectorStubs.stubAttributesAndValidate(wireMockServer);
+        Certificate cert = seedCertificate(fixture, CertificateState.ISSUED);
+
+        wireMockServer.stubFor(post(urlEqualTo(V3_REVOKE_PATH))
+                .willReturn(aResponse().withStatus(202)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"certificateData\": null, \"meta\": []}")));
+
+        ClientCertificateRevocationDto request = new ClientCertificateRevocationDto();
+        request.setAttributes(List.of());
+
+        Assertions.assertDoesNotThrow(() ->
+                clientOperationInternalService.revokeCertificateAction(cert.getUuid(), request, true));
+
+        Assertions.assertEquals(CertificateState.PENDING_REVOKE, reloadCert(cert.getUuid()).getState(),
+                "an accepted async v3 revoke (202) must park the certificate in PENDING_REVOKE");
+        wireMockServer.verify(1, postRequestedFor(urlEqualTo(V3_REVOKE_PATH)));
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private AuthorityFixtures.Repos repos() {
+        return new AuthorityFixtures.Repos(
+                connectorRepository,
+                functionGroupRepository,
+                connector2FunctionGroupRepository,
+                authorityInstanceReferenceRepository,
+                raProfileRepository,
+                connectorInterfaceRepository);
+    }
+
+    private AuthorityFixtures.Fixture buildV3Fixture() {
+        return AuthorityFixtures.v3Authority(repos(), wireMockServer);
+    }
+
+    private Certificate seedCertificate(AuthorityFixtures.Fixture fixture, CertificateState state) {
+        CertificateContent content = certificateContentRepository.save(new CertificateContent());
+        Certificate cert = new Certificate();
+        cert.setSubjectDn("CN=v3-op-" + UUID.randomUUID());
+        cert.setIssuerDn("CN=test-issuer");
+        cert.setSerialNumber(UUID.randomUUID().toString());
+        cert.setCertificateContent(content);
+        cert.setCertificateContentId(content.getId());
+        cert.setState(state);
+        cert.setValidationStatus(CertificateValidationStatus.VALID);
+        cert.setRaProfile(fixture.raProfile());
+        return certificateRepository.save(cert);
+    }
+
+    /**
+     * Seeds an ISSUED predecessor and a REQUESTED successor (with a CSR) linked by a PENDING relation,
+     * as the renew/rekey actions require. Returns the predecessor UUID.
+     */
+    private UUID seedRenewalPair(AuthorityFixtures.Fixture fixture) throws Exception {
+        Certificate predecessor = seedCertificate(fixture, CertificateState.ISSUED);
+
+        CertificateRequestEntity csr = new CertificateRequestEntity();
+        csr.setContent("content");
+        certificateRequestRepository.save(csr);
+
+        Certificate successor = seedCertificate(fixture, CertificateState.REQUESTED);
+        successor.setCertificateRequest(csr);
+        successor.setCertificateRequestUuid(csr.getUuid());
+        certificateRepository.save(successor);
+
+        CertificateRelation relation = new CertificateRelation();
+        relation.setSuccessorCertificate(successor);
+        relation.setPredecessorCertificate(predecessor);
+        relation.setRelationType(CertificateRelationType.PENDING);
+        certificateRelationRepository.save(relation);
+
+        return predecessor.getUuid();
+    }
+
+    private UUID successorUuid(UUID predecessorUuid) {
+        return certificateRelationRepository.findAll().stream()
+                .filter(r -> predecessorUuid.equals(r.getPredecessorCertificate().getUuid()))
+                .map(r -> r.getSuccessorCertificate().getUuid())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No successor relation for " + predecessorUuid));
+    }
+
+    private Certificate reloadCert(UUID uuid) {
+        return certificateRepository.findByUuid(uuid)
+                .orElseThrow(() -> new AssertionError("Certificate not found: " + uuid));
+    }
+}

--- a/src/test/java/com/otilm/core/integration/service/v3/V3RenewRevokeITest.java
+++ b/src/test/java/com/otilm/core/integration/service/v3/V3RenewRevokeITest.java
@@ -116,6 +116,31 @@ class V3RenewRevokeITest extends BaseSpringBootTest {
     }
 
     @Test
+    void renew_sync200_postAcceptanceLocalFailure_leavesSuccessorPendingIssue() throws Exception {
+        AuthorityFixtures.Fixture fixture = buildV3Fixture();
+        V3ConnectorStubs.stubAttributesAndValidate(wireMockServer);
+        UUID predecessorUuid = seedRenewalPair(fixture);
+        UUID successorUuid = successorUuid(predecessorUuid);
+
+        // 200 with certificate data the connector accepted but Core cannot parse: the local
+        // issueRequestedCertificate step fails after the connector already issued. The successor must stay
+        // PENDING_ISSUE (not FAILED) so it can be reconciled against the authority.
+        wireMockServer.stubFor(post(urlEqualTo(V3_RENEW_PATH))
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"certificateData\": \"bm90LWEtY2VydA==\", \"meta\": []}")));
+
+        Assertions.assertThrows(Exception.class, () ->
+                clientOperationInternalService.renewCertificateAction(
+                        successorUuid, ClientCertificateRenewRequestDto.builder().build(), true));
+
+        Assertions.assertEquals(CertificateState.PENDING_ISSUE, reloadCert(successorUuid).getState(),
+                "a post-acceptance local failure must leave the successor PENDING_ISSUE, not FAILED");
+        Assertions.assertEquals(CertificateState.ISSUED, reloadCert(predecessorUuid).getState(),
+                "the predecessor must stay ISSUED");
+    }
+
+    @Test
     void revoke_sync200_transitionsToRevoked_viaV3_notV2() {
         AuthorityFixtures.Fixture fixture = buildV3Fixture();
         V3ConnectorStubs.stubAttributesAndValidate(wireMockServer);

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV2AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV2AdapterTest.java
@@ -7,8 +7,11 @@ import com.otilm.api.interfaces.client.v1.AuthorityInstanceSyncApiClient;
 import com.otilm.api.interfaces.client.v2.CertificateSyncApiClient;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.connector.v2.CertRevocationDto;
 import com.otilm.api.model.connector.v2.CertificateDataResponseDto;
+import com.otilm.api.model.connector.v2.CertificateIdentificationRequestDto;
+import com.otilm.api.model.connector.v2.CertificateIdentificationResponseDto;
 import com.otilm.api.model.connector.v2.CertificateRenewRequestDto;
 import com.otilm.api.model.connector.v2.CertificateSignRequestDto;
 import com.otilm.api.model.core.authority.CertificateRevocationReason;
@@ -278,6 +281,47 @@ class AuthorityProviderV2AdapterTest {
         ArgumentCaptor<CertRevocationDto> captor = ArgumentCaptor.forClass(CertRevocationDto.class);
         verify(certClient).revokeCertificate(eq(connectorInfo), eq("auth-instance-uuid"), captor.capture());
         assertEquals(CertificateRevocationReason.UNSPECIFIED, captor.getValue().getReason());
+    }
+
+    // --- identify ---
+
+    @Test
+    void identify_delegatesToCertClientAndReturnsMeta() throws Exception {
+        CertificateIdentificationResponseDto response = new CertificateIdentificationResponseDto();
+        List<MetadataAttribute> meta = List.of(mock(MetadataAttribute.class));
+        response.setMeta(meta);
+        when(certClient.identifyCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateIdentificationRequestDto.class)))
+                .thenReturn(response);
+
+        List<MetadataAttribute> result = adapter.identify(raProfile, "dGVzdGNlcnQ=");
+
+        assertSame(meta, result);
+        ArgumentCaptor<CertificateIdentificationRequestDto> captor = ArgumentCaptor.forClass(CertificateIdentificationRequestDto.class);
+        verify(certClient).identifyCertificate(eq(connectorInfo), eq("auth-instance-uuid"), captor.capture());
+        assertEquals("dGVzdGNlcnQ=", captor.getValue().getCertificate());
+    }
+
+    @Test
+    void identify_passesStoredRaProfileAttributesUnchanged() throws Exception {
+        // v2 is stateful: stored ra-profile attributes must reach the wire exactly as stored (no dereference).
+        List<RequestAttribute> stored = List.of(mock(RequestAttribute.class));
+        when(attributeEngine.getRequestObjectDataAttributesContent(any())).thenReturn(stored);
+        when(certClient.identifyCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateIdentificationRequestDto.class)))
+                .thenReturn(new CertificateIdentificationResponseDto());
+
+        adapter.identify(raProfile, "dGVzdGNlcnQ=");
+
+        ArgumentCaptor<CertificateIdentificationRequestDto> captor = ArgumentCaptor.forClass(CertificateIdentificationRequestDto.class);
+        verify(certClient).identifyCertificate(eq(connectorInfo), eq("auth-instance-uuid"), captor.capture());
+        assertSame(stored, captor.getValue().getRaProfileAttributes());
+    }
+
+    @Test
+    void identify_normalizesNullMetaToEmptyList() throws Exception {
+        when(certClient.identifyCertificate(eq(connectorInfo), eq("auth-instance-uuid"), any(CertificateIdentificationRequestDto.class)))
+                .thenReturn(new CertificateIdentificationResponseDto());
+
+        assertEquals(List.of(), adapter.identify(raProfile, "dGVzdGNlcnQ="));
     }
 
     // --- listIssueAttributes / listRevokeAttributes ---

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV2AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV2AdapterTest.java
@@ -9,6 +9,8 @@ import com.otilm.api.interfaces.client.v2.CertificateSyncApiClient;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
+import com.otilm.api.model.connector.authority.CaCertificatesRequestDto;
+import com.otilm.api.model.connector.authority.CaCertificatesResponseDto;
 import com.otilm.api.model.connector.v2.CertRevocationDto;
 import com.otilm.api.model.connector.v2.CertificateDataResponseDto;
 import com.otilm.api.model.connector.v2.CertificateIdentificationRequestDto;
@@ -16,6 +18,7 @@ import com.otilm.api.model.connector.v2.CertificateIdentificationResponseDto;
 import com.otilm.api.model.connector.v2.CertificateRenewRequestDto;
 import com.otilm.api.model.connector.v2.CertificateSignRequestDto;
 import com.otilm.api.model.core.authority.CertificateRevocationReason;
+import com.otilm.api.model.core.certificate.CertificateType;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
 import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
@@ -323,6 +326,54 @@ class AuthorityProviderV2AdapterTest {
                 .thenReturn(new CertificateIdentificationResponseDto());
 
         assertEquals(List.of(), adapter.identify(raProfile, "dGVzdGNlcnQ="));
+    }
+
+    // --- getCaCertificates ---
+
+    @Test
+    void getCaCertificates_delegatesToAuthorityClientAndMapsCertificates() throws Exception {
+        CertificateDataResponseDto chainCert = new CertificateDataResponseDto();
+        chainCert.setCertificateData("chainCert==");
+        List<MetadataAttribute> meta = List.of(mock(MetadataAttribute.class));
+        chainCert.setMeta(meta);
+        chainCert.setCertificateType(CertificateType.X509);
+        CaCertificatesResponseDto response = new CaCertificatesResponseDto();
+        response.setCertificates(List.of(chainCert));
+        when(authorityClient.getCaCertificates(eq(connectorInfo), eq("auth-instance-uuid"), any(CaCertificatesRequestDto.class)))
+                .thenReturn(response);
+
+        List<AdapterOperationResult> result = adapter.getCaCertificates(authority, raProfile);
+
+        assertEquals(1, result.size());
+        assertEquals(AdapterOperationOutcome.SYNC_OK, result.get(0).outcome());
+        assertEquals("chainCert==", result.get(0).certificateData());
+        assertSame(meta, result.get(0).meta());
+        assertEquals(CertificateType.X509, result.get(0).certificateType());
+    }
+
+    @Test
+    void getCaCertificates_passesStoredRaProfileAttributesUnchanged() throws Exception {
+        // v2 is stateful: stored ra-profile attributes must reach the wire exactly as stored (no dereference).
+        List<RequestAttribute> stored = List.of(mock(RequestAttribute.class));
+        when(attributeEngine.getRequestObjectDataAttributesContent(any())).thenReturn(stored);
+        CaCertificatesResponseDto response = new CaCertificatesResponseDto();
+        response.setCertificates(List.of());
+        when(authorityClient.getCaCertificates(eq(connectorInfo), eq("auth-instance-uuid"), any(CaCertificatesRequestDto.class)))
+                .thenReturn(response);
+
+        adapter.getCaCertificates(authority, raProfile);
+
+        ArgumentCaptor<CaCertificatesRequestDto> captor = ArgumentCaptor.forClass(CaCertificatesRequestDto.class);
+        verify(authorityClient).getCaCertificates(eq(connectorInfo), eq("auth-instance-uuid"), captor.capture());
+        assertSame(stored, captor.getValue().getRaProfileAttributes());
+    }
+
+    @Test
+    void getCaCertificates_normalizesNullCertificatesToEmptyList() throws Exception {
+        when(authorityClient.getCaCertificates(eq(connectorInfo), eq("auth-instance-uuid"), any(CaCertificatesRequestDto.class)))
+                .thenReturn(new CaCertificatesResponseDto());
+
+        assertEquals(List.of(), adapter.getCaCertificates(authority, raProfile));
     }
 
     // --- listIssueAttributes / listRevokeAttributes ---

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -470,9 +470,20 @@ class AuthorityProviderV3AdapterTest {
     }
 
     @Test
-    void getCaCertificatesCarriesRaProfileAttributesOnWire() throws ConnectorException {
-        List<RequestAttribute> stored = List.of(mock(RequestAttribute.class));
-        when(attributeEngine.getRequestObjectDataAttributesContent(any())).thenReturn(stored);
+    void getCaCertificatesCarriesResolvedAttributesOnWire() throws ConnectorException {
+        UUID connectorUuid = authority.getConnectorUuid();
+        List<RequestAttribute> storedAuthority = List.of(mock(RequestAttribute.class));
+        List<RequestAttribute> storedRaProfile = List.of(mock(RequestAttribute.class));
+        List<RequestAttribute> resolvedAuthority = List.of(mock(RequestAttribute.class));
+        List<RequestAttribute> resolvedRaProfile = List.of(mock(RequestAttribute.class));
+        when(attributeEngine.getRequestObjectDataAttributesContent(argThat(info -> info != null && info.objectType() == Resource.AUTHORITY)))
+                .thenReturn(storedAuthority);
+        when(attributeEngine.getRequestObjectDataAttributesContent(argThat(info -> info != null && info.objectType() == Resource.RA_PROFILE)))
+                .thenReturn(storedRaProfile);
+        when(operationAttributeResolver.resolveForConnectorRequestAsSystem(connectorUuid, storedAuthority))
+                .thenReturn(resolvedAuthority);
+        when(operationAttributeResolver.resolveForConnectorRequestAsSystem(connectorUuid, storedRaProfile))
+                .thenReturn(resolvedRaProfile);
         CaCertificatesResponseDto response = new CaCertificatesResponseDto();
         response.setCertificates(List.of());
         when(authorityClientV3.getCaCertificates(eq(connectorInfo), any(CaCertificatesRequestDtoV3.class)))
@@ -482,7 +493,10 @@ class AuthorityProviderV3AdapterTest {
 
         ArgumentCaptor<CaCertificatesRequestDtoV3> captor = ArgumentCaptor.forClass(CaCertificatesRequestDtoV3.class);
         verify(authorityClientV3).getCaCertificates(eq(connectorInfo), captor.capture());
-        assertSame(stored, captor.getValue().getRaProfileAttributes());
+        assertSame(resolvedRaProfile, captor.getValue().getRaProfileAttributes(),
+                "raProfileAttributes must carry the resolved ra-profile-scoped list");
+        assertSame(resolvedAuthority, captor.getValue().getAuthorityAttributes(),
+                "authorityAttributes must carry the resolved authority-scoped list");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -13,6 +13,8 @@ import com.otilm.api.model.common.error.ProblemDetailExtended;
 import com.otilm.api.model.connector.v3.certificate.CertificateAttributeListRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateDataResponseDto;
 import com.otilm.api.model.connector.v3.certificate.CertificateIdentificationRequestDtoV3;
+import com.otilm.api.model.connector.v3.authority.CaCertificatesRequestDtoV3;
+import com.otilm.api.model.connector.v3.authority.CaCertificatesResponseDto;
 import com.otilm.api.model.connector.v3.certificate.CertificateIdentificationResponseDto;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationCancelRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatus;
@@ -25,6 +27,7 @@ import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.authority.CertificateRevocationReason;
+import com.otilm.api.model.core.certificate.CertificateType;
 import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.attribute.RequestAttributeV3;
@@ -441,6 +444,53 @@ class AuthorityProviderV3AdapterTest {
                 .thenReturn(new CertificateIdentificationResponseDto());
 
         assertEquals(List.of(), adapter.identify(raProfile, "dGVzdGNlcnQ="));
+    }
+
+    // ---- getCaCertificates ----
+
+    @Test
+    void getCaCertificatesDelegatesToV3ClientAndMapsCertificates() throws ConnectorException {
+        CertificateDataResponseDto chainCert = new CertificateDataResponseDto();
+        chainCert.setCertificateData("chainCert==");
+        List<MetadataAttribute> meta = List.of(mock(MetadataAttribute.class));
+        chainCert.setMeta(meta);
+        chainCert.setCertificateType(CertificateType.X509);
+        CaCertificatesResponseDto response = new CaCertificatesResponseDto();
+        response.setCertificates(List.of(chainCert));
+        when(authorityClientV3.getCaCertificates(eq(connectorInfo), any(CaCertificatesRequestDtoV3.class)))
+                .thenReturn(response);
+
+        List<AdapterOperationResult> result = adapter.getCaCertificates(authority, raProfile);
+
+        assertEquals(1, result.size());
+        assertEquals(AdapterOperationOutcome.SYNC_OK, result.get(0).outcome());
+        assertEquals("chainCert==", result.get(0).certificateData());
+        assertSame(meta, result.get(0).meta());
+        assertEquals(CertificateType.X509, result.get(0).certificateType());
+    }
+
+    @Test
+    void getCaCertificatesCarriesRaProfileAttributesOnWire() throws ConnectorException {
+        List<RequestAttribute> stored = List.of(mock(RequestAttribute.class));
+        when(attributeEngine.getRequestObjectDataAttributesContent(any())).thenReturn(stored);
+        CaCertificatesResponseDto response = new CaCertificatesResponseDto();
+        response.setCertificates(List.of());
+        when(authorityClientV3.getCaCertificates(eq(connectorInfo), any(CaCertificatesRequestDtoV3.class)))
+                .thenReturn(response);
+
+        adapter.getCaCertificates(authority, raProfile);
+
+        ArgumentCaptor<CaCertificatesRequestDtoV3> captor = ArgumentCaptor.forClass(CaCertificatesRequestDtoV3.class);
+        verify(authorityClientV3).getCaCertificates(eq(connectorInfo), captor.capture());
+        assertSame(stored, captor.getValue().getRaProfileAttributes());
+    }
+
+    @Test
+    void getCaCertificatesNormalizesNullCertificatesToEmptyList() throws ConnectorException {
+        when(authorityClientV3.getCaCertificates(eq(connectorInfo), any(CaCertificatesRequestDtoV3.class)))
+                .thenReturn(new CaCertificatesResponseDto());
+
+        assertEquals(List.of(), adapter.getCaCertificates(authority, raProfile));
     }
 
     // ---- register: delegates to v3 /register ----

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderV3AdapterTest.java
@@ -12,6 +12,8 @@ import com.otilm.api.model.common.error.ErrorCode;
 import com.otilm.api.model.common.error.ProblemDetailExtended;
 import com.otilm.api.model.connector.v3.certificate.CertificateAttributeListRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateDataResponseDto;
+import com.otilm.api.model.connector.v3.certificate.CertificateIdentificationRequestDtoV3;
+import com.otilm.api.model.connector.v3.certificate.CertificateIdentificationResponseDto;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationCancelRequestDtoV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatus;
 import com.otilm.api.model.connector.v3.certificate.CertificateOperationStatusRequestDtoV3;
@@ -412,6 +414,33 @@ class AuthorityProviderV3AdapterTest {
                 ArgumentCaptor.forClass(CertificateRevocationRequestDtoV3.class);
         verify(certClientV3).revoke(eq(connectorInfo), captor.capture());
         assertEquals(CertificateRevocationReason.UNSPECIFIED, captor.getValue().getReason());
+    }
+
+    // ---- identify ----
+
+    @Test
+    void identifyDelegatesToV3ClientAndReturnsMeta() throws ConnectorException {
+        CertificateIdentificationResponseDto response = new CertificateIdentificationResponseDto();
+        List<MetadataAttribute> meta = List.of(mock(MetadataAttribute.class));
+        response.setMeta(meta);
+        when(certClientV3.identify(eq(connectorInfo), any(CertificateIdentificationRequestDtoV3.class)))
+                .thenReturn(response);
+
+        List<MetadataAttribute> result = adapter.identify(raProfile, "dGVzdGNlcnQ=");
+
+        assertSame(meta, result);
+        ArgumentCaptor<CertificateIdentificationRequestDtoV3> captor =
+                ArgumentCaptor.forClass(CertificateIdentificationRequestDtoV3.class);
+        verify(certClientV3).identify(eq(connectorInfo), captor.capture());
+        assertEquals("dGVzdGNlcnQ=", captor.getValue().getCertificate());
+    }
+
+    @Test
+    void identifyNormalizesNullMetaToEmptyList() throws ConnectorException {
+        when(certClientV3.identify(eq(connectorInfo), any(CertificateIdentificationRequestDtoV3.class)))
+                .thenReturn(new CertificateIdentificationResponseDto());
+
+        assertEquals(List.of(), adapter.identify(raProfile, "dGVzdGNlcnQ="));
     }
 
     // ---- register: delegates to v3 /register ----

--- a/src/test/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImplTest.java
@@ -1,0 +1,216 @@
+package com.otilm.core.service.v2.impl;
+
+import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.client.attribute.RequestAttribute;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.AttributeOperation;
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.entity.Connector2FunctionGroup;
+import com.otilm.core.dao.entity.FunctionGroup;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.service.handler.authority.AuthorityProviderAdapter;
+import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExtendedAttributeServiceImplTest {
+
+    @Mock
+    ConnectorRepository connectorRepository;
+    @Mock
+    AuthorityProviderAdapterFactory adapterFactory;
+    @Mock
+    AuthorityProviderAdapter adapter;
+    @Mock
+    AttributeEngine attributeEngine;
+
+    @InjectMocks
+    ExtendedAttributeServiceImpl service;
+
+    private Connector connector;
+    private AuthorityInstanceReference authority;
+    private RaProfile raProfile;
+
+    @BeforeEach
+    void setUp() {
+        connector = new Connector();
+        connector.setUuid(UUID.randomUUID());
+
+        authority = new AuthorityInstanceReference();
+        authority.setUuid(UUID.randomUUID());
+        authority.setConnector(connector);
+
+        raProfile = new RaProfile();
+        raProfile.setUuid(UUID.randomUUID());
+        raProfile.setAuthorityInstanceReference(authority);
+
+        // Lenient: the connector-missing and legacy-rejection tests never reach the factory.
+        lenient().when(adapterFactory.forAuthority(authority)).thenReturn(adapter);
+    }
+
+    // --- listIssueCertificateAttributes ---
+
+    @Test
+    void listIssueCertificateAttributes_delegatesToAdapter() throws Exception {
+        List<BaseAttribute> expected = List.of(mock(BaseAttribute.class));
+        when(adapter.listIssueAttributes(authority, raProfile)).thenReturn(expected);
+
+        assertSame(expected, service.listIssueCertificateAttributes(raProfile));
+    }
+
+    @Test
+    void listIssueCertificateAttributes_throwsWhenConnectorMissing() {
+        authority.setConnector(null);
+
+        assertThrows(NotFoundException.class, () -> service.listIssueCertificateAttributes(raProfile));
+        verifyNoInteractions(adapterFactory);
+    }
+
+    @Test
+    void listIssueCertificateAttributes_rejectsLegacyConnector() {
+        FunctionGroup functionGroup = new FunctionGroup();
+        Connector2FunctionGroup c2fg = new Connector2FunctionGroup();
+        c2fg.setFunctionGroup(functionGroup);
+        connector.getFunctionGroups().add(c2fg);
+        when(connectorRepository.findConnectedByFunctionGroupAndKind(functionGroup, "LegacyEjbca"))
+                .thenReturn(List.of(new Connector()));
+
+        assertThrows(NotFoundException.class, () -> service.listIssueCertificateAttributes(raProfile));
+        verifyNoInteractions(adapterFactory);
+    }
+
+    // --- validateIssueCertificateAttributes / validateRevokeCertificateAttributes ---
+
+    @Test
+    void validateIssueCertificateAttributes_delegatesToAdapter() throws Exception {
+        List<RequestAttribute> attrs = List.of(mock(RequestAttribute.class));
+
+        service.validateIssueCertificateAttributes(raProfile, attrs);
+
+        verify(adapter).validateIssueAttributes(authority, attrs);
+    }
+
+    @Test
+    void validateRevokeCertificateAttributes_delegatesToAdapter() throws Exception {
+        List<RequestAttribute> attrs = List.of(mock(RequestAttribute.class));
+
+        service.validateRevokeCertificateAttributes(raProfile, attrs);
+
+        verify(adapter).validateRevokeAttributes(authority, attrs);
+    }
+
+    // --- mergeAndValidateIssueAttributes ---
+
+    @Test
+    void mergeAndValidateIssueAttributes_validatesThenListsThenUpdatesEngine() throws Exception {
+        List<RequestAttribute> attrs = List.of(mock(RequestAttribute.class));
+        List<BaseAttribute> definitions = List.of(mock(BaseAttribute.class));
+        when(adapter.listIssueAttributes(authority, raProfile)).thenReturn(definitions);
+
+        service.mergeAndValidateIssueAttributes(raProfile, attrs);
+
+        InOrder order = inOrder(adapter, attributeEngine);
+        order.verify(adapter).validateIssueAttributes(authority, attrs);
+        order.verify(adapter).listIssueAttributes(authority, raProfile);
+        order.verify(attributeEngine).validateUpdateDataAttributes(
+                connector.getUuid(), AttributeOperation.CERTIFICATE_ISSUE, definitions, attrs);
+    }
+
+    @Test
+    void mergeAndValidateIssueAttributes_normalizesNullAttributesToEmptyList() throws Exception {
+        when(adapter.listIssueAttributes(authority, raProfile)).thenReturn(List.of());
+
+        service.mergeAndValidateIssueAttributes(raProfile, null);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<RequestAttribute>> captor = ArgumentCaptor.forClass(List.class);
+        verify(adapter).validateIssueAttributes(eq(authority), captor.capture());
+        assertNotNull(captor.getValue());
+        assertTrue(captor.getValue().isEmpty());
+        verify(attributeEngine).validateUpdateDataAttributes(
+                eq(connector.getUuid()), eq(AttributeOperation.CERTIFICATE_ISSUE), eq(List.of()), eq(captor.getValue()));
+    }
+
+    @Test
+    void mergeAndValidateIssueAttributes_throwsWhenConnectorMissing() {
+        authority.setConnector(null);
+
+        assertThrows(ValidationException.class, () -> service.mergeAndValidateIssueAttributes(raProfile, List.of()));
+        verifyNoInteractions(adapterFactory, attributeEngine);
+    }
+
+    @Test
+    void mergeAndValidateIssueAttributes_connectorRejectionShortCircuits() throws Exception {
+        List<RequestAttribute> attrs = List.of(mock(RequestAttribute.class));
+        doThrow(new ValidationException("rejected")).when(adapter).validateIssueAttributes(authority, attrs);
+
+        assertThrows(ValidationException.class, () -> service.mergeAndValidateIssueAttributes(raProfile, attrs));
+
+        verify(adapter, never()).listIssueAttributes(any(), any());
+        verifyNoInteractions(attributeEngine);
+    }
+
+    @Test
+    void mergeAndValidateIssueAttributes_propagatesConnectorException() throws Exception {
+        List<RequestAttribute> attrs = List.of(mock(RequestAttribute.class));
+        doThrow(new ConnectorException("connector down")).when(adapter).validateIssueAttributes(authority, attrs);
+
+        assertThrows(ConnectorException.class, () -> service.mergeAndValidateIssueAttributes(raProfile, attrs));
+        verifyNoInteractions(attributeEngine);
+    }
+
+    // --- listRevokeCertificateAttributes / mergeAndValidateRevokeAttributes ---
+
+    @Test
+    void listRevokeCertificateAttributes_delegatesToAdapter() throws Exception {
+        List<BaseAttribute> expected = List.of(mock(BaseAttribute.class));
+        when(adapter.listRevokeAttributes(authority, raProfile)).thenReturn(expected);
+
+        assertSame(expected, service.listRevokeCertificateAttributes(raProfile));
+    }
+
+    @Test
+    void mergeAndValidateRevokeAttributes_usesRevokeOperationAndDefinitions() throws Exception {
+        List<RequestAttribute> attrs = List.of(mock(RequestAttribute.class));
+        List<BaseAttribute> definitions = List.of(mock(BaseAttribute.class));
+        when(adapter.listRevokeAttributes(authority, raProfile)).thenReturn(definitions);
+
+        service.mergeAndValidateRevokeAttributes(raProfile, attrs);
+
+        InOrder order = inOrder(adapter, attributeEngine);
+        order.verify(adapter).validateRevokeAttributes(authority, attrs);
+        order.verify(adapter).listRevokeAttributes(authority, raProfile);
+        order.verify(attributeEngine).validateUpdateDataAttributes(
+                connector.getUuid(), AttributeOperation.CERTIFICATE_REVOKE, definitions, attrs);
+    }
+}

--- a/src/test/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImplTest.java
@@ -158,7 +158,7 @@ class ExtendedAttributeServiceImplTest {
         assertNotNull(captor.getValue());
         assertTrue(captor.getValue().isEmpty());
         verify(attributeEngine).validateUpdateDataAttributes(
-                eq(connector.getUuid()), eq(AttributeOperation.CERTIFICATE_ISSUE), eq(List.of()), eq(captor.getValue()));
+                connector.getUuid(), AttributeOperation.CERTIFICATE_ISSUE, List.of(), captor.getValue());
     }
 
     @Test


### PR DESCRIPTION
Routes certificate operations through the version-aware authority adapter layer (`AuthorityProviderAdapterFactory`) instead of calling the v2 connector API client directly, so they work for both v2 and v3 authority connectors:

- `ExtendedAttributeServiceImpl`: issue/revoke attribute listing and validation (`mergeAndValidateIssueAttributes`, `validateIssueCertificateAttributes`, `listRevokeCertificateAttributes`, `validateRevokeCertificateAttributes`, `mergeAndValidateRevokeAttributes`) now dispatch through the adapter; for v3 there is no connector-side `/validate` round-trip (Core validates against the listed definitions).
- `ClientOperationServiceImpl`: `renewCertificateAction`, `rekeyCertificateAction`, and `revokeCertificateAction` now use the adapter's `renew`/`revoke` operations.
- also routes CA certificate chain from authority via adapter methods

Split out of the RA profile adapter work (#1777) to keep the two scopes reviewable separately.

Fixes #1795 
Fixes #1794
