### PR TITLE
Resolve the request-attribute set over the CSR-attributes endpoint

### DIFF
--- a/src/main/java/com/otilm/core/api/web/CertificateControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CertificateControllerImpl.java
@@ -165,11 +165,11 @@ public class CertificateControllerImpl implements CertificateController {
 
     @Override
     @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "csr", affiliatedResource = Resource.CERTIFICATE, operation = Operation.LIST_ATTRIBUTES)
-    public List<BaseAttribute> getCsrGenerationAttributes(String raProfileUuid) throws NotFoundException, ConnectorException {
-        if (raProfileUuid == null || raProfileUuid.isBlank()) {
+    public List<BaseAttribute> getCsrGenerationAttributes(UUID raProfileUuid) throws NotFoundException, ConnectorException {
+        if (raProfileUuid == null) {
             return certificateService.getCsrGenerationAttributes();
         }
-        return certificateService.getCsrGenerationAttributes(SecuredUUID.fromString(raProfileUuid));
+        return certificateService.getCsrGenerationAttributes(SecuredUUID.fromUUID(raProfileUuid));
     }
 
     @Override

--- a/src/main/java/com/otilm/core/api/web/CertificateControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CertificateControllerImpl.java
@@ -164,8 +164,8 @@ public class CertificateControllerImpl implements CertificateController {
     }
 
     @Override
-    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "csr", affiliatedResource = Resource.CERTIFICATE, operation = Operation.LIST_ATTRIBUTES)
-    public List<BaseAttribute> getCsrGenerationAttributes(UUID raProfileUuid) throws NotFoundException, ConnectorException {
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "csr", affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
+    public List<BaseAttribute> getCsrGenerationAttributes(@LogResource(uuid = true, affiliated = true) UUID raProfileUuid) throws NotFoundException, ConnectorException {
         if (raProfileUuid == null) {
             return certificateService.getCsrGenerationAttributes();
         }

--- a/src/main/java/com/otilm/core/api/web/CertificateControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/CertificateControllerImpl.java
@@ -165,8 +165,11 @@ public class CertificateControllerImpl implements CertificateController {
 
     @Override
     @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "csr", affiliatedResource = Resource.CERTIFICATE, operation = Operation.LIST_ATTRIBUTES)
-    public List<BaseAttribute> getCsrGenerationAttributes() {
-        return certificateService.getCsrGenerationAttributes();
+    public List<BaseAttribute> getCsrGenerationAttributes(String raProfileUuid) throws NotFoundException, ConnectorException {
+        if (raProfileUuid == null || raProfileUuid.isBlank()) {
+            return certificateService.getCsrGenerationAttributes();
+        }
+        return certificateService.getCsrGenerationAttributes(SecuredUUID.fromString(raProfileUuid));
     }
 
     @Override

--- a/src/main/java/com/otilm/core/attribute/CsrAttributes.java
+++ b/src/main/java/com/otilm/core/attribute/CsrAttributes.java
@@ -41,6 +41,7 @@ public class CsrAttributes {
 
     private CsrAttributes() {}
 
+    @CoreAttributeDefinitions
     public static List<DataAttributeV3> csrAttributesAsDataAttributesV3() {
         return List.of(
                 commonNameAttribute(),

--- a/src/main/java/com/otilm/core/attribute/CsrAttributes.java
+++ b/src/main/java/com/otilm/core/attribute/CsrAttributes.java
@@ -1,7 +1,6 @@
 package com.otilm.core.attribute;
 
 import com.otilm.api.model.common.attribute.common.AttributeType;
-import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.common.constraint.BaseAttributeConstraint;
 import com.otilm.api.model.common.attribute.common.constraint.RegexpAttributeConstraint;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
@@ -41,18 +40,6 @@ public class CsrAttributes {
     public static final String COUNTRY_ATTRIBUTE_LABEL = "Country";
 
     private CsrAttributes() {}
-
-    @CoreAttributeDefinitions
-    public static List<BaseAttribute> csrAttributes() {
-        return List.of(
-                commonNameAttribute(),
-                organizationalUnitAttribute(),
-                organizationAttribute(),
-                localityAttribute(),
-                stateAttribute(),
-                countryAttribute()
-        );
-    }
 
     public static List<DataAttributeV3> csrAttributesAsDataAttributesV3() {
         return List.of(

--- a/src/main/java/com/otilm/core/dao/repository/RaProfileRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/RaProfileRepository.java
@@ -14,12 +14,16 @@ public interface RaProfileRepository extends SecurityFilterRepository<RaProfile,
     Optional<RaProfile> findByUuid(UUID uuid);
 
     /**
-     * Loads an RA profile with its authority, connector and connector interface eagerly.
+     * Loads an RA profile with its authority, connector, connector interface and the connector's
+     * function groups eagerly. The function groups are fetched so callers that traverse the connector
+     * outside an active transaction (e.g. request-attribute resolution under
+     * {@code Propagation.NOT_SUPPORTED}) do not depend on open-session-in-view for the lazy collection.
      */
     @EntityGraph(attributePaths = {
             "authorityInstanceReference",
             "authorityInstanceReference.connectorInterface",
-            "authorityInstanceReference.connector"
+            "authorityInstanceReference.connector",
+            "authorityInstanceReference.connector.functionGroups"
     })
     Optional<RaProfile> findWithAuthorityByUuid(UUID uuid);
 

--- a/src/main/java/com/otilm/core/service/CertificateExternalService.java
+++ b/src/main/java/com/otilm/core/service/CertificateExternalService.java
@@ -85,6 +85,29 @@ public interface CertificateExternalService {
     List<BaseAttribute> getCsrGenerationAttributes();
 
     /**
+     * Get the resolved request-attribute set for an RA profile.
+     *
+     * <p><b>Composition:</b> combines the RA-profile static set with the authority-connector set
+     * according to the profile's merge mode, then applies the profile's value-source bindings.
+     *
+     * <p><b>Fallback:</b> when the profile configures no static set, the platform default
+     * request-attribute set is used instead.
+     *
+     * <p><b>Projection:</b> the result is narrowed to the projectable v3 definitions — the exact set
+     * the platform projects into the certificate request content on issue and register.
+     *
+     * <p><b>Empty result:</b> when nothing is projectable anywhere (profile, connector, and default set
+     * all yield no definitions), the call fails with {@link com.otilm.api.exception.ValidationException}
+     * (surfaced as HTTP 422) rather than returning an empty list.
+     *
+     * @param raProfileUuid UUID of the enabled RA profile
+     * @return the resolved request-attribute definitions
+     * @throws NotFoundException  when the RA profile does not exist or is disabled
+     * @throws ConnectorException when the authority connector fails while listing its issue attributes
+     */
+    List<BaseAttribute> getCsrGenerationAttributes(SecuredUUID raProfileUuid) throws NotFoundException, ConnectorException;
+
+    /**
      * Get the list of the certificate contents for the provided certificate UUIDs
      *
      * @param uuids UUIDs of the certificate

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -1,7 +1,6 @@
 package com.otilm.core.service.impl;
 
 import com.otilm.api.model.common.UuidDto;
-import com.otilm.core.attribute.CsrAttributes;
 import com.otilm.api.exception.*;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.attribute.ResponseAttribute;
@@ -35,6 +34,7 @@ import com.otilm.core.attribute.engine.AttributeContentPurpose;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeOperation;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
+import com.otilm.core.certificate.request.IssuanceDefinitionResolver;
 import com.otilm.core.comparator.SearchFieldDataComparator;
 import com.otilm.core.config.cache.CacheConfig;
 import com.otilm.core.dao.entity.*;
@@ -149,6 +149,8 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
     private CertificateValidationWriter validationWriter;
     private CertificateRequestRepository certificateRequestRepository;
     private RaProfileRepository raProfileRepository;
+    private IssuanceDefinitionResolver issuanceDefinitionResolver;
+    private RaProfileCertificateRequestAttributeService requestAttributeService;
     private CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository;
     private RaProfileInternalService raProfileService;
     private GroupRepository groupRepository;
@@ -287,6 +289,16 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
     @Autowired
     public void setRaProfileRepository(RaProfileRepository raProfileRepository) {
         this.raProfileRepository = raProfileRepository;
+    }
+
+    @Autowired
+    public void setIssuanceDefinitionResolver(IssuanceDefinitionResolver issuanceDefinitionResolver) {
+        this.issuanceDefinitionResolver = issuanceDefinitionResolver;
+    }
+
+    @Autowired
+    public void setRequestAttributeService(RaProfileCertificateRequestAttributeService requestAttributeService) {
+        this.requestAttributeService = requestAttributeService;
     }
 
     @Autowired
@@ -1589,7 +1601,19 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
     @Override
     @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.ANY)
     public List<BaseAttribute> getCsrGenerationAttributes() {
-        return CsrAttributes.csrAttributes();
+        return requestAttributeService.getDefaultSet();
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.DETAIL)
+    public List<BaseAttribute> getCsrGenerationAttributes(SecuredUUID raProfileUuid) throws NotFoundException, ConnectorException {
+        RaProfile raProfile = raProfileRepository.findWithAuthorityByUuid(raProfileUuid.getValue())
+                .orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
+        if (!Boolean.TRUE.equals(raProfile.getEnabled())) {
+            throw new NotFoundException(RaProfile.class, raProfileUuid);
+        }
+        return new ArrayList<>(issuanceDefinitionResolver.resolve(raProfile));
     }
 
     @Override

--- a/src/test/java/com/otilm/core/api/web/CertificateControllerImplTest.java
+++ b/src/test/java/com/otilm/core/api/web/CertificateControllerImplTest.java
@@ -41,20 +41,6 @@ class CertificateControllerImplTest {
     }
 
     @Test
-    void blankProfileParameterBehavesAsAbsent() throws Exception {
-        // given
-        List<BaseAttribute> defaults = List.of(new DataAttributeV3());
-        when(certificateService.getCsrGenerationAttributes()).thenReturn(defaults);
-
-        // when
-        List<BaseAttribute> result = controller.getCsrGenerationAttributes("  ");
-
-        // then
-        assertThat(result).isSameAs(defaults);
-        verify(certificateService, never()).getCsrGenerationAttributes(any(SecuredUUID.class));
-    }
-
-    @Test
     void withProfileParameterDelegatesToTheResolvedSet() throws Exception {
         // given
         UUID raProfileUuid = UUID.randomUUID();
@@ -62,7 +48,7 @@ class CertificateControllerImplTest {
         when(certificateService.getCsrGenerationAttributes(any(SecuredUUID.class))).thenReturn(resolved);
 
         // when
-        List<BaseAttribute> result = controller.getCsrGenerationAttributes(raProfileUuid.toString());
+        List<BaseAttribute> result = controller.getCsrGenerationAttributes(raProfileUuid);
 
         // then
         assertThat(result).isSameAs(resolved);

--- a/src/test/java/com/otilm/core/api/web/CertificateControllerImplTest.java
+++ b/src/test/java/com/otilm/core/api/web/CertificateControllerImplTest.java
@@ -1,0 +1,73 @@
+package com.otilm.core.api.web;
+
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
+import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.service.CertificateExternalService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CertificateControllerImplTest {
+
+    private final CertificateExternalService certificateService = mock(CertificateExternalService.class);
+    private final CertificateControllerImpl controller = new CertificateControllerImpl();
+
+    CertificateControllerImplTest() {
+        controller.setCertificateService(certificateService);
+    }
+
+    @Test
+    void withoutProfileParameterDelegatesToTheDefaultSet() throws Exception {
+        // given
+        List<BaseAttribute> defaults = List.of(new DataAttributeV3());
+        when(certificateService.getCsrGenerationAttributes()).thenReturn(defaults);
+
+        // when
+        List<BaseAttribute> result = controller.getCsrGenerationAttributes(null);
+
+        // then
+        assertThat(result).isSameAs(defaults);
+        verify(certificateService, never()).getCsrGenerationAttributes(any(SecuredUUID.class));
+    }
+
+    @Test
+    void blankProfileParameterBehavesAsAbsent() throws Exception {
+        // given
+        List<BaseAttribute> defaults = List.of(new DataAttributeV3());
+        when(certificateService.getCsrGenerationAttributes()).thenReturn(defaults);
+
+        // when
+        List<BaseAttribute> result = controller.getCsrGenerationAttributes("  ");
+
+        // then
+        assertThat(result).isSameAs(defaults);
+        verify(certificateService, never()).getCsrGenerationAttributes(any(SecuredUUID.class));
+    }
+
+    @Test
+    void withProfileParameterDelegatesToTheResolvedSet() throws Exception {
+        // given
+        UUID raProfileUuid = UUID.randomUUID();
+        List<BaseAttribute> resolved = List.of(new DataAttributeV3());
+        when(certificateService.getCsrGenerationAttributes(any(SecuredUUID.class))).thenReturn(resolved);
+
+        // when
+        List<BaseAttribute> result = controller.getCsrGenerationAttributes(raProfileUuid.toString());
+
+        // then
+        assertThat(result).isSameAs(resolved);
+        ArgumentCaptor<SecuredUUID> captor = ArgumentCaptor.forClass(SecuredUUID.class);
+        verify(certificateService).getCsrGenerationAttributes(captor.capture());
+        assertThat(captor.getValue().getValue()).isEqualTo(raProfileUuid);
+    }
+}

--- a/src/test/java/com/otilm/core/integration/service/CsrGenerationAttributesITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CsrGenerationAttributesITest.java
@@ -1,0 +1,204 @@
+package com.otilm.core.integration.service;
+
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.client.connector.v2.ConnectorVersion;
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import com.otilm.api.model.common.attribute.common.properties.DataAttributeProperties;
+import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
+import com.otilm.api.model.core.connector.ConnectorStatus;
+import com.otilm.api.model.core.raprofile.AttributeSetMergeMode;
+import com.otilm.api.model.core.settings.SettingsSection;
+import com.otilm.api.model.core.settings.SettingsSectionCategory;
+import com.otilm.core.certificate.request.DefaultRequestAttributeSet;
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.dao.entity.Setting;
+import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
+import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.dao.repository.RaProfileRepository;
+import com.otilm.core.dao.repository.SettingRepository;
+import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.service.CertificateExternalService;
+import com.otilm.core.service.v2.ExtendedAttributeService;
+import com.otilm.core.service.writer.RaProfileCertificateRequestAttributeWriter;
+import com.otilm.core.util.AttributeDefinitionUtils;
+import com.otilm.core.util.BaseSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CsrGenerationAttributesITest extends BaseSpringBootTest {
+
+    @Autowired
+    private CertificateExternalService certificateService;
+    @Autowired
+    private RaProfileRepository raProfileRepository;
+    @Autowired
+    private RaProfileCertificateRequestAttributeWriter writer;
+    @Autowired
+    private SettingRepository settingRepository;
+    @Autowired
+    private AuthorityInstanceReferenceRepository authorityInstanceReferenceRepository;
+    @Autowired
+    private ConnectorRepository connectorRepository;
+
+    // Stub the connector dynamic-set fetch so no test needs a live authority/connector round-trip.
+    @MockitoBean
+    private ExtendedAttributeService extendedAttributeService;
+
+    private static DataAttributeV3 def(String uuid, String name) {
+        DataAttributeV3 attribute = new DataAttributeV3();
+        attribute.setUuid(uuid);
+        attribute.setName(name);
+        attribute.setContentType(AttributeContentType.STRING);
+        DataAttributeProperties properties = new DataAttributeProperties();
+        properties.setLabel(name);
+        attribute.setProperties(properties);
+        return attribute;
+    }
+
+    private RaProfile newEnabledRaProfile() {
+        RaProfile raProfile = new RaProfile();
+        raProfile.setName("rp-" + UUID.randomUUID());
+        raProfile.setEnabled(true);
+        return raProfileRepository.save(raProfile);
+    }
+
+    @Test
+    void withProfileReturnsTheResolvedSetNotTheSeed() throws Exception {
+        // given: an enabled profile with a stored STATIC_ONLY set; no authority -> no connector fetch
+        RaProfile raProfile = newEnabledRaProfile();
+        writer.saveStaticSet(raProfile, AttributeDefinitionUtils.serialize(List.of(def("s1", "department"))),
+                AttributeSetMergeMode.STATIC_ONLY, null);
+
+        // when
+        List<BaseAttribute> resolved = certificateService.getCsrGenerationAttributes(SecuredUUID.fromUUID(raProfile.getUuid()));
+
+        // then: the configured set shapes the response, and the connector was never consulted
+        assertThat(resolved).extracting(BaseAttribute::getName).containsExactly("department");
+        verify(extendedAttributeService, never()).listIssueCertificateAttributes(any());
+    }
+
+    @Test
+    void withProfileFallsBackToPlatformDefaultSetWhenNothingConfigured() throws Exception {
+        // given: an enabled profile with no static set and no authority
+        RaProfile raProfile = newEnabledRaProfile();
+
+        // when
+        List<BaseAttribute> resolved = certificateService.getCsrGenerationAttributes(SecuredUUID.fromUUID(raProfile.getUuid()));
+
+        // then: the platform default set (built-in seed while unset)
+        assertThat(resolved).extracting(BaseAttribute::getName)
+                .containsExactlyElementsOf(DefaultRequestAttributeSet.seed().stream().map(BaseAttribute::getName).toList());
+    }
+
+    @Test
+    void withProfileMergesPersistedConnectorSet() throws Exception {
+        // given: an enabled profile with a persisted authority/connector reference
+        Connector connector = new Connector();
+        connector.setUrl("http://localhost");
+        connector.setVersion(ConnectorVersion.V1);
+        connector.setStatus(ConnectorStatus.CONNECTED);
+        connector = connectorRepository.save(connector);
+
+        AuthorityInstanceReference authority = new AuthorityInstanceReference();
+        authority.setAuthorityInstanceUuid("1");
+        authority.setConnector(connector);
+        authority = authorityInstanceReferenceRepository.save(authority);
+
+        RaProfile raProfile = new RaProfile();
+        raProfile.setName("rp-" + UUID.randomUUID());
+        raProfile.setEnabled(true);
+        raProfile.setAuthorityInstanceReference(authority);
+        raProfile.setAuthorityInstanceReferenceUuid(authority.getUuid());
+        raProfile = raProfileRepository.save(raProfile);
+
+        when(extendedAttributeService.listIssueCertificateAttributes(any()))
+                .thenReturn(List.of(def("c1", "connector-attr")));
+
+        // when
+        List<BaseAttribute> resolved = certificateService.getCsrGenerationAttributes(SecuredUUID.fromUUID(raProfile.getUuid()));
+
+        // then: the stubbed connector set is projected, and the connector attribute fetch was invoked
+        assertThat(resolved).extracting(BaseAttribute::getName).containsExactly("connector-attr");
+        verify(extendedAttributeService).listIssueCertificateAttributes(any());
+    }
+
+    @Test
+    void withDisabledProfileThrowsNotFound() {
+        // given
+        RaProfile disabled = new RaProfile();
+        disabled.setName("rp-disabled-" + UUID.randomUUID());
+        disabled.setEnabled(false);
+        SecuredUUID uuid = SecuredUUID.fromUUID(raProfileRepository.save(disabled).getUuid());
+
+        // when / then
+        assertThatThrownBy(() -> certificateService.getCsrGenerationAttributes(uuid))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void withUnknownProfileThrowsNotFound() {
+        // when / then
+        assertThatThrownBy(() -> certificateService.getCsrGenerationAttributes(SecuredUUID.fromUUID(UUID.randomUUID())))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void withProfileAndNothingProjectableAnywhereThrowsValidation() {
+        // given: nothing configured on the profile and the default set edited down to an empty list
+        RaProfile raProfile = newEnabledRaProfile();
+        Setting defaultSet = new Setting();
+        defaultSet.setSection(SettingsSection.PLATFORM);
+        defaultSet.setCategory(SettingsSectionCategory.PLATFORM_CERTIFICATES.getCode());
+        defaultSet.setName(DefaultRequestAttributeSet.SETTING_NAME);
+        defaultSet.setValue(AttributeDefinitionUtils.serialize(List.of()));
+        settingRepository.save(defaultSet);
+        SecuredUUID uuid = SecuredUUID.fromUUID(raProfile.getUuid());
+
+        // when / then: surfaced as ValidationException (HTTP 422) with an actionable message
+        assertThatThrownBy(() -> certificateService.getCsrGenerationAttributes(uuid))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("No projectable request attribute definitions");
+    }
+
+    @Test
+    void withoutProfileReturnsTheBuiltInSeedWhileDefaultSetIsUnset() {
+        // when
+        List<BaseAttribute> result = certificateService.getCsrGenerationAttributes();
+
+        // then: same attribute names as the historical fixed seed — the unscoped contract is preserved
+        assertThat(result).extracting(BaseAttribute::getName)
+                .containsExactlyElementsOf(DefaultRequestAttributeSet.seed().stream().map(BaseAttribute::getName).toList());
+    }
+
+    @Test
+    void withoutProfileHonoursTheEditedDefaultSet() {
+        // given: an admin-edited platform default set
+        Setting defaultSet = new Setting();
+        defaultSet.setSection(SettingsSection.PLATFORM);
+        defaultSet.setCategory(SettingsSectionCategory.PLATFORM_CERTIFICATES.getCode());
+        defaultSet.setName(DefaultRequestAttributeSet.SETTING_NAME);
+        defaultSet.setValue(AttributeDefinitionUtils.serialize(List.of(def("d1", "server-fqdn"))));
+        settingRepository.save(defaultSet);
+
+        // when
+        List<BaseAttribute> result = certificateService.getCsrGenerationAttributes();
+
+        // then
+        assertThat(result).extracting(BaseAttribute::getName).containsExactly("server-fqdn");
+    }
+}


### PR DESCRIPTION
Extend GET /v1/certificates/csr/attributes with an optional raProfileUuid query parameter so one endpoint serves all three fe-administrator call sites:

- With raProfileUuid: return the resolved request-attribute set for the RA profile (RA-Profile static set merged with the connector set per the profile's merge mode, falling back to the editable platform default set), narrowed to the projectable v3 definitions via IssuanceDefinitionResolver. Object-level RA_PROFILE authorization; runs NOT_SUPPORTED and loads the authority->connector graph eagerly (findWithAuthorityByUuid) so the connector call does not hit a LazyInitializationException; disabled and unknown profiles surface NotFoundException, an empty projection surfaces ValidationException (HTTP 422).

- Without raProfileUuid: return the editable platform default set (RaProfileCertificateRequestAttributeService.getDefaultSet) instead of the hardcoded CsrAttributes.csrAttributes() seed. Behaviour is identical to the old seed until an operator edits the default set. Drop the now-dead csrAttributes() definition.