### PR TITLE
Dispatch empty dependsOn as NG fire-on-mount callback

### DIFF
--- a/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/AuthorityInstanceControllerImpl.java
@@ -102,7 +102,7 @@ public class AuthorityInstanceControllerImpl implements AuthorityInstanceControl
 
     @Override
     @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "raProfile", affiliatedResource = Resource.AUTHORITY, operation = Operation.LIST_ATTRIBUTES)
-    public List<BaseAttribute> listRAProfileAttributes(@LogResource(uuid = true, affiliated = true) @PathVariable String uuid) throws ConnectorException, NotFoundException {
+    public List<BaseAttribute> listRAProfileAttributes(@LogResource(uuid = true, affiliated = true) @PathVariable String uuid) throws ConnectorException, NotFoundException, AttributeException {
         return authorityInstanceService.listRAProfileAttributes(SecuredUUID.fromString(uuid));
     }
 

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -1122,13 +1122,15 @@ public class AttributeEngine {
 
     /**
      * Declaration validity for the NG ({@code dependsOn}) callback shape at the ingest
-     * choke point. {@code dependsOn} (NG, scope-resolved) and {@code callbackContext} (legacy, body-mapped)
-     * are mutually exclusive: a definition declaring both is ambiguous to dispatch, so the NG branch can
-     * safely gate on {@code dependsOn != null}. {@code dependsOn} on a RESOURCE-content attribute is also
-     * rejected — RESOURCE content is resolved through the core resource path, not an NG callback.
+     * choke point. A non-null {@code dependsOn} — including an empty list ("fire once on form open") — is an NG
+     * declaration, so the guards below must run for the empty case too. {@code dependsOn} (NG, scope-resolved) and
+     * {@code callbackContext} (legacy, body-mapped) are mutually exclusive: a definition declaring both is ambiguous
+     * to dispatch, so the NG branch can safely gate on {@code dependsOn != null}. {@code dependsOn} on a
+     * RESOURCE-content attribute is also rejected — RESOURCE content is resolved through the core resource path,
+     * not an NG callback.
      */
     private static void validateCallbackDeclaration(BaseAttribute attribute, AttributeCallback callback, String connectorUuidStr) throws AttributeException {
-        if (callback == null || callback.getDependsOn() == null || callback.getDependsOn().isEmpty()) {
+        if (callback == null || callback.getDependsOn() == null) {
             return;
         }
         if (callback.getCallbackContext() != null) {

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -1121,13 +1121,16 @@ public class AttributeEngine {
     }
 
     /**
-     * Declaration validity for the NG ({@code dependsOn}) callback shape at the ingest
-     * choke point. A non-null {@code dependsOn} — including an empty list ("fire once on form open") — is an NG
-     * declaration, so the guards below must run for the empty case too. {@code dependsOn} (NG, scope-resolved) and
-     * {@code callbackContext} (legacy, body-mapped) are mutually exclusive: a definition declaring both is ambiguous
-     * to dispatch, so the NG branch can safely gate on {@code dependsOn != null}. {@code dependsOn} on a
-     * RESOURCE-content attribute is also rejected — RESOURCE content is resolved through the core resource path,
-     * not an NG callback.
+     * Declaration validity for the NG ({@code dependsOn}) callback shape at the ingest choke point.
+     *
+     * <p><b>Empty list is still NG.</b> A non-null {@code dependsOn} — including an empty list ("fire once on form
+     * open") — is an NG declaration, so the guards below must run for the empty case too.
+     *
+     * <p><b>Mutual exclusion.</b> {@code dependsOn} (NG, scope-resolved) and {@code callbackContext} (legacy,
+     * body-mapped) cannot both be set; that lets the dispatch path gate NG on {@code dependsOn != null}.
+     *
+     * <p><b>RESOURCE is rejected.</b> {@code dependsOn} on a RESOURCE-content attribute is refused — RESOURCE content
+     * resolves through the core resource path, not an NG callback.
      */
     private static void validateCallbackDeclaration(BaseAttribute attribute, AttributeCallback callback, String connectorUuidStr) throws AttributeException {
         if (callback == null || callback.getDependsOn() == null) {

--- a/src/main/java/com/otilm/core/service/AuthorityInstanceExternalService.java
+++ b/src/main/java/com/otilm/core/service/AuthorityInstanceExternalService.java
@@ -40,7 +40,7 @@ public interface AuthorityInstanceExternalService {
      */
     List<BaseAttribute> listAuthorityInstanceAttributes(SecuredUUID connectorUuid, UUID interfaceUuid) throws ConnectorException, AttributeException, NotFoundException;
 
-    List<BaseAttribute> listRAProfileAttributes(SecuredUUID uuid) throws ConnectorException, NotFoundException;
+    List<BaseAttribute> listRAProfileAttributes(SecuredUUID uuid) throws ConnectorException, NotFoundException, AttributeException;
 
     Boolean validateRAProfileAttributes(SecuredUUID uuid, List<RequestAttribute> attributes) throws ConnectorException, AttributeException, NotFoundException;
 

--- a/src/main/java/com/otilm/core/service/callback/NgCallbackDispatcher.java
+++ b/src/main/java/com/otilm/core/service/callback/NgCallbackDispatcher.java
@@ -167,7 +167,9 @@ public class NgCallbackDispatcher {
         }
         envelope.setAttributeName(definition.getName());
         envelope.setContextAttributes(context.contextAttributes());
-        envelope.setCurrentAttributes(context.currentAttributes());
+        // currentAttributes is @NotNull and the DTO is @JsonInclude(NON_NULL): a null (fire-on-mount callback with
+        // no in-form dependency) would be dropped from the JSON, so a conformant connector rejects the body. Send [].
+        envelope.setCurrentAttributes(context.currentAttributes() == null ? List.of() : context.currentAttributes());
         envelope.setPagination(callback.getPagination());
         return envelope;
     }

--- a/src/main/java/com/otilm/core/service/callback/NgCallbackDispatcher.java
+++ b/src/main/java/com/otilm/core/service/callback/NgCallbackDispatcher.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -168,8 +169,9 @@ public class NgCallbackDispatcher {
         envelope.setAttributeName(definition.getName());
         envelope.setContextAttributes(context.contextAttributes());
         // currentAttributes is @NotNull and the DTO is @JsonInclude(NON_NULL): a null (fire-on-mount callback with
-        // no in-form dependency) would be dropped from the JSON, so a conformant connector rejects the body. Send [].
-        envelope.setCurrentAttributes(context.currentAttributes() == null ? List.of() : context.currentAttributes());
+        // no in-form dependency) would be dropped from the JSON, so a conformant connector rejects the body. Send an
+        // empty list — mutable, to match the pass-through branch's Jackson-deserialized ArrayList.
+        envelope.setCurrentAttributes(context.currentAttributes() == null ? new ArrayList<>() : context.currentAttributes());
         envelope.setPagination(callback.getPagination());
         return envelope;
     }

--- a/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
@@ -353,9 +353,17 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceExternalSe
 
     @Override
     @ExternalAuthorization(resource = Resource.AUTHORITY, action = ResourceAction.ANY)
-    public List<BaseAttribute> listRAProfileAttributes(SecuredUUID uuid) throws ConnectorException, NotFoundException {
+    public List<BaseAttribute> listRAProfileAttributes(SecuredUUID uuid) throws ConnectorException, NotFoundException, AttributeException {
         AuthorityInstanceReference authorityInstance = getAuthorityInstanceReferenceEntity(uuid);
-        return adapterFactory.forAuthority(authorityInstance).listRaProfileAttributes(authorityInstance);
+        List<BaseAttribute> attributes = adapterFactory.forAuthority(authorityInstance).listRaProfileAttributes(authorityInstance);
+        if (isV3(authorityInstance.getConnectorInterface())) {
+            // v3 is stateless: the resourceCallback RA-profile arm has no connector-side authorityInstanceUuid to
+            // re-list with, so a fire-on-mount callback resolves its definition from Core storage by name. Ingest at
+            // list time — mirroring listAuthorityInstanceAttributes — so resolution succeeds on a fresh system;
+            // otherwise the first callback 404s before any definition row exists.
+            attributeEngine.updateDataAttributeDefinitions(authorityInstance.getConnectorUuid(), null, attributes);
+        }
+        return attributes;
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
@@ -353,11 +353,10 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceExternalSe
 
     @Override
     @ExternalAuthorization(resource = Resource.AUTHORITY, action = ResourceAction.ANY)
-    // NOT_SUPPORTED (as in listAuthorityInstanceAttributes): the connector list call is HTTP and must not hold a DB
-    // connection across the round-trip; the v3 ingest below opens its own short transaction via
-    // updateDataAttributeDefinitions. Lazy entity reads ride the open-session-in-view session.
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public List<BaseAttribute> listRAProfileAttributes(SecuredUUID uuid) throws ConnectorException, NotFoundException, AttributeException {
+        // Runs under the class-level (REQUIRED) transaction: adapter selection and the v3 check below dereference the
+        // LAZY connectorInterface, so a persistence context must be open — do not switch this to NOT_SUPPORTED without
+        // eagerly loading that association first.
         AuthorityInstanceReference authorityInstance = getAuthorityInstanceReferenceEntity(uuid);
         List<BaseAttribute> attributes = adapterFactory.forAuthority(authorityInstance).listRaProfileAttributes(authorityInstance);
         if (isV3(authorityInstance.getConnectorInterface())) {

--- a/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/AuthorityInstanceServiceImpl.java
@@ -353,14 +353,18 @@ public class AuthorityInstanceServiceImpl implements AuthorityInstanceExternalSe
 
     @Override
     @ExternalAuthorization(resource = Resource.AUTHORITY, action = ResourceAction.ANY)
+    // NOT_SUPPORTED (as in listAuthorityInstanceAttributes): the connector list call is HTTP and must not hold a DB
+    // connection across the round-trip; the v3 ingest below opens its own short transaction via
+    // updateDataAttributeDefinitions. Lazy entity reads ride the open-session-in-view session.
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public List<BaseAttribute> listRAProfileAttributes(SecuredUUID uuid) throws ConnectorException, NotFoundException, AttributeException {
         AuthorityInstanceReference authorityInstance = getAuthorityInstanceReferenceEntity(uuid);
         List<BaseAttribute> attributes = adapterFactory.forAuthority(authorityInstance).listRaProfileAttributes(authorityInstance);
         if (isV3(authorityInstance.getConnectorInterface())) {
             // v3 is stateless: the resourceCallback RA-profile arm has no connector-side authorityInstanceUuid to
             // re-list with, so a fire-on-mount callback resolves its definition from Core storage by name. Ingest at
-            // list time — mirroring listAuthorityInstanceAttributes — so resolution succeeds on a fresh system;
-            // otherwise the first callback 404s before any definition row exists.
+            // list time so resolution succeeds on a fresh system; otherwise the first callback 404s before any
+            // definition row exists.
             attributeEngine.updateDataAttributeDefinitions(authorityInstance.getConnectorUuid(), null, attributes);
         }
         return attributes;

--- a/src/main/java/com/otilm/core/service/impl/CallbackServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CallbackServiceImpl.java
@@ -192,7 +192,7 @@ public class CallbackServiceImpl implements CallbackExternalService {
         // callbackContext/callbackMethod (which AttributeDefinitionUtils.validateCallback requires); the NG
         // declaration is validated at ingest instead. Both-set is rejected at ingest, so the
         // callbackContext == null conjunct here is defensive. Legacy callbacks fall through unchanged.
-        if (isNgCallback(attributeCallback)) {
+        if (isNgCallback(attribute, attributeCallback)) {
             return dispatchNg(connector, attribute, callback, scopeResource, scopeResourceUuid, connectorInterface, interfaceVersion);
         }
 
@@ -292,12 +292,18 @@ public class CallbackServiceImpl implements CallbackExternalService {
         return attribute instanceof DataAttribute dataAttribute ? dataAttribute.getProperties().getResource() : null;
     }
 
-    private static boolean isNgCallback(AttributeCallback attributeCallback) {
-        // A DATA attribute can be stored without any callback, so getAttributeCallback returns null here. This runs
-        // before validateCallback (which would surface a controlled 400), so a null deref would become a 500 NPE.
-        return attributeCallback != null
-                && attributeCallback.getDependsOn() != null && !attributeCallback.getDependsOn().isEmpty()
-                && attributeCallback.getCallbackContext() == null;
+    private static boolean isNgCallback(BaseAttribute attribute, AttributeCallback attributeCallback) {
+        // A non-null dependsOn marks an NG callback; an empty (non-null) list is valid and means "fire once on form
+        // open" (a scope-only dropdown), so it must dispatch NG, not fall to the legacy rung. RESOURCE content is
+        // answered by the core resource path (ladder rung 1), so it is excluded — otherwise a live-listed definition
+        // (which bypasses the ingest-time declaration guard) could route a RESOURCE attribute through NG.
+        if (attributeCallback == null
+                || attributeCallback.getDependsOn() == null
+                || attributeCallback.getCallbackContext() != null) {
+            return false;
+        }
+        return !(attribute instanceof DataAttribute dataAttribute
+                && dataAttribute.getContentType() == AttributeContentType.RESOURCE);
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeDeclarationValidityITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeDeclarationValidityITest.java
@@ -114,8 +114,11 @@ class AttributeDeclarationValidityITest extends BaseSpringBootTest {
         callback.setDependsOn(List.of());
         a.setAttributeCallback(callback);
 
-        Assertions.assertThrows(AttributeException.class,
+        // Assert the message so the test pins the RESOURCE dependsOn guard, not the earlier validateAttributeProperties
+        // step (which also throws AttributeException) — the "green but covers nothing" hazard.
+        AttributeException ex = Assertions.assertThrows(AttributeException.class,
                 () -> attributeEngine.updateDataAttributeDefinitions(connectorUuid, null, List.of(a)));
+        Assertions.assertTrue(ex.getMessage().contains("dependsOn"));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeDeclarationValidityITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeDeclarationValidityITest.java
@@ -93,6 +93,43 @@ class AttributeDeclarationValidityITest extends BaseSpringBootTest {
     }
 
     @Test
+    void emptyDependsOnAndCallbackContextTogether_rejected() {
+        // An empty (non-null) dependsOn is still an NG declaration, so the mutual-exclusion guard applies to it too.
+        DataAttributeV2 a = base(AttributeContentType.STRING);
+        AttributeCallback callback = new AttributeCallback();
+        callback.setDependsOn(List.of());
+        callback.setCallbackContext("/legacy");
+        a.setAttributeCallback(callback);
+
+        AttributeException ex = Assertions.assertThrows(AttributeException.class,
+                () -> attributeEngine.updateDataAttributeDefinitions(connectorUuid, null, List.of(a)));
+        Assertions.assertTrue(ex.getMessage().contains("dependsOn"));
+    }
+
+    @Test
+    void emptyDependsOnOnResourceContent_rejected() {
+        // The RESOURCE guard must fire for an empty dependsOn too — RESOURCE content is never resolved via NG.
+        DataAttributeV2 a = base(AttributeContentType.RESOURCE);
+        AttributeCallback callback = new AttributeCallback();
+        callback.setDependsOn(List.of());
+        a.setAttributeCallback(callback);
+
+        Assertions.assertThrows(AttributeException.class,
+                () -> attributeEngine.updateDataAttributeDefinitions(connectorUuid, null, List.of(a)));
+    }
+
+    @Test
+    void emptyDependsOnOnly_ingestsCleanly() {
+        // An empty dependsOn ("fire once on form open") is a valid NG declaration on its own.
+        DataAttributeV2 a = base(AttributeContentType.STRING);
+        AttributeCallback callback = new AttributeCallback();
+        callback.setDependsOn(List.of());
+        a.setAttributeCallback(callback);
+
+        Assertions.assertDoesNotThrow(() -> attributeEngine.updateDataAttributeDefinitions(connectorUuid, null, List.of(a)));
+    }
+
+    @Test
     void callbackContextOnly_ingestsCleanly() {
         DataAttributeV2 a = base(AttributeContentType.STRING);
         AttributeCallback callback = new AttributeCallback();

--- a/src/test/java/com/otilm/core/integration/service/AttributesV2CallbackDispatchITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AttributesV2CallbackDispatchITest.java
@@ -132,6 +132,29 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
     }
 
     @Test
+    void emptyDependsOnDispatchesNgWithEmptyCurrentAttributes() throws AttributeException, NotFoundException, ConnectorException {
+        // An empty (non-null) dependsOn is a fire-on-mount NG callback: it must dispatch to /v2/attributes/callback
+        // (not fall to the legacy rung and 400), and the envelope must carry currentAttributes as [] — the field is
+        // @NotNull and the DTO is @JsonInclude(NON_NULL), so a null would be dropped and a conformant connector would
+        // reject the body.
+        DataAttributeV2 ng = ngDataAttribute("ngFireOnMount");
+        ng.getAttributeCallback().setDependsOn(List.of());
+        attributeEngine.updateDataAttributeDefinitions(connector.getUuid(), null, List.of(ng));
+
+        mockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/v2/attributes/callback"))
+                .willReturn(WireMock.okJson("{\"content\":[]}")));
+
+        RequestAttributeCallback req = new RequestAttributeCallback();
+        req.setName(ng.getName());
+        callbackService.callback(connector.getUuid(), req);
+
+        // containing (not matchingJsonPath): a JSONPath match on an empty array reports no-match in WireMock, so the
+        // raw-body substring is the reliable way to assert currentAttributes is present AND empty (not dropped).
+        mockServer.verify(WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback"))
+                .withRequestBody(WireMock.containing("\"currentAttributes\":[]")));
+    }
+
+    @Test
     void callbackContextOnly_usesLegacyEndpoint() throws AttributeException, NotFoundException, ConnectorException {
         // A definition with both set is rejected at ingest; route the test through a callbackContext-only def to
         // assert the legacy endpoint (NOT /v2/attributes/callback) is used whenever callbackContext is present.

--- a/src/test/java/com/otilm/core/integration/service/AuthorityInstanceServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AuthorityInstanceServiceITest.java
@@ -215,7 +215,7 @@ class AuthorityInstanceServiceITest extends BaseSpringBootTest {
     }
 
     @Test
-    void testGetRaProfileAttributes() throws ConnectorException, NotFoundException {
+    void testGetRaProfileAttributes() throws ConnectorException, NotFoundException, AttributeException {
         mockServer.stubFor(WireMock
                 .get(WireMock.urlPathMatching("/v1/authorityProvider/authorities/[^/]+/raProfile/attributes"))
                 .willReturn(WireMock.ok()));

--- a/src/test/java/com/otilm/core/service/impl/AuthorityInstanceServiceImplV3Test.java
+++ b/src/test/java/com/otilm/core/service/impl/AuthorityInstanceServiceImplV3Test.java
@@ -318,9 +318,10 @@ class AuthorityInstanceServiceImplV3Test {
         v2Iface.setConnectorUuid(connectorUuid);
         existing.setConnectorInterface(v2Iface);
         when(authorityInstanceReferenceRepository.findByUuid(any(SecuredUUID.class))).thenReturn(Optional.of(existing));
-        when(v3Adapter.listRaProfileAttributes(existing)).thenReturn(List.of(mock(BaseAttribute.class)));
+        List<BaseAttribute> definitions = List.of(mock(BaseAttribute.class));
+        when(v3Adapter.listRaProfileAttributes(existing)).thenReturn(definitions);
 
-        service.listRAProfileAttributes(SecuredUUID.fromUUID(existing.uuid));
+        assertThat(service.listRAProfileAttributes(SecuredUUID.fromUUID(existing.uuid))).isSameAs(definitions);
 
         // Legacy (v1/v2) authorities re-list on the callback path, so list-time ingest must stay v3-only.
         verify(attributeEngine, never()).updateDataAttributeDefinitions(any(), any(), any());

--- a/src/test/java/com/otilm/core/service/impl/AuthorityInstanceServiceImplV3Test.java
+++ b/src/test/java/com/otilm/core/service/impl/AuthorityInstanceServiceImplV3Test.java
@@ -304,6 +304,26 @@ class AuthorityInstanceServiceImplV3Test {
         when(v3Adapter.listRaProfileAttributes(existing)).thenReturn(definitions);
 
         assertThat(service.listRAProfileAttributes(SecuredUUID.fromUUID(existing.uuid))).isSameAs(definitions);
+        // v3 ingests the definitions at list time so a name-only fire-on-mount callback resolves them from storage;
+        // without this the first RA-profile callback on a fresh system 404s.
+        verify(attributeEngine).updateDataAttributeDefinitions(eq(connectorUuid), any(), eq(definitions));
+    }
+
+    @Test
+    void listRAProfileAttributesDoesNotIngestForNonV3() throws Exception {
+        AuthorityInstanceReference existing = v3AuthorityEntity();
+        ConnectorInterfaceEntity v2Iface = new ConnectorInterfaceEntity();
+        v2Iface.setInterfaceCode(ConnectorInterface.AUTHORITY);
+        v2Iface.setVersion("v2");
+        v2Iface.setConnectorUuid(connectorUuid);
+        existing.setConnectorInterface(v2Iface);
+        when(authorityInstanceReferenceRepository.findByUuid(any(SecuredUUID.class))).thenReturn(Optional.of(existing));
+        when(v3Adapter.listRaProfileAttributes(existing)).thenReturn(List.of(mock(BaseAttribute.class)));
+
+        service.listRAProfileAttributes(SecuredUUID.fromUUID(existing.uuid));
+
+        // Legacy (v1/v2) authorities re-list on the callback path, so list-time ingest must stay v3-only.
+        verify(attributeEngine, never()).updateDataAttributeDefinitions(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
Closes #1807.

**Depends on** OmniTrustILM/interfaces#775 — that PR widens the
`AuthorityInstanceController.listRAProfileAttributes` contract with
`throws AttributeException`; this branch will not compile against `main`
interfaces until #775 is merged and the snapshot is published.

## Problem

An empty (non-null) `dependsOn` declares an Attributes v2 callback that
fires once when the form opens — a dropdown reading only the parent
scope via `contextAttributes`, never a sibling field. Delivered Core
rejected it: `isNgCallback` required a *non-empty* list, so an empty one
fell through to the legacy rung and 400'd (`Callback context not set`).
This permanently blocked scope-only dropdowns for every stateless
(authority provider v3 / NG) connector; first hit is the ms-adcs-ng
certificate-template dropdown.

## Fix

- **`isNgCallback`** — gate on `dependsOn != null` (drop the `!isEmpty()`
  conjunct), matching the design dispatch ladder. Also exclude RESOURCE
  content so a connector-level live-listed definition (which bypasses the
  ingest-time declaration guard) cannot route a RESOURCE attribute
  through NG — RESOURCE is answered by the core resource path (rung 1).
- **`validateCallbackDeclaration`** — run the both-set and RESOURCE
  guards for an empty list too; the early return no longer short-circuits
  on empty.
- **`buildEnvelope`** — coalesce a null `currentAttributes` to `[]`. The
  field is `@NotNull` and the DTO is `@JsonInclude(NON_NULL)`, so a
  fire-on-mount callback with no in-form dependency would otherwise drop
  the field and a conformant connector would reject the body.
- **`listRAProfileAttributes`** — v3 authorities ingest their RA-profile
  definitions at list time (mirroring `listAuthorityInstanceAttributes`),
  so the name-only fire-on-mount callback resolves the definition from
  Core storage instead of 404'ing on a fresh system. (The FE fire-on-mount
  payload is name-only, so a UUID-keyed registry resolve would not fire.)

## Regression bar

Legacy callbacks (`callbackContext` set, `dependsOn` null) unchanged;
non-empty `dependsOn` NG unchanged; RESOURCE / GROUP / no-callback
unchanged. Only empty flips from 400 to NG fire-on-mount — nothing ships
an empty list successfully today.

## Tests

- `AttributeDeclarationValidityITest` — empty-list variants (empty +
  callbackContext rejected; empty + RESOURCE rejected; empty-only
  ingests).
- `AttributesV2CallbackDispatchITest` — an empty-`dependsOn` definition
  dispatches to `POST /v2/attributes/callback` and the envelope carries
  `currentAttributes: []`.

Part of the Connector Attributes v2 API epic (ilm#251). Sibling fixes:
interfaces `@Schema` wording (#775), fe-administrator#1764, ms-adcs-ng#26.