### PR TITLE
Dispatch NG callbacks on parent-less connector forms

### DIFF
--- a/src/main/java/com/otilm/core/service/CallbackExternalService.java
+++ b/src/main/java/com/otilm/core/service/CallbackExternalService.java
@@ -43,7 +43,9 @@ public interface CallbackExternalService {
      * Function to execute the callback on the connector. This method executes the callback only for the attributes
      * that are derived from the primary objects of the connector
      * @param resource Type of the resource for which the callback has to be executed
-     * @param resourceUuid UUID of the resource to which the callback will be executed
+     * @param parentObjectUuid UUID of the parent scope object the form is nested under (the authority behind an
+     *                         RA profile, the token instance behind a token profile, ...), not an object of the
+     *                         named resource itself
      * @param callback Callback request containing information regarding the
      * @return Callback
      * @throws ConnectorException when there are issues with the connector communication
@@ -51,7 +53,7 @@ public interface CallbackExternalService {
      */
     Object resourceCallback(
             Resource resource,
-            String resourceUuid,
+            String parentObjectUuid,
             RequestAttributeCallback callback
     ) throws ConnectorException, ValidationException, NotFoundException, AttributeException;
 }

--- a/src/main/java/com/otilm/core/service/callback/AttributeCallbackScopeResolver.java
+++ b/src/main/java/com/otilm/core/service/callback/AttributeCallbackScopeResolver.java
@@ -190,8 +190,8 @@ public class AttributeCallbackScopeResolver {
         // TOKEN_PROFILE -> [{tokenInstance}]), so the parent UUID identifies the instance, not a token profile.
         TokenInstanceReference tokenInstance = tokenInstanceReferenceRepository.findByUuid(tokenInstanceUuid)
                 .orElseThrow(() -> notFound(TokenInstanceReference.class, tokenInstanceUuid));
-        return List.of(new ScopeStep(Resource.TOKEN, tokenInstance.getUuid(),
-                tokenInstance.getConnector() == null ? null : tokenInstance.getConnector().getUuid()));
+        // Read the connectorUuid column directly rather than walking the LAZY connector association.
+        return List.of(new ScopeStep(Resource.TOKEN, tokenInstance.getUuid(), tokenInstance.getConnectorUuid()));
     }
 
     private List<ScopeStep> walkCryptographicKey(UUID tokenProfileUuid) throws NotFoundException {

--- a/src/main/java/com/otilm/core/service/callback/AttributeCallbackScopeResolver.java
+++ b/src/main/java/com/otilm/core/service/callback/AttributeCallbackScopeResolver.java
@@ -14,10 +14,12 @@ import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.EntityInstanceReference;
 import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.dao.entity.TokenInstanceReference;
 import com.otilm.core.dao.entity.TokenProfile;
 import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.EntityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
+import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
 import com.otilm.core.dao.repository.TokenProfileRepository;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.AuthorizationEnforcer;
@@ -64,6 +66,7 @@ public class AttributeCallbackScopeResolver {
     private final AuthorityInstanceReferenceRepository authorityInstanceReferenceRepository;
     private final RaProfileRepository raProfileRepository;
     private final TokenProfileRepository tokenProfileRepository;
+    private final TokenInstanceReferenceRepository tokenInstanceReferenceRepository;
     private final EntityInstanceReferenceRepository entityInstanceReferenceRepository;
 
     private final Map<Resource, ScopeWalker> walkers = new EnumMap<>(Resource.class);
@@ -71,7 +74,7 @@ public class AttributeCallbackScopeResolver {
     /** A scope-chain walker that may fail with a 404 when a referenced object is absent. */
     @FunctionalInterface
     private interface ScopeWalker {
-        List<ScopeStep> walk(UUID resourceUuid) throws NotFoundException;
+        List<ScopeStep> walk(UUID parentObjectUuid) throws NotFoundException;
     }
 
     public AttributeCallbackScopeResolver(AttributeEngine attributeEngine,
@@ -80,6 +83,7 @@ public class AttributeCallbackScopeResolver {
                                           AuthorityInstanceReferenceRepository authorityInstanceReferenceRepository,
                                           RaProfileRepository raProfileRepository,
                                           TokenProfileRepository tokenProfileRepository,
+                                          TokenInstanceReferenceRepository tokenInstanceReferenceRepository,
                                           EntityInstanceReferenceRepository entityInstanceReferenceRepository) {
         this.attributeEngine = attributeEngine;
         this.expander = expander;
@@ -87,6 +91,7 @@ public class AttributeCallbackScopeResolver {
         this.authorityInstanceReferenceRepository = authorityInstanceReferenceRepository;
         this.raProfileRepository = raProfileRepository;
         this.tokenProfileRepository = tokenProfileRepository;
+        this.tokenInstanceReferenceRepository = tokenInstanceReferenceRepository;
         this.entityInstanceReferenceRepository = entityInstanceReferenceRepository;
         registerWalkers();
     }
@@ -107,7 +112,7 @@ public class AttributeCallbackScopeResolver {
      * Resolve the ordered (parent-first) scope chain for the given scoped resource into expanded
      * {@link ScopedAttributes} blobs. An unmapped resource fails closed with a {@link ValidationException}.
      */
-    public List<ScopedAttributes> resolveScopeChain(Resource resource, UUID resourceUuid, Set<String> expandedSecrets)
+    public List<ScopedAttributes> resolveScopeChain(Resource resource, UUID parentObjectUuid, Set<String> expandedSecrets)
             throws NotFoundException, AttributeException, ConnectorException {
         ScopeWalker walker = walkers.get(resource);
         if (walker == null) {
@@ -117,7 +122,7 @@ public class AttributeCallbackScopeResolver {
                     "Callback scope chain is not supported for resource " + resource));
         }
         List<ScopedAttributes> chain = new ArrayList<>();
-        for (ScopeStep step : walker.walk(resourceUuid)) {
+        for (ScopeStep step : walker.walk(parentObjectUuid)) {
             chain.add(buildScopedAttributes(step, expandedSecrets));
         }
         return chain;
@@ -180,10 +185,13 @@ public class AttributeCallbackScopeResolver {
         return List.of(authorityStep(authority), raProfileStep(raProfile));
     }
 
-    private List<ScopeStep> walkTokenProfile(UUID tokenProfileUuid) throws NotFoundException {
-        TokenProfile tokenProfile = tokenProfileRepository.findByUuid(tokenProfileUuid)
-                .orElseThrow(() -> notFound(TokenProfile.class, tokenProfileUuid));
-        return List.of(tokenInstanceStep(tokenProfile));
+    private List<ScopeStep> walkTokenProfile(UUID tokenInstanceUuid) throws NotFoundException {
+        // The token-profile create form is scoped by its parent token INSTANCE (per the scope table
+        // TOKEN_PROFILE -> [{tokenInstance}]), so the parent UUID identifies the instance, not a token profile.
+        TokenInstanceReference tokenInstance = tokenInstanceReferenceRepository.findByUuid(tokenInstanceUuid)
+                .orElseThrow(() -> notFound(TokenInstanceReference.class, tokenInstanceUuid));
+        return List.of(new ScopeStep(Resource.TOKEN, tokenInstance.getUuid(),
+                tokenInstance.getConnector() == null ? null : tokenInstance.getConnector().getUuid()));
     }
 
     private List<ScopeStep> walkCryptographicKey(UUID tokenProfileUuid) throws NotFoundException {

--- a/src/main/java/com/otilm/core/service/callback/NgCallbackDispatcher.java
+++ b/src/main/java/com/otilm/core/service/callback/NgCallbackDispatcher.java
@@ -149,15 +149,15 @@ public class NgCallbackDispatcher {
     }
 
     private AttributeCallbackRequestDto buildEnvelope(NgDispatchContext context, RequestAttributeCallback callback) {
-        // connectorInterface and interfaceVersion are a pair (the envelope marks interfaceVersion @NotBlank). The
-        // connector-scoped entrypoints legitimately stamp neither; a form-context scope arm that stamps the interface
-        // but not the version would emit an envelope omitting the required version (NON_NULL drops it). Fail fast
-        // rather than ship a malformed envelope a conformant connector silently rejects.
-        if (context.connectorInterface() != null
-                && (context.interfaceVersion() == null || context.interfaceVersion().isBlank())) {
+        // Every NG dispatch stamps a full (connectorInterface, interfaceVersion) pair: the envelope marks
+        // connectorInterface @NotNull and interfaceVersion @NotBlank, and @JsonInclude(NON_NULL) drops nulls, so a
+        // missing coordinate ships a body a conformant connector rejects. The dispatch ladder always resolves the
+        // pair before reaching here — from the scoped object (resource-scoped forms) or the request's interfaceUuid
+        // (connector route). A both-null or half-pair shape is a wiring error; fail fast rather than dispatch it.
+        if (context.connectorInterface() == null
+                || context.interfaceVersion() == null || context.interfaceVersion().isBlank()) {
             throw new ValidationException(ValidationError.create(
-                    "NG callback envelope stamps connectorInterface " + context.connectorInterface()
-                            + " but no interfaceVersion; the scope arm must stamp both or neither"));
+                    "NG callback envelope requires both connectorInterface and interfaceVersion"));
         }
         BaseAttribute definition = context.definition();
         AttributeCallbackRequestDto envelope = new AttributeCallbackRequestDto();

--- a/src/main/java/com/otilm/core/service/impl/CallbackServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CallbackServiceImpl.java
@@ -397,7 +397,11 @@ public class CallbackServiceImpl implements CallbackExternalService {
         Set<String> present = new HashSet<>();
         if (currentAttributes != null) {
             for (RequestAttribute current : currentAttributes) {
-                present.add(current.getName());
+                // Client-supplied list: a null element (or null name) must not NPE into a 500. Skip it so the
+                // dependsOn name it was meant to satisfy stays unsatisfied — fail closed via the missing-name check.
+                if (current != null && current.getName() != null) {
+                    present.add(current.getName());
+                }
             }
         }
         List<String> missing = dependsOn.stream().filter(name -> !present.contains(name)).toList();

--- a/src/main/java/com/otilm/core/service/impl/CallbackServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CallbackServiceImpl.java
@@ -27,9 +27,12 @@ import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.ConnectorInterfaceEntity;
 import com.otilm.core.dao.entity.EntityInstanceReference;
 import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.dao.entity.TokenInstanceReference;
 import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
+import com.otilm.core.dao.repository.ConnectorInterfaceRepository;
 import com.otilm.core.dao.repository.EntityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
+import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
 import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.service.callback.AttributeCallbackScopeResolver;
@@ -65,6 +68,8 @@ public class CallbackServiceImpl implements CallbackExternalService {
     private AuthorityInstanceReferenceRepository authorityInstanceReferenceRepository;
     private EntityInstanceReferenceRepository entityInstanceReferenceRepository;
     private RaProfileRepository raProfileRepository;
+    private TokenInstanceReferenceRepository tokenInstanceReferenceRepository;
+    private ConnectorInterfaceRepository connectorInterfaceRepository;
     private CryptographicKeyExternalService cryptographicKeyService;
     private TokenProfileInternalService tokenProfileService;
     private AttributeEngine attributeEngine;
@@ -134,6 +139,16 @@ public class CallbackServiceImpl implements CallbackExternalService {
     }
 
     @Autowired
+    public void setTokenInstanceReferenceRepository(TokenInstanceReferenceRepository tokenInstanceReferenceRepository) {
+        this.tokenInstanceReferenceRepository = tokenInstanceReferenceRepository;
+    }
+
+    @Autowired
+    public void setConnectorInterfaceRepository(ConnectorInterfaceRepository connectorInterfaceRepository) {
+        this.connectorInterfaceRepository = connectorInterfaceRepository;
+    }
+
+    @Autowired
     public void setCryptographicKeyExternalService(CryptographicKeyExternalService cryptographicKeyService) {
         this.cryptographicKeyService = cryptographicKeyService;
     }
@@ -164,14 +179,16 @@ public class CallbackServiceImpl implements CallbackExternalService {
     }
 
     private Object getCallbackObject(RequestAttributeCallback callback, List<BaseAttribute> definitions, ConnectorDetailDto connector) throws NotFoundException, ConnectorException, AttributeException {
-        // Connector-level entrypoints carry no form/resource context, so no scope coordinates and no
-        // connectorInterface to stamp. The form-context NG paths (resourceCallback) stamp connectorInterface per
-        // resource. NG callbacks are a form-driven flow (resourceCallback), not the bare connector-level path.
+        // Connector-scoped entrypoints carry no parent scope object, so no scope coordinates and no pre-resolved
+        // connectorInterface. This is the route parent-less forms (the connector/authority instance create-edit
+        // form) use for NG callbacks: the interface is stamped in dispatchNg from the request's interfaceUuid, and
+        // the scope chain is empty. Resource-scoped forms (resourceCallback) instead pass the interface pre-resolved
+        // from the scoped object. Legacy callbacks ignore both.
         return getCallbackObject(callback, definitions, connector, null, null, null, null);
     }
 
     private Object getCallbackObject(RequestAttributeCallback callback, List<BaseAttribute> definitions, ConnectorDetailDto connector,
-                                     Resource scopeResource, UUID scopeResourceUuid, ConnectorInterface connectorInterface,
+                                     Resource scopeResource, UUID scopeParentUuid, ConnectorInterface connectorInterface,
                                      String interfaceVersion) throws NotFoundException, ConnectorException, AttributeException {
         UUID connectorUuid = UUID.fromString(connector.getUuid());
         BaseAttribute attribute = getBaseAttribute(callback, definitions, connectorUuid);
@@ -193,7 +210,7 @@ public class CallbackServiceImpl implements CallbackExternalService {
         // declaration is validated at ingest instead. Both-set is rejected at ingest, so the
         // callbackContext == null conjunct here is defensive. Legacy callbacks fall through unchanged.
         if (isNgCallback(attribute, attributeCallback)) {
-            return dispatchNg(connector, attribute, callback, scopeResource, scopeResourceUuid, connectorInterface, interfaceVersion);
+            return dispatchNg(connector, attribute, attributeCallback, callback, scopeResource, scopeParentUuid, connectorInterface, interfaceVersion);
         }
 
         AttributeDefinitionUtils.validateCallback(attributeCallback, callback, attributeResource != null);
@@ -312,18 +329,34 @@ public class CallbackServiceImpl implements CallbackExternalService {
      * supplied with the callback (the dependsOn-named attributes), expanded per the calling user via the same
      * {@link AttributeReferenceExpander} used for the scope chain.
      */
-    private Object dispatchNg(ConnectorDetailDto connector, BaseAttribute attribute,
-                              RequestAttributeCallback callback, Resource scopeResource, UUID scopeResourceUuid,
+    private Object dispatchNg(ConnectorDetailDto connector, BaseAttribute attribute, AttributeCallback attributeCallback,
+                              RequestAttributeCallback callback, Resource scopeResource, UUID scopeParentUuid,
                               ConnectorInterface connectorInterface, String interfaceVersion)
             throws NotFoundException, ConnectorException, AttributeException {
+        UUID connectorUuid = UUID.fromString(connector.getUuid());
+        List<RequestAttribute> currentAttributes = callback.getAttributes();
+
+        // Defence-in-depth behind the FE trigger rule: a dependsOn callback only fires once its named siblings are
+        // populated, so every dependsOn name must be present in currentAttributes. This checks presence by name (a
+        // value cleared to empty still counts as present); reject before touching the connector.
+        assertDependsOnNamesPresent(attributeCallback.getDependsOn(), currentAttributes);
+
+        // Stamp the envelope interface. Resource-scoped forms pass it pre-resolved from the scoped object; the
+        // connector-scoped route leaves it null and carries the form's connector-interface row UUID on the request
+        // instead. Resolving it here (rather than the entrypoint) keeps the lookup on the NG branch only.
+        if (connectorInterface == null) {
+            ConnectorInterfaceEntity iface = resolveRequestInterface(callback, connectorUuid);
+            connectorInterface = iface.getInterfaceCode();
+            interfaceVersion = iface.getVersion();
+        }
+
         // The scope chain is resolved HERE (not in resourceCallback) so legacy callbacks never pay its per-object
         // DETAIL authorization. One accumulator spans the scope chain + currentAttributes expansion so the
         // dispatcher can reject a connector echoing any server-expanded secret back toward the FE.
         Set<String> expandedSecrets = new HashSet<>();
         List<ScopedAttributes> contextAttributes = scopeResource == null
                 ? List.of()
-                : scopeResolver.resolveScopeChain(scopeResource, scopeResourceUuid, expandedSecrets);
-        List<RequestAttribute> currentAttributes = callback.getAttributes();
+                : scopeResolver.resolveScopeChain(scopeResource, scopeParentUuid, expandedSecrets);
         if (currentAttributes != null && !currentAttributes.isEmpty()) {
             attributeReferenceExpander.expandForCaller(currentAttributes, expandedSecrets);
         }
@@ -333,9 +366,50 @@ public class CallbackServiceImpl implements CallbackExternalService {
         return response.getContent() != null ? response.getContent() : response.getAttributes();
     }
 
+    /**
+     * Resolve the connector-interface row a callback carries on the request. When the dispatch ladder has not
+     * pre-resolved the interface from a scoped object — the connector-scoped route, and the token-instance /
+     * cryptographic-key / location arms that carry no {@link ConnectorInterfaceEntity} — an NG callback must supply
+     * {@code interfaceUuid}. The row disambiguates parallel NG interface versions on one connector and supplies the
+     * interface/version Core stamps on the envelope. It must belong to the route connector — otherwise a caller
+     * could stamp another connector's interface onto the dispatch.
+     */
+    private ConnectorInterfaceEntity resolveRequestInterface(RequestAttributeCallback callback, UUID connectorUuid) {
+        UUID interfaceUuid = callback.getInterfaceUuid();
+        if (interfaceUuid == null) {
+            throw new ValidationException(ValidationError.create(
+                    "NG attribute callback requires interfaceUuid identifying the form's connector interface"));
+        }
+        // Collapse "no such row" and "row owned by another connector" into one message: distinct messages would let
+        // a caller with connector access probe which interface UUIDs exist globally.
+        ConnectorInterfaceEntity iface = connectorInterfaceRepository.findById(interfaceUuid).orElse(null);
+        if (iface == null || !connectorUuid.equals(iface.getConnectorUuid())) {
+            throw new ValidationException(ValidationError.create(
+                    "Connector interface " + interfaceUuid + " is not valid for connector " + connectorUuid));
+        }
+        return iface;
+    }
+
+    private static void assertDependsOnNamesPresent(List<String> dependsOn, List<RequestAttribute> currentAttributes) {
+        if (dependsOn == null || dependsOn.isEmpty()) {
+            return;
+        }
+        Set<String> present = new HashSet<>();
+        if (currentAttributes != null) {
+            for (RequestAttribute current : currentAttributes) {
+                present.add(current.getName());
+            }
+        }
+        List<String> missing = dependsOn.stream().filter(name -> !present.contains(name)).toList();
+        if (!missing.isEmpty()) {
+            throw new ValidationException(ValidationError.create(
+                    "NG attribute callback is missing current values for dependsOn attributes: " + missing));
+        }
+    }
+
     @Override
     @ExternalAuthorization(resource = Resource.CONNECTOR, action = ResourceAction.LIST)
-    public Object resourceCallback(Resource resource, String resourceUuid, RequestAttributeCallback callback) throws ConnectorException, ValidationException, NotFoundException, AttributeException {
+    public Object resourceCallback(Resource resource, String parentObjectUuid, RequestAttributeCallback callback) throws ConnectorException, ValidationException, NotFoundException, AttributeException {
         List<BaseAttribute> definitions = null;
         Connector connector = null;
         ConnectorInterface connectorInterface = null;
@@ -343,11 +417,11 @@ public class CallbackServiceImpl implements CallbackExternalService {
         switch (resource) {
             case RA_PROFILE:
                 AuthorityInstanceReference authorityInstance = authorityInstanceReferenceRepository.findByUuid(
-                                UUID.fromString(resourceUuid))
+                                UUID.fromString(parentObjectUuid))
                         .orElseThrow(
                                 () -> new NotFoundException(
                                         AuthorityInstanceReference.class,
-                                        resourceUuid
+                                        parentObjectUuid
                                 )
                         );
                 connector = authorityInstance.getConnector();
@@ -369,11 +443,11 @@ public class CallbackServiceImpl implements CallbackExternalService {
                 // Issuance scope (NG-only): the FE issuance form sends (CERTIFICATE, raProfile). Resolve the
                 // connector via the raProfile -> authority chain, consistent with the scope walker
                 // (walkCertificateIssuance). Inert until the FE issuance form is wired; the scope chain is resolved by the NG path below.
-                RaProfile issuanceRaProfile = raProfileRepository.findByUuid(UUID.fromString(resourceUuid))
-                        .orElseThrow(() -> new NotFoundException(RaProfile.class, resourceUuid));
+                RaProfile issuanceRaProfile = raProfileRepository.findByUuid(UUID.fromString(parentObjectUuid))
+                        .orElseThrow(() -> new NotFoundException(RaProfile.class, parentObjectUuid));
                 AuthorityInstanceReference issuanceAuthority = issuanceRaProfile.getAuthorityInstanceReference();
                 if (issuanceAuthority == null) {
-                    throw new NotFoundException(AuthorityInstanceReference.class, resourceUuid);
+                    throw new NotFoundException(AuthorityInstanceReference.class, parentObjectUuid);
                 }
                 connector = issuanceAuthority.getConnector();
                 connectorInterface = interfaceCodeOf(issuanceAuthority);
@@ -381,46 +455,47 @@ public class CallbackServiceImpl implements CallbackExternalService {
                 break;
 
             case TOKEN_PROFILE:
-                // TOKEN_PROFILE is sent by the FE today but had no switch arm (it threw "not supported"). Route
-                // it via the token-profile -> token-instance FK like CRYPTOGRAPHIC_KEY; the NG scope chain (when
-                // the definition declares dependsOn) is resolved below.
-                connector = tokenProfileService.getTokenProfileEntity(SecuredUUID.fromString(resourceUuid))
-                        .getTokenInstanceReference().getConnector();
-                // No stored interface version for this route — only authorities carry a ConnectorInterfaceEntity, so
-                // unlike RA_PROFILE/CERTIFICATE there is no version to pair with a connectorInterface. Leave both unset
-                // (the connector-scoped envelope shape) rather than stamp a half-pair the dispatcher rejects; the FE
-                // wiring supplies the interface context when this NG route goes live.
+                // The token-profile create form's parent scope is the token INSTANCE (a token profile is created
+                // under an instance), so the FE sends the token-instance UUID as the parent — matching the scope
+                // table (TOKEN_PROFILE -> [{tokenInstance}]). Load the instance directly; loading a TokenProfile by
+                // this UUID would 404.
+                TokenInstanceReference tokenInstance = tokenInstanceReferenceRepository.findByUuid(UUID.fromString(parentObjectUuid))
+                        .orElseThrow(() -> new NotFoundException(TokenInstanceReference.class, parentObjectUuid));
+                connector = tokenInstance.getConnector();
+                // Token connectors carry no ConnectorInterfaceEntity, so this arm pre-resolves no interface: a legacy
+                // callback stamps none, and an NG definition dispatched here must carry interfaceUuid on the request
+                // (like the connector route) or the dispatch is rejected for a missing interface.
                 break;
 
             case CRYPTOGRAPHIC_KEY:
                 connector =
                         tokenProfileService.getTokenProfileEntity(
                                 SecuredUUID.fromString(
-                                        resourceUuid
+                                        parentObjectUuid
                                 )
                         ).getTokenInstanceReference().getConnector();
-                // See TOKEN_PROFILE: no stored interface version for this route, so leave the envelope's interface
-                // context unset (both-null) rather than stamp a half-pair the dispatcher rejects.
+                // See TOKEN_PROFILE: token connectors carry no ConnectorInterfaceEntity, so this arm pre-resolves no
+                // interface; an NG definition here must carry interfaceUuid on the request.
                 definitions = cryptographicKeyService.listCreateKeyAttributes(
                         null,
                         SecuredParentUUID.fromString(
-                                resourceUuid
+                                parentObjectUuid
                         ),
                         KeyRequestType.KEY_PAIR
                 );
                 break;
 
             case LOCATION:
-                EntityInstanceReference entityInstance = entityInstanceReferenceRepository.findByUuid(UUID.fromString(resourceUuid))
+                EntityInstanceReference entityInstance = entityInstanceReferenceRepository.findByUuid(UUID.fromString(parentObjectUuid))
                         .orElseThrow(
                                 () -> new NotFoundException(
                                         EntityInstanceReference.class,
-                                        resourceUuid
+                                        parentObjectUuid
                                 )
                         );
                 connector = entityInstance.getConnector();
-                // See TOKEN_PROFILE: no stored interface version for this route, so leave the envelope's interface
-                // context unset (both-null) rather than stamp a half-pair the dispatcher rejects.
+                // See TOKEN_PROFILE: entity connectors carry no ConnectorInterfaceEntity, so this arm pre-resolves no
+                // interface; an NG definition here must carry interfaceUuid on the request.
                 ApiClientConnectorInfo locationConnectorDto = connectorInternalService.getConnectorForApiClient(connector.getUuid());
                 definitions = connectorApiFactory.getEntityInstanceApiClient(locationConnectorDto).listLocationAttributes(locationConnectorDto, entityInstance.getEntityInstanceUuid());
                 break;
@@ -436,7 +511,7 @@ public class CallbackServiceImpl implements CallbackExternalService {
         LoggingHelper.putLogResourceInfo(Resource.CONNECTOR, true, connector.getUuid().toString(), connector.getName());
         // The scope chain is resolved lazily inside the NG branch (dispatchNg) so legacy callbacks never pay its
         // per-object DETAIL authorization; pass the scope coordinates rather than a pre-resolved chain.
-        return getCallbackObject(callback, definitions, connector.mapToDetailDto(), resource, UUID.fromString(resourceUuid), connectorInterface, interfaceVersion);
+        return getCallbackObject(callback, definitions, connector.mapToDetailDto(), resource, UUID.fromString(parentObjectUuid), connectorInterface, interfaceVersion);
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/impl/CallbackServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CallbackServiceImpl.java
@@ -341,9 +341,12 @@ public class CallbackServiceImpl implements CallbackExternalService {
         // value cleared to empty still counts as present); reject before touching the connector.
         assertDependsOnNamesPresent(attributeCallback.getDependsOn(), currentAttributes);
 
-        // Stamp the envelope interface. Resource-scoped forms pass it pre-resolved from the scoped object; the
-        // connector-scoped route leaves it null and carries the form's connector-interface row UUID on the request
-        // instead. Resolving it here (rather than the entrypoint) keeps the lookup on the NG branch only.
+        // Stamp the envelope interface. Precedence: a route that pre-resolved it from the scoped object
+        // (RA_PROFILE/CERTIFICATE, from the authority's ConnectorInterfaceEntity) wins, and a request-supplied
+        // interfaceUuid is ignored there — those forms derive their interface from the object, so the FE does not
+        // send one. Only when nothing is pre-resolved (the connector route, and the arms with no
+        // ConnectorInterfaceEntity) is the request's interfaceUuid consulted. Resolving here (not the entrypoint)
+        // keeps the lookup on the NG branch only.
         if (connectorInterface == null) {
             ConnectorInterfaceEntity iface = resolveRequestInterface(callback, connectorUuid);
             connectorInterface = iface.getInterfaceCode();

--- a/src/test/java/com/otilm/core/integration/service/AttributesV2CallbackDispatchITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AttributesV2CallbackDispatchITest.java
@@ -8,6 +8,8 @@ import com.otilm.api.model.client.connector.v2.ConnectorInterface;
 import com.otilm.api.model.client.connector.v2.ConnectorVersion;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.api.model.client.attribute.RequestAttribute;
+import com.otilm.api.model.client.attribute.RequestAttributeV3;
 import com.otilm.api.model.common.attribute.common.DataAttribute;
 import com.otilm.api.model.common.attribute.common.callback.AttributeCallback;
 import com.otilm.api.model.common.attribute.common.callback.RequestAttributeCallback;
@@ -114,16 +116,33 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
         return a;
     }
 
+    /** A saved authority-interface row for {@link #connector}; its UUID is what a connector-route NG callback carries. */
+    private ConnectorInterfaceEntity authorityInterface() {
+        ConnectorInterfaceEntity iface = new ConnectorInterfaceEntity();
+        iface.setConnectorUuid(connector.getUuid());
+        iface.setInterfaceCode(ConnectorInterface.AUTHORITY);
+        iface.setVersion("v3");
+        return connectorInterfaceRepository.save(iface);
+    }
+
+    /** Minimal current-attribute value carrying only the name the completeness guard checks. */
+    private static RequestAttribute currentValue(String name) {
+        return new RequestAttributeV3(UUID.randomUUID(), name, AttributeContentType.STRING, List.of());
+    }
+
     @Test
     void dependsOnCallbackDispatchesToV2Endpoint() throws AttributeException, NotFoundException, ConnectorException {
         DataAttributeV2 ng = ngDataAttribute("ngAttr");
         attributeEngine.updateDataAttributeDefinitions(connector.getUuid(), null, List.of(ng));
+        ConnectorInterfaceEntity iface = authorityInterface();
 
         mockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/v2/attributes/callback"))
                 .willReturn(WireMock.okJson("{\"content\":[]}")));
 
         RequestAttributeCallback req = new RequestAttributeCallback();
         req.setName(ng.getName());
+        req.setInterfaceUuid(iface.getUuid());
+        req.setAttributes(List.of(currentValue("dep")));
         callbackService.callback(connector.getUuid(), req);
 
         // Envelope carries the resolved attribute name; legacy endpoint must NOT be hit.
@@ -140,12 +159,14 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
         DataAttributeV2 ng = ngDataAttribute("ngFireOnMount");
         ng.getAttributeCallback().setDependsOn(List.of());
         attributeEngine.updateDataAttributeDefinitions(connector.getUuid(), null, List.of(ng));
+        ConnectorInterfaceEntity iface = authorityInterface();
 
         mockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/v2/attributes/callback"))
                 .willReturn(WireMock.okJson("{\"content\":[]}")));
 
         RequestAttributeCallback req = new RequestAttributeCallback();
         req.setName(ng.getName());
+        req.setInterfaceUuid(iface.getUuid());
         callbackService.callback(connector.getUuid(), req);
 
         // containing (not matchingJsonPath): a JSONPath match on an empty array reports no-match in WireMock, so the
@@ -210,6 +231,7 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
     void noTransactionActiveDuringConnectorCall() throws AttributeException, NotFoundException, ConnectorException {
         DataAttributeV2 ng = ngDataAttribute("txAttr");
         attributeEngine.updateDataAttributeDefinitions(connector.getUuid(), null, List.of(ng));
+        ConnectorInterfaceEntity iface = authorityInterface();
 
         mockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/v2/attributes/callback"))
                 .willReturn(WireMock.okJson("{\"content\":[]}")));
@@ -229,6 +251,8 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
 
         RequestAttributeCallback req = new RequestAttributeCallback();
         req.setName(ng.getName());
+        req.setInterfaceUuid(iface.getUuid());
+        req.setAttributes(List.of(currentValue("dep")));
         callbackService.callback(connector.getUuid(), req);
 
         Assertions.assertNotNull(captured.get(), "the connector POST must have fired");
@@ -273,6 +297,7 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
         DataAttributeV2 b = ngDataAttribute("dup");
         attributeEngine.updateDataAttributeDefinitions(connector.getUuid(), null, List.of(a));
         attributeEngine.updateDataAttributeDefinitions(connector.getUuid(), null, List.of(b));
+        ConnectorInterfaceEntity iface = authorityInterface();
 
         mockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/v2/attributes/callback"))
                 .willReturn(WireMock.okJson("{\"content\":[]}")));
@@ -280,6 +305,8 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
         RequestAttributeCallback req = new RequestAttributeCallback();
         req.setName("dup");
         req.setUuid(b.getUuid());
+        req.setInterfaceUuid(iface.getUuid());
+        req.setAttributes(List.of(currentValue("dep")));
         callbackService.callback(connector.getUuid(), req);
 
         mockServer.verify(WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback"))
@@ -311,6 +338,7 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
         RequestAttributeCallback req = new RequestAttributeCallback();
         req.setName("ngScoped");
         req.setUuid(ng.getUuid());
+        req.setAttributes(List.of(currentValue("dep")));
         callbackService.resourceCallback(Resource.RA_PROFILE, authority.getUuid().toString(), req);
 
         mockServer.verify(WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback"))
@@ -346,6 +374,7 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
         RequestAttributeCallback req = new RequestAttributeCallback();
         req.setName("ngDenied");
         req.setUuid(ng.getUuid());
+        req.setAttributes(List.of(currentValue("dep")));
 
         Assertions.assertThrows(org.springframework.security.access.AccessDeniedException.class,
                 () -> callbackService.resourceCallback(Resource.RA_PROFILE, authority.getUuid().toString(), req),
@@ -355,20 +384,16 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
     }
 
     @Test
-    void ngTokenProfileRouteDispatchesWithBothNullInterfaceContext() throws Exception {
-        // TOKEN_PROFILE/CRYPTOGRAPHIC_KEY/LOCATION have no stored interface version (only authorities carry one), so
-        // the arm emits a both-null interface envelope. A dependsOn callback on this route must still dispatch — the
-        // interface-version fail-fast must not trip on the both-null shape, and the envelope omits connectorInterface.
+    void ngTokenProfileRouteWithoutInterfaceUuidIsRejected() throws Exception {
+        // TOKEN_PROFILE/CRYPTOGRAPHIC_KEY/LOCATION carry no ConnectorInterfaceEntity, so their arm pre-resolves no
+        // interface. An NG dispatch on such a route must therefore carry interfaceUuid on the request; absent it the
+        // callback fails closed (422) and no connector POST fires. The route's parent is the token INSTANCE.
         TokenInstanceReference tokenInstance = new TokenInstanceReference();
         tokenInstance.setConnector(connector);
         tokenInstance = tokenInstanceReferenceRepository.save(tokenInstance);
 
-        TokenProfile tokenProfile = new TokenProfile();
-        tokenProfile.setName("tp-ng");
-        tokenProfile.setTokenInstanceReference(tokenInstance);
-        tokenProfile = tokenProfileRepository.save(tokenProfile);
-
         DataAttributeV2 ng = ngDataAttribute("ngTokenProfile");
+        ng.getAttributeCallback().setDependsOn(List.of());
         attributeEngine.updateDataAttributeDefinitions(connector.getUuid(), null, List.of(ng));
 
         mockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/v2/attributes/callback"))
@@ -377,9 +402,112 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
         RequestAttributeCallback req = new RequestAttributeCallback();
         req.setName("ngTokenProfile");
         req.setUuid(ng.getUuid());
-        callbackService.resourceCallback(Resource.TOKEN_PROFILE, tokenProfile.getUuid().toString(), req);
+
+        UUID tokenInstanceUuid = tokenInstance.getUuid();
+        Assertions.assertThrows(com.otilm.api.exception.ValidationException.class,
+                () -> callbackService.resourceCallback(Resource.TOKEN_PROFILE, tokenInstanceUuid.toString(), req));
+
+        mockServer.verify(0, WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback")));
+    }
+
+    @Test
+    void ngConnectorRouteStampsInterfaceFromRow() throws Exception {
+        // The parent-less connector route stamps the envelope interface from the interfaceUuid the form carries —
+        // the row's own interfaceCode/version — and sends an empty contextAttributes (no parent scope).
+        DataAttributeV2 ng = ngDataAttribute("ngConnRoute");
+        ng.getAttributeCallback().setDependsOn(List.of());
+        attributeEngine.updateDataAttributeDefinitions(connector.getUuid(), null, List.of(ng));
+        ConnectorInterfaceEntity iface = authorityInterface();
+
+        mockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/v2/attributes/callback"))
+                .willReturn(WireMock.okJson("{\"content\":[]}")));
+
+        RequestAttributeCallback req = new RequestAttributeCallback();
+        req.setName("ngConnRoute");
+        req.setUuid(ng.getUuid());
+        req.setInterfaceUuid(iface.getUuid());
+        callbackService.callback(connector.getUuid(), req);
 
         mockServer.verify(WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback"))
-                .withRequestBody(WireMock.notMatching("(?s).*\"connectorInterface\".*")));
+                .withRequestBody(matchingJsonPath("$.connectorInterface", WireMock.equalTo("authority")))
+                .withRequestBody(matchingJsonPath("$.interfaceVersion", WireMock.equalTo("v3")))
+                .withRequestBody(WireMock.containing("\"contextAttributes\":[]")));
+    }
+
+    @Test
+    void ngConnectorRouteRejectsInterfaceFromAnotherConnector() throws Exception {
+        // The interfaceUuid must belong to the route connector; a row owned by a different connector must be
+        // rejected (422) before any connector POST — otherwise a caller could stamp a foreign interface.
+        Connector other = new Connector();
+        other.setName("other");
+        other.setUrl(mockServer.baseUrl() + "/other");
+        other.setVersion(ConnectorVersion.V1);
+        other.setStatus(ConnectorStatus.CONNECTED);
+        connectorRepository.save(other);
+        ConnectorInterfaceEntity foreign = new ConnectorInterfaceEntity();
+        foreign.setConnectorUuid(other.getUuid());
+        foreign.setInterfaceCode(ConnectorInterface.AUTHORITY);
+        foreign.setVersion("v3");
+        foreign = connectorInterfaceRepository.save(foreign);
+
+        DataAttributeV2 ng = ngDataAttribute("ngForeignIface");
+        ng.getAttributeCallback().setDependsOn(List.of());
+        attributeEngine.updateDataAttributeDefinitions(connector.getUuid(), null, List.of(ng));
+
+        mockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/v2/attributes/callback"))
+                .willReturn(WireMock.okJson("{\"content\":[]}")));
+
+        RequestAttributeCallback req = new RequestAttributeCallback();
+        req.setName("ngForeignIface");
+        req.setUuid(ng.getUuid());
+        req.setInterfaceUuid(foreign.getUuid());
+
+        Assertions.assertThrows(com.otilm.api.exception.ValidationException.class,
+                () -> callbackService.callback(connector.getUuid(), req));
+
+        mockServer.verify(0, WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback")));
+    }
+
+    @Test
+    void ngConnectorRouteWithoutInterfaceUuidIsRejected() throws Exception {
+        // NG on the connector route requires interfaceUuid (nothing else supplies the form's interface). Absent it,
+        // fail closed (422); no connector POST.
+        DataAttributeV2 ng = ngDataAttribute("ngNoIface");
+        ng.getAttributeCallback().setDependsOn(List.of());
+        attributeEngine.updateDataAttributeDefinitions(connector.getUuid(), null, List.of(ng));
+
+        mockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/v2/attributes/callback"))
+                .willReturn(WireMock.okJson("{\"content\":[]}")));
+
+        RequestAttributeCallback req = new RequestAttributeCallback();
+        req.setName("ngNoIface");
+        req.setUuid(ng.getUuid());
+
+        Assertions.assertThrows(com.otilm.api.exception.ValidationException.class,
+                () -> callbackService.callback(connector.getUuid(), req));
+
+        mockServer.verify(0, WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback")));
+    }
+
+    @Test
+    void ngCallbackMissingDependsOnValueIsRejected() throws Exception {
+        // Completeness guard: a dependsOn name with no value in currentAttributes fails closed (422) before the
+        // connector is called, even with a valid interfaceUuid.
+        DataAttributeV2 ng = ngDataAttribute("ngMissingDep");
+        attributeEngine.updateDataAttributeDefinitions(connector.getUuid(), null, List.of(ng));
+        ConnectorInterfaceEntity iface = authorityInterface();
+
+        mockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/v2/attributes/callback"))
+                .willReturn(WireMock.okJson("{\"content\":[]}")));
+
+        RequestAttributeCallback req = new RequestAttributeCallback();
+        req.setName("ngMissingDep");
+        req.setUuid(ng.getUuid());
+        req.setInterfaceUuid(iface.getUuid());
+
+        Assertions.assertThrows(com.otilm.api.exception.ValidationException.class,
+                () -> callbackService.callback(connector.getUuid(), req));
+
+        mockServer.verify(0, WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback")));
     }
 }

--- a/src/test/java/com/otilm/core/integration/service/AttributesV2CallbackDispatchITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AttributesV2CallbackDispatchITest.java
@@ -3,6 +3,7 @@ package com.otilm.core.integration.service;
 import com.otilm.api.exception.AttributeException;
 import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.exception.ValidationException;
 import com.otilm.api.interfaces.client.v2.AttributesSyncApiClient;
 import com.otilm.api.model.client.connector.v2.ConnectorInterface;
 import com.otilm.api.model.client.connector.v2.ConnectorVersion;
@@ -206,7 +207,7 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
         RequestAttributeCallback req = new RequestAttributeCallback();
         req.setName(noCallback.getName());
 
-        Assertions.assertThrows(com.otilm.api.exception.ValidationException.class,
+        Assertions.assertThrows(ValidationException.class,
                 () -> callbackService.callback(connector.getUuid(), req));
     }
 
@@ -404,10 +405,40 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
         req.setUuid(ng.getUuid());
 
         UUID tokenInstanceUuid = tokenInstance.getUuid();
-        Assertions.assertThrows(com.otilm.api.exception.ValidationException.class,
+        Assertions.assertThrows(ValidationException.class,
                 () -> callbackService.resourceCallback(Resource.TOKEN_PROFILE, tokenInstanceUuid.toString(), req));
 
         mockServer.verify(0, WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback")));
+    }
+
+    @Test
+    void ngTokenProfileRouteDispatchesWithTokenInstanceScope() throws Exception {
+        // Happy path of the token-profile 404 fix: TOKEN_PROFILE + a token-INSTANCE UUID + a valid interfaceUuid
+        // dispatches, and the arm and the scope walker agree the parent UUID is the token instance — the envelope's
+        // sole scope step carries that instance UUID. This is the arm/walker agreement that was broken before the fix.
+        TokenInstanceReference tokenInstance = new TokenInstanceReference();
+        tokenInstance.setConnector(connector);
+        tokenInstance = tokenInstanceReferenceRepository.save(tokenInstance);
+
+        DataAttributeV2 ng = ngDataAttribute("ngTpScope");
+        ng.getAttributeCallback().setDependsOn(List.of());
+        attributeEngine.updateDataAttributeDefinitions(connector.getUuid(), null, List.of(ng));
+        ConnectorInterfaceEntity iface = authorityInterface();
+
+        mockServer.stubFor(WireMock.post(WireMock.urlPathEqualTo("/v2/attributes/callback"))
+                .willReturn(WireMock.okJson("{\"content\":[]}")));
+
+        RequestAttributeCallback req = new RequestAttributeCallback();
+        req.setName("ngTpScope");
+        req.setUuid(ng.getUuid());
+        req.setInterfaceUuid(iface.getUuid());
+        callbackService.resourceCallback(Resource.TOKEN_PROFILE, tokenInstance.getUuid().toString(), req);
+
+        // scope serializes as the plural resource code ("tokens"); objectUuid is the token-instance UUID.
+        mockServer.verify(WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback"))
+                .withRequestBody(matchingJsonPath("$.contextAttributes[0].scope", WireMock.equalTo("tokens")))
+                .withRequestBody(matchingJsonPath("$.contextAttributes[0].objectUuid",
+                        WireMock.equalTo(tokenInstance.getUuid().toString()))));
     }
 
     @Test
@@ -462,7 +493,7 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
         req.setUuid(ng.getUuid());
         req.setInterfaceUuid(foreign.getUuid());
 
-        Assertions.assertThrows(com.otilm.api.exception.ValidationException.class,
+        Assertions.assertThrows(ValidationException.class,
                 () -> callbackService.callback(connector.getUuid(), req));
 
         mockServer.verify(0, WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback")));
@@ -483,7 +514,7 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
         req.setName("ngNoIface");
         req.setUuid(ng.getUuid());
 
-        Assertions.assertThrows(com.otilm.api.exception.ValidationException.class,
+        Assertions.assertThrows(ValidationException.class,
                 () -> callbackService.callback(connector.getUuid(), req));
 
         mockServer.verify(0, WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback")));
@@ -505,7 +536,7 @@ class AttributesV2CallbackDispatchITest extends BaseSpringBootTest {
         req.setUuid(ng.getUuid());
         req.setInterfaceUuid(iface.getUuid());
 
-        Assertions.assertThrows(com.otilm.api.exception.ValidationException.class,
+        Assertions.assertThrows(ValidationException.class,
                 () -> callbackService.callback(connector.getUuid(), req));
 
         mockServer.verify(0, WireMock.postRequestedFor(WireMock.urlPathEqualTo("/v2/attributes/callback")));

--- a/src/test/java/com/otilm/core/service/callback/AttributeCallbackScopeResolverTest.java
+++ b/src/test/java/com/otilm/core/service/callback/AttributeCallbackScopeResolverTest.java
@@ -98,12 +98,12 @@ class AttributeCallbackScopeResolverTest {
     @Test
     void tokenProfileAuthorizesTokenInstance() throws Exception {
         // The token-profile create form is scoped by its parent token INSTANCE, so the parent UUID identifies the
-        // instance; the chain is [{tokenInstance}] and only TOKEN:DETAIL is enforced.
+        // instance; the chain is [{tokenInstance}] and only TOKEN:DETAIL is enforced. The walker reads the
+        // connectorUuid column (not the lazy connector association), so stub that to mirror production.
         UUID tokenInstanceUuid = UUID.randomUUID();
-        Connector connector = connectorWithUuid();
         TokenInstanceReference tokenInstance = mock(TokenInstanceReference.class);
         when(tokenInstance.getUuid()).thenReturn(tokenInstanceUuid);
-        when(tokenInstance.getConnector()).thenReturn(connector);
+        when(tokenInstance.getConnectorUuid()).thenReturn(UUID.randomUUID());
         when(tokenInstanceRepo.findByUuid(tokenInstanceUuid)).thenReturn(Optional.of(tokenInstance));
 
         resolver.resolveScopeChain(Resource.TOKEN_PROFILE, tokenInstanceUuid, new HashSet<>());

--- a/src/test/java/com/otilm/core/service/callback/AttributeCallbackScopeResolverTest.java
+++ b/src/test/java/com/otilm/core/service/callback/AttributeCallbackScopeResolverTest.java
@@ -13,6 +13,7 @@ import com.otilm.core.dao.entity.TokenProfile;
 import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.EntityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
+import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
 import com.otilm.core.dao.repository.TokenProfileRepository;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.AuthorizationEnforcer;
@@ -44,6 +45,7 @@ class AttributeCallbackScopeResolverTest {
     private AuthorityInstanceReferenceRepository authorityRepo;
     private RaProfileRepository raProfileRepo;
     private TokenProfileRepository tokenProfileRepo;
+    private TokenInstanceReferenceRepository tokenInstanceRepo;
     private EntityInstanceReferenceRepository entityRepo;
     private AttributeCallbackScopeResolver resolver;
 
@@ -55,9 +57,10 @@ class AttributeCallbackScopeResolverTest {
         authorityRepo = mock(AuthorityInstanceReferenceRepository.class);
         raProfileRepo = mock(RaProfileRepository.class);
         tokenProfileRepo = mock(TokenProfileRepository.class);
+        tokenInstanceRepo = mock(TokenInstanceReferenceRepository.class);
         entityRepo = mock(EntityInstanceReferenceRepository.class);
         resolver = new AttributeCallbackScopeResolver(attributeEngine, expander, authorizationEnforcer,
-                authorityRepo, raProfileRepo, tokenProfileRepo, entityRepo);
+                authorityRepo, raProfileRepo, tokenProfileRepo, tokenInstanceRepo, entityRepo);
     }
 
     private Connector connectorWithUuid() {
@@ -90,6 +93,22 @@ class AttributeCallbackScopeResolverTest {
 
         verify(authorizationEnforcer).enforce(eq(Resource.AUTHORITY), eq(ResourceAction.DETAIL), any(SecuredUUID.class));
         verify(authorizationEnforcer).enforce(eq(Resource.RA_PROFILE), eq(ResourceAction.DETAIL), any(SecuredUUID.class));
+    }
+
+    @Test
+    void tokenProfileAuthorizesTokenInstance() throws Exception {
+        // The token-profile create form is scoped by its parent token INSTANCE, so the parent UUID identifies the
+        // instance; the chain is [{tokenInstance}] and only TOKEN:DETAIL is enforced.
+        UUID tokenInstanceUuid = UUID.randomUUID();
+        Connector connector = connectorWithUuid();
+        TokenInstanceReference tokenInstance = mock(TokenInstanceReference.class);
+        when(tokenInstance.getUuid()).thenReturn(tokenInstanceUuid);
+        when(tokenInstance.getConnector()).thenReturn(connector);
+        when(tokenInstanceRepo.findByUuid(tokenInstanceUuid)).thenReturn(Optional.of(tokenInstance));
+
+        resolver.resolveScopeChain(Resource.TOKEN_PROFILE, tokenInstanceUuid, new HashSet<>());
+
+        verify(authorizationEnforcer).enforce(eq(Resource.TOKEN), eq(ResourceAction.DETAIL), any(SecuredUUID.class));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/callback/NgCallbackDispatcherTest.java
+++ b/src/test/java/com/otilm/core/service/callback/NgCallbackDispatcherTest.java
@@ -70,7 +70,8 @@ class NgCallbackDispatcherTest {
         def.setUuid(UUID.randomUUID().toString());
         def.setName("ngAttr");
         def.setContentType(AttributeContentType.STRING);
-        return new NgCallbackDispatcher.NgDispatchContext(def, null, "v2", List.of(), List.of());
+        return new NgCallbackDispatcher.NgDispatchContext(def,
+                com.otilm.api.model.client.connector.v2.ConnectorInterface.AUTHORITY, "v3", List.of(), List.of());
     }
 
     @Test
@@ -172,22 +173,20 @@ class NgCallbackDispatcherTest {
     }
 
     @Test
-    void bothNullInterfaceContextDispatchesWithoutTrippingTheVersionGuard() throws Exception {
-        // The connector-scoped path AND the TOKEN_PROFILE/CRYPTOGRAPHIC_KEY/LOCATION arms emit a both-null interface
-        // context (no stored version to pair with an interface). The guard is directional — it must allow both-null
-        // and reject only interface-without-version.
+    void bothNullInterfaceContextIsRejected() {
+        // Every NG dispatch must stamp a full (connectorInterface, interfaceVersion) pair — the dispatch ladder
+        // resolves it from the scoped object or the request's interfaceUuid before reaching here. A both-null context
+        // is a wiring error; fail closed before the connector POST rather than ship an envelope dropping both fields.
         DataAttributeV2 def = new DataAttributeV2();
         def.setUuid(UUID.randomUUID().toString());
         def.setName("ngAttr");
         def.setContentType(AttributeContentType.STRING);
         NgCallbackDispatcher.NgDispatchContext bothNull = new NgCallbackDispatcher.NgDispatchContext(
                 def, null, null, List.of(), List.of());
-        AttributeCallbackResponseDto ok = new AttributeCallbackResponseDto();
-        ok.setContent(List.of());
-        Mockito.when(client.callback(any(), any())).thenReturn(ok);
 
-        assertDoesNotThrow(() ->
+        assertThrows(ValidationException.class, () ->
                 dispatcher.dispatchNgCallback(connector, bothNull, new RequestAttributeCallback(), new HashSet<>()));
+        Mockito.verifyNoInteractions(client);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/callback/NgCallbackDispatcherTest.java
+++ b/src/test/java/com/otilm/core/service/callback/NgCallbackDispatcherTest.java
@@ -4,6 +4,7 @@ import com.otilm.api.clients.ApiClientConnectorInfo;
 import com.otilm.api.exception.ConnectorProblemException;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.interfaces.client.v2.AttributesSyncApiClient;
+import com.otilm.api.model.client.connector.v2.ConnectorInterface;
 import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackRequestDto;
 import com.otilm.api.model.client.connector.v2.attribute.AttributeCallbackResponseDto;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
@@ -71,7 +72,7 @@ class NgCallbackDispatcherTest {
         def.setName("ngAttr");
         def.setContentType(AttributeContentType.STRING);
         return new NgCallbackDispatcher.NgDispatchContext(def,
-                com.otilm.api.model.client.connector.v2.ConnectorInterface.AUTHORITY, "v3", List.of(), List.of());
+                ConnectorInterface.AUTHORITY, "v3", List.of(), List.of());
     }
 
     @Test
@@ -165,7 +166,7 @@ class NgCallbackDispatcherTest {
         def.setName("ngAttr");
         def.setContentType(AttributeContentType.STRING);
         NgCallbackDispatcher.NgDispatchContext bad = new NgCallbackDispatcher.NgDispatchContext(
-                def, com.otilm.api.model.client.connector.v2.ConnectorInterface.CRYPTOGRAPHY, null, List.of(), List.of());
+                def, ConnectorInterface.CRYPTOGRAPHY, null, List.of(), List.of());
 
         assertThrows(ValidationException.class, () ->
                 dispatcher.dispatchNgCallback(connector, bad, new RequestAttributeCallback(), new HashSet<>()));


### PR DESCRIPTION
Closes OmniTrustILM/core#1842. Part of the Connector Attributes v2 API epic ilm#251.

NG (`dependsOn`) callbacks failed on forms with no parent object — notably the authority-instance create-edit form, where a group/dropdown depends on a sibling field on the same form. With no parent, the frontend dispatches on the connector callback route, which stamped a both-null `connectorInterface`/`interfaceVersion` pair; a conformant NG connector rejects that body.

## Connector-route NG stamping
`POST /v2/connectors/{uuid}/callback`, when the resolved definition is NG:
- requires `interfaceUuid` (422 if absent) — nothing else on this route supplies the form's interface;
- loads the connector-interface row, asserts it belongs to the route connector (rejects a foreign row);
- stamps `connectorInterface`/`interfaceVersion` from its columns; `contextAttributes = []`.

Parallel NG interface versions on one connector (e.g. v3 and v4) resolve by the interface-row UUID — no version inference.

## Folded-in hardening
- **Completeness guard** — every `dependsOn` name must have a value in `currentAttributes`, else 422 before the connector is called.
- **buildEnvelope both-null forbid** — every NG dispatch must stamp a full interface pair; a both-null / half-pair shape fails closed.
- **Token-profile parent fix** — the token-profile callback route (route arm + scope walker) resolves its parent as the token instance, not a token profile, fixing a latent 404.
- **Rename** — `resourceUuid`/`scopeResourceUuid` → `parentObjectUuid`/`scopeParentUuid` (the UUID is the parent scope object, not an object of the named resource).

No dedicated authority resource-callback arm and no create/edit split.

## Tests
`AttributesV2CallbackDispatchITest`: interface stamped from the row (v3), belongs-to-connector rejection, missing `interfaceUuid` → 422, missing `dependsOn` value → 422, both-null NG → 422; legacy + resource-scoped regression unchanged. Unit coverage in `NgCallbackDispatcherTest` (both-null rejected) and `AttributeCallbackScopeResolverTest` (token-profile → token-instance chain).

Depends on OmniTrustILM/interfaces#782 (the `interfaceUuid` field).