### PR TITLE
Support optional owner and groups on certificate registration

### DIFF
--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -51,6 +51,7 @@ import com.otilm.core.logging.LoggerWrapper;
 import com.otilm.core.messaging.jms.producers.ActionProducer;
 import com.otilm.core.messaging.jms.producers.EventProducer;
 import com.otilm.core.messaging.model.ActionMessage;
+import com.otilm.core.service.ResourceObjectAssociationService;
 import com.otilm.core.service.handler.authority.AdapterOperationOutcome;
 import com.otilm.core.service.handler.authority.AdapterOperationResult;
 import com.otilm.core.service.handler.authority.AsyncOperationCapability;
@@ -164,6 +165,12 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     private RegistrationChallengeStore registrationChallengeStore;
     private CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository;
     private CertificateRegistrationAuthorizationWriter registrationAuthorizationWriter;
+    private ResourceObjectAssociationService objectAssociationService;
+
+    @Autowired
+    public void setObjectAssociationService(ResourceObjectAssociationService objectAssociationService) {
+        this.objectAssociationService = objectAssociationService;
+    }
 
     @Autowired
     public void setProtocolRequestAttributeValidator(ProtocolRequestAttributeValidator protocolRequestAttributeValidator) {
@@ -480,6 +487,9 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             if (createCustomAttributes && request.getCustomAttributes() != null && !request.getCustomAttributes().isEmpty()) {
                 attributeEngine.updateObjectCustomAttributesContent(Resource.CERTIFICATE, certificate.getUuid(), request.getCustomAttributes());
             }
+            // Apply owner/groups before the connector call, alongside custom attributes: an invalid owner/group
+            // UUID fails the placeholder here (pre-acceptance) rather than after a connector has already accepted.
+            applyRegistrationAssociations(certificate, request);
             // Persist the challenge authorization before the connector call — on every arc that can leave the
             // certificate reconcilable to REGISTERED (see the method) — but inside the try, so a store/save
             // failure fails the placeholder via the catch below rather than orphaning it in PENDING_REGISTRATION.
@@ -563,6 +573,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             if (createCustomAttributes && request.getCustomAttributes() != null && !request.getCustomAttributes().isEmpty()) {
                 attributeEngine.updateObjectCustomAttributesContent(Resource.CERTIFICATE, certificate.getUuid(), request.getCustomAttributes());
             }
+            applyRegistrationAssociations(certificate, request);
             maybeCreateRegistrationAuthorization(certificate, request);
             // Write the register->issue binding (no connector meta) so a platform-level placeholder carries the same
             // marker as a connector-backed one — the discriminator both the issue routing and the approval-reject
@@ -583,6 +594,32 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         response.setUuid(certificate.getUuid().toString());
         response.setCertificateData("");
         return response;
+    }
+
+    /**
+     * Applies the optional owner and groups from the registration request onto the placeholder certificate.
+     *
+     * <p>An explicit {@code ownerUuid} is set as the owner; when it is absent the registering user becomes the
+     * owner (mirroring the plain issue path). {@code groupUuids}, when supplied, replace the certificate's group
+     * set. Both associations are set through {@link ResourceObjectAssociationService}, which validates that the
+     * owner and each group exist and throws {@link NotFoundException} otherwise.</p>
+     *
+     * <p>Called before the connector call (alongside custom attributes) so an invalid owner/group UUID fails the
+     * placeholder pre-acceptance rather than diverging from a connector that has already accepted the
+     * registration. The values are preserved when the pre-registered certificate is later issued, because the
+     * register-&gt;issue path reuses the same entity and does not reset owner or groups.</p>
+     */
+    private void applyRegistrationAssociations(Certificate certificate, ClientCertificateRegistrationDto request)
+            throws NotFoundException {
+        UUID certificateUuid = certificate.getUuid();
+        if (request.getOwnerUuid() != null && !request.getOwnerUuid().isBlank()) {
+            objectAssociationService.setOwner(Resource.CERTIFICATE, certificateUuid, UUID.fromString(request.getOwnerUuid()));
+        } else {
+            objectAssociationService.setOwnerFromProfile(Resource.CERTIFICATE, certificateUuid);
+        }
+        if (request.getGroupUuids() != null && !request.getGroupUuids().isEmpty()) {
+            objectAssociationService.setGroups(Resource.CERTIFICATE, certificateUuid, request.getGroupUuids());
+        }
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -2,7 +2,9 @@ package com.otilm.core.integration.service;
 
 import com.otilm.api.exception.AttributeException;
 import com.otilm.api.exception.ConnectorException;
+import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.attribute.RequestAttributeV3;
 import com.otilm.api.model.client.connector.v2.ConnectorVersion;
@@ -37,9 +39,11 @@ import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.OperationSupport;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.certificate.request.IssuanceDefinitionResolver;
+import com.otilm.api.model.core.auth.UserDetailDto;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.entity.Group;
 import com.otilm.core.dao.entity.RaProfile;
 import com.otilm.core.dao.entity.CertificateRegistration;
 import com.otilm.core.dao.entity.CertificateRegistrationAuthorization;
@@ -49,6 +53,7 @@ import com.otilm.core.dao.repository.CertificateRegistrationAuthorizationReposit
 import com.otilm.core.dao.repository.CertificateRegistrationRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.dao.repository.GroupRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
 import com.otilm.core.exception.ConnectorAcceptedButLocalFailureException;
 import com.otilm.core.messaging.jms.producers.ActionProducer;
@@ -60,7 +65,9 @@ import com.otilm.core.security.authn.PlatformUserDetails;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.security.authn.client.UserManagementApiClient;
 import com.otilm.core.service.CertificateInternalService;
+import com.otilm.core.service.ResourceObjectAssociationService;
 import com.otilm.core.service.handler.ConnectorCapabilityService;
 import com.otilm.core.service.handler.authority.AdapterOperationResult;
 import com.otilm.core.service.handler.authority.AsyncOperationCapability;
@@ -97,6 +104,7 @@ import java.security.KeyPairGenerator;
 import java.time.OffsetDateTime;
 import java.util.Base64;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.mockito.Mockito.doThrow;
@@ -176,6 +184,19 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     // the flat register tests never call resolve(), so the default no-op mock is inert for them.
     @MockitoBean
     private IssuanceDefinitionResolver issuanceDefinitionResolver;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    // The generic association service is the real bean, so setOwner/setGroups actually persist against the
+    // placeholder; getOwner/getGroupUuids are then used to assert what registration stored.
+    @Autowired
+    private ResourceObjectAssociationService objectAssociationService;
+
+    // Mocked so an explicit owner UUID resolves to a username without a live auth service (setOwner resolves the
+    // owner's username through this client). The default-owner path uses the logged profile and never calls it.
+    @MockitoBean
+    private UserManagementApiClient userManagementApiClient;
 
     private RaProfile raProfile;
     // Pre-computed secured UUIDs so each assertThrows lambda contains only the call under test.
@@ -932,6 +953,117 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
         Assertions.assertThrows(ValidationException.class, () -> clientOperationService.issueExistingCertificate(
                 authorityParent,
                 securedRaProfile, certUuid, null));
+    }
+
+    // ── owner & groups on registration (#1835) ───────────────────────────────
+
+    private Group persistGroup(String name) {
+        Group group = new Group();
+        group.setName(name);
+        return groupRepository.save(group);
+    }
+
+    private void stubResolvableOwner(UUID ownerUuid, String username) {
+        UserDetailDto userDetail = new UserDetailDto();
+        userDetail.setUuid(ownerUuid.toString());
+        userDetail.setUsername(username);
+        when(userManagementApiClient.getUserDetail(ownerUuid.toString())).thenReturn(userDetail);
+    }
+
+    @Test
+    void registrationDefaultsOwnerToLoggedUserWhenNoneProvided() throws Exception {
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
+
+        ClientCertificateDataResponseDto response = register();
+
+        NameAndUuidDto owner = objectAssociationService.getOwner(Resource.CERTIFICATE, UUID.fromString(response.getUuid()));
+        Assertions.assertNotNull(owner, "an omitted owner defaults to the registering user");
+        Assertions.assertEquals("tst-user", owner.getName());
+    }
+
+    @Test
+    void registrationPersistsExplicitOwnerAndGroups() throws Exception {
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
+        UUID ownerUuid = UUID.randomUUID();
+        stubResolvableOwner(ownerUuid, "device-owner");
+        Group group = persistGroup("registration-group");
+
+        ClientCertificateRegistrationDto request = registrationRequest();
+        request.setOwnerUuid(ownerUuid.toString());
+        request.setGroupUuids(Set.of(group.getUuid()));
+
+        ClientCertificateDataResponseDto response =
+                clientOperationService.registerCertificate(authorityParent, securedRaProfile, request);
+
+        UUID certUuid = UUID.fromString(response.getUuid());
+        Assertions.assertEquals(ownerUuid.toString(),
+                objectAssociationService.getOwner(Resource.CERTIFICATE, certUuid).getUuid());
+        Assertions.assertEquals(List.of(group.getUuid()),
+                objectAssociationService.getGroupUuids(Resource.CERTIFICATE, certUuid));
+    }
+
+    @Test
+    void platformLevelRegistrationPersistsOwnerAndGroups() throws Exception {
+        when(adapterFactory.forAuthority(Mockito.any())).thenReturn(mock(AuthorityProviderAdapter.class));
+        UUID ownerUuid = UUID.randomUUID();
+        stubResolvableOwner(ownerUuid, "device-owner");
+        Group group = persistGroup("platform-level-group");
+
+        ClientCertificateRegistrationDto request = registrationRequest();
+        request.setOwnerUuid(ownerUuid.toString());
+        request.setGroupUuids(Set.of(group.getUuid()));
+
+        ClientCertificateDataResponseDto response =
+                clientOperationService.registerCertificate(authorityParent, securedRaProfile, request);
+
+        UUID certUuid = UUID.fromString(response.getUuid());
+        Assertions.assertEquals(ownerUuid.toString(),
+                objectAssociationService.getOwner(Resource.CERTIFICATE, certUuid).getUuid());
+        Assertions.assertEquals(List.of(group.getUuid()),
+                objectAssociationService.getGroupUuids(Resource.CERTIFICATE, certUuid));
+    }
+
+    @Test
+    void registrationWithUnknownGroupFailsPlaceholderPreAcceptance() throws Exception {
+        RegisterCapability adapter = registeringAdapter();
+        ClientCertificateRegistrationDto request = registrationRequest();
+        request.setGroupUuids(Set.of(UUID.randomUUID())); // no such Group exists
+
+        Assertions.assertThrows(NotFoundException.class, () -> clientOperationService.registerCertificate(
+                authorityParent, securedRaProfile, request));
+
+        List<Certificate> certs = certificateRepository.findAll();
+        Assertions.assertEquals(1, certs.size());
+        Assertions.assertEquals(CertificateState.FAILED, certs.get(0).getState(),
+                "an unknown group must fail the placeholder before the connector call");
+        verify(adapter, never()).register(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void issuingRegisteredCertificatePreservesOwnerAndGroups() throws Exception {
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
+        UUID ownerUuid = UUID.randomUUID();
+        stubResolvableOwner(ownerUuid, "device-owner");
+        Group group = persistGroup("preserved-group");
+        ClientCertificateRegistrationDto request = registrationRequest();
+        request.setOwnerUuid(ownerUuid.toString());
+        request.setGroupUuids(Set.of(group.getUuid()));
+        UUID certUuid = UUID.fromString(
+                clientOperationService.registerCertificate(authorityParent, securedRaProfile, request).getUuid());
+
+        ClientCertificateIssueRequestDto issueRequest = new ClientCertificateIssueRequestDto();
+        issueRequest.setRequest(generateCsrBase64());
+        clientOperationService.issueExistingCertificate(authorityParent, securedRaProfile, certUuid.toString(), issueRequest);
+
+        Assertions.assertEquals(ownerUuid.toString(),
+                objectAssociationService.getOwner(Resource.CERTIFICATE, certUuid).getUuid(),
+                "attaching the operator CSR at issuance must not change the registered owner");
+        Assertions.assertEquals(List.of(group.getUuid()),
+                objectAssociationService.getGroupUuids(Resource.CERTIFICATE, certUuid),
+                "attaching the operator CSR at issuance must not change the registered groups");
     }
 
     // ── register->issue binding persistence ──────────────────────────────────


### PR DESCRIPTION
Closes #1835

## What

Certificate registration can now preset the certificate **owner** and **groups**, and those values are preserved when the pre-registered certificate is later issued.

- New `applyRegistrationAssociations(Certificate, ClientCertificateRegistrationDto)` helper in `ClientOperationServiceImpl`, called in both registration paths (connector-backed `registerCertificate` and `registerPlatformLevel`).
- Explicit `ownerUuid` → set as owner; when absent → `setOwnerFromProfile` (the registering user becomes owner, mirroring the plain `POST /issue` path).
- Non-empty `groupUuids` → replace the certificate's group set.
- Applied through the existing `ResourceObjectAssociationService`, reusing the `setProtocolAssociations` precedent.

## Placement / failure semantics

The helper runs inside the registration `try` block, **after** custom-attribute persistence and **before** the connector `register()` call. An invalid owner/group UUID (`NotFoundException`) or a malformed owner UUID string (`IllegalArgumentException`) therefore fails the placeholder **pre-acceptance** (→ `FAILED`), never diverging from a connector that has already accepted the registration.

## Issuance preservation

No production change needed: the register→issue path (`issueExistingCertificate` → `addCertificateRequestToExisting` → `issueRequestedCertificate`) reuses the same entity and never resets owner/groups. A regression test locks this in.

## Tests

5 new tests in `ClientOperationServiceRegisterITest` (explicit owner+groups on connector and platform-level paths; default-to-registering-user when omitted; unknown group fails the placeholder pre-acceptance; issuance of a registered cert preserves owner+groups). Full class 74/74 green.

## Dependency

Requires interfaces PR OmniTrustILM/interfaces#781 (adds `ownerUuid`/`groupUuids` to the DTO). Merge/publish that SNAPSHOT before this PR's CI.

## Review

Independent review pass (Claude reviewer + Copilot CLI) — both returned SHIP; no correctness, race, state-divergence, transaction-boundary, or information-leak issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)