### PR TITLE
Fix duplicate notification profile version numbers on concurrent edits

### DIFF
--- a/src/main/java/com/otilm/core/dao/entity/notifications/NotificationProfileVersion.java
+++ b/src/main/java/com/otilm/core/dao/entity/notifications/NotificationProfileVersion.java
@@ -24,8 +24,16 @@ import java.util.UUID;
 @ToString
 @RequiredArgsConstructor
 @Entity
-@Table(name = "notification_profile_version")
+@Table(
+        name = "notification_profile_version",
+        uniqueConstraints = @UniqueConstraint(
+                name = NotificationProfileVersion.UNIQUE_VERSION_CONSTRAINT,
+                columnNames = {"notification_profile_uuid", "version"}
+        )
+)
 public class NotificationProfileVersion extends UniquelyIdentified {
+
+    public static final String UNIQUE_VERSION_CONSTRAINT = "uq_notification_profile_version";
 
     @Column(name = "notification_profile_uuid", nullable = false)
     private UUID notificationProfileUuid;

--- a/src/main/java/com/otilm/core/dao/repository/notifications/NotificationProfileRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/notifications/NotificationProfileRepository.java
@@ -2,7 +2,9 @@ package com.otilm.core.dao.repository.notifications;
 
 import com.otilm.core.dao.entity.notifications.NotificationProfile;
 import com.otilm.core.dao.repository.SecurityFilterRepository;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -16,5 +18,13 @@ public interface NotificationProfileRepository extends SecurityFilterRepository<
     @EntityGraph(attributePaths = {"versions"})
     Optional<NotificationProfile> findWithVersionsByUuid(UUID uuid);
 
+    /**
+     * Pessimistic-write variant of {@code findByUuid} for paths that assign the next profile version number.
+     * Issues {@code SELECT ... FOR UPDATE} on the profile row so concurrent edits serialize instead of both
+     * reading the same latest version and inserting duplicate version numbers. Must be called inside an active
+     * transaction, otherwise the lock is released immediately on query completion.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<NotificationProfile> findAndLockByUuid(UUID uuid);
 
 }

--- a/src/main/java/com/otilm/core/service/impl/NotificationProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/NotificationProfileServiceImpl.java
@@ -166,10 +166,10 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
     @ExternalAuthorization(resource = Resource.NOTIFICATION_PROFILE, action = ResourceAction.UPDATE)
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public NotificationProfileDetailDto editNotificationProfile(SecuredUUID uuid, NotificationProfileUpdateRequestDto updateRequestDto) throws NotFoundException {
+        validateNotificationInstanceExists(updateRequestDto.getNotificationInstanceUuid());
         // Resolve recipient info from the request before opening the write transaction: recipient lookup
         // can call the auth service over HTTP and must not hold a DB connection or the profile row lock.
         List<NameAndUuidDto> recipients = resolveRecipients(updateRequestDto.getRecipientType(), updateRequestDto.getRecipientUuids());
-        validateNotificationInstanceExists(updateRequestDto.getNotificationInstanceUuid());
 
         // The transaction boundary comes from the self-proxied call; invoking persistEditedVersion directly
         // on `this` would skip the @Transactional advice and reintroduce the version race.

--- a/src/main/java/com/otilm/core/service/impl/NotificationProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/NotificationProfileServiceImpl.java
@@ -8,9 +8,11 @@ import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.scheduler.PaginationRequestDto;
+import com.otilm.core.dao.entity.notifications.NotificationInstanceReference;
 import com.otilm.core.dao.entity.notifications.NotificationProfile;
 import com.otilm.core.dao.entity.notifications.NotificationProfileVersion;
 import com.otilm.core.dao.entity.workflows.Execution;
+import com.otilm.core.dao.repository.notifications.NotificationInstanceReferenceRepository;
 import com.otilm.core.dao.repository.notifications.NotificationProfileRepository;
 import com.otilm.core.dao.repository.notifications.NotificationProfileVersionRepository;
 import com.otilm.core.dao.repository.workflows.ExecutionRepository;
@@ -48,6 +50,7 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
     private NotificationProfileServiceImpl self;
     private NotificationProfileRepository notificationProfileRepository;
     private NotificationProfileVersionRepository notificationProfileVersionRepository;
+    private NotificationInstanceReferenceRepository notificationInstanceReferenceRepository;
 
     private ExecutionRepository executionRepository;
     private ResourceObjectAssociationService resourceObjectAssociationService;
@@ -66,6 +69,11 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
     @Autowired
     public void setNotificationProfileVersionRepository(NotificationProfileVersionRepository notificationProfileVersionRepository) {
         this.notificationProfileVersionRepository = notificationProfileVersionRepository;
+    }
+
+    @Autowired
+    public void setNotificationInstanceReferenceRepository(NotificationInstanceReferenceRepository notificationInstanceReferenceRepository) {
+        this.notificationInstanceReferenceRepository = notificationInstanceReferenceRepository;
     }
 
     @Autowired
@@ -131,6 +139,7 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
         if (notificationProfileRepository.findByName(requestDto.getName()).isPresent()) {
             throw new AlreadyExistException("Notification profile with name " + requestDto.getName() + " already exists.");
         }
+        validateNotificationInstanceExists(requestDto.getNotificationInstanceUuid());
 
         NotificationProfile notificationProfile = new NotificationProfile();
         notificationProfile.setName(requestDto.getName());
@@ -160,7 +169,10 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
         // Resolve recipient info from the request before opening the write transaction: recipient lookup
         // can call the auth service over HTTP and must not hold a DB connection or the profile row lock.
         List<NameAndUuidDto> recipients = resolveRecipients(updateRequestDto.getRecipientType(), updateRequestDto.getRecipientUuids());
+        validateNotificationInstanceExists(updateRequestDto.getNotificationInstanceUuid());
 
+        // The transaction boundary comes from the self-proxied call; invoking persistEditedVersion directly
+        // on `this` would skip the @Transactional advice and reintroduce the version race.
         return self.persistEditedVersion(uuid, updateRequestDto, recipients);
     }
 
@@ -205,6 +217,17 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
         }
 
         return notificationProfileVersion.mapToDetailDto(recipients);
+    }
+
+    /**
+     * Fails fast with a not-found error for a client-supplied notification instance reference that does not
+     * exist; without this check the insert would fail the foreign key and surface as a server error. The
+     * foreign key still guards the race with a concurrent instance deletion.
+     */
+    private void validateNotificationInstanceExists(UUID notificationInstanceUuid) throws NotFoundException {
+        if (notificationInstanceUuid != null && notificationInstanceReferenceRepository.findByUuid(notificationInstanceUuid).isEmpty()) {
+            throw new NotFoundException(NotificationInstanceReference.class, notificationInstanceUuid);
+        }
     }
 
     private static boolean isUniqueVersionViolation(DataIntegrityViolationException e) {

--- a/src/main/java/com/otilm/core/service/impl/NotificationProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/NotificationProfileServiceImpl.java
@@ -28,7 +28,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -38,16 +40,23 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class NotificationProfileServiceImpl implements NotificationProfileExternalService {
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationProfileServiceImpl.class);
 
+    private NotificationProfileServiceImpl self;
     private NotificationProfileRepository notificationProfileRepository;
     private NotificationProfileVersionRepository notificationProfileVersionRepository;
 
     private ExecutionRepository executionRepository;
     private ResourceObjectAssociationService resourceObjectAssociationService;
+
+    @Lazy
+    @Autowired
+    public void setSelf(NotificationProfileServiceImpl self) {
+        this.self = self;
+    }
 
     @Autowired
     public void setNotificationProfileRepository(NotificationProfileRepository notificationProfileRepository) {
@@ -146,11 +155,17 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
 
     @Override
     @ExternalAuthorization(resource = Resource.NOTIFICATION_PROFILE, action = ResourceAction.UPDATE)
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public NotificationProfileDetailDto editNotificationProfile(SecuredUUID uuid, NotificationProfileUpdateRequestDto updateRequestDto) throws NotFoundException {
-        // Resolve recipient info from the request before locking the profile row: recipient lookup can call
-        // the auth service over HTTP and must not extend the lock window.
+        // Resolve recipient info from the request before opening the write transaction: recipient lookup
+        // can call the auth service over HTTP and must not hold a DB connection or the profile row lock.
         List<NameAndUuidDto> recipients = resolveRecipients(updateRequestDto.getRecipientType(), updateRequestDto.getRecipientUuids());
 
+        return self.persistEditedVersion(uuid, updateRequestDto, recipients);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    NotificationProfileDetailDto persistEditedVersion(SecuredUUID uuid, NotificationProfileUpdateRequestDto updateRequestDto, List<NameAndUuidDto> recipients) throws NotFoundException {
         // The row lock serializes concurrent edits; without it, both could read the same latest version and
         // insert duplicate version numbers.
         NotificationProfile notificationProfile = notificationProfileRepository.findAndLockByUuid(uuid.getValue()).orElseThrow(() -> new NotFoundException(NotificationProfile.class, uuid));

--- a/src/main/java/com/otilm/core/service/impl/NotificationProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/NotificationProfileServiceImpl.java
@@ -6,6 +6,7 @@ import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.notification.*;
 import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.scheduler.PaginationRequestDto;
 import com.otilm.core.dao.entity.notifications.NotificationProfile;
 import com.otilm.core.dao.entity.notifications.NotificationProfileVersion;
@@ -20,9 +21,11 @@ import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.NotificationProfileExternalService;
 import com.otilm.core.service.ResourceObjectAssociationService;
 import com.otilm.core.util.RequestValidatorHelper;
+import org.hibernate.exception.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -144,17 +147,24 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
     @Override
     @ExternalAuthorization(resource = Resource.NOTIFICATION_PROFILE, action = ResourceAction.UPDATE)
     public NotificationProfileDetailDto editNotificationProfile(SecuredUUID uuid, NotificationProfileUpdateRequestDto updateRequestDto) throws NotFoundException {
-        NotificationProfile notificationProfile = notificationProfileRepository.findByUuid(uuid).orElseThrow(() -> new NotFoundException(NotificationProfile.class, uuid));
-        NotificationProfileVersion currentVersion = notificationProfile.getCurrentVersion();
+        // Resolve recipient info from the request before locking the profile row: recipient lookup can call
+        // the auth service over HTTP and must not extend the lock window.
+        List<NameAndUuidDto> recipients = resolveRecipients(updateRequestDto.getRecipientType(), updateRequestDto.getRecipientUuids());
 
-        if (areVersionsEqual(currentVersion, updateRequestDto)) {
-            logger.debug("Current version of notification profile {} is same as in request. New version is not created", notificationProfile.getName());
-            return getNotificationProfileDetailDto(currentVersion);
-        }
+        // The row lock serializes concurrent edits; without it, both could read the same latest version and
+        // insert duplicate version numbers.
+        NotificationProfile notificationProfile = notificationProfileRepository.findAndLockByUuid(uuid.getValue()).orElseThrow(() -> new NotFoundException(NotificationProfile.class, uuid));
+        NotificationProfileVersion currentVersion = notificationProfileVersionRepository.findTopByNotificationProfileUuidOrderByVersionDesc(uuid.getValue()).orElseThrow(() -> new NotFoundException(NotificationProfileVersion.class, uuid));
 
+        // Description lives on the profile, not on the version — persist it even when no new version is created
         if (!Objects.equals(notificationProfile.getDescription(), updateRequestDto.getDescription())) {
             notificationProfile.setDescription(updateRequestDto.getDescription());
             notificationProfileRepository.save(notificationProfile);
+        }
+
+        if (areVersionsEqual(currentVersion, updateRequestDto)) {
+            logger.debug("Current version of notification profile {} is same as in request. New version is not created", notificationProfile.getName());
+            return currentVersion.mapToDetailDto(recipients);
         }
 
         NotificationProfileVersion notificationProfileVersion = new NotificationProfileVersion();
@@ -167,22 +177,44 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
         notificationProfileVersion.setInternalNotification(updateRequestDto.isInternalNotification());
         notificationProfileVersion.setFrequency(updateRequestDto.getFrequency());
         notificationProfileVersion.setRepetitions(updateRequestDto.getRepetitions());
-        notificationProfileVersion = notificationProfileVersionRepository.save(notificationProfileVersion);
-
-        return getNotificationProfileDetailDto(notificationProfileVersion);
-    }
-
-    private NotificationProfileDetailDto getNotificationProfileDetailDto(NotificationProfileVersion notificationProfileVersion) throws NotFoundException {
-        // retrieve recipients info and check for existence of such object
-        List<NameAndUuidDto> recipients = new ArrayList<>();
-        if (notificationProfileVersion.getRecipientUuids() != null) {
-            recipients = new ArrayList<>();
-            for (UUID recipientUuid : notificationProfileVersion.getRecipientUuids()) {
-                recipients.add(resourceObjectAssociationService.getRecipientObjectInfo(notificationProfileVersion.getRecipientType(), recipientUuid));
+        try {
+            notificationProfileVersion = notificationProfileVersionRepository.saveAndFlush(notificationProfileVersion);
+        } catch (DataIntegrityViolationException e) {
+            // Backstop for the unique (notification_profile_uuid, version) constraint, reachable only if a
+            // writer bypasses the row lock above. Other integrity violations (e.g. a foreign key on a
+            // concurrently deleted notification instance) are not concurrent-edit collisions and must surface as-is.
+            if (isUniqueVersionViolation(e)) {
+                throw new ValidationException("Notification profile %s was concurrently modified. Retry the edit.".formatted(notificationProfile.getName()));
             }
+            throw e;
         }
 
         return notificationProfileVersion.mapToDetailDto(recipients);
+    }
+
+    private static boolean isUniqueVersionViolation(DataIntegrityViolationException e) {
+        for (Throwable cause = e.getCause(); cause != null; cause = cause.getCause()) {
+            if (cause instanceof ConstraintViolationException constraintViolation) {
+                return NotificationProfileVersion.UNIQUE_VERSION_CONSTRAINT.equalsIgnoreCase(constraintViolation.getConstraintName());
+            }
+        }
+        return false;
+    }
+
+    private NotificationProfileDetailDto getNotificationProfileDetailDto(NotificationProfileVersion notificationProfileVersion) throws NotFoundException {
+        return notificationProfileVersion.mapToDetailDto(resolveRecipients(notificationProfileVersion.getRecipientType(), notificationProfileVersion.getRecipientUuids()));
+    }
+
+    // retrieve recipients info and check for existence of such object
+    private List<NameAndUuidDto> resolveRecipients(RecipientType recipientType, List<UUID> recipientUuids) throws NotFoundException {
+        List<NameAndUuidDto> recipients = new ArrayList<>();
+        if (recipientUuids != null) {
+            for (UUID recipientUuid : recipientUuids) {
+                recipients.add(resourceObjectAssociationService.getRecipientObjectInfo(recipientType, recipientUuid));
+            }
+        }
+
+        return recipients;
     }
 
     private boolean areVersionsEqual(NotificationProfileVersion currentVersion, NotificationProfileUpdateRequestDto requestDto) {

--- a/src/main/java/com/otilm/core/service/impl/ResourceObjectAssociationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ResourceObjectAssociationServiceImpl.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
@@ -179,6 +180,9 @@ public class ResourceObjectAssociationServiceImpl implements ResourceObjectAssoc
     }
 
     @Override
+    // The USER and ROLE branches call the auth service over HTTP; suppressing the class-level
+    // @Transactional keeps transaction-less callers from opening a DB transaction around that call.
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public NameAndUuidDto getRecipientObjectInfo(RecipientType recipientType, UUID recipientUuid) throws NotFoundException {
         String name = switch (recipientType) {
             case USER -> getUserUsername(recipientUuid);

--- a/src/main/java/com/otilm/core/service/impl/ResourceObjectAssociationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ResourceObjectAssociationServiceImpl.java
@@ -180,8 +180,9 @@ public class ResourceObjectAssociationServiceImpl implements ResourceObjectAssoc
     }
 
     @Override
-    // The USER and ROLE branches call the auth service over HTTP; suppressing the class-level
-    // @Transactional keeps transaction-less callers from opening a DB transaction around that call.
+    // The USER and ROLE branches call the auth service over HTTP, so this method runs without a
+    // transaction: transaction-less callers do not get one opened around the call, and a caller's
+    // active transaction is suspended for the duration of the call rather than joined.
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public NameAndUuidDto getRecipientObjectInfo(RecipientType recipientType, UUID recipientUuid) throws NotFoundException {
         String name = switch (recipientType) {

--- a/src/main/resources/db/migration/V202607211000__notification_profile_version_unique_version.sql
+++ b/src/main/resources/db/migration/V202607211000__notification_profile_version_unique_version.sql
@@ -1,0 +1,62 @@
+-- Flyway runs this file in a single transaction; the explicit locks block concurrent writers (e.g. the
+-- notification listener on a not-yet-migrated instance) so no pending_notification row can be written
+-- against pre-renumbering version numbers between the statements below. Reads stay unblocked and the
+-- repair is a few local statements, so the lock window is short.
+LOCK TABLE "pending_notification", "notification_profile_version" IN SHARE ROW EXCLUSIVE MODE;
+
+-- Concurrent profile edits could assign the same version number before the application serialized
+-- version assignment. Renumber the versions of affected profiles into a dense sequence ordered by
+-- version, then creation time, so the unique constraint below can be added. Profiles without
+-- duplicate version numbers are left untouched.
+--
+-- pending_notification rows reference profile versions by (notification_profile_uuid, version) and
+-- must be remapped consistently. This runs BEFORE the renumbering so the old->new mapping can be
+-- computed from the untouched data. A reference to a duplicated version number is inherently
+-- ambiguous (several rows claimed it); it maps to the latest-created of those rows, which is the
+-- row the version-resolution query would most plausibly have meant.
+UPDATE "pending_notification" pn
+SET "version" = mapping.mapped_version
+FROM (
+    SELECT "notification_profile_uuid",
+           "version" AS old_version,
+           MAX(new_version) AS mapped_version
+    FROM (
+        SELECT "notification_profile_uuid",
+               "version",
+               ROW_NUMBER() OVER (
+                   PARTITION BY "notification_profile_uuid"
+                   ORDER BY "version", "created_at", "uuid"
+               ) AS new_version
+        FROM "notification_profile_version"
+        WHERE "notification_profile_uuid" IN (
+            SELECT "notification_profile_uuid"
+            FROM "notification_profile_version"
+            GROUP BY "notification_profile_uuid", "version"
+            HAVING COUNT(*) > 1
+        )
+    ) renumbered
+    GROUP BY "notification_profile_uuid", old_version
+) mapping
+WHERE pn."notification_profile_uuid" = mapping."notification_profile_uuid"
+  AND pn."version" = mapping.old_version;
+
+UPDATE "notification_profile_version" npv
+SET "version" = renumbered.new_version
+FROM (
+    SELECT "uuid",
+           ROW_NUMBER() OVER (
+               PARTITION BY "notification_profile_uuid"
+               ORDER BY "version", "created_at", "uuid"
+           ) AS new_version
+    FROM "notification_profile_version"
+    WHERE "notification_profile_uuid" IN (
+        SELECT "notification_profile_uuid"
+        FROM "notification_profile_version"
+        GROUP BY "notification_profile_uuid", "version"
+        HAVING COUNT(*) > 1
+    )
+) renumbered
+WHERE npv."uuid" = renumbered."uuid";
+
+ALTER TABLE "notification_profile_version"
+    ADD CONSTRAINT "uq_notification_profile_version" UNIQUE ("notification_profile_uuid", "version");

--- a/src/test/java/com/otilm/core/integration/migration/NotificationProfileVersionUniqueMigrationITest.java
+++ b/src/test/java/com/otilm/core/integration/migration/NotificationProfileVersionUniqueMigrationITest.java
@@ -1,0 +1,140 @@
+package com.otilm.core.integration.migration;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+
+import javax.sql.DataSource;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Verifies the data repair of {@code V202607211000__notification_profile_version_unique_version.sql}
+ * against seeded duplicate version rows. The regular test bootstrap generates the unique constraint
+ * from the entity annotation on an empty schema, so without this test the renumbering and the
+ * {@code pending_notification} remap would never execute against data.
+ */
+class NotificationProfileVersionUniqueMigrationITest extends BaseMigrationTest {
+
+    private static final String MIGRATION_RESOURCE = "db/migration/V202607211000__notification_profile_version_unique_version.sql";
+
+    private static final String PROFILE_A = "aaaaaaaa-0000-0000-0000-000000000000";
+    private static final String PROFILE_B = "bbbbbbbb-0000-0000-0000-000000000000";
+
+    @Autowired
+    DataSource dataSource;
+
+    @Test
+    void testMigration() throws Exception {
+        try (Connection connection = dataSource.getConnection()) {
+            seedPreMigrationState(connection);
+
+            String migrationSql = new ClassPathResource(MIGRATION_RESOURCE).getContentAsString(StandardCharsets.UTF_8);
+            // Flyway runs the migration in a single transaction; LOCK TABLE requires one, so mirror that here.
+            connection.setAutoCommit(false);
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(migrationSql);
+                connection.commit();
+            } catch (SQLException e) {
+                connection.rollback();
+                throw e;
+            } finally {
+                connection.setAutoCommit(true);
+            }
+
+            // Profile A had versions [1, 2, 2, 2, 3]; duplicates are renumbered densely by creation time.
+            Map<String, Integer> profileAVersions = versionsByUuid(connection, PROFILE_A);
+            Assertions.assertEquals(1, profileAVersions.get("a0000000-0000-0000-0000-000000000001"));
+            Assertions.assertEquals(2, profileAVersions.get("a0000000-0000-0000-0000-000000000002"));
+            Assertions.assertEquals(3, profileAVersions.get("a0000000-0000-0000-0000-000000000005"));
+            Assertions.assertEquals(4, profileAVersions.get("a0000000-0000-0000-0000-000000000003"));
+            Assertions.assertEquals(5, profileAVersions.get("a0000000-0000-0000-0000-000000000004"));
+
+            // Profile B had no duplicates and must be untouched.
+            Map<String, Integer> profileBVersions = versionsByUuid(connection, PROFILE_B);
+            Assertions.assertEquals(1, profileBVersions.get("b0000000-0000-0000-0000-000000000001"));
+            Assertions.assertEquals(2, profileBVersions.get("b0000000-0000-0000-0000-000000000002"));
+
+            // Pending references follow the renumbering: an unambiguous version follows its row, an
+            // ambiguous (duplicated) version maps to the latest-created duplicate, clean profiles stay.
+            Assertions.assertEquals(5, pendingVersion(connection, "e0000000-0000-0000-0000-000000000001"));
+            Assertions.assertEquals(4, pendingVersion(connection, "e0000000-0000-0000-0000-000000000002"));
+            Assertions.assertEquals(1, pendingVersion(connection, "e0000000-0000-0000-0000-000000000003"));
+            Assertions.assertEquals(2, pendingVersion(connection, "e0000000-0000-0000-0000-000000000004"));
+
+            // The unique constraint is in place again and rejects duplicates.
+            try (Statement statement = connection.createStatement()) {
+                SQLException rejection = Assertions.assertThrows(SQLException.class, () -> statement.execute("""
+                        INSERT INTO notification_profile_version
+                            (uuid, notification_profile_uuid, version, recipient_type, internal_notification, created_at)
+                        VALUES ('c0000000-0000-0000-0000-000000000001', '%s', 1, 'OWNER', true, now())
+                        """.formatted(PROFILE_A)));
+                Assertions.assertTrue(rejection.getMessage().contains("uq_notification_profile_version"),
+                        "Duplicate insert should be rejected by the unique constraint, but was: " + rejection.getMessage());
+            }
+        }
+    }
+
+    private void seedPreMigrationState(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            // The entity-generated schema already carries the constraint; drop it to seed pre-migration data.
+            statement.execute("ALTER TABLE notification_profile_version DROP CONSTRAINT uq_notification_profile_version");
+
+            statement.execute("""
+                    INSERT INTO notification_profile (uuid, name, version_lock, created_at) VALUES
+                        ('%s', 'ProfileWithDuplicates', 0, now()),
+                        ('%s', 'CleanProfile', 0, now())
+                    """.formatted(PROFILE_A, PROFILE_B));
+
+            statement.execute("""
+                    INSERT INTO notification_profile_version
+                        (uuid, notification_profile_uuid, version, recipient_type, internal_notification, created_at)
+                    VALUES
+                        ('a0000000-0000-0000-0000-000000000001', '%1$s', 1, 'OWNER', true, TIMESTAMP '2026-01-01 10:00:00'),
+                        ('a0000000-0000-0000-0000-000000000002', '%1$s', 2, 'OWNER', true, TIMESTAMP '2026-01-02 10:00:00'),
+                        ('a0000000-0000-0000-0000-000000000003', '%1$s', 2, 'OWNER', true, TIMESTAMP '2026-01-02 10:05:00'),
+                        ('a0000000-0000-0000-0000-000000000005', '%1$s', 2, 'OWNER', true, TIMESTAMP '2026-01-02 10:02:00'),
+                        ('a0000000-0000-0000-0000-000000000004', '%1$s', 3, 'OWNER', true, TIMESTAMP '2026-01-03 10:00:00'),
+                        ('b0000000-0000-0000-0000-000000000001', '%2$s', 1, 'OWNER', true, TIMESTAMP '2026-01-01 10:00:00'),
+                        ('b0000000-0000-0000-0000-000000000002', '%2$s', 2, 'OWNER', true, TIMESTAMP '2026-01-02 10:00:00')
+                    """.formatted(PROFILE_A, PROFILE_B));
+
+            statement.execute("""
+                    INSERT INTO pending_notification
+                        (uuid, resource, object_uuid, notification_profile_uuid, version, last_sent_at, repetitions)
+                    VALUES
+                        ('e0000000-0000-0000-0000-000000000001', 'CERTIFICATE', 'd0000000-0000-0000-0000-000000000001', '%1$s', 3, now(), 0),
+                        ('e0000000-0000-0000-0000-000000000002', 'CERTIFICATE', 'd0000000-0000-0000-0000-000000000002', '%1$s', 2, now(), 0),
+                        ('e0000000-0000-0000-0000-000000000003', 'CERTIFICATE', 'd0000000-0000-0000-0000-000000000003', '%1$s', 1, now(), 0),
+                        ('e0000000-0000-0000-0000-000000000004', 'CERTIFICATE', 'd0000000-0000-0000-0000-000000000004', '%2$s', 2, now(), 0)
+                    """.formatted(PROFILE_A, PROFILE_B));
+        }
+    }
+
+    private Map<String, Integer> versionsByUuid(Connection connection, String profileUuid) throws SQLException {
+        Map<String, Integer> versions = new LinkedHashMap<>();
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(
+                     "SELECT uuid, version FROM notification_profile_version WHERE notification_profile_uuid = '%s' ORDER BY version".formatted(profileUuid))) {
+            while (resultSet.next()) {
+                versions.put(resultSet.getString("uuid"), resultSet.getInt("version"));
+            }
+        }
+        return versions;
+    }
+
+    private int pendingVersion(Connection connection, String pendingUuid) throws SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(
+                     "SELECT version FROM pending_notification WHERE uuid = '%s'".formatted(pendingUuid))) {
+            Assertions.assertTrue(resultSet.next(), "pending_notification row " + pendingUuid + " should exist");
+            return resultSet.getInt("version");
+        }
+    }
+}

--- a/src/test/java/com/otilm/core/integration/migration/NotificationProfileVersionUniqueMigrationITest.java
+++ b/src/test/java/com/otilm/core/integration/migration/NotificationProfileVersionUniqueMigrationITest.java
@@ -75,6 +75,8 @@ class NotificationProfileVersionUniqueMigrationITest extends BaseMigrationTest {
                             (uuid, notification_profile_uuid, version, recipient_type, internal_notification, created_at)
                         VALUES ('c0000000-0000-0000-0000-000000000001', '%s', 1, 'OWNER', true, now())
                         """.formatted(PROFILE_A)));
+                Assertions.assertEquals("23505", rejection.getSQLState(),
+                        "Duplicate insert should fail with the unique-violation SQLSTATE, but was: " + rejection.getMessage());
                 Assertions.assertTrue(rejection.getMessage().contains("uq_notification_profile_version"),
                         "Duplicate insert should be rejected by the unique constraint, but was: " + rejection.getMessage());
             }

--- a/src/test/java/com/otilm/core/integration/service/NotificationProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/NotificationProfileServiceITest.java
@@ -282,7 +282,10 @@ class NotificationProfileServiceITest extends BaseSpringBootTest {
                         "Concurrent edits must serialize version assignment and never produce duplicate version numbers (round " + round + ")");
             }
         } finally {
-            executor.shutdownNow();
+            executor.shutdown();
+            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
         }
     }
 

--- a/src/test/java/com/otilm/core/integration/service/NotificationProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/NotificationProfileServiceITest.java
@@ -30,6 +30,7 @@ import com.otilm.core.dao.entity.notifications.NotificationProfileVersion;
 import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.notifications.NotificationInstanceMappedAttributeRepository;
 import com.otilm.core.dao.repository.notifications.NotificationInstanceReferenceRepository;
+import com.otilm.core.dao.repository.notifications.NotificationProfileRepository;
 import com.otilm.core.dao.repository.notifications.NotificationProfileVersionRepository;
 import com.otilm.core.messaging.jms.listeners.NotificationListener;
 import com.otilm.core.messaging.model.NotificationMessage;
@@ -59,6 +60,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 class NotificationProfileServiceITest extends BaseSpringBootTest {
 
@@ -84,6 +86,9 @@ class NotificationProfileServiceITest extends BaseSpringBootTest {
 
     @Autowired
     private NotificationInstanceMappedAttributeRepository notificationInstanceMappedAttributeRepository;
+
+    @Autowired
+    private NotificationProfileRepository notificationProfileRepository;
 
     @Autowired
     private NotificationProfileVersionRepository notificationProfileVersionRepository;
@@ -238,52 +243,73 @@ class NotificationProfileServiceITest extends BaseSpringBootTest {
 
     @Test
     void testConcurrentEditsAssignDistinctVersions() throws Exception {
-        SecuredUUID profileUuid = SecuredUUID.fromString(originalNotificationProfile.getUuid());
-
-        int editorCount = 2;
-        CyclicBarrier startBarrier = new CyclicBarrier(editorCount);
+        int editorCount = 4;
+        int rounds = 3;
+        List<Integer> expectedVersions = IntStream.rangeClosed(1, editorCount + 1).boxed().toList();
         ExecutorService executor = Executors.newFixedThreadPool(editorCount);
         try {
-            List<Future<NotificationProfileDetailDto>> edits = new ArrayList<>();
-            for (int i = 0; i < editorCount; i++) {
-                int repetitions = i + 1;
-                edits.add(executor.submit(() -> {
-                    SecurityContextHolder.getContext().setAuthentication(getAuthentication());
-                    NotificationProfileUpdateRequestDto updateRequest = new NotificationProfileUpdateRequestDto();
-                    updateRequest.setRecipientType(RecipientType.OWNER);
-                    updateRequest.setInternalNotification(true);
-                    updateRequest.setRepetitions(repetitions);
-                    startBarrier.await();
-                    return notificationProfileService.editNotificationProfile(profileUuid, updateRequest);
-                }));
-            }
-            for (Future<NotificationProfileDetailDto> edit : edits) {
-                edit.get(30, TimeUnit.SECONDS);
+            for (int round = 0; round < rounds; round++) {
+                NotificationProfileRequestDto createRequest = new NotificationProfileRequestDto();
+                createRequest.setName("ConcurrentEditProfile" + round);
+                createRequest.setRecipientType(RecipientType.OWNER);
+                createRequest.setInternalNotification(true);
+                SecuredUUID profileUuid = SecuredUUID.fromString(notificationProfileService.createNotificationProfile(createRequest).getUuid());
+
+                CyclicBarrier startBarrier = new CyclicBarrier(editorCount);
+                List<Future<NotificationProfileDetailDto>> edits = new ArrayList<>();
+                for (int i = 0; i < editorCount; i++) {
+                    int repetitions = i + 1;
+                    edits.add(executor.submit(() -> {
+                        SecurityContextHolder.getContext().setAuthentication(getAuthentication());
+                        NotificationProfileUpdateRequestDto updateRequest = new NotificationProfileUpdateRequestDto();
+                        updateRequest.setRecipientType(RecipientType.OWNER);
+                        updateRequest.setInternalNotification(true);
+                        updateRequest.setRepetitions(repetitions);
+                        startBarrier.await();
+                        return notificationProfileService.editNotificationProfile(profileUuid, updateRequest);
+                    }));
+                }
+                for (Future<NotificationProfileDetailDto> edit : edits) {
+                    edit.get(30, TimeUnit.SECONDS);
+                }
+
+                List<Integer> versions = notificationProfileVersionRepository.findAll().stream()
+                        .filter(version -> version.getNotificationProfileUuid().equals(profileUuid.getValue()))
+                        .map(NotificationProfileVersion::getVersion)
+                        .sorted()
+                        .toList();
+                Assertions.assertEquals(expectedVersions, versions,
+                        "Concurrent edits must serialize version assignment and never produce duplicate version numbers (round " + round + ")");
             }
         } finally {
             executor.shutdownNow();
         }
-
-        List<Integer> versions = notificationProfileVersionRepository.findAll().stream()
-                .filter(version -> version.getNotificationProfileUuid().equals(profileUuid.getValue()))
-                .map(NotificationProfileVersion::getVersion)
-                .sorted()
-                .toList();
-        Assertions.assertEquals(List.of(1, 2, 3), versions,
-                "Concurrent edits must serialize version assignment and never produce duplicate version numbers");
     }
 
     @Test
-    void testEditWithUnknownNotificationInstanceFailsWithIntegrityError() {
+    void testEditWithUnknownNotificationInstanceFailsWithNotFound() {
         NotificationProfileUpdateRequestDto requestDto = new NotificationProfileUpdateRequestDto();
         requestDto.setRecipientType(RecipientType.OWNER);
         requestDto.setInternalNotification(true);
         requestDto.setNotificationInstanceUuid(UUID.randomUUID());
         SecuredUUID profileUuid = SecuredUUID.fromString(originalNotificationProfile.getUuid());
 
-        // The foreign key violation must surface as-is, not be mislabeled as a concurrent modification
-        Assertions.assertThrows(DataIntegrityViolationException.class,
+        Assertions.assertThrows(NotFoundException.class,
                 () -> notificationProfileService.editNotificationProfile(profileUuid, requestDto));
+    }
+
+    @Test
+    void testCreateWithUnknownNotificationInstanceFailsWithNotFound() {
+        NotificationProfileRequestDto requestDto = new NotificationProfileRequestDto();
+        requestDto.setName("ProfileWithUnknownInstance");
+        requestDto.setRecipientType(RecipientType.OWNER);
+        requestDto.setInternalNotification(true);
+        requestDto.setNotificationInstanceUuid(UUID.randomUUID());
+
+        Assertions.assertThrows(NotFoundException.class,
+                () -> notificationProfileService.createNotificationProfile(requestDto));
+        Assertions.assertTrue(notificationProfileRepository.findByName(requestDto.getName()).isEmpty(),
+                "Failed create should not leave a partially created profile behind");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/NotificationProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/NotificationProfileServiceITest.java
@@ -26,9 +26,11 @@ import com.otilm.api.model.core.scheduler.PaginationRequestDto;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.notifications.NotificationInstanceMappedAttributes;
 import com.otilm.core.dao.entity.notifications.NotificationInstanceReference;
+import com.otilm.core.dao.entity.notifications.NotificationProfileVersion;
 import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.notifications.NotificationInstanceMappedAttributeRepository;
 import com.otilm.core.dao.repository.notifications.NotificationInstanceReferenceRepository;
+import com.otilm.core.dao.repository.notifications.NotificationProfileVersionRepository;
 import com.otilm.core.messaging.jms.listeners.NotificationListener;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.security.authz.SecuredUUID;
@@ -38,16 +40,25 @@ import com.otilm.core.service.NotificationProfileExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 class NotificationProfileServiceITest extends BaseSpringBootTest {
 
@@ -73,6 +84,9 @@ class NotificationProfileServiceITest extends BaseSpringBootTest {
 
     @Autowired
     private NotificationInstanceMappedAttributeRepository notificationInstanceMappedAttributeRepository;
+
+    @Autowired
+    private NotificationProfileVersionRepository notificationProfileVersionRepository;
 
     @Autowired
     private AttributeExternalService attributeService;
@@ -204,6 +218,7 @@ class NotificationProfileServiceITest extends BaseSpringBootTest {
         requestDto.setInternalNotification(true);
         NotificationProfileDetailDto updatedNotificationProfileDetailDto = notificationProfileService.editNotificationProfile(SecuredUUID.fromString(originalNotificationProfile.getUuid()), requestDto);
         Assertions.assertEquals(originalNotificationProfile.getVersion(), updatedNotificationProfileDetailDto.getVersion(), "Versions should not change, no change in profile props");
+        Assertions.assertEquals(requestDto.getDescription(), updatedNotificationProfileDetailDto.getDescription(), "Description-only edit should persist the new description without creating a new version");
 
         requestDto.setFrequency(Duration.ofDays(1));
         requestDto.setRepetitions(5);
@@ -219,6 +234,80 @@ class NotificationProfileServiceITest extends BaseSpringBootTest {
         Assertions.assertEquals(originalNotificationProfile.getRecipientType(), olderVersion.getRecipientType());
 
         mockServer.stop();
+    }
+
+    @Test
+    void testConcurrentEditsAssignDistinctVersions() throws Exception {
+        SecuredUUID profileUuid = SecuredUUID.fromString(originalNotificationProfile.getUuid());
+
+        int editorCount = 2;
+        CyclicBarrier startBarrier = new CyclicBarrier(editorCount);
+        ExecutorService executor = Executors.newFixedThreadPool(editorCount);
+        try {
+            List<Future<NotificationProfileDetailDto>> edits = new ArrayList<>();
+            for (int i = 0; i < editorCount; i++) {
+                int repetitions = i + 1;
+                edits.add(executor.submit(() -> {
+                    SecurityContextHolder.getContext().setAuthentication(getAuthentication());
+                    NotificationProfileUpdateRequestDto updateRequest = new NotificationProfileUpdateRequestDto();
+                    updateRequest.setRecipientType(RecipientType.OWNER);
+                    updateRequest.setInternalNotification(true);
+                    updateRequest.setRepetitions(repetitions);
+                    startBarrier.await();
+                    return notificationProfileService.editNotificationProfile(profileUuid, updateRequest);
+                }));
+            }
+            for (Future<NotificationProfileDetailDto> edit : edits) {
+                edit.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        List<Integer> versions = notificationProfileVersionRepository.findAll().stream()
+                .filter(version -> version.getNotificationProfileUuid().equals(profileUuid.getValue()))
+                .map(NotificationProfileVersion::getVersion)
+                .sorted()
+                .toList();
+        Assertions.assertEquals(List.of(1, 2, 3), versions,
+                "Concurrent edits must serialize version assignment and never produce duplicate version numbers");
+    }
+
+    @Test
+    void testEditWithUnknownNotificationInstanceFailsWithIntegrityError() {
+        NotificationProfileUpdateRequestDto requestDto = new NotificationProfileUpdateRequestDto();
+        requestDto.setRecipientType(RecipientType.OWNER);
+        requestDto.setInternalNotification(true);
+        requestDto.setNotificationInstanceUuid(UUID.randomUUID());
+
+        // The foreign key violation must surface as-is, not be mislabeled as a concurrent modification
+        Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> notificationProfileService.editNotificationProfile(SecuredUUID.fromString(originalNotificationProfile.getUuid()), requestDto));
+    }
+
+    @Test
+    void testDuplicateVersionInsertIsRejectedByUniqueConstraint() {
+        NotificationProfileVersion duplicate = new NotificationProfileVersion();
+        duplicate.setNotificationProfileUuid(UUID.fromString(originalNotificationProfile.getUuid()));
+        duplicate.setVersion(originalNotificationProfile.getVersion());
+        duplicate.setRecipientType(RecipientType.OWNER);
+        duplicate.setInternalNotification(true);
+
+        DataIntegrityViolationException e = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> notificationProfileVersionRepository.saveAndFlush(duplicate));
+
+        // Pins the constraint name reported by Hibernate — the service backstop matches on it to
+        // distinguish concurrent-edit collisions from other integrity violations
+        ConstraintViolationException constraintViolation = null;
+        for (Throwable cause = e.getCause(); cause != null; cause = cause.getCause()) {
+            if (cause instanceof ConstraintViolationException cve) {
+                constraintViolation = cve;
+                break;
+            }
+        }
+        Assertions.assertNotNull(constraintViolation, "Cause chain should carry the Hibernate constraint violation");
+        Assertions.assertTrue(NotificationProfileVersion.UNIQUE_VERSION_CONSTRAINT.equalsIgnoreCase(constraintViolation.getConstraintName()),
+                "Constraint name should be reported as " + NotificationProfileVersion.UNIQUE_VERSION_CONSTRAINT + " but was " + constraintViolation.getConstraintName());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/NotificationProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/NotificationProfileServiceITest.java
@@ -279,10 +279,11 @@ class NotificationProfileServiceITest extends BaseSpringBootTest {
         requestDto.setRecipientType(RecipientType.OWNER);
         requestDto.setInternalNotification(true);
         requestDto.setNotificationInstanceUuid(UUID.randomUUID());
+        SecuredUUID profileUuid = SecuredUUID.fromString(originalNotificationProfile.getUuid());
 
         // The foreign key violation must surface as-is, not be mislabeled as a concurrent modification
         Assertions.assertThrows(DataIntegrityViolationException.class,
-                () -> notificationProfileService.editNotificationProfile(SecuredUUID.fromString(originalNotificationProfile.getUuid()), requestDto));
+                () -> notificationProfileService.editNotificationProfile(profileUuid, requestDto));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/impl/NotificationProfileServiceImplPersistEditTest.java
+++ b/src/test/java/com/otilm/core/service/impl/NotificationProfileServiceImplPersistEditTest.java
@@ -1,0 +1,107 @@
+package com.otilm.core.service.impl;
+
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.client.notification.NotificationProfileUpdateRequestDto;
+import com.otilm.api.model.core.notification.RecipientType;
+import com.otilm.core.dao.entity.notifications.NotificationProfile;
+import com.otilm.core.dao.entity.notifications.NotificationProfileVersion;
+import com.otilm.core.dao.repository.notifications.NotificationProfileRepository;
+import com.otilm.core.dao.repository.notifications.NotificationProfileVersionRepository;
+import com.otilm.core.security.authz.SecuredUUID;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.dao.DataIntegrityViolationException;
+
+/**
+ * Unit-level coverage for the constraint-violation mapping in {@code persistEditedVersion}: the row lock
+ * makes the duplicate-version path unreachable through the service in integration tests, so the mapping
+ * is exercised here with synthesized exceptions.
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificationProfileServiceImplPersistEditTest {
+
+    @Mock
+    private NotificationProfileRepository notificationProfileRepository;
+
+    @Mock
+    private NotificationProfileVersionRepository notificationProfileVersionRepository;
+
+    private NotificationProfileServiceImpl service;
+
+    private SecuredUUID profileUuid;
+    private NotificationProfileUpdateRequestDto updateRequest;
+
+    @BeforeEach
+    void setUp() {
+        service = new NotificationProfileServiceImpl();
+        service.setNotificationProfileRepository(notificationProfileRepository);
+        service.setNotificationProfileVersionRepository(notificationProfileVersionRepository);
+
+        profileUuid = SecuredUUID.fromUUID(UUID.randomUUID());
+
+        NotificationProfile profile = new NotificationProfile();
+        profile.uuid = profileUuid.getValue();
+        profile.setName("TestProfile");
+
+        NotificationProfileVersion currentVersion = new NotificationProfileVersion();
+        currentVersion.setVersion(1);
+        currentVersion.setRecipientType(RecipientType.OWNER);
+        currentVersion.setInternalNotification(true);
+
+        updateRequest = new NotificationProfileUpdateRequestDto();
+        updateRequest.setRecipientType(RecipientType.OWNER);
+        updateRequest.setInternalNotification(true);
+        updateRequest.setRepetitions(5);
+
+        Mockito.when(notificationProfileRepository.findAndLockByUuid(profileUuid.getValue())).thenReturn(Optional.of(profile));
+        Mockito.when(notificationProfileVersionRepository.findTopByNotificationProfileUuidOrderByVersionDesc(profileUuid.getValue())).thenReturn(Optional.of(currentVersion));
+    }
+
+    @Test
+    void duplicateVersionConstraintViolationIsReportedAsConcurrentModification() {
+        Mockito.when(notificationProfileVersionRepository.saveAndFlush(Mockito.any()))
+                .thenThrow(integrityViolation(NotificationProfileVersion.UNIQUE_VERSION_CONSTRAINT));
+
+        ValidationException e = Assertions.assertThrows(ValidationException.class,
+                () -> service.persistEditedVersion(profileUuid, updateRequest, List.of()));
+        Assertions.assertTrue(e.getMessage().contains("concurrently modified"),
+                "Message should tell the client to retry, but was: " + e.getMessage());
+    }
+
+    @Test
+    void otherIntegrityViolationsAreRethrownUnchanged() {
+        DataIntegrityViolationException foreignKeyViolation = integrityViolation("fk_notification_profile_version_instance");
+        Mockito.when(notificationProfileVersionRepository.saveAndFlush(Mockito.any())).thenThrow(foreignKeyViolation);
+
+        DataIntegrityViolationException e = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> service.persistEditedVersion(profileUuid, updateRequest, List.of()));
+        Assertions.assertSame(foreignKeyViolation, e, "Non-duplicate integrity violations must surface unchanged");
+    }
+
+    @Test
+    void integrityViolationWithoutConstraintNameIsRethrownUnchanged() {
+        DataIntegrityViolationException anonymousViolation = integrityViolation(null);
+        Mockito.when(notificationProfileVersionRepository.saveAndFlush(Mockito.any())).thenThrow(anonymousViolation);
+
+        DataIntegrityViolationException e = Assertions.assertThrows(DataIntegrityViolationException.class,
+                () -> service.persistEditedVersion(profileUuid, updateRequest, List.of()));
+        Assertions.assertSame(anonymousViolation, e);
+    }
+
+    private static DataIntegrityViolationException integrityViolation(String constraintName) {
+        return new DataIntegrityViolationException("could not execute statement",
+                new ConstraintViolationException("could not execute statement", new SQLException("duplicate key"), constraintName));
+    }
+}

--- a/src/test/java/com/otilm/core/service/impl/NotificationProfileServiceImplPersistEditTest.java
+++ b/src/test/java/com/otilm/core/service/impl/NotificationProfileServiceImplPersistEditTest.java
@@ -14,15 +14,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.dao.DataIntegrityViolationException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit-level coverage for the constraint-violation mapping in {@code persistEditedVersion}: the row lock
@@ -65,13 +66,13 @@ class NotificationProfileServiceImplPersistEditTest {
         updateRequest.setInternalNotification(true);
         updateRequest.setRepetitions(5);
 
-        Mockito.when(notificationProfileRepository.findAndLockByUuid(profileUuid.getValue())).thenReturn(Optional.of(profile));
-        Mockito.when(notificationProfileVersionRepository.findTopByNotificationProfileUuidOrderByVersionDesc(profileUuid.getValue())).thenReturn(Optional.of(currentVersion));
+        when(notificationProfileRepository.findAndLockByUuid(profileUuid.getValue())).thenReturn(Optional.of(profile));
+        when(notificationProfileVersionRepository.findTopByNotificationProfileUuidOrderByVersionDesc(profileUuid.getValue())).thenReturn(Optional.of(currentVersion));
     }
 
     @Test
     void duplicateVersionConstraintViolationIsReportedAsConcurrentModification() {
-        Mockito.when(notificationProfileVersionRepository.saveAndFlush(Mockito.any()))
+        when(notificationProfileVersionRepository.saveAndFlush(any()))
                 .thenThrow(integrityViolation(NotificationProfileVersion.UNIQUE_VERSION_CONSTRAINT));
 
         ValidationException e = Assertions.assertThrows(ValidationException.class,
@@ -83,7 +84,7 @@ class NotificationProfileServiceImplPersistEditTest {
     @Test
     void otherIntegrityViolationsAreRethrownUnchanged() {
         DataIntegrityViolationException foreignKeyViolation = integrityViolation("fk_notification_profile_version_instance");
-        Mockito.when(notificationProfileVersionRepository.saveAndFlush(Mockito.any())).thenThrow(foreignKeyViolation);
+        when(notificationProfileVersionRepository.saveAndFlush(any())).thenThrow(foreignKeyViolation);
 
         DataIntegrityViolationException e = Assertions.assertThrows(DataIntegrityViolationException.class,
                 () -> service.persistEditedVersion(profileUuid, updateRequest, List.of()));
@@ -93,7 +94,7 @@ class NotificationProfileServiceImplPersistEditTest {
     @Test
     void integrityViolationWithoutConstraintNameIsRethrownUnchanged() {
         DataIntegrityViolationException anonymousViolation = integrityViolation(null);
-        Mockito.when(notificationProfileVersionRepository.saveAndFlush(Mockito.any())).thenThrow(anonymousViolation);
+        when(notificationProfileVersionRepository.saveAndFlush(any())).thenThrow(anonymousViolation);
 
         DataIntegrityViolationException e = Assertions.assertThrows(DataIntegrityViolationException.class,
                 () -> service.persistEditedVersion(profileUuid, updateRequest, List.of()));


### PR DESCRIPTION
## What changed

Concurrent edits of a notification profile could assign the same version number twice: `editNotificationProfile` computed the next version from the latest existing row without any serialization, and the schema had no uniqueness guarantee on `(notification_profile_uuid, version)`. Duplicate version numbers made version resolution for notifications nondeterministic.

- `editNotificationProfile` now takes a pessimistic lock on the profile row (`SELECT … FOR UPDATE`) while assigning the next version number, so concurrent edits serialize and each produces a distinct version.
- New unique constraint `uq_notification_profile_version` on `notification_profile_version (notification_profile_uuid, version)`, declared on the entity and added by a Flyway migration. The migration renumbers already-existing duplicate version numbers chronologically and remaps `pending_notification` version references accordingly.
- Recipient info is resolved before the row lock is taken, keeping the auth service call outside the lock window.
- A violation of the new unique constraint is reported as a validation error (profile was concurrently modified); other integrity violations surface unchanged.
- Description changes are persisted even when the edit does not result in a new version.