### PR TITLE
Add system OID listing endpoint

### DIFF
--- a/src/main/java/com/otilm/core/api/web/CustomOidEntryControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CustomOidEntryControllerImpl.java
@@ -62,6 +62,12 @@ public class CustomOidEntryControllerImpl implements CustomOidEntryController {
     }
 
     @Override
+    @AuditLogged(module = Module.CORE, resource = Resource.OID, operation = Operation.LIST)
+    public List<CustomOidEntryDetailResponseDto> listSystemOidEntries(OidCategory category) {
+        return customOidEntryService.listSystemOidEntries(category);
+    }
+
+    @Override
     @AuditLogged(module = Module.CORE, resource = Resource.SEARCH_FILTER, affiliatedResource = Resource.OID, operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableInformation() {
         return customOidEntryService.getSearchableFieldInformation();

--- a/src/main/java/com/otilm/core/config/WebAppConfig.java
+++ b/src/main/java/com/otilm/core/config/WebAppConfig.java
@@ -108,15 +108,8 @@ public class WebAppConfig implements WebMvcConfigurer {
                 return SigningRecordStatisticsPeriod.findByCode(source);
             }
         });
-        registry.addConverter(new Converter<String, OidCategory>() {
-            @Override
-            public OidCategory convert(String source) {
-                if (StringUtils.isBlank(source)) {
-                    return null;
-                }
-                return OidCategory.fromCode(source);
-            }
-        });
+        registry.addConverter(String.class, OidCategory.class,
+                source -> StringUtils.isBlank(source) ? null : OidCategory.fromCode(source));
     }
 
     @Bean

--- a/src/main/java/com/otilm/core/config/WebAppConfig.java
+++ b/src/main/java/com/otilm/core/config/WebAppConfig.java
@@ -2,6 +2,7 @@ package com.otilm.core.config;
 
 import com.otilm.api.model.client.dashboard.SigningRecordStatisticsPeriod;
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.otilm.api.model.core.oid.OidCategory;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -105,6 +106,12 @@ public class WebAppConfig implements WebMvcConfigurer {
             @Override
             public SigningRecordStatisticsPeriod convert(String source) {
                 return SigningRecordStatisticsPeriod.findByCode(source);
+            }
+        });
+        registry.addConverter(new Converter<String, OidCategory>() {
+            @Override
+            public OidCategory convert(String source) {
+                return OidCategory.fromCode(source);
             }
         });
     }

