### PR TITLE
Fix discovery stuck in Processing status

### DIFF
--- a/src/main/java/com/otilm/core/dao/repository/DiscoveryCertificateRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/DiscoveryCertificateRepository.java
@@ -25,6 +25,7 @@ public interface DiscoveryCertificateRepository extends SecurityFilterRepository
 
     Long countByDiscoveryAndNewlyDiscovered(DiscoveryHistory history, boolean newlyDiscovered);
     Long countByDiscoveryAndNewlyDiscoveredAndProcessed(DiscoveryHistory history, boolean newlyDiscovered, boolean processed);
+    Long countByDiscoveryAndProcessedErrorNotNull(DiscoveryHistory history);
     List<DiscoveryCertificate> findByCertificateContent(CertificateContent certificateContent);
 
 }

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -151,9 +151,28 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
         List<DiscoveryCertificate> discoveredCertificates = discoveryCertificateRepository.findByDiscoveryUuidAndNewlyDiscovered(eventMessage.getOverrideObjectUuid(), true, Pageable.unpaged());
         logger.debug("Going to process {} triggers on {} discovered certificates", mergedIgnoreTriggers.size() + mergedTriggers.size(), context.getResourceObjects().size());
 
+        // The DISCOVERY_FINISHED event is the only signal that rolls the top-level status out of PROCESSING, so it
+        // must be emitted even when post-processing fails partway; otherwise the discovery is stranded in PROCESSING
+        // with a growing duration and can never be finalized.
+        boolean discoveryFinishEmitted = false;
+        try {
+            discoveryFinishEmitted = handleDiscoveredCertificates(context, discovery, originalMessage, discoveredCertificates, mergedIgnoreTriggers, mergedTriggers);
+        } catch (Exception e) {
+            logger.error("Post-processing of discovered certificates for discovery {} did not complete: {}", discovery.getName(), e.getMessage(), e);
+        } finally {
+            if (!discoveryFinishEmitted) {
+                emitDiscoveryFinished(discovery, context, DiscoveryStatus.WARNING,
+                        "Discovery post-processing did not complete; some certificates may not have been processed.");
+            }
+        }
+    }
+
+    private boolean handleDiscoveredCertificates(EventContext<Certificate> context, DiscoveryHistory discovery, String originalMessage,
+                                                 List<DiscoveryCertificate> discoveredCertificates, List<TriggerAssociation> mergedIgnoreTriggers,
+                                                 List<TriggerAssociation> mergedTriggers) {
         if (discoveredCertificates.isEmpty()) {
-            eventProducer.produceMessage(DiscoveryFinishedEventHandler.constructEventMessage(discovery.getUuid(), context.getUserUuid(), context.getScheduledJobInfo(), new DiscoveryResult(DiscoveryStatus.PROCESSING, originalMessage)));
-            return;
+            emitDiscoveryFinished(discovery, context, DiscoveryStatus.PROCESSING, originalMessage);
+            return true;
         }
 
         EventHistory eventHistoryDiscovery = createEventHistory(ResourceEvent.CERTIFICATE_DISCOVERED, Resource.DISCOVERY, discovery.getUuid());
@@ -224,9 +243,23 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
         saveEventHistory(eventHistoryDiscovery, EventStatus.FINISHED);
         saveEventHistory(eventHistoryPlatform, EventStatus.FINISHED);
 
-        // trigger other events
-        eventProducer.produceMessage(DiscoveryFinishedEventHandler.constructEventMessage(discovery.getUuid(), context.getUserUuid(), context.getScheduledJobInfo(), new DiscoveryResult(DiscoveryStatus.PROCESSING, originalMessage)));
+        // A WARNING finish surfaces certificates that could not be processed (recorded per DiscoveryCertificate);
+        // a clean run reports PROCESSING, which the finish handler rolls up to COMPLETED.
+        long erroredCertificates = discoveryCertificateRepository.countByDiscoveryAndProcessedErrorNotNull(discovery);
         validationProducer.produceMessage(new ValidationMessage(Resource.CERTIFICATE, null, discovery.getUuid(), discovery.getName(), null, null));
+        if (erroredCertificates > 0) {
+            emitDiscoveryFinished(discovery, context, DiscoveryStatus.WARNING,
+                    "%d certificate(s) could not be processed during discovery.".formatted(erroredCertificates));
+        } else {
+            emitDiscoveryFinished(discovery, context, DiscoveryStatus.PROCESSING, originalMessage);
+        }
+        return true;
+    }
+
+    private void emitDiscoveryFinished(DiscoveryHistory discovery, EventContext<Certificate> context, DiscoveryStatus status, String message) {
+        eventProducer.produceMessage(DiscoveryFinishedEventHandler.constructEventMessage(
+                discovery.getUuid(), context.getUserUuid(), context.getScheduledJobInfo(),
+                new DiscoveryResult(status, message)));
     }
 
     private void processDiscoveredCertificate(EventContext<Certificate> eventContext, List<TriggerAssociation> mergedIgnoreTriggers, List<TriggerAssociation> mergedTriggers, int certIndex, int totalCount, DiscoveryHistory discovery, DiscoveryCertificate discoveryCertificate, ConcurrentMap<PublicKey, List<UUID>> keysToCertificatesMap,

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -159,6 +159,9 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
             handleDiscoveredCertificates(context, discovery, originalMessage, discoveredCertificates, mergedIgnoreTriggers, mergedTriggers);
             discoveryFinishEmitted = true;
         } catch (Exception e) {
+            // Catch broadly on purpose: exceptions escaping handleEvent are only logged and dropped by the JMS
+            // listener (no redelivery, no DLQ), so letting one propagate would strand the discovery in PROCESSING.
+            // Finalizing as WARNING in the finally block is strictly better; the failure is still logged here.
             logger.error("Post-processing of discovered certificates for discovery {} did not complete: {}", discovery.getName(), e.getMessage(), e);
         } finally {
             if (!discoveryFinishEmitted) {

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -156,7 +156,8 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
         // with a growing duration and can never be finalized.
         boolean discoveryFinishEmitted = false;
         try {
-            discoveryFinishEmitted = handleDiscoveredCertificates(context, discovery, originalMessage, discoveredCertificates, mergedIgnoreTriggers, mergedTriggers);
+            handleDiscoveredCertificates(context, discovery, originalMessage, discoveredCertificates, mergedIgnoreTriggers, mergedTriggers);
+            discoveryFinishEmitted = true;
         } catch (Exception e) {
             logger.error("Post-processing of discovered certificates for discovery {} did not complete: {}", discovery.getName(), e.getMessage(), e);
         } finally {
@@ -167,12 +168,12 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
         }
     }
 
-    private boolean handleDiscoveredCertificates(EventContext<Certificate> context, DiscoveryHistory discovery, String originalMessage,
-                                                 List<DiscoveryCertificate> discoveredCertificates, List<TriggerAssociation> mergedIgnoreTriggers,
-                                                 List<TriggerAssociation> mergedTriggers) {
+    private void handleDiscoveredCertificates(EventContext<Certificate> context, DiscoveryHistory discovery, String originalMessage,
+                                              List<DiscoveryCertificate> discoveredCertificates, List<TriggerAssociation> mergedIgnoreTriggers,
+                                              List<TriggerAssociation> mergedTriggers) {
         if (discoveredCertificates.isEmpty()) {
             emitDiscoveryFinished(discovery, context, DiscoveryStatus.PROCESSING, originalMessage);
-            return true;
+            return;
         }
 
         EventHistory eventHistoryDiscovery = createEventHistory(ResourceEvent.CERTIFICATE_DISCOVERED, Resource.DISCOVERY, discovery.getUuid());
@@ -243,8 +244,8 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
         saveEventHistory(eventHistoryDiscovery, EventStatus.FINISHED);
         saveEventHistory(eventHistoryPlatform, EventStatus.FINISHED);
 
-        // A WARNING finish surfaces certificates that could not be processed (recorded per DiscoveryCertificate);
-        // a clean run reports PROCESSING, which the finish handler rolls up to COMPLETED.
+        // A clean run reports PROCESSING, which the finish handler rolls up to COMPLETED. When certificates
+        // recorded a processing error, report WARNING instead so the partial failure stays visible to the user.
         long erroredCertificates = discoveryCertificateRepository.countByDiscoveryAndProcessedErrorNotNull(discovery);
         validationProducer.produceMessage(new ValidationMessage(Resource.CERTIFICATE, null, discovery.getUuid(), discovery.getName(), null, null));
         if (erroredCertificates > 0) {
@@ -253,7 +254,6 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
         } else {
             emitDiscoveryFinished(discovery, context, DiscoveryStatus.PROCESSING, originalMessage);
         }
-        return true;
     }
 
     private void emitDiscoveryFinished(DiscoveryHistory discovery, EventContext<Certificate> context, DiscoveryStatus status, String message) {

--- a/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
@@ -40,8 +40,13 @@ public class DiscoveryFinishedEventHandler extends EventHandler<DiscoveryHistory
         DiscoveryHistory discovery = discoveryRepository.findByUuid(eventMessage.getObjectUuid()).orElseThrow(() -> new EventException(eventMessage.getEvent(), "Discovery with UUID %s not found".formatted(eventMessage.getObjectUuid())));
         DiscoveryResult discoveryResult = objectMapper.convertValue(eventMessage.getData(), DiscoveryResult.class);
 
-        // set discovery status to completed when discovery is in preprocessing state coming from certificate discovered event
-        if (discoveryResult.getDiscoveryStatus() == DiscoveryStatus.PROCESSING) {
+        // Complete post-processing from persisted state; the event payload may already report the final outcome.
+        boolean providerCompletedProcessingDiscovery =
+                discovery.getStatus() == DiscoveryStatus.PROCESSING
+                        && discovery.getConnectorStatus() == DiscoveryStatus.COMPLETED
+                        && discoveryResult.getDiscoveryStatus() == DiscoveryStatus.COMPLETED;
+        if (providerCompletedProcessingDiscovery
+                || discoveryResult.getDiscoveryStatus() == DiscoveryStatus.PROCESSING) {
             String message = discoveryResult.getMessage() == null ? "Discovery completed successfully." : "Discovery completed successfully. " + discoveryResult.getMessage();
             discovery.setMessage(message);
             discovery.setStatus(DiscoveryStatus.COMPLETED);

--- a/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
@@ -43,8 +43,8 @@ public class DiscoveryFinishedEventHandler extends EventHandler<DiscoveryHistory
         // Certificate post-processing reports back once the discovered certificates have been handled, signalling
         // PROCESSING on a clean run or WARNING when some certificates failed; only then is the top-level status
         // finalized. COMPLETED/FAILED payloads originate from the discovery service, which has already persisted
-        // that terminal state, so they are ignored here. Acting only on a not-yet-terminal discovery keeps this
-        // idempotent against event redelivery and leaves a service-finalized discovery untouched.
+        // that terminal state, so they are ignored here. The not-yet-terminal guard makes only this persisted
+        // write idempotent on redelivery; the base handler still dispatches follow-up notifications either way.
         DiscoveryStatus reportedStatus = discoveryResult.getDiscoveryStatus();
         if (!isTerminal(discovery.getStatus()) && isPostProcessingFinishSignal(reportedStatus)) {
             DiscoveryStatus finalStatus = reportedStatus == DiscoveryStatus.PROCESSING ? DiscoveryStatus.COMPLETED : reportedStatus;

--- a/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
@@ -40,17 +40,16 @@ public class DiscoveryFinishedEventHandler extends EventHandler<DiscoveryHistory
         DiscoveryHistory discovery = discoveryRepository.findByUuid(eventMessage.getObjectUuid()).orElseThrow(() -> new EventException(eventMessage.getEvent(), "Discovery with UUID %s not found".formatted(eventMessage.getObjectUuid())));
         DiscoveryResult discoveryResult = objectMapper.convertValue(eventMessage.getData(), DiscoveryResult.class);
 
-        // Complete post-processing from persisted state; the event payload may already report the final outcome.
-        boolean providerCompletedProcessingDiscovery =
-                discovery.getStatus() == DiscoveryStatus.PROCESSING
-                        && discovery.getConnectorStatus() == DiscoveryStatus.COMPLETED
-                        && discoveryResult.getDiscoveryStatus() == DiscoveryStatus.COMPLETED;
-        if (providerCompletedProcessingDiscovery
-                || discoveryResult.getDiscoveryStatus() == DiscoveryStatus.PROCESSING) {
-            String message = discoveryResult.getMessage() == null ? "Discovery completed successfully." : "Discovery completed successfully. " + discoveryResult.getMessage();
-            discovery.setMessage(message);
-            discovery.setStatus(DiscoveryStatus.COMPLETED);
+        // Post-processing reports back once the discovered certificates have been handled; only then is the
+        // top-level status finalized. A PROCESSING payload is the clean-completion signal, a terminal payload
+        // carries the actual outcome. Finalizing only from the persisted PROCESSING state keeps this idempotent
+        // and leaves an already-terminal discovery (finalized directly by the discovery service) untouched.
+        DiscoveryStatus reportedStatus = discoveryResult.getDiscoveryStatus();
+        if (discovery.getStatus() == DiscoveryStatus.PROCESSING && isFinalizeSignal(reportedStatus)) {
+            DiscoveryStatus finalStatus = reportedStatus == DiscoveryStatus.PROCESSING ? DiscoveryStatus.COMPLETED : reportedStatus;
+            discovery.setStatus(finalStatus);
             discovery.setEndTime(new Date());
+            discovery.setMessage(buildFinishedMessage(finalStatus, discoveryResult.getMessage()));
             discoveryRepository.save(discovery);
         }
 
@@ -81,6 +80,22 @@ public class DiscoveryFinishedEventHandler extends EventHandler<DiscoveryHistory
 
     public static EventMessage constructEventMessage(UUID discoveryUuid, UUID userUuid, ScheduledJobInfo scheduledJobInfo, DiscoveryResult discoveryResult) {
         return new EventMessage(ResourceEvent.DISCOVERY_FINISHED, Resource.DISCOVERY, discoveryUuid, null, null, discoveryResult, userUuid, scheduledJobInfo);
+    }
+
+    private static boolean isFinalizeSignal(DiscoveryStatus reportedStatus) {
+        return reportedStatus == DiscoveryStatus.PROCESSING
+                || reportedStatus == DiscoveryStatus.COMPLETED
+                || reportedStatus == DiscoveryStatus.WARNING
+                || reportedStatus == DiscoveryStatus.FAILED;
+    }
+
+    private static String buildFinishedMessage(DiscoveryStatus finalStatus, String detail) {
+        String summary = switch (finalStatus) {
+            case WARNING -> "Discovery completed with warnings.";
+            case FAILED -> "Discovery failed.";
+            default -> "Discovery completed successfully.";
+        };
+        return detail == null ? summary : summary + " " + detail;
     }
 
 }

--- a/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/DiscoveryFinishedEventHandler.java
@@ -40,12 +40,13 @@ public class DiscoveryFinishedEventHandler extends EventHandler<DiscoveryHistory
         DiscoveryHistory discovery = discoveryRepository.findByUuid(eventMessage.getObjectUuid()).orElseThrow(() -> new EventException(eventMessage.getEvent(), "Discovery with UUID %s not found".formatted(eventMessage.getObjectUuid())));
         DiscoveryResult discoveryResult = objectMapper.convertValue(eventMessage.getData(), DiscoveryResult.class);
 
-        // Post-processing reports back once the discovered certificates have been handled; only then is the
-        // top-level status finalized. A PROCESSING payload is the clean-completion signal, a terminal payload
-        // carries the actual outcome. Finalizing only from the persisted PROCESSING state keeps this idempotent
-        // and leaves an already-terminal discovery (finalized directly by the discovery service) untouched.
+        // Certificate post-processing reports back once the discovered certificates have been handled, signalling
+        // PROCESSING on a clean run or WARNING when some certificates failed; only then is the top-level status
+        // finalized. COMPLETED/FAILED payloads originate from the discovery service, which has already persisted
+        // that terminal state, so they are ignored here. Acting only on a not-yet-terminal discovery keeps this
+        // idempotent against event redelivery and leaves a service-finalized discovery untouched.
         DiscoveryStatus reportedStatus = discoveryResult.getDiscoveryStatus();
-        if (discovery.getStatus() == DiscoveryStatus.PROCESSING && isFinalizeSignal(reportedStatus)) {
+        if (!isTerminal(discovery.getStatus()) && isPostProcessingFinishSignal(reportedStatus)) {
             DiscoveryStatus finalStatus = reportedStatus == DiscoveryStatus.PROCESSING ? DiscoveryStatus.COMPLETED : reportedStatus;
             discovery.setStatus(finalStatus);
             discovery.setEndTime(new Date());
@@ -82,19 +83,18 @@ public class DiscoveryFinishedEventHandler extends EventHandler<DiscoveryHistory
         return new EventMessage(ResourceEvent.DISCOVERY_FINISHED, Resource.DISCOVERY, discoveryUuid, null, null, discoveryResult, userUuid, scheduledJobInfo);
     }
 
-    private static boolean isFinalizeSignal(DiscoveryStatus reportedStatus) {
-        return reportedStatus == DiscoveryStatus.PROCESSING
-                || reportedStatus == DiscoveryStatus.COMPLETED
-                || reportedStatus == DiscoveryStatus.WARNING
-                || reportedStatus == DiscoveryStatus.FAILED;
+    private static boolean isPostProcessingFinishSignal(DiscoveryStatus reportedStatus) {
+        return reportedStatus == DiscoveryStatus.PROCESSING || reportedStatus == DiscoveryStatus.WARNING;
+    }
+
+    private static boolean isTerminal(DiscoveryStatus status) {
+        return status == DiscoveryStatus.COMPLETED || status == DiscoveryStatus.WARNING || status == DiscoveryStatus.FAILED;
     }
 
     private static String buildFinishedMessage(DiscoveryStatus finalStatus, String detail) {
-        String summary = switch (finalStatus) {
-            case WARNING -> "Discovery completed with warnings.";
-            case FAILED -> "Discovery failed.";
-            default -> "Discovery completed successfully.";
-        };
+        String summary = finalStatus == DiscoveryStatus.WARNING
+                ? "Discovery completed with warnings."
+                : "Discovery completed successfully.";
         return detail == null ? summary : summary + " " + detail;
     }
 

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -53,7 +53,9 @@ import com.otilm.core.events.data.EventDataBuilder;
 import com.otilm.core.events.handlers.*;
 import com.otilm.core.helpers.CertificateGeneratorHelper;
 import com.otilm.core.messaging.jms.listeners.NotificationListener;
+import com.otilm.core.messaging.jms.producers.EventProducer;
 import com.otilm.core.messaging.model.CertificateUploadEventMessageData;
+import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
 import com.otilm.core.model.ScheduledTaskResult;
@@ -69,7 +71,9 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
@@ -125,6 +129,12 @@ class EventHandlersITest extends BaseSpringBootTest {
     private DiscoveryRepository discoveryRepository;
     @Autowired
     private DiscoveryFinishedEventHandler discoveryFinishedEventHandler;
+    @Autowired
+    private CertificateDiscoveredEventHandler certificateDiscoveredEventHandler;
+    @Autowired
+    private DiscoveryCertificateRepository discoveryCertificateRepository;
+    @MockitoSpyBean
+    private EventProducer eventProducer;
 
     @Autowired
     private AttributeEngine attributeEngine;
@@ -528,6 +538,45 @@ class EventHandlersITest extends BaseSpringBootTest {
         Assertions.assertEquals(DiscoveryStatus.COMPLETED, persisted.getStatus());
         Assertions.assertEquals(endTimeBefore, persisted.getEndTime());
         Assertions.assertEquals("Discovery completed successfully.", persisted.getMessage());
+    }
+
+    @Test
+    void testCertificateDiscoveredEmitsFinishWhenNoNewCertificates() throws EventException {
+        DiscoveryHistory discovery = persistProcessingDiscovery();
+
+        certificateDiscoveredEventHandler.handleEvent(
+                CertificateDiscoveredEventHandler.constructEventMessage(discovery.getUuid(), null, null));
+
+        Mockito.verify(eventProducer).produceMessage(Mockito.argThat((EventMessage msg) ->
+                msg.getEvent() == ResourceEvent.DISCOVERY_FINISHED
+                        && discovery.getUuid().equals(msg.getObjectUuid())
+                        && ((DiscoveryResult) msg.getData()).getDiscoveryStatus() == DiscoveryStatus.PROCESSING));
+    }
+
+    @Test
+    void testCertificateDiscoveredEmitsWarningWhenCertificateProcessingFails() throws EventException {
+        DiscoveryHistory discovery = persistProcessingDiscovery();
+
+        CertificateContent certificateContent = new CertificateContent();
+        certificateContent.setContent("not-a-valid-certificate");
+        certificateContent = certificateContentRepository.save(certificateContent);
+
+        DiscoveryCertificate discoveryCertificate = new DiscoveryCertificate();
+        discoveryCertificate.setCommonName("failing-cert");
+        discoveryCertificate.setNewlyDiscovered(true);
+        discoveryCertificate.setCertificateContent(certificateContent);
+        discoveryCertificate.setDiscovery(discovery);
+        discoveryCertificateRepository.save(discoveryCertificate);
+
+        certificateDiscoveredEventHandler.handleEvent(
+                CertificateDiscoveredEventHandler.constructEventMessage(discovery.getUuid(), null, null));
+
+        Mockito.verify(eventProducer).produceMessage(Mockito.argThat((EventMessage msg) ->
+                msg.getEvent() == ResourceEvent.DISCOVERY_FINISHED
+                        && discovery.getUuid().equals(msg.getObjectUuid())
+                        && ((DiscoveryResult) msg.getData()).getDiscoveryStatus() == DiscoveryStatus.WARNING));
+        DiscoveryCertificate processed = discoveryCertificateRepository.findByUuid(discoveryCertificate.getUuid()).orElseThrow();
+        Assertions.assertNotNull(processed.getProcessedError());
     }
 
     private DiscoveryHistory persistProcessingDiscovery() {

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -71,7 +71,6 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -81,6 +80,9 @@ import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.verify;
 
 class EventHandlersITest extends BaseSpringBootTest {
 
@@ -547,7 +549,7 @@ class EventHandlersITest extends BaseSpringBootTest {
         certificateDiscoveredEventHandler.handleEvent(
                 CertificateDiscoveredEventHandler.constructEventMessage(discovery.getUuid(), null, null));
 
-        Mockito.verify(eventProducer).produceMessage(Mockito.argThat((EventMessage msg) ->
+        verify(eventProducer).produceMessage(argThat((EventMessage msg) ->
                 msg.getEvent() == ResourceEvent.DISCOVERY_FINISHED
                         && discovery.getUuid().equals(msg.getObjectUuid())
                         && ((DiscoveryResult) msg.getData()).getDiscoveryStatus() == DiscoveryStatus.PROCESSING));
@@ -571,7 +573,7 @@ class EventHandlersITest extends BaseSpringBootTest {
         certificateDiscoveredEventHandler.handleEvent(
                 CertificateDiscoveredEventHandler.constructEventMessage(discovery.getUuid(), null, null));
 
-        Mockito.verify(eventProducer).produceMessage(Mockito.argThat((EventMessage msg) ->
+        verify(eventProducer).produceMessage(argThat((EventMessage msg) ->
                 msg.getEvent() == ResourceEvent.DISCOVERY_FINISHED
                         && discovery.getUuid().equals(msg.getObjectUuid())
                         && ((DiscoveryResult) msg.getData()).getDiscoveryStatus() == DiscoveryStatus.WARNING));

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -497,16 +497,18 @@ class EventHandlersITest extends BaseSpringBootTest {
     }
 
     @Test
-    void testDiscoveryFinishedEventFinalizesFailedProcessingDiscovery() throws EventException {
+    void testDiscoveryFinishedEventIgnoresNonFinishSignal() throws EventException {
         DiscoveryHistory discovery = persistProcessingDiscovery();
 
+        // COMPLETED/FAILED payloads come from the discovery service with the state already persisted; only a
+        // PROCESSING or WARNING signal from certificate post-processing finalizes a processing discovery.
         discoveryFinishedEventHandler.handleEvent(
                 DiscoveryFinishedEventHandler.constructEventMessage(
                         discovery.getUuid(), null, null, new DiscoveryResult(DiscoveryStatus.FAILED, "Provider failed.")));
 
         DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
-        Assertions.assertEquals(DiscoveryStatus.FAILED, persisted.getStatus());
-        Assertions.assertNotNull(persisted.getEndTime());
+        Assertions.assertEquals(DiscoveryStatus.PROCESSING, persisted.getStatus());
+        Assertions.assertNull(persisted.getEndTime());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -469,59 +469,73 @@ class EventHandlersITest extends BaseSpringBootTest {
 
     @Test
     void testDiscoveryFinishedEventCompletesProcessingDiscovery() throws EventException {
-        DiscoveryHistory discovery = new DiscoveryHistory();
-        discovery.setName("TestDiscovery");
-        discovery.setKind("IP");
-        discovery.setStatus(DiscoveryStatus.PROCESSING);
-        discovery.setConnectorUuid(UUID.randomUUID());
-        discovery.setConnectorStatus(DiscoveryStatus.COMPLETED);
-        discovery = discoveryRepository.save(discovery);
+        DiscoveryHistory discovery = persistProcessingDiscovery();
 
         discoveryFinishedEventHandler.handleEvent(
                 DiscoveryFinishedEventHandler.constructEventMessage(
-                        discovery.getUuid(), null, null, new DiscoveryResult(DiscoveryStatus.COMPLETED, "Provider completed.")));
+                        discovery.getUuid(), null, null, new DiscoveryResult(DiscoveryStatus.PROCESSING, "Provider completed.")));
 
         DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
         Assertions.assertEquals(DiscoveryStatus.COMPLETED, persisted.getStatus());
         Assertions.assertNotNull(persisted.getEndTime());
+        Assertions.assertEquals("Discovery completed successfully. Provider completed.", persisted.getMessage());
     }
 
     @Test
-    void testDiscoveryFinishedEventDoesNotCompleteFailedProcessingDiscovery() throws EventException {
-        DiscoveryHistory discovery = new DiscoveryHistory();
-        discovery.setName("TestDiscovery");
-        discovery.setKind("IP");
-        discovery.setStatus(DiscoveryStatus.PROCESSING);
-        discovery.setConnectorUuid(UUID.randomUUID());
-        discovery.setConnectorStatus(DiscoveryStatus.COMPLETED);
-        discovery = discoveryRepository.save(discovery);
+    void testDiscoveryFinishedEventMarksWarningWhenCertificatesFailed() throws EventException {
+        DiscoveryHistory discovery = persistProcessingDiscovery();
+
+        discoveryFinishedEventHandler.handleEvent(
+                DiscoveryFinishedEventHandler.constructEventMessage(
+                        discovery.getUuid(), null, null,
+                        new DiscoveryResult(DiscoveryStatus.WARNING, "2 certificate(s) could not be processed during discovery.")));
+
+        DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
+        Assertions.assertEquals(DiscoveryStatus.WARNING, persisted.getStatus());
+        Assertions.assertNotNull(persisted.getEndTime());
+        Assertions.assertEquals("Discovery completed with warnings. 2 certificate(s) could not be processed during discovery.", persisted.getMessage());
+    }
+
+    @Test
+    void testDiscoveryFinishedEventFinalizesFailedProcessingDiscovery() throws EventException {
+        DiscoveryHistory discovery = persistProcessingDiscovery();
 
         discoveryFinishedEventHandler.handleEvent(
                 DiscoveryFinishedEventHandler.constructEventMessage(
                         discovery.getUuid(), null, null, new DiscoveryResult(DiscoveryStatus.FAILED, "Provider failed.")));
 
         DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
-        Assertions.assertEquals(DiscoveryStatus.PROCESSING, persisted.getStatus());
-        Assertions.assertNull(persisted.getEndTime());
+        Assertions.assertEquals(DiscoveryStatus.FAILED, persisted.getStatus());
+        Assertions.assertNotNull(persisted.getEndTime());
     }
 
     @Test
-    void testDiscoveryFinishedEventDoesNotCompleteWhileProviderIsRunning() throws EventException {
+    void testDiscoveryFinishedEventLeavesTerminalDiscoveryUnchanged() throws EventException {
+        DiscoveryHistory discovery = persistProcessingDiscovery();
+        discovery.setStatus(DiscoveryStatus.COMPLETED);
+        discovery.setEndTime(new Date());
+        discovery.setMessage("Discovery completed successfully.");
+        discoveryRepository.save(discovery);
+        Date endTimeBefore = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow().getEndTime();
+
+        discoveryFinishedEventHandler.handleEvent(
+                DiscoveryFinishedEventHandler.constructEventMessage(
+                        discovery.getUuid(), null, null, new DiscoveryResult(DiscoveryStatus.COMPLETED, "Late duplicate event.")));
+
+        DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
+        Assertions.assertEquals(DiscoveryStatus.COMPLETED, persisted.getStatus());
+        Assertions.assertEquals(endTimeBefore, persisted.getEndTime());
+        Assertions.assertEquals("Discovery completed successfully.", persisted.getMessage());
+    }
+
+    private DiscoveryHistory persistProcessingDiscovery() {
         DiscoveryHistory discovery = new DiscoveryHistory();
         discovery.setName("TestDiscovery");
         discovery.setKind("IP");
         discovery.setStatus(DiscoveryStatus.PROCESSING);
         discovery.setConnectorUuid(UUID.randomUUID());
-        discovery.setConnectorStatus(DiscoveryStatus.IN_PROGRESS);
-        discovery = discoveryRepository.save(discovery);
-
-        discoveryFinishedEventHandler.handleEvent(
-                DiscoveryFinishedEventHandler.constructEventMessage(
-                        discovery.getUuid(), null, null, new DiscoveryResult(DiscoveryStatus.COMPLETED, "Provider completed.")));
-
-        DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
-        Assertions.assertEquals(DiscoveryStatus.PROCESSING, persisted.getStatus());
-        Assertions.assertNull(persisted.getEndTime());
+        discovery.setConnectorStatus(DiscoveryStatus.COMPLETED);
+        return discoveryRepository.save(discovery);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -468,6 +468,63 @@ class EventHandlersITest extends BaseSpringBootTest {
     }
 
     @Test
+    void testDiscoveryFinishedEventCompletesProcessingDiscovery() throws EventException {
+        DiscoveryHistory discovery = new DiscoveryHistory();
+        discovery.setName("TestDiscovery");
+        discovery.setKind("IP");
+        discovery.setStatus(DiscoveryStatus.PROCESSING);
+        discovery.setConnectorUuid(UUID.randomUUID());
+        discovery.setConnectorStatus(DiscoveryStatus.COMPLETED);
+        discovery = discoveryRepository.save(discovery);
+
+        discoveryFinishedEventHandler.handleEvent(
+                DiscoveryFinishedEventHandler.constructEventMessage(
+                        discovery.getUuid(), null, null, new DiscoveryResult(DiscoveryStatus.COMPLETED, "Provider completed.")));
+
+        DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
+        Assertions.assertEquals(DiscoveryStatus.COMPLETED, persisted.getStatus());
+        Assertions.assertNotNull(persisted.getEndTime());
+    }
+
+    @Test
+    void testDiscoveryFinishedEventDoesNotCompleteFailedProcessingDiscovery() throws EventException {
+        DiscoveryHistory discovery = new DiscoveryHistory();
+        discovery.setName("TestDiscovery");
+        discovery.setKind("IP");
+        discovery.setStatus(DiscoveryStatus.PROCESSING);
+        discovery.setConnectorUuid(UUID.randomUUID());
+        discovery.setConnectorStatus(DiscoveryStatus.COMPLETED);
+        discovery = discoveryRepository.save(discovery);
+
+        discoveryFinishedEventHandler.handleEvent(
+                DiscoveryFinishedEventHandler.constructEventMessage(
+                        discovery.getUuid(), null, null, new DiscoveryResult(DiscoveryStatus.FAILED, "Provider failed.")));
+
+        DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
+        Assertions.assertEquals(DiscoveryStatus.PROCESSING, persisted.getStatus());
+        Assertions.assertNull(persisted.getEndTime());
+    }
+
+    @Test
+    void testDiscoveryFinishedEventDoesNotCompleteWhileProviderIsRunning() throws EventException {
+        DiscoveryHistory discovery = new DiscoveryHistory();
+        discovery.setName("TestDiscovery");
+        discovery.setKind("IP");
+        discovery.setStatus(DiscoveryStatus.PROCESSING);
+        discovery.setConnectorUuid(UUID.randomUUID());
+        discovery.setConnectorStatus(DiscoveryStatus.IN_PROGRESS);
+        discovery = discoveryRepository.save(discovery);
+
+        discoveryFinishedEventHandler.handleEvent(
+                DiscoveryFinishedEventHandler.constructEventMessage(
+                        discovery.getUuid(), null, null, new DiscoveryResult(DiscoveryStatus.COMPLETED, "Provider completed.")));
+
+        DiscoveryHistory persisted = discoveryRepository.findByUuid(discovery.getUuid()).orElseThrow();
+        Assertions.assertEquals(DiscoveryStatus.PROCESSING, persisted.getStatus());
+        Assertions.assertNull(persisted.getEndTime());
+    }
+
+    @Test
     void testDiscoveryFinishedEvent() throws EventException, AttributeException, AlreadyExistException, NotFoundException {
         DiscoveryHistory discovery = new DiscoveryHistory();
         discovery.setName("TestDiscovery");


### PR DESCRIPTION
## Summary
- roll persisted discovery status from `PROCESSING` to `COMPLETED` when provider and finish event both completed
- set discovery end time so duration stops increasing
- preserve failed, running-provider, and legacy processing-event behavior

## Test plan
- `mvn test -q`

Closes #1800