### PR TITLE
Expose pre-registration settings, details, and failure handling

### DIFF
--- a/src/main/java/com/otilm/core/dao/repository/CertificateRegistrationAuthorizationRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CertificateRegistrationAuthorizationRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -20,6 +21,18 @@ public interface CertificateRegistrationAuthorizationRepository extends JpaRepos
 
     /** Presence check for the fire guards — avoids loading the secret-bearing row just to test existence. */
     boolean existsByCertificateUuid(UUID certificateUuid);
+
+    /** Projection over the non-secret detail fields, so the certificate-detail read never loads the challenge column. */
+    interface RegistrationDetailView {
+        RegistrationState getState();
+
+        OffsetDateTime getExpiresAt();
+
+        int getFailedAttempts();
+    }
+
+    /** Reads only the detail fields (no challenge ciphertext) for the read-only certificate-detail registration block. */
+    Optional<RegistrationDetailView> findDetailByCertificateUuid(UUID certificateUuid);
 
     /**
      * Pessimistic-write finder ({@code SELECT ... FOR UPDATE}) so a concurrent verify / failed-attempt update

--- a/src/main/java/com/otilm/core/dao/repository/CertificateRegistrationAuthorizationRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CertificateRegistrationAuthorizationRepository.java
@@ -1,6 +1,7 @@
 package com.otilm.core.dao.repository;
 
 import com.otilm.core.dao.entity.CertificateRegistrationAuthorization;
+import com.otilm.core.dao.entity.RegistrationState;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -30,4 +31,8 @@ public interface CertificateRegistrationAuthorizationRepository extends JpaRepos
     @Modifying
     @Query("DELETE FROM CertificateRegistrationAuthorization r WHERE r.certificateUuid = :certificateUuid")
     void deleteByCertificateUuid(@Param("certificateUuid") UUID certificateUuid);
+
+    @Modifying
+    @Query("UPDATE CertificateRegistrationAuthorization r SET r.state = :state, r.updated = CURRENT_TIMESTAMP WHERE r.certificateUuid = :certificateUuid")
+    void updateStateByCertificateUuid(@Param("certificateUuid") UUID certificateUuid, @Param("state") RegistrationState state);
 }

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
@@ -228,6 +228,7 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
                 // reach ISSUED without persisting a certificate, so fail it rather than reach an empty ISSUED.
                 stateMachine.transition(locked, op.terminalFailureState(), null,
                         "Async " + op + " reported COMPLETED but connector returned no certificate data");
+                closeRegistrationAuthorizationIfPresent(locked);
             }
             return CertificateRevocationFinalizer.KeyCleanup.NONE;
         }
@@ -246,6 +247,11 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
         }
         CertificateState targetState = completed ? op.terminalSuccessState() : op.terminalFailureState();
         stateMachine.transition(locked, targetState, null, reasonFor(op, status));
+        // Fate-coupling: only a terminal FAILED verdict retires a pre-registered cert's authorization. A failed
+        // REVOKE returns to ISSUED (not FAILED) and must keep its registration for renew/rekey reuse.
+        if (targetState == CertificateState.FAILED) {
+            closeRegistrationAuthorizationIfPresent(locked);
+        }
         return CertificateRevocationFinalizer.KeyCleanup.NONE;
     }
 
@@ -362,15 +368,23 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
             }
             CertificateState terminal = op.terminalFailureState();
             stateMachine.transition(locked, terminal, null, reason);
-            // Fate-coupling: on a terminal FAILED verdict, close a pre-registered cert's authorization in the same
-            // locked transaction. Only on FAILED — a failed REVOKE returns to ISSUED and must keep its registration.
-            if (terminal == CertificateState.FAILED
-                    && registrationAuthorizationRepository.existsByCertificateUuid(locked.getUuid())) {
-                registrationAuthorizationWriter.close(locked.getUuid());
+            if (terminal == CertificateState.FAILED) {
+                closeRegistrationAuthorizationIfPresent(locked);
             }
         });
         // Resolved (failed, or already resolved by a racing actor) — stop polling it.
         stopPolling(cert, op);
+    }
+
+    /**
+     * Retires a pre-registered certificate's authorization (state → CLOSED) in the caller's locked transaction
+     * when it reaches a terminal FAILED verdict. Guarded, so it is a no-op for non-self-service certs and for
+     * renew/rekey successors that carry no authorization.
+     */
+    private void closeRegistrationAuthorizationIfPresent(Certificate locked) {
+        if (registrationAuthorizationRepository.existsByCertificateUuid(locked.getUuid())) {
+            registrationAuthorizationWriter.close(locked.getUuid());
+        }
     }
 
 

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
@@ -387,7 +387,6 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
         }
     }
 
