### PR TITLE
Fix CMP revocation falsely rejecting as diverted-to-ISSUED

### DIFF
--- a/src/main/java/com/otilm/core/service/cmp/message/handler/PollFeature.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/handler/PollFeature.java
@@ -141,11 +141,15 @@ public class PollFeature {
      * (e.g. an operator cancel flipped an in-flight issue to FAILED). The one exception is
      * {@code ISSUED} while waiting for {@code REVOKED}: {@code ISSUED} is the resting state a
      * certificate occupies <em>before</em> a revocation transition lands, so observing it
-     * means "revocation not applied yet", not a divergence. Treating it as divergence made a
-     * revocation poll reject on its first sample before the async {@code ISSUED -> REVOKED}
-     * transition completed (issue #1833). Such a poll instead keeps waiting and, if the
-     * transition never lands within the budget, ends as a timeout — a rejection either way,
-     * but never a false "diverted to ISSUED".
+     * means "revocation not applied yet", not a divergence — treating it as one would reject
+     * a revocation poll on its first sample, before the async {@code ISSUED -> REVOKED}
+     * transition can land. Such a poll instead keeps waiting and, if the transition never
+     * lands within the budget, ends as a timeout — a rejection either way, but never a false
+     * "diverted to ISSUED".
+     *
+     * <p>The {@code current == expectedState} guard is unreachable from the poll loop (which
+     * returns {@code Reached} before calling this) but keeps the predicate correct on its
+     * own terms: the expected state is never divergent.</p>
      */
     private static boolean isDivergentTerminal(CertificateState current, CertificateState expectedState) {
         if (!isTerminal(current) || current == expectedState) {

--- a/src/main/java/com/otilm/core/service/cmp/message/handler/PollFeature.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/handler/PollFeature.java
@@ -105,7 +105,7 @@ public class PollFeature {
                             tid, serialNumber, certUUID, current);
                     return new PollResult.StillPending(current);
                 }
-                if (isTerminal(current)) {
+                if (isDivergentTerminal(current, expectedState)) {
                     log.warn("TID={}, SN={} | certificate uuid={} diverted to {} while waiting for {}",
                             tid, serialNumber, certUUID, current, expectedState);
                     return new PollResult.Diverted(current);
@@ -134,5 +134,23 @@ public class PollFeature {
                 || state == CertificateState.REVOKED
                 || state == CertificateState.FAILED
                 || state == CertificateState.REJECTED;
+    }
+
+    /**
+     * A terminal state that is not the expected one usually means the operation diverged
+     * (e.g. an operator cancel flipped an in-flight issue to FAILED). The one exception is
+     * {@code ISSUED} while waiting for {@code REVOKED}: {@code ISSUED} is the resting state a
+     * certificate occupies <em>before</em> a revocation transition lands, so observing it
+     * means "revocation not applied yet", not a divergence. Treating it as divergence made a
+     * revocation poll reject on its first sample before the async {@code ISSUED -> REVOKED}
+     * transition completed (issue #1833). Such a poll instead keeps waiting and, if the
+     * transition never lands within the budget, ends as a timeout — a rejection either way,
+     * but never a false "diverted to ISSUED".
+     */
+    private static boolean isDivergentTerminal(CertificateState current, CertificateState expectedState) {
+        if (!isTerminal(current) || current == expectedState) {
+            return false;
+        }
+        return !(expectedState == CertificateState.REVOKED && current == CertificateState.ISSUED);
     }
 }

--- a/src/test/java/com/otilm/core/service/cmp/message/handler/PollFeatureTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/handler/PollFeatureTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link PollFeature}.
@@ -61,7 +62,7 @@ class PollFeatureTest {
     void returnsStillPending_whenCertReachesPendingIssue() throws Exception {
         UUID certUuid = UUID.randomUUID();
         Certificate cert = certificateInState(certUuid, CertificateState.PENDING_ISSUE);
-        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+        when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenReturn(cert);
 
         PollResult result = pollFeature.pollCertificate(
@@ -75,7 +76,7 @@ class PollFeatureTest {
     void returnsStillPending_whenCertReachesPendingRevoke() throws Exception {
         UUID certUuid = UUID.randomUUID();
         Certificate cert = certificateInState(certUuid, CertificateState.PENDING_REVOKE);
-        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+        when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenReturn(cert);
 
         PollResult result = pollFeature.pollCertificate(
@@ -89,7 +90,7 @@ class PollFeatureTest {
     void returnsReached_whenCertAlreadyInExpectedState() throws Exception {
         UUID certUuid = UUID.randomUUID();
         Certificate cert = certificateInState(certUuid, CertificateState.ISSUED);
-        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+        when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenReturn(cert);
 
         PollResult result = pollFeature.pollCertificate(
@@ -106,7 +107,7 @@ class PollFeatureTest {
         // Caller must reject the operation cleanly rather than time out with systemFailure.
         UUID certUuid = UUID.randomUUID();
         Certificate cert = certificateInState(certUuid, CertificateState.FAILED);
-        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+        when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenReturn(cert);
 
         PollResult result = pollFeature.pollCertificate(
@@ -122,7 +123,7 @@ class PollFeatureTest {
         // a terminal state that is not ISSUED. Caller must reject cleanly.
         UUID certUuid = UUID.randomUUID();
         Certificate cert = certificateInState(certUuid, CertificateState.REJECTED);
-        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+        when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenReturn(cert);
 
         PollResult result = pollFeature.pollCertificate(
@@ -140,7 +141,7 @@ class PollFeatureTest {
         UUID certUuid = UUID.randomUUID();
         Certificate cert = certificateInState(certUuid, CertificateState.ISSUED);
         AtomicInteger reads = new AtomicInteger();
-        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+        when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenAnswer(invocation -> {
                     if (reads.incrementAndGet() >= 2) {
                         cert.setState(CertificateState.REVOKED);
@@ -163,8 +164,12 @@ class PollFeatureTest {
         // which the revocation handler surfaces as a plain rejection.
         UUID certUuid = UUID.randomUUID();
         Certificate cert = certificateInState(certUuid, CertificateState.ISSUED);
-        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+        when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenReturn(cert);
+
+        Field timeoutField = PollFeature.class.getDeclaredField("pollFeatureTimeout");
+        timeoutField.setAccessible(true);
+        timeoutField.set(pollFeature, 0);
 
         assertThatThrownBy(() -> pollFeature.pollCertificate(
                 new DEROctetString(new byte[]{1}), "01", certUuid.toString(), CertificateState.REVOKED))
@@ -178,7 +183,7 @@ class PollFeatureTest {
         // is still reported as Diverted so the caller rejects cleanly.
         UUID certUuid = UUID.randomUUID();
         Certificate cert = certificateInState(certUuid, CertificateState.FAILED);
-        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+        when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenReturn(cert);
 
         PollResult result = pollFeature.pollCertificate(
@@ -191,7 +196,7 @@ class PollFeatureTest {
     @Test
     void wrapsNotFoundException_withCmpProcessingException() throws Exception {
         UUID certUuid = UUID.randomUUID();
-        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+        when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenThrow(new NotFoundException(Certificate.class, certUuid));
 
         assertThatThrownBy(() -> pollFeature.pollCertificate(
@@ -208,7 +213,7 @@ class PollFeatureTest {
         // outcome messages carry the right SN.
         UUID certUuid = UUID.randomUUID();
         Certificate cert = certificateInState(certUuid, CertificateState.ISSUED);
-        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+        when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenReturn(cert);
 
         PollResult result = pollFeature.pollCertificate(
@@ -226,7 +231,7 @@ class PollFeatureTest {
         // observe the interrupt.
         UUID certUuid = UUID.randomUUID();
         Certificate cert = certificateInState(certUuid, CertificateState.REQUESTED);
-        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+        when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenReturn(cert);
 
         Thread.currentThread().interrupt();
@@ -248,7 +253,7 @@ class PollFeatureTest {
         // Cert in REQUESTED state never reaches ISSUED; timeout config is 1s in setUp().
         UUID certUuid = UUID.randomUUID();
         Certificate cert = certificateInState(certUuid, CertificateState.REQUESTED);
-        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+        when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenReturn(cert);
 
         assertThatThrownBy(() -> pollFeature.pollCertificate(

--- a/src/test/java/com/otilm/core/service/cmp/message/handler/PollFeatureTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/handler/PollFeatureTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -132,11 +133,51 @@ class PollFeatureTest {
     }
 
     @Test
-    void returnsDiverted_whenCertEndsInIssuedButExpectedRevoked() throws Exception {
-        // Equivalent race in the revoke direction: a concurrent cancelPendingCertificateOperation
-        // (cancel-revoke) sets the cert back to ISSUED while this poll waits for REVOKED.
+    void ridesThroughIssued_andReturnsReached_whenRevocationLandsWithinBudget() throws Exception {
+        // Issue #1833: ISSUED is the resting state a certificate occupies before a revocation
+        // transitions, so a revoke poll that samples ISSUED first must keep waiting for the
+        // async ISSUED -> REVOKED transition instead of rejecting it as "diverted to ISSUED".
         UUID certUuid = UUID.randomUUID();
         Certificate cert = certificateInState(certUuid, CertificateState.ISSUED);
+        AtomicInteger reads = new AtomicInteger();
+        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+                .thenAnswer(invocation -> {
+                    if (reads.incrementAndGet() >= 2) {
+                        cert.setState(CertificateState.REVOKED);
+                    }
+                    return cert;
+                });
+
+        PollResult result = pollFeature.pollCertificate(
+                new DEROctetString(new byte[]{1}), "01", certUuid.toString(), CertificateState.REVOKED);
+
+        assertThat(result).isInstanceOfSatisfying(PollResult.Reached.class,
+                r -> assertThat(r.certificate()).isSameAs(cert));
+        assertThat(reads.get()).isGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    void timesOut_whenRevokeNeverLeavesIssued_ratherThanReportingDivertedToIssued() throws Exception {
+        // If the revocation never takes effect (cert stuck at ISSUED), the poll must NOT
+        // report a false "diverted to ISSUED"; it rides out the budget and ends as a timeout,
+        // which the revocation handler surfaces as a plain rejection.
+        UUID certUuid = UUID.randomUUID();
+        Certificate cert = certificateInState(certUuid, CertificateState.ISSUED);
+        Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
+                .thenReturn(cert);
+
+        assertThatThrownBy(() -> pollFeature.pollCertificate(
+                new DEROctetString(new byte[]{1}), "01", certUuid.toString(), CertificateState.REVOKED))
+                .isInstanceOf(CmpProcessingException.class)
+                .hasMessageContaining("polling timed out");
+    }
+
+    @Test
+    void returnsDiverted_whenCertEndsInFailedButExpectedRevoked() throws Exception {
+        // A genuine divergence on the revoke path (FAILED, not the benign ISSUED precursor)
+        // is still reported as Diverted so the caller rejects cleanly.
+        UUID certUuid = UUID.randomUUID();
+        Certificate cert = certificateInState(certUuid, CertificateState.FAILED);
         Mockito.when(certificateService.getCertificateEntity(Mockito.any(SecuredUUID.class)))
                 .thenReturn(cert);
 
@@ -144,7 +185,7 @@ class PollFeatureTest {
                 new DEROctetString(new byte[]{1}), "01", certUuid.toString(), CertificateState.REVOKED);
 
         assertThat(result).isInstanceOfSatisfying(PollResult.Diverted.class,
-                d -> assertThat(d.currentState()).isEqualTo(CertificateState.ISSUED));
+                d -> assertThat(d.currentState()).isEqualTo(CertificateState.FAILED));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/cmp/message/handler/PollFeatureTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/handler/PollFeatureTest.java
@@ -135,7 +135,7 @@ class PollFeatureTest {
 
     @Test
     void ridesThroughIssued_andReturnsReached_whenRevocationLandsWithinBudget() throws Exception {
-        // Issue #1833: ISSUED is the resting state a certificate occupies before a revocation
+        // ISSUED is the resting state a certificate occupies before a revocation
         // transitions, so a revoke poll that samples ISSUED first must keep waiting for the
         // async ISSUED -> REVOKED transition instead of rejecting it as "diverted to ISSUED".
         UUID certUuid = UUID.randomUUID();


### PR DESCRIPTION
Closes #1833 

**Operational note:** a genuine cancel-revoke that returns the certificate to `ISSUED` is now rejected via poll timeout (up to `cmp.protocol.poll.feature.timeout`, default 10 s) instead of an immediate `Diverted` rejection. The client-visible failure (`PKIFailureInfo.systemFailure`) is unchanged; only latency in that rare case increases.
