### PR TITLE
Restore connector status to online on successful reconnect

### DIFF
--- a/src/main/java/com/otilm/core/service/v2/impl/ConnectorServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ConnectorServiceImpl.java
@@ -587,6 +587,11 @@ public class ConnectorServiceImpl implements ConnectorExternalService, Connector
         try {
             ConnectInfo connectInfo = connectorAdapter.validateConnection(connector.mapToApiClientDtoV2());
             connectorAdapter.updateConnectorFunctions(connector, connectInfo);
+            if (connector.getStatus() == ConnectorStatus.OFFLINE) {
+                connector.setStatus(ConnectorStatus.CONNECTED);
+                connectorRepository.save(connector);
+                evictConnectorCache(connector.getUuid());
+            }
             return connectInfo;
         } catch (ConnectorCommunicationException | NotFoundException e) {
             String message = String.format("Unable to reconnect to connector %s. Error in communication or no connector of version %s is running on the provided URL '%s'.", connector.getName(), connectorAdapter.getVersion().getLabel(), connector.getUrl());

--- a/src/test/java/com/otilm/core/integration/service/ConnectorServiceV2ITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ConnectorServiceV2ITest.java
@@ -32,7 +32,10 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 class ConnectorServiceV2ITest extends BaseSpringBootTest {
 
@@ -250,6 +253,45 @@ class ConnectorServiceV2ITest extends BaseSpringBootTest {
         ConnectInfo connectInfo = connectorService.reconnect(connector.getSecuredUuid());
         Assertions.assertNotNull(connectInfo);
         Assertions.assertEquals(ConnectorVersion.V2, connectInfo.getVersion());
+    }
+
+    @Test
+    void testReconnectConnector_offlineBecomesConnected() throws NotFoundException, ConnectorException, JsonProcessingException {
+        connector.setStatus(ConnectorStatus.OFFLINE);
+        connectorRepository.save(connector);
+        mockInfoEndpoint();
+
+        ConnectInfo connectInfo = connectorService.reconnect(connector.getSecuredUuid());
+        Assertions.assertNotNull(connectInfo);
+        Assertions.assertEquals(ConnectorVersion.V2, connectInfo.getVersion());
+
+        Connector reconnected = connectorRepository.findByUuid(connector.getUuid()).orElseThrow();
+        Assertions.assertEquals(ConnectorStatus.CONNECTED, reconnected.getStatus());
+    }
+
+    @Test
+    void testReconnectConnector_alreadyConnectedSkipsStatusWrite() throws NotFoundException, ConnectorException, JsonProcessingException {
+        mockInfoEndpoint();
+        clearInvocations(connectorRepositorySpy);
+
+        connectorService.reconnect(connector.getSecuredUuid());
+
+        verify(connectorRepositorySpy, never()).save(any());
+        Connector reconnected = connectorRepository.findByUuid(connector.getUuid()).orElseThrow();
+        Assertions.assertEquals(ConnectorStatus.CONNECTED, reconnected.getStatus());
+    }
+
+    @Test
+    void testReconnectConnector_waitingForApprovalRejected() throws JsonProcessingException {
+        connector.setStatus(ConnectorStatus.WAITING_FOR_APPROVAL);
+        connectorRepository.save(connector);
+        mockInfoEndpoint();
+
+        SecuredUUID connectorUuid = connector.getSecuredUuid();
+        Assertions.assertThrows(ValidationException.class, () -> connectorService.reconnect(connectorUuid));
+
+        Connector reconnected = connectorRepository.findByUuid(connector.getUuid()).orElseThrow();
+        Assertions.assertEquals(ConnectorStatus.WAITING_FOR_APPROVAL, reconnected.getStatus());
     }
 
     @Test


### PR DESCRIPTION
## Problem

`ConnectorServiceImpl.reconnect` set a connector's status to `OFFLINE` on a failed reconnect but never restored `CONNECTED` on a successful one. A connector that went offline and then recovered stayed stuck at `OFFLINE` — the reconnect that should have brought it back online had no effect on status.

## Fix

On a successful `validateConnection`, transition `OFFLINE` → `CONNECTED` (save + evict cache). Guarded with `== OFFLINE` so:

- an already-`CONNECTED` connector skips the redundant write/evict (the common "refresh connection" path);
- `WAITING_FOR_APPROVAL` is left untouched for the deliberate approval workflow (`approve()`), rather than relying solely on the upstream `BaseApiClient` status gate.

The v1 `reconnect` delegates to this v2 method, so both API versions are covered.

## Tests

`ConnectorServiceV2ITest`:
- `testReconnectConnector_offlineBecomesConnected` — offline connector becomes connected after a successful reconnect (red before, green after); asserts the returned `ConnectInfo`.
- `testReconnectConnector_alreadyConnectedSkipsStatusWrite` — already-connected reconnect issues no `save` (guard's false branch).
- `testReconnectConnector_waitingForApprovalRejected` — reconnect on a pending connector is rejected and status is preserved.

Full `ConnectorServiceV2ITest` class green.

Closes #1845

🤖 Generated with [Claude Code](https://claude.com/claude-code)