--- a/src/main/java/com/otilm/core/config/WebAppConfig.java
+++ b/src/main/java/com/otilm/core/config/WebAppConfig.java
@@ -111,6 +111,9 @@ public class WebAppConfig implements WebMvcConfigurer {
         registry.addConverter(new Converter<String, OidCategory>() {
             @Override
             public OidCategory convert(String source) {
+                if (StringUtils.isBlank(source)) {
+                    return null;
+                }
                 return OidCategory.fromCode(source);
             }
         });

--- a/src/main/java/com/otilm/core/mapper/oid/CustomOidEntryMapper.java
+++ b/src/main/java/com/otilm/core/mapper/oid/CustomOidEntryMapper.java
@@ -34,6 +34,8 @@ public class CustomOidEntryMapper {
         dto.setOid(systemOid.getOid());
         dto.setCategory(systemOid.getCategory());
         dto.setDisplayName(systemOid.getDisplayName());
+        // SystemOid only carries RDN code/altCodes; EKU and GENERIC entries have no additional
+        // properties, and the enum has no fields to represent a CERTIFICATE_EXTENSION's typed properties.
         if (systemOid.getCategory() == OidCategory.RDN_ATTRIBUTE_TYPE) {
             RdnAttributeTypeOidPropertiesDto props = new RdnAttributeTypeOidPropertiesDto();
             props.setCode(systemOid.getCode());

--- a/src/main/java/com/otilm/core/mapper/oid/CustomOidEntryMapper.java
+++ b/src/main/java/com/otilm/core/mapper/oid/CustomOidEntryMapper.java
@@ -2,6 +2,8 @@ package com.otilm.core.mapper.oid;
 
 import com.otilm.api.model.core.oid.CustomOidEntryDetailResponseDto;
 import com.otilm.api.model.core.oid.CustomOidEntryResponseDto;
+import com.otilm.api.model.core.oid.OidCategory;
+import com.otilm.api.model.core.oid.SystemOid;
 import com.otilm.api.model.core.oid.properties.AdditionalOidPropertiesDto;
 import com.otilm.api.model.core.oid.properties.CertificateExtensionOidPropertiesDto;
 import com.otilm.api.model.core.oid.properties.RdnAttributeTypeOidPropertiesDto;
@@ -24,6 +26,20 @@ public class CustomOidEntryMapper {
         CustomOidEntryDetailResponseDto dto = new CustomOidEntryDetailResponseDto();
         populateBaseFields(entry, dto);
         dto.setAdditionalProperties(toAdditionalProperties(entry));
+        return dto;
+    }
+
+    public static CustomOidEntryDetailResponseDto toDetailDto(SystemOid systemOid) {
+        CustomOidEntryDetailResponseDto dto = new CustomOidEntryDetailResponseDto();
+        dto.setOid(systemOid.getOid());
+        dto.setCategory(systemOid.getCategory());
+        dto.setDisplayName(systemOid.getDisplayName());
+        if (systemOid.getCategory() == OidCategory.RDN_ATTRIBUTE_TYPE) {
+            RdnAttributeTypeOidPropertiesDto props = new RdnAttributeTypeOidPropertiesDto();
+            props.setCode(systemOid.getCode());
+            props.setAltCodes(systemOid.getAltCodes());
+            dto.setAdditionalProperties(props);
+        }
         return dto;
     }
 

--- a/src/main/java/com/otilm/core/service/CustomOidEntryExternalService.java
+++ b/src/main/java/com/otilm/core/service/CustomOidEntryExternalService.java
@@ -67,7 +67,6 @@ public interface CustomOidEntryExternalService {
      */
     List<CustomOidEntryDetailResponseDto> listSystemOidEntries(OidCategory category);
 
-
     /**
      * Returns a list of properties for filtering custom OID entries
      *

--- a/src/main/java/com/otilm/core/service/CustomOidEntryExternalService.java
+++ b/src/main/java/com/otilm/core/service/CustomOidEntryExternalService.java
@@ -59,6 +59,14 @@ public interface CustomOidEntryExternalService {
      */
     CustomOidEntryListResponseDto listCustomOidEntries(SearchRequestDto request);
 
+    /**
+     * Returns the built-in system OID entries, optionally filtered by category.
+     *
+     * @param category optional category filter; when {@code null}, all system OIDs are returned
+     * @return list of system OID entries
+     */
+    List<CustomOidEntryDetailResponseDto> listSystemOidEntries(OidCategory category);
+
 
     /**
      * Returns a list of properties for filtering custom OID entries

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -246,6 +246,15 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
 
     @Override
     @ExternalAuthorization(resource = Resource.OID, action = ResourceAction.LIST)
+    public List<CustomOidEntryDetailResponseDto> listSystemOidEntries(OidCategory category) {
+        return Arrays.stream(SystemOid.values())
+                .filter(systemOid -> category == null || systemOid.getCategory() == category)
+                .map(CustomOidEntryMapper::toDetailDto)
+                .toList();
+    }
+
+    @Override
+    @ExternalAuthorization(resource = Resource.OID, action = ResourceAction.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         List<SearchFieldDataByGroupDto> searchFieldDataByGroupDtos = new ArrayList<>();
         List<SearchFieldDataDto> fields = List.of(

--- a/src/test/java/com/otilm/core/integration/api/web/CustomOidEntrySystemControllerITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/CustomOidEntrySystemControllerITest.java
@@ -1,0 +1,45 @@
+package com.otilm.core.integration.api.web;
+
+import com.otilm.api.model.core.oid.OidCategory;
+import com.otilm.api.model.core.oid.SystemOid;
+import com.otilm.core.util.BaseSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+class CustomOidEntrySystemControllerITest extends BaseSpringBootTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void listSystemOidEntries_returnsAllWhenNoCategory() throws Exception {
+        mockMvc.perform(get("/v1/oids/system"))
+            .andExpectAll(status().isOk(),
+                jsonPath("$.length()").value(SystemOid.values().length),
+                jsonPath("$[?(@.oid == '" + SystemOid.COMMON_NAME.getOid() + "')].additionalProperties.code").value(SystemOid.COMMON_NAME.getCode()));
+    }
+
+    @Test
+    void listSystemOidEntries_bindsCategoryCodeAndFilters() throws Exception {
+        long expectedRdnCount = Arrays.stream(SystemOid.values())
+            .filter(o -> o.getCategory() == OidCategory.RDN_ATTRIBUTE_TYPE).count();
+        mockMvc.perform(get("/v1/oids/system").param("category", OidCategory.RDN_ATTRIBUTE_TYPE.getCode()))
+            .andExpectAll(status().isOk(),
+                jsonPath("$.length()").value((int) expectedRdnCount));
+    }
+
+    @Test
+    void listSystemOidEntries_rejectsUnknownCategoryCode() throws Exception {
+        mockMvc.perform(get("/v1/oids/system").param("category", "notACategory"))
+            .andExpect(status().is4xxClientError());
+    }
+}

--- a/src/test/java/com/otilm/core/integration/api/web/CustomOidEntrySystemControllerITest.java
+++ b/src/test/java/com/otilm/core/integration/api/web/CustomOidEntrySystemControllerITest.java
@@ -10,6 +10,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Arrays;
 
+import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -25,7 +26,8 @@ class CustomOidEntrySystemControllerITest extends BaseSpringBootTest {
         mockMvc.perform(get("/v1/oids/system"))
             .andExpectAll(status().isOk(),
                 jsonPath("$.length()").value(SystemOid.values().length),
-                jsonPath("$[?(@.oid == '" + SystemOid.COMMON_NAME.getOid() + "')].additionalProperties.code").value(SystemOid.COMMON_NAME.getCode()));
+                jsonPath("$[?(@.oid == '" + SystemOid.COMMON_NAME.getOid() + "')].additionalProperties.code",
+                    hasItem(SystemOid.COMMON_NAME.getCode())));
     }
 
     @Test
@@ -38,8 +40,15 @@ class CustomOidEntrySystemControllerITest extends BaseSpringBootTest {
     }
 
     @Test
+    void listSystemOidEntries_blankCategoryReturnsAll() throws Exception {
+        mockMvc.perform(get("/v1/oids/system").param("category", ""))
+            .andExpectAll(status().isOk(),
+                jsonPath("$.length()").value(SystemOid.values().length));
+    }
+
+    @Test
     void listSystemOidEntries_rejectsUnknownCategoryCode() throws Exception {
         mockMvc.perform(get("/v1/oids/system").param("category", "notACategory"))
-            .andExpect(status().is4xxClientError());
+            .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
@@ -229,7 +229,10 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
                 .findFirst().orElseThrow();
         Assertions.assertEquals(SystemOid.EMAIL.getAltCodes(), ((RdnAttributeTypeOidPropertiesDto) email.getAdditionalProperties()).getAltCodes());
 
+        long expectedEkuCount = Arrays.stream(SystemOid.values())
+                .filter(o -> o.getCategory() == OidCategory.EXTENDED_KEY_USAGE).count();
         List<CustomOidEntryDetailResponseDto> ekus = customOidEntryService.listSystemOidEntries(OidCategory.EXTENDED_KEY_USAGE);
+        Assertions.assertEquals(expectedEkuCount, ekus.size());
         Assertions.assertTrue(ekus.stream().allMatch(e -> e.getCategory() == OidCategory.EXTENDED_KEY_USAGE));
         Assertions.assertTrue(ekus.stream().allMatch(e -> e.getAdditionalProperties() == null));
 

--- a/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.Arrays;
 import java.util.List;
 
 class CustomOidEntryServiceITest extends BaseSpringBootTest {
@@ -202,6 +203,37 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
         response = customOidEntryService.listCustomOidEntries(searchRequestDto);
         Assertions.assertEquals(1, response.getOidEntries().size());
         Assertions.assertEquals(rdnOidEntry.getOid(), response.getOidEntries().getFirst().getOid());
+    }
+
+    @Test
+    void testListSystemOidEntries() {
+        List<CustomOidEntryDetailResponseDto> all = customOidEntryService.listSystemOidEntries(null);
+        Assertions.assertEquals(SystemOid.values().length, all.size());
+
+        CustomOidEntryDetailResponseDto commonName = all.stream()
+                .filter(e -> e.getOid().equals(SystemOid.COMMON_NAME.getOid()))
+                .findFirst().orElseThrow();
+        Assertions.assertEquals(SystemOid.COMMON_NAME.getDisplayName(), commonName.getDisplayName());
+        Assertions.assertEquals(OidCategory.RDN_ATTRIBUTE_TYPE, commonName.getCategory());
+        RdnAttributeTypeOidPropertiesDto commonNameProps = (RdnAttributeTypeOidPropertiesDto) commonName.getAdditionalProperties();
+        Assertions.assertEquals(SystemOid.COMMON_NAME.getCode(), commonNameProps.getCode());
+        Assertions.assertEquals(SystemOid.COMMON_NAME.getAltCodes(), commonNameProps.getAltCodes());
+
+        long expectedRdnCount = Arrays.stream(SystemOid.values())
+                .filter(o -> o.getCategory() == OidCategory.RDN_ATTRIBUTE_TYPE).count();
+        List<CustomOidEntryDetailResponseDto> rdns = customOidEntryService.listSystemOidEntries(OidCategory.RDN_ATTRIBUTE_TYPE);
+        Assertions.assertEquals(expectedRdnCount, rdns.size());
+        Assertions.assertTrue(rdns.stream().allMatch(e -> e.getCategory() == OidCategory.RDN_ATTRIBUTE_TYPE));
+        CustomOidEntryDetailResponseDto email = rdns.stream()
+                .filter(e -> e.getOid().equals(SystemOid.EMAIL.getOid()))
+                .findFirst().orElseThrow();
+        Assertions.assertEquals(SystemOid.EMAIL.getAltCodes(), ((RdnAttributeTypeOidPropertiesDto) email.getAdditionalProperties()).getAltCodes());
+
+        List<CustomOidEntryDetailResponseDto> ekus = customOidEntryService.listSystemOidEntries(OidCategory.EXTENDED_KEY_USAGE);
+        Assertions.assertTrue(ekus.stream().allMatch(e -> e.getCategory() == OidCategory.EXTENDED_KEY_USAGE));
+        Assertions.assertTrue(ekus.stream().allMatch(e -> e.getAdditionalProperties() == null));
+
+        Assertions.assertTrue(customOidEntryService.listSystemOidEntries(OidCategory.CERTIFICATE_EXTENSION).isEmpty());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
@@ -206,7 +206,7 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
     }
 
     @Test
-    void testListSystemOidEntries() {
+    void testListSystemOidEntriesReturnsAllWhenNoCategory() {
         List<CustomOidEntryDetailResponseDto> all = customOidEntryService.listSystemOidEntries(null);
         Assertions.assertEquals(SystemOid.values().length, all.size());
 
@@ -218,7 +218,10 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
         RdnAttributeTypeOidPropertiesDto commonNameProps = (RdnAttributeTypeOidPropertiesDto) commonName.getAdditionalProperties();
         Assertions.assertEquals(SystemOid.COMMON_NAME.getCode(), commonNameProps.getCode());
         Assertions.assertEquals(SystemOid.COMMON_NAME.getAltCodes(), commonNameProps.getAltCodes());
+    }
 
+    @Test
+    void testListSystemOidEntriesFiltersByRdnCategory() {
         long expectedRdnCount = Arrays.stream(SystemOid.values())
                 .filter(o -> o.getCategory() == OidCategory.RDN_ATTRIBUTE_TYPE).count();
         List<CustomOidEntryDetailResponseDto> rdns = customOidEntryService.listSystemOidEntries(OidCategory.RDN_ATTRIBUTE_TYPE);
@@ -228,14 +231,20 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
                 .filter(e -> e.getOid().equals(SystemOid.EMAIL.getOid()))
                 .findFirst().orElseThrow();
         Assertions.assertEquals(SystemOid.EMAIL.getAltCodes(), ((RdnAttributeTypeOidPropertiesDto) email.getAdditionalProperties()).getAltCodes());
+    }
 
+    @Test
+    void testListSystemOidEntriesFiltersByEkuCategoryWithNoProperties() {
         long expectedEkuCount = Arrays.stream(SystemOid.values())
                 .filter(o -> o.getCategory() == OidCategory.EXTENDED_KEY_USAGE).count();
         List<CustomOidEntryDetailResponseDto> ekus = customOidEntryService.listSystemOidEntries(OidCategory.EXTENDED_KEY_USAGE);
         Assertions.assertEquals(expectedEkuCount, ekus.size());
         Assertions.assertTrue(ekus.stream().allMatch(e -> e.getCategory() == OidCategory.EXTENDED_KEY_USAGE));
         Assertions.assertTrue(ekus.stream().allMatch(e -> e.getAdditionalProperties() == null));
+    }
 
+    @Test
+    void testListSystemOidEntriesCertificateExtensionReturnsEmpty() {
         Assertions.assertTrue(customOidEntryService.listSystemOidEntries(OidCategory.CERTIFICATE_EXTENSION).isEmpty());
     }
 


### PR DESCRIPTION
## What

Implements `GET /v1/oids/system` (contract: OmniTrustILM/interfaces#778):

- `CustomOidEntryMapper.toDetailDto(SystemOid)` — maps enum entries to `CustomOidEntryDetailResponseDto`; RDN attribute types carry `code`/`altCodes` via `RdnAttributeTypeOidPropertiesDto`, other categories have null additional properties.
- `CustomOidEntryServiceImpl.listSystemOidEntries(OidCategory)` — streams `SystemOid.values()`, optional category filter, `Resource.OID` / `LIST` authorization.
- `CustomOidEntryControllerImpl` — audited delegate.
- `WebAppConfig` — `Converter<String, OidCategory>` (via `OidCategory.fromCode`) so `?category=rdnAttributeType` binds; an unknown code returns 400. Matches the existing `KeyAlgorithm` / `SigningRecordStatisticsPeriod` converter pattern.

## Why

`POST /v1/oids/list` returns only custom (DB) OID entries; standard OIDs live in the `SystemOid` enum and were unreachable over the API. Reusing the detail DTO lets clients (fe-administrator#1874 RDN dropdown) merge system and custom OIDs on one shape — no dedupe needed, since creating a custom entry that shadows a system OID is already rejected.

## Tests

- Service ITest: all `SystemOid` entries returned; category filter; RDN `code`/`altCodes` mapping; EKU null props; empty for `certificateExtension`.
- Web ITest (MockMvc): `/system` routing, category-code binding, unknown code → 4xx.

## Ordering

Depends on OmniTrustILM/interfaces#778 (SNAPSHOT). Merge that first.

Resolves #1825. Part of epic OmniTrustILM/ilm#131.