-
     /** Deletes the cert's poll row to stop polling, best-effort; a failed delete is dropped by the next poll. */
     private void stopPolling(Certificate cert, CertificateOperation op) {
         try {

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListener.java
@@ -28,6 +28,7 @@ import com.otilm.core.service.handler.authority.ConnectorOperationErrorCodes;
 import com.otilm.core.service.handler.authority.StatusPollResult;
 import com.otilm.core.service.handler.authority.lifecycle.CertificateRevocationFinalizer;
 import com.otilm.core.service.handler.authority.lifecycle.CertificateStateMachine;
+import com.otilm.core.service.writer.registration.CertificateRegistrationAuthorizationWriter;
 import com.otilm.core.service.writer.registration.CertificateRegistrationWriter;
 import com.otilm.core.service.writer.statuspoll.CertificateStatusPollWriter;
 import org.slf4j.Logger;
@@ -75,6 +76,7 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
     private CertificateRevocationFinalizer revocationFinalizer;
     private EventProducer eventProducer;
     private CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository;
+    private CertificateRegistrationAuthorizationWriter registrationAuthorizationWriter;
 
     @Override
     public void processMessage(CertificateStatusPollMessage msg) throws MessageHandlingException {
@@ -358,7 +360,14 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
             if (op == CertificateOperation.REVOKE) {
                 revocationFinalizer.clearPendingRevokeFields(locked);
             }
-            stateMachine.transition(locked, op.terminalFailureState(), null, reason);
+            CertificateState terminal = op.terminalFailureState();
+            stateMachine.transition(locked, terminal, null, reason);
+            // Fate-coupling: on a terminal FAILED verdict, close a pre-registered cert's authorization in the same
+            // locked transaction. Only on FAILED — a failed REVOKE returns to ISSUED and must keep its registration.
+            if (terminal == CertificateState.FAILED
+                    && registrationAuthorizationRepository.existsByCertificateUuid(locked.getUuid())) {
+                registrationAuthorizationWriter.close(locked.getUuid());
+            }
         });
         // Resolved (failed, or already resolved by a racing actor) — stop polling it.
         stopPolling(cert, op);
@@ -452,6 +461,11 @@ public class CertificateStatusPollListener implements MessageProcessor<Certifica
     @Autowired
     public void setRegistrationAuthorizationRepository(CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository) {
         this.registrationAuthorizationRepository = registrationAuthorizationRepository;
+    }
+
+    @Autowired
+    public void setRegistrationAuthorizationWriter(CertificateRegistrationAuthorizationWriter registrationAuthorizationWriter) {
+        this.registrationAuthorizationWriter = registrationAuthorizationWriter;
     }
 
     // Fire the Certificate Registered event when an async pre-registration completes — only for challenge-protected

--- a/src/main/java/com/otilm/core/service/handler/authority/lifecycle/CertificateStateTransition.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/lifecycle/CertificateStateTransition.java
@@ -53,6 +53,7 @@ public enum CertificateStateTransition {
     REGISTERED_TO_PENDING_ISSUE       (REGISTERED,           PENDING_ISSUE,        CertificateEvent.ISSUE,            CertificateEventStatus.SUCCESS),
     REGISTERED_TO_PENDING_APPROVAL    (REGISTERED,           PENDING_APPROVAL,     CertificateEvent.APPROVAL_REQUEST, CertificateEventStatus.SUCCESS),  // issuing a registered placeholder requires approval
     REGISTERED_TO_FAILED              (REGISTERED,           FAILED,               CertificateEvent.ISSUE,            CertificateEventStatus.FAILED),  // issuing a registered placeholder failed
+    PENDING_APPROVAL_TO_REGISTERED    (PENDING_APPROVAL,     REGISTERED,           CertificateEvent.APPROVAL_CLOSE,   CertificateEventStatus.FAILED),  // issuance approval rejected — restore the placeholder
 
     // Compliance rejection
     REQUESTED_TO_REJECTED             (REQUESTED,            REJECTED,             CertificateEvent.UPDATE_STATE,     CertificateEventStatus.FAILED),

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -493,8 +493,9 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
         dto.setCustomAttributes(attributeEngine.getObjectCustomAttributesContent(Resource.CERTIFICATE, certificate.getUuid()));
         dto.setRelatedCertificates(certificate.getSuccessorRelations().stream().map(r -> r.getSuccessorCertificate().mapToListDto()).toList());
         // Read-only registration block, present only for pre-registered certificates (those with an authorization
-        // row). The challenge is never exposed — only state, deadline, and failed-attempt count.
-        registrationAuthorizationRepository.findByCertificateUuid(certificate.getUuid()).ifPresent(authorization -> {
+        // row). A projection reads just the three non-secret fields, so the encrypted challenge column is never
+        // pulled into memory on the common detail path.
+        registrationAuthorizationRepository.findDetailByCertificateUuid(certificate.getUuid()).ifPresent(authorization -> {
             CertificateRegistrationDetailDto registration = new CertificateRegistrationDetailDto();
             registration.setState(toRegistrationDetailState(authorization.getState()));
             registration.setExpiresAt(authorization.getExpiresAt());
@@ -504,9 +505,18 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
         return dto;
     }
 
-    /** Maps the persisted registration state to its API enum (names are 1:1). */
+    /**
+     * Maps the persisted registration state to its API enum. The switch is exhaustive over {@link RegistrationState},
+     * so a future persisted value with no API counterpart is a compile error here rather than a runtime failure that
+     * would break the whole certificate-detail response.
+     */
     private static CertificateRegistrationState toRegistrationDetailState(RegistrationState state) {
-        return CertificateRegistrationState.valueOf(state.name());
+        return switch (state) {
+            case ACTIVE -> CertificateRegistrationState.ACTIVE;
+            case EXPIRED -> CertificateRegistrationState.EXPIRED;
+            case LOCKED -> CertificateRegistrationState.LOCKED;
+            case CLOSED -> CertificateRegistrationState.CLOSED;
+        };
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -152,6 +152,7 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
     private CertificateValidationWriter validationWriter;
     private CertificateRequestRepository certificateRequestRepository;
     private RaProfileRepository raProfileRepository;
+    private CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository;
     private RaProfileInternalService raProfileService;
     private GroupRepository groupRepository;
     private GroupAssociationRepository groupAssociationRepository;
@@ -213,6 +214,11 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
     @Autowired
     public void setGroupAssociationRepository(GroupAssociationRepository groupAssociationRepository) {
         this.groupAssociationRepository = groupAssociationRepository;
+    }
+
+    @Autowired
+    public void setRegistrationAuthorizationRepository(CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository) {
+        this.registrationAuthorizationRepository = registrationAuthorizationRepository;
     }
 
     @Autowired
@@ -486,7 +492,21 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
         dto.setMetadata(attributeEngine.getMappedMetadataContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).build()));
         dto.setCustomAttributes(attributeEngine.getObjectCustomAttributesContent(Resource.CERTIFICATE, certificate.getUuid()));
         dto.setRelatedCertificates(certificate.getSuccessorRelations().stream().map(r -> r.getSuccessorCertificate().mapToListDto()).toList());
+        // Read-only registration block, present only for pre-registered certificates (those with an authorization
+        // row). The challenge is never exposed — only state, deadline, and failed-attempt count.
+        registrationAuthorizationRepository.findByCertificateUuid(certificate.getUuid()).ifPresent(authorization -> {
+            CertificateRegistrationDetailDto registration = new CertificateRegistrationDetailDto();
+            registration.setState(toRegistrationDetailState(authorization.getState()));
+            registration.setExpiresAt(authorization.getExpiresAt());
+            registration.setFailedAttempts(authorization.getFailedAttempts());
+            dto.setRegistration(registration);
+        });
         return dto;
+    }
+
+    /** Maps the persisted registration state to its API enum (names are 1:1). */
+    private static CertificateRegistrationState toRegistrationDetailState(RegistrationState state) {
+        return CertificateRegistrationState.valueOf(state.name());
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
@@ -20,6 +20,7 @@ import com.otilm.core.service.SettingExternalService;
 import com.otilm.core.service.SettingInternalService;
 import com.otilm.core.service.TriggerExternalService;
 import com.otilm.core.service.TriggerInternalService;
+import com.otilm.core.service.registration.CertificateRegistrationDefaults;
 import com.otilm.core.util.SecretEncodingVersion;
 import com.otilm.core.util.SecretsUtil;
 import com.otilm.core.settings.SettingsCache;
@@ -52,8 +53,6 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
     public static final String CBOM_REPOSITORY_URL_NAME = "cbomRepositoryUrl";
     public static final String CERTIFICATES_VALIDATION_SETTINGS_NAME = "certificatesValidation";
     public static final String CERTIFICATES_REGISTRATION_SETTINGS_NAME = "certificatesRegistration";
-    public static final int DEFAULT_REGISTRATION_WINDOW_DAYS = 7;
-    public static final int DEFAULT_REGISTRATION_MAX_FAILED_ATTEMPTS = 5;
 
     public static final String LOGGING_AUDIT_LOG_OUTPUT_NAME = "output";
     public static final String LOGGING_AUDIT_LOG_VERBOSE_NAME = "verbose";
@@ -157,8 +156,8 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
         certificateSettingsDto.setRequestAttributes(readRequestAttributesSettings(certificateSettings));
 
         CertificateRegistrationSettingsDto defaultRegistrationSettings = new CertificateRegistrationSettingsDto();
-        defaultRegistrationSettings.setDefaultIssuanceWindowDays(DEFAULT_REGISTRATION_WINDOW_DAYS);
-        defaultRegistrationSettings.setMaxFailedAttempts(DEFAULT_REGISTRATION_MAX_FAILED_ATTEMPTS);
+        defaultRegistrationSettings.setDefaultIssuanceWindowDays(CertificateRegistrationDefaults.ISSUANCE_WINDOW_DAYS);
+        defaultRegistrationSettings.setMaxFailedAttempts(CertificateRegistrationDefaults.MAX_FAILED_ATTEMPTS);
         if (certificateSettings != null && certificateSettings.get(CERTIFICATES_REGISTRATION_SETTINGS_NAME) != null) {
             try {
                 certificateSettingsDto.setRegistration(objectMapper.readValue(certificateSettings.get(CERTIFICATES_REGISTRATION_SETTINGS_NAME).getValue(), CertificateRegistrationSettingsDto.class));

--- a/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
@@ -51,6 +51,9 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
     public static final String UTILS_SERVICE_URL_NAME = "utilsServiceUrl";
     public static final String CBOM_REPOSITORY_URL_NAME = "cbomRepositoryUrl";
     public static final String CERTIFICATES_VALIDATION_SETTINGS_NAME = "certificatesValidation";
+    public static final String CERTIFICATES_REGISTRATION_SETTINGS_NAME = "certificatesRegistration";
+    public static final int DEFAULT_REGISTRATION_WINDOW_DAYS = 7;
+    public static final int DEFAULT_REGISTRATION_MAX_FAILED_ATTEMPTS = 5;
 
     public static final String LOGGING_AUDIT_LOG_OUTPUT_NAME = "output";
     public static final String LOGGING_AUDIT_LOG_VERBOSE_NAME = "verbose";
@@ -152,6 +155,20 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
         }
 
         certificateSettingsDto.setRequestAttributes(readRequestAttributesSettings(certificateSettings));
+
+        CertificateRegistrationSettingsDto defaultRegistrationSettings = new CertificateRegistrationSettingsDto();
+        defaultRegistrationSettings.setDefaultIssuanceWindowDays(DEFAULT_REGISTRATION_WINDOW_DAYS);
+        defaultRegistrationSettings.setMaxFailedAttempts(DEFAULT_REGISTRATION_MAX_FAILED_ATTEMPTS);
+        if (certificateSettings != null && certificateSettings.get(CERTIFICATES_REGISTRATION_SETTINGS_NAME) != null) {
+            try {
+                certificateSettingsDto.setRegistration(objectMapper.readValue(certificateSettings.get(CERTIFICATES_REGISTRATION_SETTINGS_NAME).getValue(), CertificateRegistrationSettingsDto.class));
+            } catch (JsonProcessingException e) {
+                logger.warn("Cannot deserialize platform certificates registration settings. Returning default settings.");
+                certificateSettingsDto.setRegistration(defaultRegistrationSettings);
+            }
+        } else {
+            certificateSettingsDto.setRegistration(defaultRegistrationSettings);
+        }
 
         platformSettings.setCertificates(certificateSettingsDto);
 
@@ -256,6 +273,18 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
             strictSetting.setValue(requestAttributes.getExternalCsrValidationStrict() == null
                     ? null : requestAttributes.getExternalCsrValidationStrict().toString());
             settingRepository.save(strictSetting);
+        }
+
+        CertificateRegistrationSettingsUpdateDto registration = platformSettings.getCertificates().getRegistration();
+        if (registration != null) {
+            Setting registrationSetting = certificateSetting(certificateSettings, CERTIFICATES_REGISTRATION_SETTINGS_NAME);
+            try {
+                registrationSetting.setValue(objectMapper.writeValueAsString(registration));
+            } catch (JsonProcessingException e) {
+                logger.warn("Failed to serialize platform certificates registration settings", e);
+                throw new ValidationException("Cannot serialize platform certificates settings.");
+            }
+            settingRepository.save(registrationSetting);
         }
     }
 

--- a/src/main/java/com/otilm/core/service/registration/CertificateRegistrationDefaults.java
+++ b/src/main/java/com/otilm/core/service/registration/CertificateRegistrationDefaults.java
@@ -1,0 +1,18 @@
+package com.otilm.core.service.registration;
+
+/**
+ * Canonical defaults for certificate pre-registration, shared by the settings service (as the operator-visible
+ * default it seeds and persists) and the client-operations gate (as the cache-miss fallback) so the value the
+ * platform reports can never drift from the value it applies.
+ */
+public final class CertificateRegistrationDefaults {
+
+    private CertificateRegistrationDefaults() {
+    }
+
+    /** Default issuance window in days, applied when a pre-registration omits an explicit expiry. */
+    public static final int ISSUANCE_WINDOW_DAYS = 7;
+
+    /** Maximum failed challenge-verification attempts before the registration authorization locks. */
+    public static final int MAX_FAILED_ATTEMPTS = 5;
+}

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -67,7 +67,7 @@ import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
 import com.otilm.core.service.handler.authority.CertificateOperation;
 import com.otilm.core.service.handler.authority.RegisterCapability;
 import com.otilm.core.service.handler.authority.lifecycle.CertificateStateMachine;
-import com.otilm.core.service.impl.SettingServiceImpl;
+import com.otilm.core.service.registration.CertificateRegistrationDefaults;
 import com.otilm.core.service.registration.RegistrationChallengeStore;
 import com.otilm.core.service.writer.registration.CertificateRegistrationAuthorizationWriter;
 import com.otilm.core.service.writer.registration.CertificateRegistrationWriter;
@@ -600,18 +600,18 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
                 ? platformSettings.getCertificates().getRegistration() : null;
     }
 
-    // The fallbacks below use the single canonical defaults in SettingServiceImpl (the value the settings API
-    // reports and persists) so the value applied on a cache miss cannot drift from the operator-visible default.
+    // The fallbacks below use the single canonical defaults (the value the settings API reports and persists) so
+    // the value applied on a cache miss cannot drift from the operator-visible default.
     private int registrationWindowDays() {
         CertificateRegistrationSettingsDto settings = registrationSettings();
         return settings != null && settings.getDefaultIssuanceWindowDays() != null
-                ? settings.getDefaultIssuanceWindowDays() : SettingServiceImpl.DEFAULT_REGISTRATION_WINDOW_DAYS;
+                ? settings.getDefaultIssuanceWindowDays() : CertificateRegistrationDefaults.ISSUANCE_WINDOW_DAYS;
     }
 
     private int maxFailedRegistrationAttempts() {
         CertificateRegistrationSettingsDto settings = registrationSettings();
         return settings != null && settings.getMaxFailedAttempts() != null
-                ? settings.getMaxFailedAttempts() : SettingServiceImpl.DEFAULT_REGISTRATION_MAX_FAILED_ATTEMPTS;
+                ? settings.getMaxFailedAttempts() : CertificateRegistrationDefaults.MAX_FAILED_ATTEMPTS;
     }
 
     private void maybeCreateRegistrationAuthorization(Certificate certificate, ClientCertificateRegistrationDto request) {

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -1398,7 +1398,11 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     @Override
+    @Transactional
     public void issueCertificateRejectedAction(final UUID certificateUuid) throws NotFoundException {
+        // Transactional so the reject transition and the fate-coupling auto-CLOSE (or the approval-reject
+        // restore) commit atomically — this entry point (invoked by ActionsListener) has no ambient transaction
+        // of its own, unlike the failClaimedCertificate / poll-listener FAILED paths.
         final Certificate certificate = certificateRepository.findByUuid(certificateUuid).orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
         // A pre-registered placeholder whose completion was rejected during approval is restored to REGISTERED
         // (its authorization stays ACTIVE) so the holder can retry — mirror revokeCertificateRejectedAction.

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -76,9 +76,13 @@ import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.model.request.CertificateRequest;
 import com.otilm.core.model.request.CrmfCertificateRequest;
 import com.otilm.core.model.request.Pkcs10CertificateRequest;
+import com.otilm.api.model.core.settings.CertificateRegistrationSettingsDto;
+import com.otilm.api.model.core.settings.PlatformSettingsDto;
+import com.otilm.api.model.core.settings.SettingsSection;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.service.*;
 import com.otilm.core.service.v2.ClientOperationExternalService;
 import com.otilm.core.service.v2.ClientOperationInternalService;
@@ -132,8 +136,11 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     private static final LoggerWrapper eventLogger = new LoggerWrapper(
             ClientOperationServiceImpl.class, Module.CERTIFICATES, Resource.CERTIFICATE);
 
-    private static final Duration DEFAULT_REGISTRATION_WINDOW = Duration.ofDays(7);
-    private static final int MAX_FAILED_REGISTRATION_ATTEMPTS = 5;
+    // Fallback defaults used when the platform registration settings are unavailable (cache not yet populated,
+    // or in tests that don't boot the settings scheduler). The operator-configurable values live in platform
+    // settings (SettingServiceImpl); read them via registrationWindowDays() / maxFailedRegistrationAttempts().
+    private static final int DEFAULT_REGISTRATION_WINDOW_DAYS = 7;
+    private static final int DEFAULT_REGISTRATION_MAX_FAILED_ATTEMPTS = 5;
 
     private PlatformTransactionManager transactionManager;
 
@@ -592,6 +599,24 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
      * missing there — the later issue gate would then treat a secret-protected registration as unprotected and issue
      * with no challenge. Absent secret means no row, so the operator register→issue flow is unchanged.
      */
+    private CertificateRegistrationSettingsDto registrationSettings() {
+        PlatformSettingsDto platformSettings = SettingsCache.getSettings(SettingsSection.PLATFORM);
+        return platformSettings != null && platformSettings.getCertificates() != null
+                ? platformSettings.getCertificates().getRegistration() : null;
+    }
+
+    private int registrationWindowDays() {
+        CertificateRegistrationSettingsDto settings = registrationSettings();
+        return settings != null && settings.getDefaultIssuanceWindowDays() != null
+                ? settings.getDefaultIssuanceWindowDays() : DEFAULT_REGISTRATION_WINDOW_DAYS;
+    }
+
+    private int maxFailedRegistrationAttempts() {
+        CertificateRegistrationSettingsDto settings = registrationSettings();
+        return settings != null && settings.getMaxFailedAttempts() != null
+                ? settings.getMaxFailedAttempts() : DEFAULT_REGISTRATION_MAX_FAILED_ATTEMPTS;
+    }
+
     private void maybeCreateRegistrationAuthorization(Certificate certificate, ClientCertificateRegistrationDto request) {
         String secret = request.getAuthorizationSecret();
         if (secret == null || secret.isBlank()) {
@@ -602,7 +627,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         authorization.setCertificateUuid(certificate.getUuid());
         authorization.setState(RegistrationState.ACTIVE);
         authorization.setFailedAttempts(0);
-        authorization.setExpiresAt(expiresAt != null ? expiresAt : OffsetDateTime.now(ZoneOffset.UTC).plus(DEFAULT_REGISTRATION_WINDOW));
+        authorization.setExpiresAt(expiresAt != null ? expiresAt : OffsetDateTime.now(ZoneOffset.UTC).plus(Duration.ofDays(registrationWindowDays())));
         registrationChallengeStore.store(authorization, secret);
         registrationAuthorizationRepository.save(authorization);
     }
@@ -701,7 +726,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         }
         int attempts = authorization.getFailedAttempts() + 1;
         authorization.setFailedAttempts(attempts);
-        if (attempts >= MAX_FAILED_REGISTRATION_ATTEMPTS) {
+        if (attempts >= maxFailedRegistrationAttempts()) {
             authorization.setState(RegistrationState.LOCKED);
         }
         registrationAuthorizationRepository.save(authorization);
@@ -1292,6 +1317,13 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         }
         stateMachine.transition(certificate, state, auditEvent, auditMessage, auditDetail);
 
+        // Fate-coupling: a pre-registered certificate that reached a terminal FAILED/REJECTED verdict no longer has
+        // a live registration — close its authorization in the same transaction (guarded, so it is a no-op for
+        // non-self-service certs and for renew/rekey successors that carry no authorization).
+        if (registrationAuthorizationRepository.existsByCertificateUuid(certificate.getUuid())) {
+            registrationAuthorizationWriter.close(certificate.getUuid());
+        }
+
         certificateRelationRepository.deleteAll(certificate.getPredecessorRelations());
 
         // A failed renew/rekey also records the failure against the predecessor certificate so its
@@ -1368,6 +1400,15 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     @Override
     public void issueCertificateRejectedAction(final UUID certificateUuid) throws NotFoundException {
         final Certificate certificate = certificateRepository.findByUuid(certificateUuid).orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
+        // A pre-registered placeholder whose completion was rejected during approval is restored to REGISTERED
+        // (its authorization stays ACTIVE) so the holder can retry — mirror revokeCertificateRejectedAction.
+        // Non-registered certs keep the terminal REJECTED behaviour.
+        if (certificate.getState() == CertificateState.PENDING_APPROVAL
+                && registrationAuthorizationRepository.existsByCertificateUuid(certificateUuid)) {
+            stateMachine.transition(certificate, CertificateState.REGISTERED, CertificateEvent.APPROVAL_CLOSE,
+                    "Issuance approval was rejected; certificate restored to " + CertificateState.REGISTERED.getLabel() + ".");
+            return;
+        }
         handleFailedOrRejectedEvent(certificate, null, CertificateState.REJECTED, null, null, null);
     }
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -67,6 +67,7 @@ import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
 import com.otilm.core.service.handler.authority.CertificateOperation;
 import com.otilm.core.service.handler.authority.RegisterCapability;
 import com.otilm.core.service.handler.authority.lifecycle.CertificateStateMachine;
+import com.otilm.core.service.impl.SettingServiceImpl;
 import com.otilm.core.service.registration.RegistrationChallengeStore;
 import com.otilm.core.service.writer.registration.CertificateRegistrationAuthorizationWriter;
 import com.otilm.core.service.writer.registration.CertificateRegistrationWriter;
@@ -135,12 +136,6 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
      */
     private static final LoggerWrapper eventLogger = new LoggerWrapper(
             ClientOperationServiceImpl.class, Module.CERTIFICATES, Resource.CERTIFICATE);
-
-    // Fallback defaults used when the platform registration settings are unavailable (cache not yet populated,
-    // or in tests that don't boot the settings scheduler). The operator-configurable values live in platform
-    // settings (SettingServiceImpl); read them via registrationWindowDays() / maxFailedRegistrationAttempts().
-    private static final int DEFAULT_REGISTRATION_WINDOW_DAYS = 7;
-    private static final int DEFAULT_REGISTRATION_MAX_FAILED_ATTEMPTS = 5;
 
     private PlatformTransactionManager transactionManager;
 
@@ -605,16 +600,18 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
                 ? platformSettings.getCertificates().getRegistration() : null;
     }
 
+    // The fallbacks below use the single canonical defaults in SettingServiceImpl (the value the settings API
+    // reports and persists) so the value applied on a cache miss cannot drift from the operator-visible default.
     private int registrationWindowDays() {
         CertificateRegistrationSettingsDto settings = registrationSettings();
         return settings != null && settings.getDefaultIssuanceWindowDays() != null
-                ? settings.getDefaultIssuanceWindowDays() : DEFAULT_REGISTRATION_WINDOW_DAYS;
+                ? settings.getDefaultIssuanceWindowDays() : SettingServiceImpl.DEFAULT_REGISTRATION_WINDOW_DAYS;
     }
 
     private int maxFailedRegistrationAttempts() {
         CertificateRegistrationSettingsDto settings = registrationSettings();
         return settings != null && settings.getMaxFailedAttempts() != null
-                ? settings.getMaxFailedAttempts() : DEFAULT_REGISTRATION_MAX_FAILED_ATTEMPTS;
+                ? settings.getMaxFailedAttempts() : SettingServiceImpl.DEFAULT_REGISTRATION_MAX_FAILED_ATTEMPTS;
     }
 
     private void maybeCreateRegistrationAuthorization(Certificate certificate, ClientCertificateRegistrationDto request) {
@@ -1402,13 +1399,17 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     public void issueCertificateRejectedAction(final UUID certificateUuid) throws NotFoundException {
         // Transactional so the reject transition and the fate-coupling auto-CLOSE (or the approval-reject
         // restore) commit atomically — this entry point (invoked by ActionsListener) has no ambient transaction
-        // of its own, unlike the failClaimedCertificate / poll-listener FAILED paths.
-        final Certificate certificate = certificateRepository.findByUuid(certificateUuid).orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
-        // A pre-registered placeholder whose completion was rejected during approval is restored to REGISTERED
-        // (its authorization stays ACTIVE) so the holder can retry — mirror revokeCertificateRejectedAction.
-        // Non-registered certs keep the terminal REJECTED behaviour.
+        // of its own, unlike the failClaimedCertificate / poll-listener FAILED paths. The pessimistic lock
+        // satisfies the state-machine contract: re-assert state under SELECT ... FOR UPDATE before transitioning,
+        // so a concurrent issuance claim cannot be clobbered by a stale read.
+        final Certificate certificate = certificateRepository.findAndLockWithAssociationsByUuid(certificateUuid)
+                .orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
+        // A pre-registered placeholder whose issuance approval was rejected is restored to REGISTERED so the holder
+        // can retry — keyed on the register->issue binding, the same discriminator issueCertificateAction uses to
+        // route the placeholder (a no-secret pre-registration has a binding but no challenge authorization). Any
+        // challenge authorization stays ACTIVE. Non-registered certs keep the terminal REJECTED behaviour.
         if (certificate.getState() == CertificateState.PENDING_APPROVAL
-                && registrationAuthorizationRepository.existsByCertificateUuid(certificateUuid)) {
+                && certificateRegistrationRepository.findByCertificateUuid(certificateUuid).isPresent()) {
             stateMachine.transition(certificate, CertificateState.REGISTERED, CertificateEvent.APPROVAL_CLOSE,
                     "Issuance approval was rejected; certificate restored to " + CertificateState.REGISTERED.getLabel() + ".");
             return;

--- a/src/main/java/com/otilm/core/service/writer/registration/CertificateRegistrationAuthorizationWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/registration/CertificateRegistrationAuthorizationWriter.java
@@ -1,5 +1,6 @@
 package com.otilm.core.service.writer.registration;
 
+import com.otilm.core.dao.entity.RegistrationState;
 import com.otilm.core.dao.repository.CertificateRegistrationAuthorizationRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,5 +24,14 @@ public class CertificateRegistrationAuthorizationWriter {
     @Transactional
     public void deleteByCertificateUuid(UUID certificateUuid) {
         authorizationRepository.deleteByCertificateUuid(certificateUuid);
+    }
+
+    /**
+     * Retires the authorization (state → CLOSED) when its certificate reaches a terminal FAILED/REJECTED verdict,
+     * so a dead placeholder no longer carries an ACTIVE registration. Idempotent (no-op when no row exists).
+     */
+    @Transactional
+    public void close(UUID certificateUuid) {
+        authorizationRepository.updateStateByCertificateUuid(certificateUuid, RegistrationState.CLOSED);
     }
 }

--- a/src/test/java/com/otilm/core/integration/service/CertificateServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CertificateServiceITest.java
@@ -89,6 +89,7 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -136,6 +137,9 @@ class CertificateServiceITest extends BaseSpringBootTest {
 
     @Autowired
     private CertificateRepository certificateRepository;
+
+    @Autowired
+    private CertificateRegistrationAuthorizationRepository authorizationRepository;
 
     @Autowired
     private CertificateEventHistoryRepository certificateEventHistoryRepository;
@@ -670,6 +674,35 @@ class CertificateServiceITest extends BaseSpringBootTest {
         void throwsNotFound_whenCertificateDoesNotExist() {
             // when / then
             assertThatThrownBy(() -> certificateService.getCertificate(SecuredUUID.fromString("abfbc322-29e1-11ed-a261-0242ac120002"))).isInstanceOf(NotFoundException.class);
+        }
+
+        @Test
+        void returnsRegistrationBlock_withoutLeakingTheChallenge_whenPreRegistered() throws NotFoundException, CertificateException, IOException {
+            // given: a pre-registered certificate carries an authorization row with an (encrypted) challenge
+            CertificateRegistrationAuthorization auth = new CertificateRegistrationAuthorization();
+            auth.setCertificateUuid(certificate.getUuid());
+            auth.setState(RegistrationState.ACTIVE);
+            auth.setFailedAttempts(2);
+            auth.setExpiresAt(OffsetDateTime.now().plusDays(5));
+            auth.setChallenge("super-secret-challenge");
+            authorizationRepository.save(auth);
+
+            // when
+            CertificateDetailDto dto = certificateService.getCertificate(certificate.getSecuredUuid());
+
+            // then: the read-only block surfaces state, deadline and attempt count — never the challenge
+            assertThat(dto.getRegistration()).isNotNull();
+            assertThat(dto.getRegistration().getState()).isEqualTo(CertificateRegistrationState.ACTIVE);
+            assertThat(dto.getRegistration().getFailedAttempts()).isEqualTo(2);
+            assertThat(dto.getRegistration().getExpiresAt()).isNotNull();
+            assertThat(dto.getRegistration().toString()).doesNotContain("super-secret-challenge");
+        }
+
+        @Test
+        void omitsRegistrationBlock_whenNotPreRegistered() throws NotFoundException, CertificateException, IOException {
+            // The default fixture certificate carries no authorization row.
+            CertificateDetailDto dto = certificateService.getCertificate(certificate.getSecuredUuid());
+            assertThat(dto.getRegistration()).isNull();
         }
 
         @Test

--- a/src/test/java/com/otilm/core/integration/service/CertificateServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CertificateServiceITest.java
@@ -73,6 +73,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
@@ -696,6 +697,23 @@ class CertificateServiceITest extends BaseSpringBootTest {
             assertThat(dto.getRegistration().getFailedAttempts()).isEqualTo(2);
             assertThat(dto.getRegistration().getExpiresAt()).isNotNull();
             assertThat(dto.getRegistration().toString()).doesNotContain("super-secret-challenge");
+        }
+
+        @ParameterizedTest
+        @EnumSource(RegistrationState.class)
+        void mapsEveryRegistrationStateToItsApiEnum(RegistrationState state) throws NotFoundException, CertificateException, IOException {
+            CertificateRegistrationAuthorization auth = new CertificateRegistrationAuthorization();
+            auth.setCertificateUuid(certificate.getUuid());
+            auth.setState(state);
+            auth.setFailedAttempts(0);
+            auth.setExpiresAt(OffsetDateTime.now().plusDays(1));
+            auth.setChallenge("challenge");
+            authorizationRepository.save(auth);
+
+            CertificateDetailDto dto = certificateService.getCertificate(certificate.getSecuredUuid());
+
+            assertThat(dto.getRegistration()).isNotNull();
+            assertThat(dto.getRegistration().getState()).isEqualTo(CertificateRegistrationState.valueOf(state.name()));
         }
 
         @Test

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -950,6 +950,40 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     }
 
     @Test
+    void approvalRejectedRestoresRegisteredPlaceholderKeepingAuthorizationActive() throws Exception {
+        UUID certUuid = UUID.fromString(registerWithSecret(null)); // REGISTERED placeholder + ACTIVE authorization
+        clientOperationInternalService.approvalCreatedAction(certUuid); // issuing it requires approval -> PENDING_APPROVAL
+        Assertions.assertEquals(CertificateState.PENDING_APPROVAL,
+                certificateRepository.findByUuid(certUuid).orElseThrow().getState());
+
+        clientOperationInternalService.issueCertificateRejectedAction(certUuid);
+
+        Assertions.assertEquals(CertificateState.REGISTERED,
+                certificateRepository.findByUuid(certUuid).orElseThrow().getState(),
+                "a rejected issuance approval restores the placeholder rather than terminating it REJECTED");
+        CertificateRegistrationAuthorization auth = authorizationRepository.findByCertificateUuid(certUuid).orElseThrow();
+        Assertions.assertEquals(RegistrationState.ACTIVE, auth.getState(),
+                "the authorization stays ACTIVE so the holder can retry the issue");
+        Assertions.assertEquals(1, authorizationRepository.count());
+    }
+
+    @Test
+    void approvalRejectedOfCertWithoutAuthorizationTerminatesRejected() throws Exception {
+        // A cert carrying no registration authorization keeps the terminal REJECTED behaviour on approval rejection.
+        Certificate cert = new Certificate();
+        cert.setState(CertificateState.PENDING_APPROVAL);
+        cert.setRaProfile(raProfile);
+        cert.setRaProfileUuid(raProfile.getUuid());
+        UUID uuid = certificateRepository.save(cert).getUuid();
+
+        clientOperationInternalService.issueCertificateRejectedAction(uuid);
+
+        Assertions.assertEquals(CertificateState.REJECTED,
+                certificateRepository.findByUuid(uuid).orElseThrow().getState());
+        Assertions.assertEquals(0, authorizationRepository.count());
+    }
+
+    @Test
     void registerWithSecretFiresCertificateRegisteredEvent() throws Exception {
         when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -11,6 +11,8 @@ import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.certificate.CertificateType;
 import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.api.model.core.connector.ConnectorStatus;
+import com.otilm.api.model.core.settings.PlatformSettingsDto;
+import com.otilm.api.model.core.settings.SettingsSection;
 import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
@@ -61,7 +63,9 @@ import com.otilm.core.service.handler.authority.AuthorityProviderAdapter;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
 import com.otilm.core.service.handler.authority.CertificateOperation;
 import com.otilm.core.service.handler.authority.RegisterCapability;
+import com.otilm.core.service.SettingExternalService;
 import com.otilm.core.service.registration.RegistrationChallengeStore;
+import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.service.v2.ClientOperationExternalService;
 import com.otilm.core.service.v2.ClientOperationInternalService;
 import com.otilm.core.service.writer.registration.CertificateRegistrationWriter;
@@ -122,6 +126,10 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     private CertificateRegistrationRepository registrationRepository;
     @Autowired
     private CertificateRegistrationAuthorizationRepository authorizationRepository;
+    @Autowired
+    private SettingsCache settingsCache;
+    @Autowired
+    private SettingExternalService settingService;
     // Spied so most tests use real encryption/verification while one test stubs store() to drive the
     // local-authorization-failure arc.
     @MockitoSpyBean
@@ -793,7 +801,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     // ── registration challenge authorization ────────────────────────────────
 
     private static final String CHALLENGE = "s3cret-value-1234";
-    // Mirrors ClientOperationServiceImpl.MAX_FAILED_REGISTRATION_ATTEMPTS.
+    // The default maximum failed challenge-verification attempts before the authorization locks.
     private static final int MAX_FAILED_ATTEMPTS = 5;
 
     @Test
@@ -981,6 +989,61 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
         Assertions.assertEquals(CertificateState.REJECTED,
                 certificateRepository.findByUuid(uuid).orElseThrow().getState());
         Assertions.assertEquals(0, authorizationRepository.count());
+    }
+
+    @Test
+    void approvalRejectedRestoresRegisteredPlaceholderWithBindingButNoSecret() throws Exception {
+        UUID certUuid = UUID.fromString(registerSyncRegistered()); // operator register: binding, no challenge authorization
+        clientOperationInternalService.approvalCreatedAction(certUuid);
+        Assertions.assertEquals(CertificateState.PENDING_APPROVAL,
+                certificateRepository.findByUuid(certUuid).orElseThrow().getState());
+
+        clientOperationInternalService.issueCertificateRejectedAction(certUuid);
+
+        Assertions.assertEquals(CertificateState.REGISTERED,
+                certificateRepository.findByUuid(certUuid).orElseThrow().getState(),
+                "a no-secret pre-registration is restored too — the binding is the discriminator, not the challenge row");
+        Assertions.assertTrue(registrationRepository.findByCertificateUuid(certUuid).isPresent(),
+                "the register->issue binding is preserved so the holder can retry");
+        Assertions.assertEquals(0, authorizationRepository.count(), "a no-secret flow carries no challenge authorization");
+    }
+
+    @Test
+    void customIssuanceWindowSettingIsAppliedToNewAuthorizations() throws Exception {
+        PlatformSettingsDto custom = settingService.getPlatformSettings();
+        custom.getCertificates().getRegistration().setDefaultIssuanceWindowDays(30);
+        settingsCache.cacheSettings(SettingsSection.PLATFORM, custom);
+        try {
+            String certUuid = registerWithSecret(null); // no explicit expiry, so the configured default window applies
+            CertificateRegistrationAuthorization auth = authorizationRepository
+                    .findByCertificateUuid(UUID.fromString(certUuid)).orElseThrow();
+            Assertions.assertTrue(auth.getExpiresAt().isAfter(OffsetDateTime.now().plusDays(29)),
+                    "the operator-configured 30-day window must be applied, not the 7-day fallback");
+        } finally {
+            settingsCache.cacheSettings(SettingsSection.PLATFORM, settingService.getPlatformSettings());
+        }
+    }
+
+    @Test
+    void customMaxFailedAttemptsSettingLocksTheAuthorization() throws Exception {
+        PlatformSettingsDto custom = settingService.getPlatformSettings();
+        custom.getCertificates().getRegistration().setMaxFailedAttempts(2);
+        settingsCache.cacheSettings(SettingsSection.PLATFORM, custom);
+        try {
+            String certUuid = registerWithSecret(null);
+            ClientCertificateIssueRequestDto wrong = new ClientCertificateIssueRequestDto();
+            wrong.setRequest(generateCsrBase64());
+            wrong.setAuthorizationSecret("wrong-secret-9999");
+            for (int i = 0; i < 2; i++) {
+                Assertions.assertThrows(ValidationException.class, () -> clientOperationService.issueExistingCertificate(
+                        authorityParent, securedRaProfile, certUuid, wrong));
+            }
+            Assertions.assertEquals(RegistrationState.LOCKED,
+                    authorizationRepository.findByCertificateUuid(UUID.fromString(certUuid)).orElseThrow().getState(),
+                    "the operator-configured lockout threshold of 2 must be applied, not the 5-attempt fallback");
+        } finally {
+            settingsCache.cacheSettings(SettingsSection.PLATFORM, settingService.getPlatformSettings());
+        }
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/SettingServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SettingServiceITest.java
@@ -87,6 +87,31 @@ class SettingServiceITest extends BaseSpringBootTest {
     }
 
     @Test
+    void platformRegistrationSettingsDefaultToSevenAndFiveAndAreEditable() {
+        // A fresh platform reports the registration defaults (7-day issuance window, 5 failed attempts).
+        PlatformSettingsDto seeded = settingService.getPlatformSettings();
+        Assertions.assertNotNull(seeded.getCertificates().getRegistration());
+        Assertions.assertEquals(7, seeded.getCertificates().getRegistration().getDefaultIssuanceWindowDays());
+        Assertions.assertEquals(5, seeded.getCertificates().getRegistration().getMaxFailedAttempts());
+
+        CertificateRegistrationSettingsUpdateDto registration = new CertificateRegistrationSettingsUpdateDto();
+        registration.setDefaultIssuanceWindowDays(14);
+        registration.setMaxFailedAttempts(3);
+        CertificateSettingsUpdateDto certificateSettings = new CertificateSettingsUpdateDto();
+        certificateSettings.setRegistration(registration);
+        PlatformSettingsUpdateDto update = new PlatformSettingsUpdateDto();
+        update.setCertificates(certificateSettings);
+        settingService.updatePlatformSettings(update);
+
+        // The edited values are read back, and a registration-only update leaves validation untouched.
+        PlatformSettingsDto edited = settingService.getPlatformSettings();
+        Assertions.assertEquals(14, edited.getCertificates().getRegistration().getDefaultIssuanceWindowDays());
+        Assertions.assertEquals(3, edited.getCertificates().getRegistration().getMaxFailedAttempts());
+        Assertions.assertNotNull(edited.getCertificates().getValidation());
+        Assertions.assertTrue(edited.getCertificates().getValidation().getEnabled());
+    }
+
+    @Test
     void platformRequestAttributesDefaultSetIsSeededAndEditable() {
         // given: a fresh platform has no stored default set -> getPlatformSettings seeds it from CsrAttributes
         PlatformSettingsDto seeded = settingService.getPlatformSettings();

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
@@ -66,6 +66,7 @@ class CertificateStatusPollListenerTest {
     @Mock private com.otilm.core.service.writer.registration.CertificateRegistrationWriter registrationWriter;
     @Mock private EventProducer eventProducer;
     @Mock private CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository;
+    @Mock private com.otilm.core.service.writer.registration.CertificateRegistrationAuthorizationWriter registrationAuthorizationWriter;
 
     /**
      * Combined mock implementing both AuthorityProviderAdapter and AsyncOperationCapability.
@@ -98,6 +99,7 @@ class CertificateStatusPollListenerTest {
         listener.setRegistrationWriter(registrationWriter);
         listener.setEventProducer(eventProducer);
         listener.setRegistrationAuthorizationRepository(registrationAuthorizationRepository);
+        listener.setRegistrationAuthorizationWriter(registrationAuthorizationWriter);
 
         StatusPollProperties.PollSchedule schedule = mock(StatusPollProperties.PollSchedule.class);
         lenient().when(schedule.maxAttempts()).thenReturn(3);
@@ -481,6 +483,51 @@ class CertificateStatusPollListenerTest {
 
         verify(stateMachine).transition(eq(cert), eq(CertificateState.FAILED), isNull(), anyString());
         verify(pollWriter).delete(CERT_UUID);    }
+
+    @Test
+    void terminalIssueFailureClosesRegistrationAuthorizationWhenPresent() throws MessageHandlingException, ConnectorException {
+        Certificate cert = certInState(CertificateState.PENDING_ISSUE);
+        when(certificateRepository.findForPollingByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        when(asyncAdapter.pollStatus(cert, CertificateOperation.ISSUE))
+                .thenReturn(new StatusPollResult(CertificateOperationStatus.FAILED, null, null, "CA error"));
+        when(certificateRepository.findAndLockWithAssociationsByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        when(registrationAuthorizationRepository.existsByCertificateUuid(CERT_UUID)).thenReturn(true);
+
+        listener.processMessage(pollMsg(CertificateOperation.ISSUE, 0));
+
+        // A pre-registered placeholder that fails issuance no longer has a live registration.
+        verify(registrationAuthorizationWriter).close(CERT_UUID);
+    }
+
+    @Test
+    void terminalIssueFailureDoesNotCloseWhenNoRegistrationAuthorization() throws MessageHandlingException, ConnectorException {
+        Certificate cert = certInState(CertificateState.PENDING_ISSUE);
+        when(certificateRepository.findForPollingByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        when(asyncAdapter.pollStatus(cert, CertificateOperation.ISSUE))
+                .thenReturn(new StatusPollResult(CertificateOperationStatus.FAILED, null, null, "CA error"));
+        when(certificateRepository.findAndLockWithAssociationsByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        // existsByCertificateUuid defaults to false (setUp) — a non-self-service cert carries no authorization.
+
+        listener.processMessage(pollMsg(CertificateOperation.ISSUE, 0));
+
+        verify(registrationAuthorizationWriter, never()).close(any());
+    }
+
+    @Test
+    void failedRevokeDoesNotCloseRegistrationAuthorization() throws MessageHandlingException, ConnectorException {
+        Certificate cert = certInState(CertificateState.PENDING_REVOKE);
+        when(certificateRepository.findForPollingByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        when(asyncAdapter.pollStatus(cert, CertificateOperation.REVOKE))
+                .thenReturn(new StatusPollResult(CertificateOperationStatus.FAILED, null, null, "revoke failed"));
+        when(certificateRepository.findAndLockWithAssociationsByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        lenient().when(registrationAuthorizationRepository.existsByCertificateUuid(CERT_UUID)).thenReturn(true);
+
+        listener.processMessage(pollMsg(CertificateOperation.REVOKE, 0));
+
+        // A failed revoke returns to ISSUED, not FAILED — the registration must survive for renew/rekey reuse.
+        verify(stateMachine).transition(eq(cert), eq(CertificateState.ISSUED), isNull(), anyString());
+        verify(registrationAuthorizationWriter, never()).close(any());
+    }
 
     // -----------------------------------------------------------------------
     // failedRevokeTransitionsBackToIssued

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
@@ -500,6 +500,21 @@ class CertificateStatusPollListenerTest {
     }
 
     @Test
+    void completedIssueWithoutDataClosesRegistrationAuthorizationWhenPresent() throws Exception {
+        Certificate cert = certInState(CertificateState.PENDING_ISSUE);
+        when(certificateRepository.findForPollingByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        when(asyncAdapter.pollStatus(cert, CertificateOperation.ISSUE))
+                .thenReturn(new StatusPollResult(CertificateOperationStatus.COMPLETED, null, null, "OK"));
+        when(certificateRepository.findAndLockWithAssociationsByUuid(CERT_UUID)).thenReturn(Optional.of(cert));
+        when(registrationAuthorizationRepository.existsByCertificateUuid(CERT_UUID)).thenReturn(true);
+
+        listener.processMessage(pollMsg(CertificateOperation.ISSUE, 0));
+
+        // COMPLETED with no certificate data fails the issue; a pre-registered placeholder's authorization is retired.
+        verify(registrationAuthorizationWriter).close(CERT_UUID);
+    }
+
+    @Test
     void terminalIssueFailureDoesNotCloseWhenNoRegistrationAuthorization() throws MessageHandlingException, ConnectorException {
         Certificate cert = certInState(CertificateState.PENDING_ISSUE);
         when(certificateRepository.findForPollingByUuid(CERT_UUID)).thenReturn(Optional.of(cert));

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/CertificateStatusPollListenerTest.java
@@ -482,7 +482,8 @@ class CertificateStatusPollListenerTest {
         listener.processMessage(pollMsg(CertificateOperation.ISSUE, 0));
 
         verify(stateMachine).transition(eq(cert), eq(CertificateState.FAILED), isNull(), anyString());
-        verify(pollWriter).delete(CERT_UUID);    }
+        verify(pollWriter).delete(CERT_UUID);
+    }
 
     @Test
     void terminalIssueFailureClosesRegistrationAuthorizationWhenPresent() throws MessageHandlingException, ConnectorException {


### PR DESCRIPTION
Closes #1786. The remaining server-side work for the certificate pre-registration flow, after the authorization/challenge core (#1570) and the event (#1571).

## What it does
- **Platform settings** — `SettingServiceImpl` reads + persists the registration settings (`defaultIssuanceWindowDays`, `maxFailedAttempts`) as a `PLATFORM_CERTIFICATES` JSON setting, mirroring `validation`. The challenge-verification path reads them via `SettingsCache` (with a 7/5 fallback when the cache isn't populated / in tests), replacing the R1b constants.
- **Detail block** — `CertificateServiceImpl.getCertificate` populates `CertificateDetailDto.registration` (state, deadline, failed attempts) from the authorization row, **present only** for pre-registered certificates; the challenge is never exposed.
- **Auto-CLOSE on failure** — a pre-registered cert reaching a terminal FAILED/REJECTED verdict has its authorization closed (state→CLOSED) **in the same transaction** — hooked in `handleFailedOrRejectedEvent` and the poll-listener's locked terminal transition, guarded by `existsByCertificateUuid` (no-op for non-registered certs). `issueCertificateRejectedAction` is now `@Transactional` so the reject transition + close commit atomically. **No** close on success — the authorization stays ACTIVE for later renew/rekey reuse.
- **Approval-reject restore** — a registered placeholder rejected during approval is restored to REGISTERED (authorization stays ACTIVE) instead of terminal REJECTED, mirroring `revokeCertificateRejectedAction`; adds the `PENDING_APPROVAL→REGISTERED` state-machine row.

## Deferred (follow-up)
- **Transient-restore** on the completion path (`callRegisterBoundIssue` → `PENDING_ISSUE→REGISTERED` on a *transient* failure, keeping the authorization ACTIVE) + the failure taxonomy — the riskiest sub-piece, not E2E-blocking; completion transients fail terminal in the interim.
- Scheduled EXPIRED sweep (inventory-display accuracy) — the gate already flips EXPIRED lazily.

## Tests
Settings read/persist + 7/5 fallback (`SettingServiceITest`); detail block present/absent + no credential (`CertificateServiceITest`); auto-CLOSE on FAILED/REJECTED, no-op for non-registered, no close on success, approval-reject restore (`ClientOperationServiceRegisterITest` + `CertificateStatusPollListenerTest`). All green.