### PR TITLE
Fire CERTIFICATE_REGISTERED event on pre-registration completion

### DIFF
--- a/src/main/java/com/otilm/core/dao/repository/CertificateRegistrationAuthorizationRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CertificateRegistrationAuthorizationRepository.java
@@ -17,6 +17,9 @@ public interface CertificateRegistrationAuthorizationRepository extends JpaRepos
 
     Optional<CertificateRegistrationAuthorization> findByCertificateUuid(UUID certificateUuid);
 
+    /** Presence check for the fire guards — avoids loading the secret-bearing row just to test existence. */
+    boolean existsByCertificateUuid(UUID certificateUuid);
+
     /**
      * Pessimistic-write finder ({@code SELECT ... FOR UPDATE}) so a concurrent verify / failed-attempt update
      * serializes on the authorization row. Must run in a transaction; the lock must not span an external call.

--- a/src/main/java/com/otilm/core/events/data/EventDataBuilder.java
+++ b/src/main/java/com/otilm/core/events/data/EventDataBuilder.java
@@ -129,6 +129,15 @@ public class EventDataBuilder {
         return eventData;
     }
 
+    // Identity/authority only; the issuance deadline and credential come from the registration authorization and
+    // are filled in by CertificateRegisteredEventHandler (a static builder cannot resolve the encrypted challenge).
+    public static CertificateRegisteredEventData getCertificateRegisteredEventData(Certificate certificate) {
+        CertificateRegisteredEventData eventData = new CertificateRegisteredEventData();
+        setCertificateEventData(eventData, certificate);
+        setCertificateAuthorityData(eventData, certificate);
+        return eventData;
+    }
+
     private static void setCertificateEventData(CertificateEventData eventData, Certificate certificate) {
         eventData.setCertificateUuid(certificate.getUuid());
         eventData.setFingerprint(certificate.getFingerprint());

--- a/src/main/java/com/otilm/core/events/handlers/CertificateRegisteredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateRegisteredEventHandler.java
@@ -52,12 +52,20 @@ public class CertificateRegisteredEventHandler extends CertificateEventsHandler 
     @Override
     protected void sendFollowUpEventsNotifications(EventContext<Certificate> eventContext) {
         Certificate certificate = eventContext.getResourceObjects().getFirst();
-        Object eventData = eventContext.getResourceObjectsEventData().getFirst();
-        // Default recipient is the owner only (no groups) — a notification profile can override. The credential
-        // is delivered only on the external-provider path; the internal notification is informational.
+        Object fullEventData = eventContext.getResourceObjectsEventData().getFirst();
+        // The default (owner) notification is internal-only and never uses the credential; send a credential-free
+        // copy so the one-time secret does not ride the internal message onto the broker. External providers still
+        // receive the full data (with credential) via the trigger/profile message, published independently
+        // (TriggerEvaluator.performSendNotificationAction). Rebuild identity from the certificate so its fields
+        // cannot drift from the full payload.
+        CertificateRegisteredEventData internalData = EventDataBuilder.getCertificateRegisteredEventData(certificate);
+        if (fullEventData instanceof CertificateRegisteredEventData full) {
+            internalData.setCompletionDeadline(full.getCompletionDeadline());
+        }
+        // Default recipient is the owner only (no groups) — a notification profile can override.
         List<NotificationRecipient> recipients = NotificationRecipient.buildUsersAndGroupsNotificationRecipients(
                 certificate.getOwner() == null ? null : List.of(certificate.getOwner().getUuid()), null);
-        NotificationMessage notificationMessage = new NotificationMessage(eventContext.getEvent(), Resource.CERTIFICATE, certificate.getUuid(), null, recipients, eventData);
+        NotificationMessage notificationMessage = new NotificationMessage(eventContext.getEvent(), Resource.CERTIFICATE, certificate.getUuid(), null, recipients, internalData);
         applicationEventPublisher.publishEvent(notificationMessage);
     }
 

--- a/src/main/java/com/otilm/core/events/handlers/CertificateRegisteredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateRegisteredEventHandler.java
@@ -1,0 +1,67 @@
+package com.otilm.core.events.handlers;
+
+import com.otilm.api.model.common.events.data.CertificateRegisteredEventData;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.repository.CertificateRegistrationAuthorizationRepository;
+import com.otilm.core.dao.repository.CertificateRepository;
+import com.otilm.core.evaluator.CertificateTriggerEvaluator;
+import com.otilm.core.events.EventContext;
+import com.otilm.core.events.data.EventDataBuilder;
+import com.otilm.core.messaging.model.EventMessage;
+import com.otilm.core.messaging.model.NotificationMessage;
+import com.otilm.core.messaging.model.NotificationRecipient;
+import com.otilm.core.service.registration.RegistrationChallengeStore;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Transactional
+@Component(ResourceEvent.Codes.CERTIFICATE_REGISTERED)
+public class CertificateRegisteredEventHandler extends CertificateEventsHandler {
+
+    private final RegistrationChallengeStore registrationChallengeStore;
+    private final CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository;
+
+    protected CertificateRegisteredEventHandler(CertificateRepository repository, CertificateTriggerEvaluator ruleEvaluator,
+                                                RegistrationChallengeStore registrationChallengeStore,
+                                                CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository) {
+        super(repository, ruleEvaluator);
+        this.registrationChallengeStore = registrationChallengeStore;
+        this.registrationAuthorizationRepository = registrationAuthorizationRepository;
+    }
+
+    @Override
+    protected Object getEventData(Certificate certificate, Object eventMessageData) {
+        CertificateRegisteredEventData eventData = EventDataBuilder.getCertificateRegisteredEventData(certificate);
+        // The issuance deadline and the plaintext credential come from the registration authorization; the
+        // credential is recovered here (only this path decrypts it) and rides the event-data object to the
+        // external provider. It is excluded from the event-data toString and from the internal notification text.
+        registrationAuthorizationRepository.findByCertificateUuid(certificate.getUuid()).ifPresent(authorization -> {
+            if (authorization.getExpiresAt() != null) {
+                eventData.setIssuanceDeadline(authorization.getExpiresAt().toZonedDateTime());
+            }
+            eventData.setCredential(registrationChallengeStore.resolvePlaintext(authorization));
+        });
+        return eventData;
+    }
+
+    @Override
+    protected void sendFollowUpEventsNotifications(EventContext<Certificate> eventContext) {
+        Certificate certificate = eventContext.getResourceObjects().getFirst();
+        Object eventData = eventContext.getResourceObjectsEventData().getFirst();
+        // Default recipient is the owner only (no groups) — a notification profile can override. The credential
+        // is delivered only on the external-provider path; the internal notification is informational.
+        List<NotificationRecipient> recipients = NotificationRecipient.buildUsersAndGroupsNotificationRecipients(
+                certificate.getOwner() == null ? null : List.of(certificate.getOwner().getUuid()), null);
+        NotificationMessage notificationMessage = new NotificationMessage(eventContext.getEvent(), Resource.CERTIFICATE, certificate.getUuid(), null, recipients, eventData);
+        applicationEventPublisher.publishEvent(notificationMessage);
+    }
+
+    public static EventMessage constructEventMessage(UUID certificateUuid) {
+        return new EventMessage(ResourceEvent.CERTIFICATE_REGISTERED, Resource.CERTIFICATE, certificateUuid, null);
+    }
+}

--- a/src/main/java/com/otilm/core/events/handlers/CertificateRegisteredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateRegisteredEventHandler.java
@@ -42,7 +42,7 @@ public class CertificateRegisteredEventHandler extends CertificateEventsHandler 
         // external provider. It is excluded from the event-data toString and from the internal notification text.
         registrationAuthorizationRepository.findByCertificateUuid(certificate.getUuid()).ifPresent(authorization -> {
             if (authorization.getExpiresAt() != null) {
-                eventData.setIssuanceDeadline(authorization.getExpiresAt().toZonedDateTime());
+                eventData.setCompletionDeadline(authorization.getExpiresAt().toZonedDateTime());
             }
             eventData.setCredential(registrationChallengeStore.resolvePlaintext(authorization));
         });

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/AbstractJmsEndpointConfig.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/AbstractJmsEndpointConfig.java
@@ -91,7 +91,9 @@ public abstract class AbstractJmsEndpointConfig<T> {
                     context.setAttribute("messageClass", messageClass.getSimpleName());
 
                     String json = extractMessageText(jmsMessage, endpointId);
-                    logger.debug("Message JSON in endpoint {}: {}", endpointId, json);
+                    // Log only metadata, never the body: message payloads can carry secrets (e.g. a
+                    // registration credential) that would otherwise leak into DEBUG logs in cleartext.
+                    logger.debug("Message received in endpoint {}: type={} size={}", endpointId, messageClass.getSimpleName(), json.length());
                     T message = objectMapper.readValue(json, messageClass);
                     listenerMessageProcessor.processMessage(message);
                 } catch (JmsException | JMSException | IOException e) {

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
@@ -464,7 +464,7 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
             try {
                 eventProducer.produceMessage(CertificateRegisteredEventHandler.constructEventMessage(certificateUuid));
             } catch (RuntimeException e) {
-                logger.warn("Failed to produce CERTIFICATE_REGISTERED event for cert {}: {}", certificateUuid, e.getMessage());
+                logger.warn("Failed to produce CERTIFICATE_REGISTERED event for cert {}", certificateUuid, e);
             }
         }
     }

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
@@ -12,9 +12,12 @@ import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.repository.CertificateRegistrationAuthorizationRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
+import com.otilm.core.events.handlers.CertificateRegisteredEventHandler;
 import com.otilm.core.events.transaction.TransactionHandler;
 import com.otilm.core.messaging.jms.configuration.StatusPollProperties;
+import com.otilm.core.messaging.jms.producers.EventProducer;
 import com.otilm.core.messaging.model.CertificateStatusPollMessage;
 import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.handler.authority.AsyncOperationCapability;
@@ -34,6 +37,7 @@ import org.springframework.dao.TransientDataAccessException;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Consumes {@link CertificateStatusPollMessage}s and drives the async-operation polling loop.
@@ -69,6 +73,8 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
     private TransactionHandler transactionHandler;
     private CertificateInternalService certificateService;
     private CertificateRevocationFinalizer revocationFinalizer;
+    private EventProducer eventProducer;
+    private CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository;
 
     @Override
     public void processMessage(CertificateStatusPollMessage msg) throws MessageHandlingException {
@@ -168,6 +174,7 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
             // (a completed REVOKE must still destroy the key).
             revocationFinalizer.destroyKeyIfRequested(resolution.keyCleanup(), cert.getUuid());
             updateMetaAfterCommit(cert, op, status);
+            fireRegistrationEventIfCompleted(cert.getUuid(), op, status.status());
         }
         // Stop polling — safe even when a racing actor resolved it: the unique constraint means one poll row per cert.
         stopPolling(cert, op);
@@ -435,5 +442,25 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
     @Autowired
     public void setRevocationFinalizer(CertificateRevocationFinalizer revocationFinalizer) {
         this.revocationFinalizer = revocationFinalizer;
+    }
+
+    @Autowired
+    public void setEventProducer(EventProducer eventProducer) {
+        this.eventProducer = eventProducer;
+    }
+
+    @Autowired
+    public void setRegistrationAuthorizationRepository(CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository) {
+        this.registrationAuthorizationRepository = registrationAuthorizationRepository;
+    }
+
+    // Fire the Certificate Registered event when an async pre-registration completes — only for challenge-protected
+    // registrations (those with an authorization row). This region is post-commit (the terminal transition already
+    // committed), so the event is never emitted for a registration that rolled back.
+    private void fireRegistrationEventIfCompleted(UUID certificateUuid, CertificateOperation op, CertificateOperationStatus status) {
+        if (op == CertificateOperation.REGISTER && status == CertificateOperationStatus.COMPLETED
+                && registrationAuthorizationRepository.findByCertificateUuid(certificateUuid).isPresent()) {
+            eventProducer.produceMessage(CertificateRegisteredEventHandler.constructEventMessage(certificateUuid));
+        }
     }
 }

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
@@ -458,11 +458,13 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
     // registrations (those with an authorization row). This region is post-commit (the terminal transition already
     // committed), so the event is never emitted for a registration that rolled back.
     private void fireRegistrationEventIfCompleted(UUID certificateUuid, CertificateOperation op, CertificateOperationStatus status) {
-        if (op == CertificateOperation.REGISTER && status == CertificateOperationStatus.COMPLETED
-                && registrationAuthorizationRepository.existsByCertificateUuid(certificateUuid)) {
-            // Best-effort, like the sibling post-commit side effects: a produce failure must not abort stopPolling.
+        if (op == CertificateOperation.REGISTER && status == CertificateOperationStatus.COMPLETED) {
+            // Best-effort, like the sibling post-commit side effects: neither the authorization lookup nor the
+            // produce must abort stopPolling.
             try {
-                eventProducer.produceMessage(CertificateRegisteredEventHandler.constructEventMessage(certificateUuid));
+                if (registrationAuthorizationRepository.existsByCertificateUuid(certificateUuid)) {
+                    eventProducer.produceMessage(CertificateRegisteredEventHandler.constructEventMessage(certificateUuid));
+                }
             } catch (RuntimeException e) {
                 logger.warn("Failed to produce CERTIFICATE_REGISTERED event for cert {}", certificateUuid, e);
             }

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
@@ -459,8 +459,13 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
     // committed), so the event is never emitted for a registration that rolled back.
     private void fireRegistrationEventIfCompleted(UUID certificateUuid, CertificateOperation op, CertificateOperationStatus status) {
         if (op == CertificateOperation.REGISTER && status == CertificateOperationStatus.COMPLETED
-                && registrationAuthorizationRepository.findByCertificateUuid(certificateUuid).isPresent()) {
-            eventProducer.produceMessage(CertificateRegisteredEventHandler.constructEventMessage(certificateUuid));
+                && registrationAuthorizationRepository.existsByCertificateUuid(certificateUuid)) {
+            // Best-effort, like the sibling post-commit side effects: a produce failure must not abort stopPolling.
+            try {
+                eventProducer.produceMessage(CertificateRegisteredEventHandler.constructEventMessage(certificateUuid));
+            } catch (RuntimeException e) {
+                logger.warn("Failed to produce CERTIFICATE_REGISTERED event for cert {}: {}", certificateUuid, e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -78,7 +78,9 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
 
     @Override
     public void processMessage(NotificationMessage message) {
-        logger.debug("Received notification message: {}", message);
+        // Log only identifiers, never the whole message: after the JMS round-trip `data` is an untyped map, so
+        // a payload secret (e.g. a registration credential) would print in cleartext despite the DTO's toString exclusion.
+        logger.debug("Received notification message: event={} resource={} object={}", message.getEvent(), message.getResource(), message.getObjectUuid());
 
         if (message.getNotificationProfileUuids() == null) {
             try {
@@ -505,7 +507,8 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
                 CertificateRegisteredEventData data = (CertificateRegisteredEventData) eventData;
                 // Informational only — the credential is delivered on the external-provider path and must never be
                 // written here (this text/detail is persisted to the notifications table).
-                yield new InternalNotificationEventData("Certificate identified as '%s' has been pre-registered".formatted(data.getSubjectDn()),
+                yield new InternalNotificationEventData(
+                        "Certificate identified as '%s' has been pre-registered and is awaiting issuance completion".formatted(data.getSubjectDn()),
                         data.getCompletionDeadline() == null ? null : "Issuance must be completed by %s".formatted(data.getCompletionDeadline()));
             }
         };

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -265,6 +265,13 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
                     recipients.add(new NotificationRecipient(RecipientType.USER, eventData.getUserUuid()));
                 }
             }
+            case CERTIFICATE_REGISTERED -> {
+                // Owner only by default (no groups) — a credential-bearing event; a profile can override.
+                NameAndUuidDto ownerInfo = resourceObjectAssociationService.getOwner(resource, objectUuid);
+                if (ownerInfo != null) {
+                    recipients.add(new NotificationRecipient(RecipientType.USER, UUID.fromString(ownerInfo.getUuid())));
+                }
+            }
         }
 
         return recipients;
@@ -493,6 +500,13 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
             case SCHEDULED_JOB_FINISHED -> {
                 ScheduledJobFinishedEventData data = (ScheduledJobFinishedEventData) eventData;
                 yield new InternalNotificationEventData("%s scheduled task has finished for %s with result %s".formatted(data.getJobType(), data.getJobName(), data.getStatus()), null);
+            }
+            case CERTIFICATE_REGISTERED -> {
+                CertificateRegisteredEventData data = (CertificateRegisteredEventData) eventData;
+                // Informational only — the credential is delivered on the external-provider path and must never be
+                // written here (this text/detail is persisted to the notifications table).
+                yield new InternalNotificationEventData("Certificate identified as '%s' has been pre-registered".formatted(data.getSubjectDn()),
+                        data.getIssuanceDeadline() == null ? null : "Issuance must be completed by %s".formatted(data.getIssuanceDeadline()));
             }
         };
     }

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -506,7 +506,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
                 // Informational only — the credential is delivered on the external-provider path and must never be
                 // written here (this text/detail is persisted to the notifications table).
                 yield new InternalNotificationEventData("Certificate identified as '%s' has been pre-registered".formatted(data.getSubjectDn()),
-                        data.getIssuanceDeadline() == null ? null : "Issuance must be completed by %s".formatted(data.getIssuanceDeadline()));
+                        data.getCompletionDeadline() == null ? null : "Issuance must be completed by %s".formatted(data.getCompletionDeadline()));
             }
         };
     }

--- a/src/main/java/com/otilm/core/messaging/jms/producers/NotificationProducer.java
+++ b/src/main/java/com/otilm/core/messaging/jms/producers/NotificationProducer.java
@@ -49,7 +49,7 @@ public class NotificationProducer {
     public void produceMessage(@NonNull final NotificationMessage notificationMessage) {
         Objects.requireNonNull(notificationMessage, "Notification message cannot be null");
         if ((notificationMessage.getNotificationProfileUuids() == null || notificationMessage.getNotificationProfileUuids().isEmpty()) && (notificationMessage.getRecipients() == null || notificationMessage.getRecipients().isEmpty())) {
-            logger.warn("Recipients for notification of event {} is empty. Message: {}", notificationMessage.getEvent().getLabel(), notificationMessage);
+            logger.warn("Recipients for notification of event {} (resource {} {}) are empty; not sending.", notificationMessage.getEvent().getLabel(), notificationMessage.getResource(), notificationMessage.getObjectUuid());
         } else {
             sendMessage(notificationMessage);
         }

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -622,7 +622,14 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         // Fire the Certificate Registered event only for challenge-protected pre-registrations (those with an
         // authorization row); an operator registration without a challenge has no credential to deliver.
         if (registrationAuthorizationRepository.existsByCertificateUuid(certificateUuid)) {
-            eventProducer.produceMessage(CertificateRegisteredEventHandler.constructEventMessage(certificateUuid));
+            // Best-effort: the certificate is already committed REGISTERED, so a produce failure must not fail the
+            // caller (which would be a false failure and could drive a re-registration). Delivery durability is
+            // tracked separately.
+            try {
+                eventProducer.produceMessage(CertificateRegisteredEventHandler.constructEventMessage(certificateUuid));
+            } catch (RuntimeException e) {
+                logger.warn("Failed to produce CERTIFICATE_REGISTERED event for cert {}", certificateUuid, e);
+            }
         }
     }
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -51,6 +51,7 @@ import com.otilm.core.dao.repository.CertificateRegistrationRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
 import com.otilm.core.events.handlers.CertificateActionPerformedEventHandler;
+import com.otilm.core.events.handlers.CertificateRegisteredEventHandler;
 import com.otilm.core.logging.LoggerWrapper;
 import com.otilm.core.messaging.jms.producers.ActionProducer;
 import com.otilm.core.messaging.jms.producers.EventProducer;
@@ -510,6 +511,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         } else {
             stateMachine.transition(certificate, CertificateState.REGISTERED);
             logger.info("Certificate {} registered by authority", certificate.getUuid());
+            fireRegistrationEventIfChallengeProtected(certificate.getUuid());
         }
 
         ClientCertificateDataResponseDto response = new ClientCertificateDataResponseDto();
@@ -613,6 +615,14 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             registrationAuthorizationWriter.deleteByCertificateUuid(certificateUuid);
         } catch (RuntimeException e) {
             logger.warn("Failed to remove the registration authorization for failed certificate {}: {}", certificateUuid, e.getMessage());
+        }
+    }
+
+    private void fireRegistrationEventIfChallengeProtected(UUID certificateUuid) {
+        // Fire the Certificate Registered event only for challenge-protected pre-registrations (those with an
+        // authorization row); an operator registration without a challenge has no credential to deliver.
+        if (registrationAuthorizationRepository.findByCertificateUuid(certificateUuid).isPresent()) {
+            eventProducer.produceMessage(CertificateRegisteredEventHandler.constructEventMessage(certificateUuid));
         }
     }
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -621,15 +621,15 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     private void fireRegistrationEventIfChallengeProtected(UUID certificateUuid) {
         // Fire the Certificate Registered event only for challenge-protected pre-registrations (those with an
         // authorization row); an operator registration without a challenge has no credential to deliver.
-        if (registrationAuthorizationRepository.existsByCertificateUuid(certificateUuid)) {
-            // Best-effort: the certificate is already committed REGISTERED, so a produce failure must not fail the
-            // caller (which would be a false failure and could drive a re-registration). Delivery durability is
-            // tracked separately.
-            try {
+        // Best-effort: the certificate is already committed REGISTERED, so neither the authorization lookup nor the
+        // produce may fail the caller (a false failure could drive a re-registration). Delivery durability is
+        // tracked separately. The whole side effect — lookup included — is inside the guard.
+        try {
+            if (registrationAuthorizationRepository.existsByCertificateUuid(certificateUuid)) {
                 eventProducer.produceMessage(CertificateRegisteredEventHandler.constructEventMessage(certificateUuid));
-            } catch (RuntimeException e) {
-                logger.warn("Failed to produce CERTIFICATE_REGISTERED event for cert {}", certificateUuid, e);
             }
+        } catch (RuntimeException e) {
+            logger.warn("Failed to produce CERTIFICATE_REGISTERED event for cert {}", certificateUuid, e);
         }
     }
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -621,7 +621,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     private void fireRegistrationEventIfChallengeProtected(UUID certificateUuid) {
         // Fire the Certificate Registered event only for challenge-protected pre-registrations (those with an
         // authorization row); an operator registration without a challenge has no credential to deliver.
-        if (registrationAuthorizationRepository.findByCertificateUuid(certificateUuid).isPresent()) {
+        if (registrationAuthorizationRepository.existsByCertificateUuid(certificateUuid)) {
             eventProducer.produceMessage(CertificateRegisteredEventHandler.constructEventMessage(certificateUuid));
         }
     }

--- a/src/test/java/com/otilm/core/events/handlers/CertificateRegisteredEventHandlerTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CertificateRegisteredEventHandlerTest.java
@@ -44,7 +44,7 @@ class CertificateRegisteredEventHandlerTest {
         CertificateRegisteredEventData data = (CertificateRegisteredEventData) handler.getEventData(certificate, null);
 
         assertEquals("s3cret-challenge", data.getCredential(), "credential is recovered for external delivery");
-        assertNotNull(data.getIssuanceDeadline(), "issuance deadline comes from the authorization");
+        assertNotNull(data.getCompletionDeadline(), "completion deadline comes from the authorization");
         assertEquals("CN=device-7", data.getSubjectDn());
         assertFalse(data.toString().contains("s3cret-challenge"), "credential must not leak via the event-data toString");
     }
@@ -59,6 +59,6 @@ class CertificateRegisteredEventHandlerTest {
         CertificateRegisteredEventData data = (CertificateRegisteredEventData) handler.getEventData(certificate, null);
 
         assertNull(data.getCredential());
-        assertNull(data.getIssuanceDeadline());
+        assertNull(data.getCompletionDeadline());
     }
 }

--- a/src/test/java/com/otilm/core/events/handlers/CertificateRegisteredEventHandlerTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CertificateRegisteredEventHandlerTest.java
@@ -1,15 +1,25 @@
 package com.otilm.core.events.handlers;
 
 import com.otilm.api.model.common.events.data.CertificateRegisteredEventData;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.RecipientType;
+import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CertificateRegistrationAuthorization;
+import com.otilm.core.dao.entity.OwnerAssociation;
 import com.otilm.core.dao.repository.CertificateRegistrationAuthorizationRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.evaluator.CertificateTriggerEvaluator;
+import com.otilm.core.events.EventContext;
+import com.otilm.core.messaging.model.EventMessage;
+import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.service.registration.RegistrationChallengeStore;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -18,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class CertificateRegisteredEventHandlerTest {
@@ -60,5 +71,41 @@ class CertificateRegisteredEventHandlerTest {
 
         assertNull(data.getCredential());
         assertNull(data.getCompletionDeadline());
+    }
+
+    @Test
+    void sendFollowUpPublishesOwnerOnlyInternalNotificationWithoutCredential() {
+        ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+        handler.setApplicationEventPublisher(publisher);
+
+        UUID certUuid = UUID.randomUUID();
+        UUID ownerUuid = UUID.randomUUID();
+        Certificate certificate = new Certificate();
+        certificate.setUuid(certUuid);
+        certificate.setSubjectDn("CN=device-7");
+        OwnerAssociation owner = new OwnerAssociation();
+        owner.setUuid(ownerUuid);
+        certificate.setOwner(owner);
+
+        CertificateRegisteredEventData full = new CertificateRegisteredEventData();
+        full.setSubjectDn("CN=device-7");
+        full.setCompletionDeadline(ZonedDateTime.parse("2026-08-01T00:00:00Z"));
+        full.setCredential("s3cret-challenge");
+
+        EventMessage eventMessage = new EventMessage(ResourceEvent.CERTIFICATE_REGISTERED, Resource.CERTIFICATE, certUuid, null);
+        EventContext<Certificate> ctx = new EventContext<>(eventMessage, mock(CertificateTriggerEvaluator.class), certificate, full);
+
+        handler.sendFollowUpEventsNotifications(ctx);
+
+        ArgumentCaptor<NotificationMessage> captor = ArgumentCaptor.forClass(NotificationMessage.class);
+        verify(publisher).publishEvent(captor.capture());
+        NotificationMessage msg = captor.getValue();
+        assertNull(msg.getNotificationProfileUuids(), "default notification is internal (no profile)");
+        assertEquals(1, msg.getRecipients().size(), "owner-only recipient (no groups)");
+        assertEquals(RecipientType.USER, msg.getRecipients().get(0).getRecipientType());
+        assertEquals(ownerUuid, msg.getRecipients().get(0).getRecipientUuid());
+        CertificateRegisteredEventData internal = (CertificateRegisteredEventData) msg.getData();
+        assertNull(internal.getCredential(), "the internal message must not carry the credential");
+        assertEquals("CN=device-7", internal.getSubjectDn(), "identity is preserved for the internal notification");
     }
 }

--- a/src/test/java/com/otilm/core/events/handlers/CertificateRegisteredEventHandlerTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CertificateRegisteredEventHandlerTest.java
@@ -1,0 +1,64 @@
+package com.otilm.core.events.handlers;
+
+import com.otilm.api.model.common.events.data.CertificateRegisteredEventData;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.CertificateRegistrationAuthorization;
+import com.otilm.core.dao.repository.CertificateRegistrationAuthorizationRepository;
+import com.otilm.core.dao.repository.CertificateRepository;
+import com.otilm.core.evaluator.CertificateTriggerEvaluator;
+import com.otilm.core.service.registration.RegistrationChallengeStore;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CertificateRegisteredEventHandlerTest {
+
+    private final CertificateRegistrationAuthorizationRepository authorizationRepository =
+            mock(CertificateRegistrationAuthorizationRepository.class);
+    private final RegistrationChallengeStore challengeStore = mock(RegistrationChallengeStore.class);
+    private final CertificateRegisteredEventHandler handler = new CertificateRegisteredEventHandler(
+            mock(CertificateRepository.class), mock(CertificateTriggerEvaluator.class), challengeStore, authorizationRepository);
+
+    @Test
+    void getEventDataResolvesCredentialAndDeadlineAndKeepsCredentialOutOfToString() {
+        UUID certUuid = UUID.randomUUID();
+        Certificate certificate = new Certificate();
+        certificate.setUuid(certUuid);
+        certificate.setSubjectDn("CN=device-7");
+
+        CertificateRegistrationAuthorization authorization = new CertificateRegistrationAuthorization();
+        authorization.setCertificateUuid(certUuid);
+        authorization.setExpiresAt(OffsetDateTime.parse("2026-08-01T00:00:00Z"));
+        when(authorizationRepository.findByCertificateUuid(certUuid)).thenReturn(Optional.of(authorization));
+        when(challengeStore.resolvePlaintext(authorization)).thenReturn("s3cret-challenge");
+
+        CertificateRegisteredEventData data = (CertificateRegisteredEventData) handler.getEventData(certificate, null);
+
+        assertEquals("s3cret-challenge", data.getCredential(), "credential is recovered for external delivery");
+        assertNotNull(data.getIssuanceDeadline(), "issuance deadline comes from the authorization");
+        assertEquals("CN=device-7", data.getSubjectDn());
+        assertFalse(data.toString().contains("s3cret-challenge"), "credential must not leak via the event-data toString");
+    }
+
+    @Test
+    void getEventDataWithoutAuthorizationLeavesCredentialNull() {
+        UUID certUuid = UUID.randomUUID();
+        Certificate certificate = new Certificate();
+        certificate.setUuid(certUuid);
+        when(authorizationRepository.findByCertificateUuid(certUuid)).thenReturn(Optional.empty());
+
+        CertificateRegisteredEventData data = (CertificateRegisteredEventData) handler.getEventData(certificate, null);
+
+        assertNull(data.getCredential());
+        assertNull(data.getIssuanceDeadline());
+    }
+}

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -9,6 +9,7 @@ import com.otilm.api.model.client.connector.v2.ConnectorVersion;
 import com.otilm.api.model.client.connector.v2.FeatureFlag;
 import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.certificate.CertificateType;
+import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
@@ -47,6 +48,8 @@ import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
 import com.otilm.core.exception.ConnectorAcceptedButLocalFailureException;
 import com.otilm.core.messaging.jms.producers.ActionProducer;
+import com.otilm.core.messaging.jms.producers.EventProducer;
+import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
@@ -138,6 +141,10 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     // Mocked so issue enqueue is a deterministic no-op (no async action processing during the test).
     @MockitoBean
     private ActionProducer actionProducer;
+
+    // Mocked so the Certificate Registered event fire is a verifiable no-op (no JMS during the test).
+    @MockitoBean
+    private EventProducer eventProducer;
 
     // The service-layer capability gate (layer 2). Mocked here so each test controls advertisement
     // directly; the real flag-resolution logic is covered by ConnectorCapabilityServiceTest.
@@ -940,6 +947,31 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
                 () -> clientOperationService.rekeyCertificate(authorityParent, securedRaProfile, certUuid, request));
         Assertions.assertTrue(ex.getMessage().contains("not supported yet"),
                 "the fail-closed guard must reject rekey too (verification comes later)");
+    }
+
+    @Test
+    void registerWithSecretFiresCertificateRegisteredEvent() throws Exception {
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
+        ClientCertificateRegistrationDto request = registrationRequest();
+        request.setAuthorizationSecret(CHALLENGE);
+
+        clientOperationService.registerCertificate(authorityParent, securedRaProfile, request);
+
+        ArgumentCaptor<EventMessage> captor = ArgumentCaptor.forClass(EventMessage.class);
+        verify(eventProducer).produceMessage(captor.capture());
+        Assertions.assertEquals(ResourceEvent.CERTIFICATE_REGISTERED, captor.getValue().getEvent(),
+                "a challenge-protected pre-registration fires the Certificate Registered event");
+    }
+
+    @Test
+    void registerWithoutSecretFiresNoRegistrationEvent() throws Exception {
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
+
+        clientOperationService.registerCertificate(authorityParent, securedRaProfile, registrationRequest());
+
+        verify(eventProducer, never()).produceMessage(Mockito.any());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -975,6 +975,22 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     }
 
     @Test
+    void registerSucceedsWhenRegistrationEventProduceFails() throws Exception {
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
+        doThrow(new RuntimeException("broker down")).when(eventProducer).produceMessage(Mockito.any());
+        ClientCertificateRegistrationDto request = registrationRequest();
+        request.setAuthorizationSecret(CHALLENGE);
+
+        // Best-effort fire: the cert is already committed REGISTERED, so a produce failure must not fail the caller.
+        ClientCertificateDataResponseDto response =
+                clientOperationService.registerCertificate(authorityParent, securedRaProfile, request);
+
+        Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
+        Assertions.assertEquals(CertificateState.REGISTERED, cert.getState());
+    }
+
+    @Test
     void registrationStoreFailureFailsPlaceholderInsteadOfOrphaning() {
         // A local authorization-store failure (encryption/persistence) must fail the placeholder via the
         // pre-acceptance catch, not leave it stranded in PENDING_REGISTRATION with no authorization.

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
@@ -374,6 +374,22 @@ class CertificateStatusPollListenerTest {
     }
 
     @Test
+    void registerEventProduceFailureDoesNotAbortPollCleanup() throws MessageHandlingException, ConnectorException {
+        Certificate cert = certInState(CertificateState.PENDING_REGISTRATION);
+        when(certificateRepository.findForPollingByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        when(asyncAdapter.pollStatus(cert, CertificateOperation.REGISTER))
+                .thenReturn(new StatusPollResult(CertificateOperationStatus.COMPLETED, null, null, null));
+        when(certificateRepository.findAndLockWithAssociationsByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        when(registrationAuthorizationRepository.existsByCertificateUuid(CERT_UUID)).thenReturn(true);
+        doThrow(new RuntimeException("broker down")).when(eventProducer).produceMessage(Mockito.any());
+
+        // Best-effort fire: a produce failure must not propagate or abort poll-row cleanup.
+        listener.processMessage(pollMsg(CertificateOperation.REGISTER, 0));
+
+        verify(pollWriter).delete(CERT_UUID);
+    }
+
+    @Test
     void completedRegisterDoesNotFireEventWhenNoAuthorization() throws MessageHandlingException, ConnectorException {
         Certificate cert = certInState(CertificateState.PENDING_REGISTRATION);
         when(certificateRepository.findForPollingByUuid(CERT_UUID)).thenReturn(Optional.of(cert));

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
@@ -11,7 +11,9 @@ import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.dao.repository.CertificateRegistrationAuthorizationRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
+import com.otilm.core.messaging.jms.producers.EventProducer;
 import com.otilm.core.messaging.jms.configuration.StatusPollProperties;
 import com.otilm.core.messaging.model.CertificateStatusPollMessage;
 import com.otilm.core.service.handler.authority.AsyncOperationCapability;
@@ -62,8 +64,8 @@ class CertificateStatusPollListenerTest {
     @Mock private com.otilm.core.service.CertificateInternalService certificateService;
     @Mock private com.otilm.core.service.handler.authority.lifecycle.CertificateRevocationFinalizer revocationFinalizer;
     @Mock private com.otilm.core.service.writer.registration.CertificateRegistrationWriter registrationWriter;
-    @Mock private com.otilm.core.messaging.jms.producers.EventProducer eventProducer;
-    @Mock private com.otilm.core.dao.repository.CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository;
+    @Mock private EventProducer eventProducer;
+    @Mock private CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository;
 
     /**
      * Combined mock implementing both AuthorityProviderAdapter and AsyncOperationCapability.

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
@@ -60,6 +60,8 @@ class CertificateStatusPollListenerTest {
     @Mock private com.otilm.core.service.CertificateInternalService certificateService;
     @Mock private com.otilm.core.service.handler.authority.lifecycle.CertificateRevocationFinalizer revocationFinalizer;
     @Mock private com.otilm.core.service.writer.registration.CertificateRegistrationWriter registrationWriter;
+    @Mock private com.otilm.core.messaging.jms.producers.EventProducer eventProducer;
+    @Mock private com.otilm.core.dao.repository.CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository;
 
     /**
      * Combined mock implementing both AuthorityProviderAdapter and AsyncOperationCapability.
@@ -90,6 +92,8 @@ class CertificateStatusPollListenerTest {
         listener.setCertificateService(certificateService);
         listener.setRevocationFinalizer(revocationFinalizer);
         listener.setRegistrationWriter(registrationWriter);
+        listener.setEventProducer(eventProducer);
+        listener.setRegistrationAuthorizationRepository(registrationAuthorizationRepository);
 
         StatusPollProperties.PollSchedule schedule = mock(StatusPollProperties.PollSchedule.class);
         lenient().when(schedule.maxAttempts()).thenReturn(3);
@@ -103,6 +107,11 @@ class CertificateStatusPollListenerTest {
         lenient().doAnswer(inv -> ((Supplier<?>) inv.getArgument(0)).get())
                 .when(transactionHandler).runInNewTransaction(any(Supplier.class));
         lenient().when(adapterFactory.forAuthority(any())).thenReturn(adapter);
+        // Default: no registration authorization, so the register-completion event does not fire in these
+        // binding/transition tests (the fire path is covered by the register ITest). Unstubbed, the Optional
+        // return would be null and the guard's isPresent() would NPE.
+        lenient().when(registrationAuthorizationRepository.findByCertificateUuid(any()))
+                .thenReturn(java.util.Optional.empty());
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 
+import com.otilm.api.model.core.other.ResourceEvent;
+
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -107,11 +109,9 @@ class CertificateStatusPollListenerTest {
         lenient().doAnswer(inv -> ((Supplier<?>) inv.getArgument(0)).get())
                 .when(transactionHandler).runInNewTransaction(any(Supplier.class));
         lenient().when(adapterFactory.forAuthority(any())).thenReturn(adapter);
-        // Default: no registration authorization, so the register-completion event does not fire in these
-        // binding/transition tests (the fire path is covered by the register ITest). Unstubbed, the Optional
-        // return would be null and the guard's isPresent() would NPE.
-        lenient().when(registrationAuthorizationRepository.findByCertificateUuid(any()))
-                .thenReturn(java.util.Optional.empty());
+        // Default: no registration authorization, so the register-completion event does not fire in the
+        // binding/transition tests. The dedicated fire tests below re-stub this to true.
+        lenient().when(registrationAuthorizationRepository.existsByCertificateUuid(any())).thenReturn(false);
     }
 
     // -----------------------------------------------------------------------
@@ -357,6 +357,48 @@ class CertificateStatusPollListenerTest {
         verify(registrationWriter).upsert(CERT_UUID, finalMeta);
         verify(stateMachine).transition(eq(cert), eq(CertificateState.REGISTERED), isNull(), anyString());
         verify(pollWriter).delete(CERT_UUID);
+    }
+
+    @Test
+    void completedRegisterFiresRegistrationEventWhenAuthorizationPresent() throws MessageHandlingException, ConnectorException {
+        Certificate cert = certInState(CertificateState.PENDING_REGISTRATION);
+        when(certificateRepository.findForPollingByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        when(asyncAdapter.pollStatus(cert, CertificateOperation.REGISTER))
+                .thenReturn(new StatusPollResult(CertificateOperationStatus.COMPLETED, null, null, null));
+        when(certificateRepository.findAndLockWithAssociationsByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        when(registrationAuthorizationRepository.existsByCertificateUuid(CERT_UUID)).thenReturn(true);
+
+        listener.processMessage(pollMsg(CertificateOperation.REGISTER, 0));
+
+        verify(eventProducer).produceMessage(Mockito.argThat(m -> m.getEvent() == ResourceEvent.CERTIFICATE_REGISTERED));
+    }
+
+    @Test
+    void completedRegisterDoesNotFireEventWhenNoAuthorization() throws MessageHandlingException, ConnectorException {
+        Certificate cert = certInState(CertificateState.PENDING_REGISTRATION);
+        when(certificateRepository.findForPollingByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        when(asyncAdapter.pollStatus(cert, CertificateOperation.REGISTER))
+                .thenReturn(new StatusPollResult(CertificateOperationStatus.COMPLETED, null, null, null));
+        when(certificateRepository.findAndLockWithAssociationsByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        // existsByCertificateUuid defaults to false (setUp)
+
+        listener.processMessage(pollMsg(CertificateOperation.REGISTER, 0));
+
+        verify(eventProducer, never()).produceMessage(any());
+    }
+
+    @Test
+    void completedIssueDoesNotFireRegistrationEvent() throws Exception {
+        Certificate cert = certInState(CertificateState.PENDING_ISSUE);
+        when(certificateRepository.findForPollingByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        when(asyncAdapter.pollStatus(cert, CertificateOperation.ISSUE))
+                .thenReturn(new StatusPollResult(CertificateOperationStatus.COMPLETED, "PEMDATA", null, "OK"));
+        when(certificateRepository.findAndLockWithAssociationsByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        lenient().when(registrationAuthorizationRepository.existsByCertificateUuid(CERT_UUID)).thenReturn(true);
+
+        listener.processMessage(pollMsg(CertificateOperation.ISSUE, 0));
+
+        verify(eventProducer, never()).produceMessage(any());
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/NotificationListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/NotificationListenerTest.java
@@ -1,0 +1,83 @@
+package com.otilm.core.messaging.jms.listeners;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.otilm.api.model.common.events.data.CertificateRegisteredEventData;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.RecipientType;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.client.ConnectorApiFactory;
+import com.otilm.core.dao.repository.GroupRepository;
+import com.otilm.core.dao.repository.notifications.NotificationInstanceReferenceRepository;
+import com.otilm.core.dao.repository.notifications.NotificationProfileVersionRepository;
+import com.otilm.core.dao.repository.notifications.PendingNotificationRepository;
+import com.otilm.core.messaging.model.NotificationMessage;
+import com.otilm.core.messaging.model.NotificationRecipient;
+import com.otilm.core.security.authn.client.RoleManagementApiClient;
+import com.otilm.core.security.authn.client.UserManagementApiClient;
+import com.otilm.core.service.NotificationInternalService;
+import com.otilm.core.service.ResourceObjectAssociationService;
+import com.otilm.core.service.TriggerInternalService;
+import com.otilm.core.service.v2.ConnectorInternalService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class NotificationListenerTest {
+
+    private final NotificationInternalService notificationService = mock(NotificationInternalService.class);
+
+    private NotificationListener listener() {
+        ObjectMapper realMapper = JsonMapper.builder().findAndAddModules().build();
+        return new NotificationListener(
+                realMapper,
+                mock(AttributeEngine.class),
+                notificationService,
+                mock(TriggerInternalService.class),
+                mock(ConnectorApiFactory.class),
+                mock(ConnectorInternalService.class),
+                mock(PendingNotificationRepository.class),
+                mock(NotificationProfileVersionRepository.class),
+                mock(NotificationInstanceReferenceRepository.class),
+                mock(GroupRepository.class),
+                mock(UserManagementApiClient.class),
+                mock(RoleManagementApiClient.class),
+                mock(ResourceObjectAssociationService.class));
+    }
+
+    @Test
+    void certificateRegisteredInternalNotificationDescribesTheCertWithoutTheCredential() {
+        UUID certUuid = UUID.randomUUID();
+        UUID ownerUuid = UUID.randomUUID();
+        CertificateRegisteredEventData data = new CertificateRegisteredEventData();
+        data.setSubjectDn("CN=device-7");
+        data.setCompletionDeadline(ZonedDateTime.parse("2026-08-01T00:00:00Z"));
+        data.setCredential("s3cret-challenge-value");
+
+        // Default internal path: profileUuids == null, an owner USER recipient.
+        NotificationMessage message = new NotificationMessage(
+                ResourceEvent.CERTIFICATE_REGISTERED, Resource.CERTIFICATE, certUuid, null,
+                List.of(new NotificationRecipient(RecipientType.USER, ownerUuid)), data);
+
+        listener().processMessage(message);
+
+        ArgumentCaptor<String> text = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> detail = ArgumentCaptor.forClass(String.class);
+        verify(notificationService).createNotificationForUser(text.capture(), detail.capture(),
+                eq(ownerUuid.toString()), eq(Resource.CERTIFICATE), eq(certUuid.toString()));
+
+        assertTrue(text.getValue().contains("CN=device-7"), "the internal notification names the certificate");
+        assertFalse((text.getValue() + detail.getValue()).contains("s3cret-challenge-value"),
+                "the credential must never be written into the persisted internal notification");
+    }
+}


### PR DESCRIPTION
Part of #1571. Fires a `CERTIFICATE_REGISTERED` event when a challenge-protected pre-registration reaches `REGISTERED`, delivering the completion credential to the registrant. Consumes the event type added in interfaces#772.

## What it does
- **Event**: fired post-commit on both register-completion paths — synchronous (`registerCertificate`) and async (`CertificateStatusPollListener` REGISTER+COMPLETED) — exactly once, and **only** when the certificate carries a registration authorization (ordinary issuance fires nothing).
- **Payload** (`CertificateRegisteredEventData`): certificate identity + `completionDeadline` + the one-time `credential`. The handler recovers the plaintext credential via `RegistrationChallengeStore.resolvePlaintext` (only this path decrypts it).
- **Secret discipline**: the credential is delivered **only** on the external notification-provider path (rides the event-data object, forwarded verbatim as `notificationData`); it is excluded from `toString`/`equals`, omitted from the internal notification text/detail (which persists to the DB), and never touches event-history. Default recipient = certificate **owner** only; a notification profile can override.

## Scope
Does not fully close #1571: the AC's "fires on renew/rekey copy creation" is inherently deferred — copy-to-successor doesn't exist yet (lands with the R2 renew/rekey work). External credential delivery requires an operator-configured external notification provider on the event; otherwise the operator relays the challenge manually (documented fallback).

## Tests
`CertificateRegisteredEventHandlerTest` (2) — credential recovered + `completionDeadline` set + credential absent from `toString`; no-authorization → null. `ClientOperationServiceRegisterITest` (+fire/no-fire) — event produced once for a challenge-protected registration, nothing for ordinary issuance.
