### PR TITLE
Persist metadata attribute protection level and protect stored content

### DIFF
--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -722,13 +722,20 @@ public class AttributeEngine {
 
     /**
      * Returns the content item as stored, or the decrypted item when the definition's protection
-     * level put ciphertext alongside the stored placeholder.
+     * level put ciphertext alongside the stored placeholder. A ciphertext that cannot be decrypted
+     * (corrupt value, wrong encryption key) degrades to the stored placeholder — whose {@code data}
+     * is null, so callers treat it as malformed — instead of failing the whole read.
      */
     private static AttributeContent decryptedContentItem(AttributeContent contentItem, int version, AttributeContentType contentType, String encryptedContent) {
         if (encryptedContent == null) {
             return contentItem;
         }
-        return AttributeVersionHelper.decryptContent(contentItem, version, contentType, encryptedContent);
+        try {
+            return AttributeVersionHelper.decryptContent(contentItem, version, contentType, encryptedContent);
+        } catch (RuntimeException e) {
+            logger.warn("Failed to decrypt attribute content item with reference {}: {}", contentItem.getReference(), e.getMessage());
+            return contentItem;
+        }
     }
 
     /**

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -741,12 +741,10 @@ public class AttributeEngine {
     private static void applyNormalizedProtectionLevel(MetadataAttribute definitionCopy, ProtectionLevel protectionLevel) {
         MetadataAttributeProperties normalizedProperties = ATTRIBUTES_OBJECT_MAPPER.convertValue(definitionCopy.getProperties(), MetadataAttributeProperties.class);
         normalizedProperties.setProtectionLevel(protectionLevel);
-        if (definitionCopy instanceof MetadataAttributeV2 v2) {
-            v2.setProperties(normalizedProperties);
-        } else if (definitionCopy instanceof MetadataAttributeV3 v3) {
-            v3.setProperties(normalizedProperties);
-        } else {
-            throw new IllegalStateException("Unsupported MetadataAttribute version for properties normalization: "
+        switch (definitionCopy) {
+            case MetadataAttributeV2 v2 -> v2.setProperties(normalizedProperties);
+            case MetadataAttributeV3 v3 -> v3.setProperties(normalizedProperties);
+            default -> throw new IllegalStateException("Unsupported MetadataAttribute version for properties normalization: "
                     + definitionCopy.getVersion());
         }
     }

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -10,7 +10,9 @@ import com.otilm.api.model.client.metadata.ResponseMetadata;
 import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.common.attribute.common.*;
 import com.otilm.api.model.common.attribute.common.content.data.ProtectionLevel;
+import com.otilm.api.model.common.attribute.common.properties.MetadataAttributeProperties;
 import com.otilm.api.model.common.attribute.v2.*;
+import com.otilm.api.model.common.attribute.v3.MetadataAttributeV3;
 import com.otilm.api.model.common.attribute.common.callback.AttributeCallback;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.v2.content.BaseAttributeContentV2;
@@ -307,10 +309,7 @@ public class AttributeEngine {
         for (ObjectAttributeDefinitionContent objectDefinitionContent : objectDefinitionContents) {
 
             MetadataAttribute definition = (MetadataAttribute) objectDefinitionContent.definition();
-            AttributeContent contentItem = objectDefinitionContent.contentItem();
-            if (objectDefinitionContent.encryptedContent() != null) {
-                contentItem = AttributeVersionHelper.decryptContent(contentItem, definition.getVersion(), definition.getContentType(), objectDefinitionContent.encryptedContent());
-            }
+            AttributeContent contentItem = decryptedContentItem(objectDefinitionContent.contentItem(), definition.getVersion(), definition.getContentType(), objectDefinitionContent.encryptedContent());
             if (contentItem.getData() == null) {
                 continue;
             }
@@ -338,37 +337,22 @@ public class AttributeEngine {
         Map<UUID, String> connectorMapping = new HashMap<>();
         Map<UUID, Map<Resource, Map<UUID, ResponseMetadata>>> mapping = new HashMap<>();
         for (ObjectAttributeContentDetail objectMetadataContent : objectMetadataContents) {
-            AttributeContent contentItem = objectMetadataContent.contentItem();
-            if (objectMetadataContent.encryptedContent() != null) {
-                contentItem = AttributeVersionHelper.decryptContent(contentItem, objectMetadataContent.version(), objectMetadataContent.contentType(), objectMetadataContent.encryptedContent());
-            }
+            AttributeContent contentItem = decryptedContentItem(objectMetadataContent.contentItem(), objectMetadataContent.version(), objectMetadataContent.contentType(), objectMetadataContent.encryptedContent());
             // check in case data is null because of malformed data
             if (contentItem.getData() == null) {
                 continue;
             }
 
-            ResponseMetadata metadataResponseAttributeDto;
             // do we need check for empty content?
-            Map<Resource, Map<UUID, ResponseMetadata>> sourceAttributesContentsMapping;
-            Map<UUID, ResponseMetadata> sourceAttributesContents;
             if (!connectorMapping.containsKey(objectMetadataContent.connectorUuid())) {
 //                String connectorName = objectMetadataContent.connectorName() != null ? objectMetadataContent.connectorName() : "<No connector>";
                 String connectorName = objectMetadataContent.connectorName();
                 connectorMapping.put(objectMetadataContent.connectorUuid(), connectorName);
             }
-            if ((sourceAttributesContentsMapping = mapping.get(objectMetadataContent.connectorUuid())) == null) {
-                sourceAttributesContentsMapping = new HashMap<>();
-                mapping.put(objectMetadataContent.connectorUuid(), sourceAttributesContentsMapping);
-            }
-            if ((sourceAttributesContents = sourceAttributesContentsMapping.get(objectMetadataContent.sourceObjectType())) == null) {
-                sourceAttributesContents = new HashMap<>();
-                sourceAttributesContentsMapping.put(objectMetadataContent.sourceObjectType(), sourceAttributesContents);
-            }
-
-            if ((metadataResponseAttributeDto = sourceAttributesContents.get(objectMetadataContent.uuid())) == null) {
-                metadataResponseAttributeDto = AttributeVersionHelper.getResponseMetadata(objectMetadataContent.version(), new ArrayList<>(), objectMetadataContent.uuid(), objectMetadataContent.name(), objectMetadataContent.label(), objectMetadataContent.type(), objectMetadataContent.contentType(), new ArrayList<>());
-                sourceAttributesContents.put(objectMetadataContent.uuid(), metadataResponseAttributeDto);
-            }
+            Map<Resource, Map<UUID, ResponseMetadata>> sourceAttributesContentsMapping = mapping.computeIfAbsent(objectMetadataContent.connectorUuid(), k -> new HashMap<>());
+            Map<UUID, ResponseMetadata> sourceAttributesContents = sourceAttributesContentsMapping.computeIfAbsent(objectMetadataContent.sourceObjectType(), k -> new HashMap<>());
+            ResponseMetadata metadataResponseAttributeDto = sourceAttributesContents.computeIfAbsent(objectMetadataContent.uuid(),
+                    k -> AttributeVersionHelper.getResponseMetadata(objectMetadataContent.version(), new ArrayList<>(), objectMetadataContent.uuid(), objectMetadataContent.name(), objectMetadataContent.label(), objectMetadataContent.type(), objectMetadataContent.contentType(), new ArrayList<>()));
 
             AttributeVersionHelper.addResponseMetadataContent(objectMetadataContent.version(), metadataResponseAttributeDto, contentItem);
 
@@ -477,7 +461,7 @@ public class AttributeEngine {
                 for (AttributeContentItem contentItem : contents) {
                     String encryptedContent = encryptAttributeContent(attributeDefinition, contentItem.getJson());
                     contentItem.setEncryptedData(encryptedContent);
-                    contentItem.setJson(AttributeVersionHelper.createEncryptedContent(contentItem.getUuid().toString(), attributeDefinition.getContentType(), AttributeVersion.V3.getVersion()));
+                    contentItem.setJson(AttributeVersionHelper.createEncryptedContent(contentItem.getUuid().toString(), attributeDefinition.getContentType(), attributeDefinition.getVersion()));
                     attributeContentItemRepository.save(contentItem);
                 }
             }
@@ -697,6 +681,7 @@ public class AttributeEngine {
         // reference serialized at flush time, so the copy must be a distinct instance.
         MetadataAttribute definitionCopy = metadataAttribute.copy();
         definitionCopy.setContent(List.of());
+        applyNormalizedProtectionLevel(definitionCopy, protectionLevel);
 
         if (attributeDefinition != null) {
             // check for change of content type
@@ -733,6 +718,37 @@ public class AttributeEngine {
         attributeDefinitionRepository.save(attributeDefinition);
 
         return attributeDefinition;
+    }
+
+    /**
+     * Returns the content item as stored, or the decrypted item when the definition's protection
+     * level put ciphertext alongside the stored placeholder.
+     */
+    private static AttributeContent decryptedContentItem(AttributeContent contentItem, int version, AttributeContentType contentType, String encryptedContent) {
+        if (encryptedContent == null) {
+            return contentItem;
+        }
+        return AttributeVersionHelper.decryptContent(contentItem, version, contentType, encryptedContent);
+    }
+
+    /**
+     * Sets the normalized protection level on the persisted definition copy so the serialized
+     * definition always carries the same level as the entity column (a connector may send null,
+     * which is persisted as {@code NONE}). {@code copy()} shares {@code properties} by reference
+     * with the caller's instance, so the level is set on a detached properties copy — the caller's
+     * object stays untouched.
+     */
+    private static void applyNormalizedProtectionLevel(MetadataAttribute definitionCopy, ProtectionLevel protectionLevel) {
+        MetadataAttributeProperties normalizedProperties = ATTRIBUTES_OBJECT_MAPPER.convertValue(definitionCopy.getProperties(), MetadataAttributeProperties.class);
+        normalizedProperties.setProtectionLevel(protectionLevel);
+        if (definitionCopy instanceof MetadataAttributeV2 v2) {
+            v2.setProperties(normalizedProperties);
+        } else if (definitionCopy instanceof MetadataAttributeV3 v3) {
+            v3.setProperties(normalizedProperties);
+        } else {
+            throw new IllegalStateException("Unsupported MetadataAttribute version for properties normalization: "
+                    + definitionCopy.getVersion());
+        }
     }
 
     /**
@@ -789,10 +805,7 @@ public class AttributeEngine {
         Map<String, DataAttribute> mapping = new HashMap<>();
         for (ObjectAttributeDefinitionContent objectDefinitionContent : objectDefinitionContents) {
             String uuid = objectDefinitionContent.uuid().toString();
-            AttributeContent contentItem = objectDefinitionContent.contentItem();
-            if (objectDefinitionContent.encryptedContent() != null) {
-                contentItem = AttributeVersionHelper.decryptContent(contentItem, objectDefinitionContent.definition().getVersion(), ((DataAttribute) objectDefinitionContent.definition()).getContentType(), objectDefinitionContent.encryptedContent());
-            }
+            AttributeContent contentItem = decryptedContentItem(objectDefinitionContent.contentItem(), objectDefinitionContent.definition().getVersion(), ((DataAttribute) objectDefinitionContent.definition()).getContentType(), objectDefinitionContent.encryptedContent());
             if (objectDefinitionContent.definition().getVersion() == 2) {
                 DataAttributeV2 attribute;
                 if ((attribute = (DataAttributeV2) mapping.get(uuid)) == null) {

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -1707,9 +1707,11 @@ public class AttributeEngine {
     }
 
     /**
-     * Locates an already-mapped content item of the definition whose decrypted value equals the
-     * incoming plaintext item. Scoped to the target object tuple so the number of decryptions per
-     * write stays bounded by the object's own content, not by every object sharing the definition.
+     * Locates an already-mapped content item of the definition equal to the incoming item after
+     * decryption — equality requires matching data, reference and content type, so deduplication
+     * only ever merges exact-value resubmissions. Scoped to the target object tuple so the number
+     * of decryptions per write stays bounded by the object's own content, not by every object
+     * sharing the definition.
      */
     private AttributeContentItem findMappedEncryptedContentItem(AttributeDefinition attributeDefinition, AttributeContent attributeContentItem, ObjectAttributeContentInfo info) {
         List<AttributeContentItem> mappedItems = attributeContent2ObjectRepository.findMappedContentItems(

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -811,6 +811,10 @@ public class AttributeEngine {
         for (ObjectAttributeDefinitionContent objectDefinitionContent : objectDefinitionContents) {
             String uuid = objectDefinitionContent.uuid().toString();
             AttributeContent contentItem = decryptedContentItem(objectDefinitionContent.contentItem(), objectDefinitionContent.definition().getVersion(), ((DataAttribute) objectDefinitionContent.definition()).getContentType(), objectDefinitionContent.encryptedContent());
+            // skip malformed items, including undecryptable ciphertext degraded to the placeholder
+            if (contentItem.getData() == null) {
+                continue;
+            }
             if (objectDefinitionContent.definition().getVersion() == 2) {
                 DataAttributeV2 attribute;
                 if ((attribute = (DataAttributeV2) mapping.get(uuid)) == null) {

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -306,7 +306,12 @@ public class AttributeEngine {
 
         for (ObjectAttributeDefinitionContent objectDefinitionContent : objectDefinitionContents) {
 
-            if (objectDefinitionContent.contentItem().getData() == null) {
+            MetadataAttribute definition = (MetadataAttribute) objectDefinitionContent.definition();
+            AttributeContent contentItem = objectDefinitionContent.contentItem();
+            if (objectDefinitionContent.encryptedContent() != null) {
+                contentItem = AttributeVersionHelper.decryptContent(contentItem, definition.getVersion(), definition.getContentType(), objectDefinitionContent.encryptedContent());
+            }
+            if (contentItem.getData() == null) {
                 continue;
             }
 
@@ -314,15 +319,12 @@ public class AttributeEngine {
 
             MetadataAttribute attribute =
                     mapping.computeIfAbsent(uuid, k -> {
-                        MetadataAttribute def =
-                                (MetadataAttribute) objectDefinitionContent.definition();
-
-                        def.setContent(new ArrayList<>());
-                        return def;
+                        definition.setContent(new ArrayList<>());
+                        return definition;
                     });
 
             // Add content (requires raw cast because generics are invariant)
-            ((List) attribute.getContent()).add(objectDefinitionContent.contentItem());
+            ((List) attribute.getContent()).add(contentItem);
         }
 
         return mapping.values().stream().toList();
@@ -336,8 +338,12 @@ public class AttributeEngine {
         Map<UUID, String> connectorMapping = new HashMap<>();
         Map<UUID, Map<Resource, Map<UUID, ResponseMetadata>>> mapping = new HashMap<>();
         for (ObjectAttributeContentDetail objectMetadataContent : objectMetadataContents) {
+            AttributeContent contentItem = objectMetadataContent.contentItem();
+            if (objectMetadataContent.encryptedContent() != null) {
+                contentItem = AttributeVersionHelper.decryptContent(contentItem, objectMetadataContent.version(), objectMetadataContent.contentType(), objectMetadataContent.encryptedContent());
+            }
             // check in case data is null because of malformed data
-            if (objectMetadataContent.contentItem().getData() == null) {
+            if (contentItem.getData() == null) {
                 continue;
             }
 
@@ -364,7 +370,7 @@ public class AttributeEngine {
                 sourceAttributesContents.put(objectMetadataContent.uuid(), metadataResponseAttributeDto);
             }
 
-            AttributeVersionHelper.addResponseMetadataContent(objectMetadataContent.version(), metadataResponseAttributeDto, objectMetadataContent.contentItem());
+            AttributeVersionHelper.addResponseMetadataContent(objectMetadataContent.version(), metadataResponseAttributeDto, contentItem);
 
             if (objectMetadataContent.sourceObjectType() != null) {
                 metadataResponseAttributeDto.getSourceObjects().add(new NameAndUuidDto(objectMetadataContent.sourceObjectUuid().toString(), objectMetadataContent.sourceObjectName()));
@@ -655,6 +661,16 @@ public class AttributeEngine {
         return copy;
     }
 
+    /**
+     * Registers or updates a metadata attribute definition, persisting the declared
+     * {@code protectionLevel} (null is treated as {@code NONE}). When the declared level diverges
+     * from the persisted one, all stored content items of the definition are re-protected
+     * accordingly (encrypted on upgrade to {@code ENCRYPTED}, decrypted on downgrade). Definitions
+     * written before the protection level was persisted carry an unset level, so their first
+     * re-registration with a declared {@code ENCRYPTED} level encrypts any previously stored
+     * plaintext content — no separate migration exists, as Flyway migrations have no access to the
+     * content encryption key.
+     */
     public AttributeDefinition updateMetadataAttributeDefinition(MetadataAttribute metadataAttribute, UUID connectorUuid) throws AttributeException {
         var isGlobal = metadataAttribute.getProperties().isGlobal();
         if (connectorUuid == null && !isGlobal) {
@@ -670,6 +686,10 @@ public class AttributeEngine {
             attributeDefinition = attributeDefinitionRepository.findByTypeAndConnectorUuidAndAttributeUuidAndName(AttributeType.META, connectorUuid, UUID.fromString(metadataAttribute.getUuid()), metadataAttribute.getName()).orElse(null);
         }
         String label = metadataAttribute.getProperties().getLabel();
+        ProtectionLevel protectionLevel = metadataAttribute.getProperties().getProtectionLevel();
+        if (protectionLevel == null) {
+            protectionLevel = ProtectionLevel.NONE;
+        }
 
         // The definition must not carry content, but the caller's attribute object remains in use
         // after this call (e.g. it is serialized into the register->issue binding as replay meta) —
@@ -684,8 +704,12 @@ public class AttributeEngine {
                 throw new AttributeException(String.format("Metadata attribute content type changed to %s while stored attribute definition have content type %s", metadataAttribute.getContentType().getLabel(), attributeDefinition.getContentType().getLabel()), metadataAttribute.getUuid(), metadataAttribute.getName(), metadataAttribute.getType(), connectorUuid == null ? null : connectorUuid.toString());
             }
             // The same metadata definition gets (re-)sent for every repeated operation but rarely changes.
-            // Skip the write when nothing changed.
-            if (Objects.equals(attributeDefinition.getLabel(), label) && sameSerializedDefinition(attributeDefinition.getDefinition(), definitionCopy)) {
+            // Skip the write when nothing changed. The entity's protection level is compared explicitly:
+            // rows written before the level was persisted have it unset even though the serialized
+            // definition already declares it, and those must fall through to be reconciled below.
+            if (Objects.equals(attributeDefinition.getLabel(), label)
+                    && attributeDefinition.getProtectionLevel() == protectionLevel
+                    && sameSerializedDefinition(attributeDefinition.getDefinition(), definitionCopy)) {
                 return attributeDefinition;
             }
         } else {
@@ -699,6 +723,11 @@ public class AttributeEngine {
             attributeDefinition.setVersion(metadataAttribute.getVersion());
             attributeDefinition.setGlobal(isGlobal);
         }
+        // Re-protect stored content when the declared level diverges from the persisted one. This also
+        // heals definitions whose content was stored in plaintext before the metadata protection level
+        // was persisted at all: the unset->ENCRYPTED transition encrypts every existing content item.
+        encryptOrDecryptExistingContent(attributeDefinition, protectionLevel);
+        attributeDefinition.setProtectionLevel(protectionLevel);
         attributeDefinition.setLabel(label);
         attributeDefinition.setDefinition(definitionCopy);
         attributeDefinitionRepository.save(attributeDefinition);
@@ -760,6 +789,10 @@ public class AttributeEngine {
         Map<String, DataAttribute> mapping = new HashMap<>();
         for (ObjectAttributeDefinitionContent objectDefinitionContent : objectDefinitionContents) {
             String uuid = objectDefinitionContent.uuid().toString();
+            AttributeContent contentItem = objectDefinitionContent.contentItem();
+            if (objectDefinitionContent.encryptedContent() != null) {
+                contentItem = AttributeVersionHelper.decryptContent(contentItem, objectDefinitionContent.definition().getVersion(), ((DataAttribute) objectDefinitionContent.definition()).getContentType(), objectDefinitionContent.encryptedContent());
+            }
             if (objectDefinitionContent.definition().getVersion() == 2) {
                 DataAttributeV2 attribute;
                 if ((attribute = (DataAttributeV2) mapping.get(uuid)) == null) {
@@ -767,7 +800,7 @@ public class AttributeEngine {
                     attribute.setContent(new ArrayList<>());
                     mapping.put(uuid, attribute);
                 }
-                attribute.getContent().add((BaseAttributeContentV2<?>) objectDefinitionContent.contentItem());
+                attribute.getContent().add((BaseAttributeContentV2<?>) contentItem);
             }
             if (objectDefinitionContent.definition().getVersion() == 3) {
                 DataAttributeV3 attribute;
@@ -776,7 +809,7 @@ public class AttributeEngine {
                     attribute.setContent(new ArrayList<>());
                     mapping.put(uuid, attribute);
                 }
-                attribute.getContent().add((BaseAttributeContentV3<?>) objectDefinitionContent.contentItem());
+                attribute.getContent().add((BaseAttributeContentV3<?>) contentItem);
             }
         }
 

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -1652,18 +1652,24 @@ public class AttributeEngine {
             return;
         }
 
+        // Encrypted content cannot be deduplicated by its stored json (the placeholder is identical
+        // for every item and the ciphertext is salted) — dedup by comparing plaintext against the
+        // items already mapped to this object, fetched and decrypted once for the whole batch.
+        List<Map.Entry<AttributeContentItem, AttributeContent>> decryptedMappedItems =
+                attributeDefinition.getProtectionLevel() == ProtectionLevel.ENCRYPTED
+                        ? loadDecryptedMappedItems(attributeDefinition, objectAttributeContentInfo)
+                        : List.of();
+
         for (int i = 0; i < attributeContentItems.size(); i++) {
             AttributeContent attributeContentItem = attributeContentItems.get(i);
+            final AttributeContent plaintextItem = attributeContentItem;
             AttributeContentItem contentItemEntity = null;
             String encryptedData = null;
             if (attributeDefinition.getProtectionLevel() == ProtectionLevel.ENCRYPTED) {
-                // Encrypted content cannot be deduplicated by its stored json (the placeholder is
-                // identical for every item and the ciphertext is salted) — dedup by decrypting the
-                // items already mapped to this object tuple and comparing plaintext.
-                contentItemEntity = findMappedEncryptedContentItem(attributeDefinition, attributeContentItem, objectAttributeContentInfo);
+                contentItemEntity = findEqualDecryptedItem(decryptedMappedItems, plaintextItem);
                 if (contentItemEntity == null) {
-                    encryptedData = encryptAttributeContent(attributeDefinition, attributeContentItem);
-                    attributeContentItem = AttributeVersionHelper.createEncryptedContent(attributeContentItem.getReference(), attributeDefinition.getContentType(), attributeDefinition.getVersion());
+                    encryptedData = encryptAttributeContent(attributeDefinition, plaintextItem);
+                    attributeContentItem = AttributeVersionHelper.createEncryptedContent(plaintextItem.getReference(), attributeDefinition.getContentType(), attributeDefinition.getVersion());
                 }
             } else {
                 // For non-encrypted attributes, try to find existing content item, since json will be different for different content
@@ -1689,6 +1695,10 @@ public class AttributeEngine {
                 contentItemEntity.setAttributeDefinitionUuid(attributeDefinition.getUuid());
                 contentItemEntity.setEncryptedData(encryptedData);
                 contentItemEntity = attributeContentItemRepository.save(contentItemEntity);
+                if (encryptedData != null) {
+                    // keep within-batch dedup: later equal items in this list must find this one
+                    decryptedMappedItems.add(Map.entry(contentItemEntity, plaintextItem));
+                }
             }
 
             final AttributeContent2Object objectContentItem = new AttributeContent2Object();
@@ -1707,23 +1717,32 @@ public class AttributeEngine {
     }
 
     /**
-     * Locates an already-mapped content item of the definition equal to the incoming item after
-     * decryption — equality requires matching data, reference and content type, so deduplication
-     * only ever merges exact-value resubmissions. Scoped to the target object tuple so the number
-     * of decryptions per write stays bounded by the object's own content, not by every object
-     * sharing the definition.
+     * Loads and decrypts the definition's content items already mapped to the target object, as
+     * (entity, plaintext) pairs — fetched once per write so the per-item deduplication below runs
+     * in memory. Scoped to the object so the number of decryptions stays bounded by the object's
+     * own content, not by every object sharing the definition. Returns a mutable list; the caller
+     * appends items it inserts so equal values later in the same batch deduplicate too.
      */
-    private AttributeContentItem findMappedEncryptedContentItem(AttributeDefinition attributeDefinition, AttributeContent attributeContentItem, ObjectAttributeContentInfo info) {
-        List<AttributeContentItem> mappedItems = attributeContent2ObjectRepository.findMappedContentItems(
-                attributeDefinition.getUuid(), info.objectType(), info.objectUuid());
-        for (AttributeContentItem mappedItem : mappedItems) {
+    private List<Map.Entry<AttributeContentItem, AttributeContent>> loadDecryptedMappedItems(AttributeDefinition attributeDefinition, ObjectAttributeContentInfo info) {
+        List<Map.Entry<AttributeContentItem, AttributeContent>> decryptedItems = new ArrayList<>();
+        for (AttributeContentItem mappedItem : attributeContent2ObjectRepository.findMappedContentItems(attributeDefinition.getUuid(), info.objectType(), info.objectUuid())) {
             if (mappedItem.getEncryptedData() == null) {
                 continue;
             }
-            AttributeContent decrypted = decryptedContentItem(mappedItem.getJson(), attributeDefinition.getVersion(), attributeDefinition.getContentType(), mappedItem.getEncryptedData(),
-                    contentContext(attributeDefinition.getName(), info.objectType(), info.objectUuid()));
-            if (attributeContentEquals(decrypted, attributeContentItem)) {
-                return mappedItem;
+            decryptedItems.add(Map.entry(mappedItem, decryptedContentItem(mappedItem.getJson(), attributeDefinition.getVersion(), attributeDefinition.getContentType(), mappedItem.getEncryptedData(),
+                    contentContext(attributeDefinition.getName(), info.objectType(), info.objectUuid()))));
+        }
+        return decryptedItems;
+    }
+
+    /**
+     * Returns the mapped content item equal to the incoming one — equality requires matching data,
+     * reference and content type, so deduplication only ever merges exact-value resubmissions.
+     */
+    private static AttributeContentItem findEqualDecryptedItem(List<Map.Entry<AttributeContentItem, AttributeContent>> decryptedMappedItems, AttributeContent attributeContentItem) {
+        for (Map.Entry<AttributeContentItem, AttributeContent> decryptedItem : decryptedMappedItems) {
+            if (attributeContentEquals(decryptedItem.getValue(), attributeContentItem)) {
+                return decryptedItem.getKey();
             }
         }
         return null;

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -63,6 +63,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DateTimeException;
 import java.util.*;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -309,7 +310,8 @@ public class AttributeEngine {
         for (ObjectAttributeDefinitionContent objectDefinitionContent : objectDefinitionContents) {
 
             MetadataAttribute definition = (MetadataAttribute) objectDefinitionContent.definition();
-            AttributeContent contentItem = decryptedContentItem(objectDefinitionContent.contentItem(), definition.getVersion(), definition.getContentType(), objectDefinitionContent.encryptedContent());
+            AttributeContent contentItem = decryptedContentItem(objectDefinitionContent.contentItem(), definition.getVersion(), definition.getContentType(), objectDefinitionContent.encryptedContent(),
+                    "metadata attribute " + definition.getName() + " for " + contentInfo.objectType() + " " + contentInfo.objectUuid());
             if (contentItem.getData() == null) {
                 continue;
             }
@@ -337,7 +339,8 @@ public class AttributeEngine {
         Map<UUID, String> connectorMapping = new HashMap<>();
         Map<UUID, Map<Resource, Map<UUID, ResponseMetadata>>> mapping = new HashMap<>();
         for (ObjectAttributeContentDetail objectMetadataContent : objectMetadataContents) {
-            AttributeContent contentItem = decryptedContentItem(objectMetadataContent.contentItem(), objectMetadataContent.version(), objectMetadataContent.contentType(), objectMetadataContent.encryptedContent());
+            AttributeContent contentItem = decryptedContentItem(objectMetadataContent.contentItem(), objectMetadataContent.version(), objectMetadataContent.contentType(), objectMetadataContent.encryptedContent(),
+                    "metadata attribute " + objectMetadataContent.name() + " for " + contentInfo.objectType() + " " + contentInfo.objectUuid());
             // check in case data is null because of malformed data
             if (contentItem.getData() == null) {
                 continue;
@@ -722,18 +725,19 @@ public class AttributeEngine {
 
     /**
      * Returns the content item as stored, or the decrypted item when the definition's protection
-     * level put ciphertext alongside the stored placeholder. A ciphertext that cannot be decrypted
-     * (corrupt value, wrong encryption key) degrades to the stored placeholder — whose {@code data}
-     * is null, so callers treat it as malformed — instead of failing the whole read.
+     * level put ciphertext alongside the stored placeholder. A ciphertext that cannot be decoded,
+     * decrypted or parsed (corrupt value, wrong encryption key) degrades to the stored placeholder —
+     * whose {@code data} is null, so callers treat it as malformed — instead of failing the whole
+     * read. Only those failure types are degraded; unexpected runtime errors propagate.
      */
-    private static AttributeContent decryptedContentItem(AttributeContent contentItem, int version, AttributeContentType contentType, String encryptedContent) {
+    private static AttributeContent decryptedContentItem(AttributeContent contentItem, int version, AttributeContentType contentType, String encryptedContent, String context) {
         if (encryptedContent == null) {
             return contentItem;
         }
         try {
             return AttributeVersionHelper.decryptContent(contentItem, version, contentType, encryptedContent);
-        } catch (RuntimeException e) {
-            logger.warn("Failed to decrypt attribute content item with reference {}: {}", contentItem.getReference(), e.getMessage());
+        } catch (IllegalArgumentException | IllegalStateException | DateTimeException e) {
+            logger.warn("Failed to decrypt content item with reference {} of {}; returning placeholder without data", contentItem.getReference(), context, e);
             return contentItem;
         }
     }
@@ -810,7 +814,8 @@ public class AttributeEngine {
         Map<String, DataAttribute> mapping = new HashMap<>();
         for (ObjectAttributeDefinitionContent objectDefinitionContent : objectDefinitionContents) {
             String uuid = objectDefinitionContent.uuid().toString();
-            AttributeContent contentItem = decryptedContentItem(objectDefinitionContent.contentItem(), objectDefinitionContent.definition().getVersion(), ((DataAttribute) objectDefinitionContent.definition()).getContentType(), objectDefinitionContent.encryptedContent());
+            AttributeContent contentItem = decryptedContentItem(objectDefinitionContent.contentItem(), objectDefinitionContent.definition().getVersion(), ((DataAttribute) objectDefinitionContent.definition()).getContentType(), objectDefinitionContent.encryptedContent(),
+                    "attribute " + objectDefinitionContent.definition().getName() + " for " + objectType + " " + objectUuid);
             // skip malformed items, including undecryptable ciphertext degraded to the placeholder
             if (contentItem.getData() == null) {
                 continue;
@@ -1651,10 +1656,15 @@ public class AttributeEngine {
             AttributeContent attributeContentItem = attributeContentItems.get(i);
             AttributeContentItem contentItemEntity = null;
             String encryptedData = null;
-            // If attribute is encrypted, set data to null before searching for existing content item, since json for encrypted attribute content will always be the same
             if (attributeDefinition.getProtectionLevel() == ProtectionLevel.ENCRYPTED) {
-                encryptedData = encryptAttributeContent(attributeDefinition, attributeContentItem);
-                attributeContentItem = AttributeVersionHelper.createEncryptedContent(attributeContentItem.getReference(), attributeDefinition.getContentType(), attributeDefinition.getVersion());
+                // Encrypted content cannot be deduplicated by its stored json (the placeholder is
+                // identical for every item and the ciphertext is salted) — dedup by decrypting the
+                // items already mapped to this object tuple and comparing plaintext.
+                contentItemEntity = findMappedEncryptedContentItem(attributeDefinition, attributeContentItem, objectAttributeContentInfo);
+                if (contentItemEntity == null) {
+                    encryptedData = encryptAttributeContent(attributeDefinition, attributeContentItem);
+                    attributeContentItem = AttributeVersionHelper.createEncryptedContent(attributeContentItem.getReference(), attributeDefinition.getContentType(), attributeDefinition.getVersion());
+                }
             } else {
                 // For non-encrypted attributes, try to find existing content item, since json will be different for different content
                 contentItemEntity = attributeContentItemRepository.findByJsonAndAttributeDefinitionUuid(attributeContentItem, attributeDefinition.getUuid());
@@ -1694,6 +1704,28 @@ public class AttributeEngine {
             objectContentItem.setAttributeContentItem(contentItemEntity);
             attributeContent2ObjectRepository.save(objectContentItem);
         }
+    }
+
+    /**
+     * Locates an already-mapped content item of the definition whose decrypted value equals the
+     * incoming plaintext item. Scoped to the target object tuple so the number of decryptions per
+     * write stays bounded by the object's own content, not by every object sharing the definition.
+     */
+    private AttributeContentItem findMappedEncryptedContentItem(AttributeDefinition attributeDefinition, AttributeContent attributeContentItem, ObjectAttributeContentInfo info) {
+        List<AttributeContentItem> mappedItems = attributeContent2ObjectRepository.findMappedContentItems(
+                attributeDefinition.getUuid(), info.connectorUuid(), info.objectType(), info.objectUuid(),
+                info.objectVersion(), info.sourceObjectType(), info.sourceObjectUuid(), info.purpose());
+        for (AttributeContentItem mappedItem : mappedItems) {
+            if (mappedItem.getEncryptedData() == null) {
+                continue;
+            }
+            AttributeContent decrypted = decryptedContentItem(mappedItem.getJson(), attributeDefinition.getVersion(), attributeDefinition.getContentType(), mappedItem.getEncryptedData(),
+                    "attribute " + attributeDefinition.getName() + " for " + info.objectType() + " " + info.objectUuid());
+            if (attributeContentEquals(decrypted, attributeContentItem)) {
+                return mappedItem;
+            }
+        }
+        return null;
     }
 
     public static String encryptAttributeContent(AttributeDefinition attributeDefinition, AttributeContent attributeContentItem) throws AttributeException {

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -311,7 +311,7 @@ public class AttributeEngine {
 
             MetadataAttribute definition = (MetadataAttribute) objectDefinitionContent.definition();
             AttributeContent contentItem = decryptedContentItem(objectDefinitionContent.contentItem(), definition.getVersion(), definition.getContentType(), objectDefinitionContent.encryptedContent(),
-                    "metadata attribute " + definition.getName() + " for " + contentInfo.objectType() + " " + contentInfo.objectUuid());
+                    contentContext(definition.getName(), contentInfo.objectType(), contentInfo.objectUuid()));
             if (contentItem.getData() == null) {
                 continue;
             }
@@ -340,7 +340,7 @@ public class AttributeEngine {
         Map<UUID, Map<Resource, Map<UUID, ResponseMetadata>>> mapping = new HashMap<>();
         for (ObjectAttributeContentDetail objectMetadataContent : objectMetadataContents) {
             AttributeContent contentItem = decryptedContentItem(objectMetadataContent.contentItem(), objectMetadataContent.version(), objectMetadataContent.contentType(), objectMetadataContent.encryptedContent(),
-                    "metadata attribute " + objectMetadataContent.name() + " for " + contentInfo.objectType() + " " + contentInfo.objectUuid());
+                    contentContext(objectMetadataContent.name(), contentInfo.objectType(), contentInfo.objectUuid()));
             // check in case data is null because of malformed data
             if (contentItem.getData() == null) {
                 continue;
@@ -815,7 +815,7 @@ public class AttributeEngine {
         for (ObjectAttributeDefinitionContent objectDefinitionContent : objectDefinitionContents) {
             String uuid = objectDefinitionContent.uuid().toString();
             AttributeContent contentItem = decryptedContentItem(objectDefinitionContent.contentItem(), objectDefinitionContent.definition().getVersion(), ((DataAttribute) objectDefinitionContent.definition()).getContentType(), objectDefinitionContent.encryptedContent(),
-                    "attribute " + objectDefinitionContent.definition().getName() + " for " + objectType + " " + objectUuid);
+                    contentContext(objectDefinitionContent.definition().getName(), objectType, objectUuid));
             // skip malformed items, including undecryptable ciphertext degraded to the placeholder
             if (contentItem.getData() == null) {
                 continue;
@@ -1715,19 +1715,22 @@ public class AttributeEngine {
      */
     private AttributeContentItem findMappedEncryptedContentItem(AttributeDefinition attributeDefinition, AttributeContent attributeContentItem, ObjectAttributeContentInfo info) {
         List<AttributeContentItem> mappedItems = attributeContent2ObjectRepository.findMappedContentItems(
-                attributeDefinition.getUuid(), info.connectorUuid(), info.objectType(), info.objectUuid(),
-                info.objectVersion(), info.sourceObjectType(), info.sourceObjectUuid(), info.purpose());
+                attributeDefinition.getUuid(), info.objectType(), info.objectUuid());
         for (AttributeContentItem mappedItem : mappedItems) {
             if (mappedItem.getEncryptedData() == null) {
                 continue;
             }
             AttributeContent decrypted = decryptedContentItem(mappedItem.getJson(), attributeDefinition.getVersion(), attributeDefinition.getContentType(), mappedItem.getEncryptedData(),
-                    "attribute " + attributeDefinition.getName() + " for " + info.objectType() + " " + info.objectUuid());
+                    contentContext(attributeDefinition.getName(), info.objectType(), info.objectUuid()));
             if (attributeContentEquals(decrypted, attributeContentItem)) {
                 return mappedItem;
             }
         }
         return null;
+    }
+
+    private static String contentContext(String attributeName, Resource objectType, UUID objectUuid) {
+        return "attribute " + attributeName + " for " + objectType + " " + objectUuid;
     }
 
     public static String encryptAttributeContent(AttributeDefinition attributeDefinition, AttributeContent attributeContentItem) throws AttributeException {

--- a/src/main/java/com/otilm/core/attribute/engine/records/ObjectAttributeContentDetail.java
+++ b/src/main/java/com/otilm/core/attribute/engine/records/ObjectAttributeContentDetail.java
@@ -19,6 +19,7 @@ public record ObjectAttributeContentDetail(
     Resource sourceObjectType,
     UUID sourceObjectUuid,
     String sourceObjectName,
-    int version
+    int version,
+    String encryptedContent
 )
 {}

--- a/src/main/java/com/otilm/core/attribute/engine/records/ObjectAttributeDefinitionContent.java
+++ b/src/main/java/com/otilm/core/attribute/engine/records/ObjectAttributeDefinitionContent.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 public record ObjectAttributeDefinitionContent(
     UUID uuid,
     BaseAttribute definition,
-    AttributeContent contentItem
+    AttributeContent contentItem,
+    String encryptedContent
 )
 {}

--- a/src/main/java/com/otilm/core/dao/repository/AttributeContent2ObjectRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/AttributeContent2ObjectRepository.java
@@ -175,7 +175,7 @@ public interface AttributeContent2ObjectRepository extends SecurityFilterReposit
 
     @Query("""
             SELECT new com.otilm.core.attribute.engine.records.ObjectAttributeContentDetail(
-                ad.attributeUuid, ad.name, ad.label, ad.type, ad.contentType, aci.json, aco.connectorUuid, c.name, aco.sourceObjectType, aco.sourceObjectUuid, aco.sourceObjectName, ad.version)
+                ad.attributeUuid, ad.name, ad.label, ad.type, ad.contentType, aci.json, aco.connectorUuid, c.name, aco.sourceObjectType, aco.sourceObjectUuid, aco.sourceObjectName, ad.version, aci.encryptedData)
                 FROM AttributeContent2Object aco
                 LEFT JOIN Connector c ON c.uuid = aco.connectorUuid
                 JOIN AttributeContentItem aci ON aci.uuid = aco.attributeContentItemUuid
@@ -198,7 +198,7 @@ public interface AttributeContent2ObjectRepository extends SecurityFilterReposit
 
     @Query("""
             SELECT new com.otilm.core.attribute.engine.records.ObjectAttributeDefinitionContent(
-                ad.attributeUuid, ad.definition, aci.json)
+                ad.attributeUuid, ad.definition, aci.json, aci.encryptedData)
                 FROM AttributeContent2Object aco
                 JOIN AttributeContentItem aci ON aci.uuid = aco.attributeContentItemUuid
                 JOIN AttributeDefinition ad ON ad.uuid = aci.attributeDefinitionUuid

--- a/src/main/java/com/otilm/core/dao/repository/AttributeContent2ObjectRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/AttributeContent2ObjectRepository.java
@@ -6,6 +6,7 @@ import com.otilm.core.attribute.engine.records.ObjectAttributeContent;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentDetail;
 import com.otilm.core.attribute.engine.records.ObjectAttributeDefinitionContent;
 import com.otilm.core.dao.entity.AttributeContent2Object;
+import com.otilm.core.dao.entity.AttributeContentItem;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -172,6 +173,35 @@ public interface AttributeContent2ObjectRepository extends SecurityFilterReposit
                 ORDER BY aci.attributeDefinitionUuid, aco.order
             """)
     List<ObjectAttributeContent> getAllObjectDataAttributesContent(@Param("objectType") Resource objectType, @Param("objectUuid") UUID objectUuid);
+
+    /**
+     * Returns the content items of one attribute definition that are already mapped to the given
+     * object tuple. Nullable parameters use the same null-safe matching idiom as
+     * {@link #findExistingContentMapping}. Used to deduplicate encrypted content, whose salted
+     * ciphertext cannot be compared by value — the caller decrypts this (small, object-scoped) set
+     * and compares plaintext.
+     */
+    @Query("""
+            SELECT aci FROM AttributeContent2Object aco
+                JOIN AttributeContentItem aci ON aci.uuid = aco.attributeContentItemUuid
+                WHERE aci.attributeDefinitionUuid = :definitionUuid
+                    AND ((:connectorUuid IS NULL AND aco.connectorUuid IS NULL) OR aco.connectorUuid = :connectorUuid)
+                    AND aco.objectType = :objectType
+                    AND aco.objectUuid = :objectUuid
+                    AND ((:objectVersion IS NULL AND aco.objectVersion IS NULL) OR aco.objectVersion = :objectVersion)
+                    AND ((:sourceObjectType IS NULL AND aco.sourceObjectType IS NULL) OR aco.sourceObjectType = :sourceObjectType)
+                    AND ((:sourceObjectUuid IS NULL AND aco.sourceObjectUuid IS NULL) OR aco.sourceObjectUuid = :sourceObjectUuid)
+                    AND ((:purpose IS NULL AND aco.purpose IS NULL) OR aco.purpose = :purpose)
+            """)
+    List<AttributeContentItem> findMappedContentItems(
+            @Param("definitionUuid") UUID definitionUuid,
+            @Param("connectorUuid") UUID connectorUuid,
+            @Param("objectType") Resource objectType,
+            @Param("objectUuid") UUID objectUuid,
+            @Param("objectVersion") Integer objectVersion,
+            @Param("sourceObjectType") Resource sourceObjectType,
+            @Param("sourceObjectUuid") UUID sourceObjectUuid,
+            @Param("purpose") String purpose);
 
     @Query("""
             SELECT new com.otilm.core.attribute.engine.records.ObjectAttributeContentDetail(

--- a/src/main/java/com/otilm/core/dao/repository/AttributeContent2ObjectRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/AttributeContent2ObjectRepository.java
@@ -176,32 +176,22 @@ public interface AttributeContent2ObjectRepository extends SecurityFilterReposit
 
     /**
      * Returns the content items of one attribute definition that are already mapped to the given
-     * object tuple. Nullable parameters use the same null-safe matching idiom as
-     * {@link #findExistingContentMapping}. Used to deduplicate encrypted content, whose salted
-     * ciphertext cannot be compared by value — the caller decrypts this (small, object-scoped) set
-     * and compares plaintext.
+     * object, regardless of the mapping's connector/version/source/purpose — callers that need the
+     * exact tuple still guard with {@link #findExistingContentMapping} before skipping an insert.
+     * Used to deduplicate encrypted content, whose salted ciphertext cannot be compared by value —
+     * the caller decrypts this (small, object-scoped) set and compares plaintext.
      */
     @Query("""
-            SELECT aci FROM AttributeContent2Object aco
+            SELECT DISTINCT aci FROM AttributeContent2Object aco
                 JOIN AttributeContentItem aci ON aci.uuid = aco.attributeContentItemUuid
                 WHERE aci.attributeDefinitionUuid = :definitionUuid
-                    AND ((:connectorUuid IS NULL AND aco.connectorUuid IS NULL) OR aco.connectorUuid = :connectorUuid)
                     AND aco.objectType = :objectType
                     AND aco.objectUuid = :objectUuid
-                    AND ((:objectVersion IS NULL AND aco.objectVersion IS NULL) OR aco.objectVersion = :objectVersion)
-                    AND ((:sourceObjectType IS NULL AND aco.sourceObjectType IS NULL) OR aco.sourceObjectType = :sourceObjectType)
-                    AND ((:sourceObjectUuid IS NULL AND aco.sourceObjectUuid IS NULL) OR aco.sourceObjectUuid = :sourceObjectUuid)
-                    AND ((:purpose IS NULL AND aco.purpose IS NULL) OR aco.purpose = :purpose)
             """)
     List<AttributeContentItem> findMappedContentItems(
             @Param("definitionUuid") UUID definitionUuid,
-            @Param("connectorUuid") UUID connectorUuid,
             @Param("objectType") Resource objectType,
-            @Param("objectUuid") UUID objectUuid,
-            @Param("objectVersion") Integer objectVersion,
-            @Param("sourceObjectType") Resource sourceObjectType,
-            @Param("sourceObjectUuid") UUID sourceObjectUuid,
-            @Param("purpose") String purpose);
+            @Param("objectUuid") UUID objectUuid);
 
     @Query("""
             SELECT new com.otilm.core.attribute.engine.records.ObjectAttributeContentDetail(

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
@@ -1207,6 +1207,71 @@ class AttributeEngineITest extends BaseSpringBootTest {
     }
 
     @Test
+    void updateMetadataAttributeDefinition_decryptsExistingContentOnProtectionLevelDowngrade() throws AttributeException {
+        // given: metadata registered as ENCRYPTED with stored content
+        MetadataAttributeV3 metadataAttribute = new MetadataAttributeV3();
+        metadataAttribute.setUuid(UUID.randomUUID().toString());
+        metadataAttribute.setName("downgradedMeta");
+        metadataAttribute.setType(AttributeType.META);
+        metadataAttribute.setContentType(AttributeContentType.STRING);
+        MetadataAttributeProperties props = new MetadataAttributeProperties();
+        props.setLabel("Downgraded Meta");
+        props.setVisible(true);
+        props.setProtectionLevel(ProtectionLevel.ENCRYPTED);
+        metadataAttribute.setProperties(props);
+        metadataAttribute.setContent(List.of(new StringAttributeContentV3("protected-then-plain")));
+
+        ObjectAttributeContentInfo contentInfo = ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(connectorAuthority.getUuid()).build();
+        attributeEngine.updateMetadataAttribute(metadataAttribute, contentInfo);
+
+        // when: the connector re-registers the same metadata declaring NONE
+        props.setProtectionLevel(ProtectionLevel.NONE);
+        attributeEngine.updateMetadataAttributeDefinition(metadataAttribute, connectorAuthority.getUuid());
+
+        // then: the definition carries the new level and stored content is decrypted in place
+        AttributeDefinition definition = attributeDefinitionRepository.findByConnectorUuidAndAttributeUuid(connectorAuthority.getUuid(), UUID.fromString(metadataAttribute.getUuid())).orElseThrow();
+        Assertions.assertEquals(ProtectionLevel.NONE, definition.getProtectionLevel());
+        AttributeContentItem downgradedItem = attributeContentItemRepository.findByAttributeDefinitionUuid(definition.getUuid()).getFirst();
+        Assertions.assertNull(downgradedItem.getEncryptedData(), "ciphertext must be cleared on protection-level downgrade");
+        Assertions.assertEquals("protected-then-plain", downgradedItem.getJson().getData(), "stored json must hold the decrypted value");
+
+        // and: the value still reads back
+        MetadataAttribute readAttribute = attributeEngine.getMetadataAttributesDefinitionContent(contentInfo).stream()
+                .filter(a -> a.getName().equals(metadataAttribute.getName())).findFirst().orElseThrow();
+        List<AttributeContent> readContent = readAttribute.getContent();
+        Assertions.assertEquals("protected-then-plain", readContent.getFirst().getData());
+    }
+
+    @Test
+    void updateMetadataAttribute_deduplicatesRepeatedEncryptedContent() throws AttributeException {
+        MetadataAttributeV3 metadataAttribute = new MetadataAttributeV3();
+        metadataAttribute.setUuid(UUID.randomUUID().toString());
+        metadataAttribute.setName("dedupEncryptedMeta");
+        metadataAttribute.setType(AttributeType.META);
+        metadataAttribute.setContentType(AttributeContentType.STRING);
+        MetadataAttributeProperties props = new MetadataAttributeProperties();
+        props.setLabel("Dedup Encrypted Meta");
+        props.setVisible(true);
+        props.setProtectionLevel(ProtectionLevel.ENCRYPTED);
+        metadataAttribute.setProperties(props);
+        metadataAttribute.setContent(List.of(new StringAttributeContentV3("same-encrypted-value")));
+
+        // the same encrypted metadata registered repeatedly for the same object must not accumulate rows
+        ObjectAttributeContentInfo contentInfo = ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(connectorAuthority.getUuid()).build();
+        attributeEngine.updateMetadataAttribute(metadataAttribute, contentInfo);
+        attributeEngine.updateMetadataAttribute(metadataAttribute, contentInfo);
+
+        AttributeDefinition definition = attributeDefinitionRepository.findByConnectorUuidAndAttributeUuid(connectorAuthority.getUuid(), UUID.fromString(metadataAttribute.getUuid())).orElseThrow();
+        Assertions.assertEquals(1, attributeContentItemRepository.findByAttributeDefinitionUuid(definition.getUuid()).size(),
+                "re-registering identical encrypted content must reuse the existing content item");
+
+        // different content must still create a second item
+        metadataAttribute.setContent(List.of(new StringAttributeContentV3("different-encrypted-value")));
+        attributeEngine.updateMetadataAttribute(metadataAttribute, contentInfo);
+        Assertions.assertEquals(2, attributeContentItemRepository.findByAttributeDefinitionUuid(definition.getUuid()).size());
+    }
+
+    @Test
     void metadataReadsSkipContentItemsWithUndecryptableCiphertext() throws AttributeException {
         MetadataAttributeV3 metadataAttribute = new MetadataAttributeV3();
         metadataAttribute.setUuid(UUID.randomUUID().toString());

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
@@ -1092,6 +1092,111 @@ class AttributeEngineITest extends BaseSpringBootTest {
     }
 
     @Test
+    void updateMetadataAttribute_encryptedProtectionLevelStoresContentEncryptedAtRest() throws AttributeException {
+        MetadataAttributeV3 metadataAttribute = new MetadataAttributeV3();
+        metadataAttribute.setUuid(UUID.randomUUID().toString());
+        metadataAttribute.setName("encryptedMeta");
+        metadataAttribute.setType(AttributeType.META);
+        metadataAttribute.setContentType(AttributeContentType.STRING);
+        MetadataAttributeProperties props = new MetadataAttributeProperties();
+        props.setLabel("Encrypted Meta");
+        props.setVisible(true);
+        props.setProtectionLevel(ProtectionLevel.ENCRYPTED);
+        metadataAttribute.setProperties(props);
+        metadataAttribute.setContent(List.of(new StringAttributeContentV3("sensitive-meta-value")));
+
+        ObjectAttributeContentInfo contentInfo = ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(connectorAuthority.getUuid()).build();
+        attributeEngine.updateMetadataAttribute(metadataAttribute, contentInfo);
+
+        AttributeDefinition definition = attributeDefinitionRepository.findByConnectorUuidAndAttributeUuid(connectorAuthority.getUuid(), UUID.fromString(metadataAttribute.getUuid())).orElseThrow();
+        Assertions.assertEquals(ProtectionLevel.ENCRYPTED, definition.getProtectionLevel(), "declared metadata protection level must be persisted on the definition");
+
+        AttributeContentItem contentItem = attributeContentItemRepository.findByAttributeDefinitionUuid(definition.getUuid()).getFirst();
+        Assertions.assertNotNull(contentItem.getEncryptedData(), "metadata content declared ENCRYPTED must be encrypted at rest");
+        Assertions.assertNull(contentItem.getJson().getData(), "stored json must be the encrypted-content placeholder, not plaintext");
+
+        MetadataAttribute readAttribute = attributeEngine.getMetadataAttributesDefinitionContent(contentInfo).stream()
+                .filter(a -> a.getName().equals(metadataAttribute.getName())).findFirst().orElseThrow();
+        List<AttributeContent> readContent = readAttribute.getContent();
+        Assertions.assertEquals("sensitive-meta-value", readContent.getFirst().getData(), "definition content read must return the decrypted value");
+
+        var mappedItem = attributeEngine.getMappedMetadataContent(contentInfo).stream()
+                .flatMap(dto -> dto.getItems().stream())
+                .filter(item -> item.getName().equals(metadataAttribute.getName())).findFirst().orElseThrow();
+        Assertions.assertEquals("sensitive-meta-value", mappedItem.getContent().getFirst().getData(), "mapped metadata read must return the decrypted value");
+    }
+
+    @Test
+    void updateMetadataAttributeDefinition_encryptsExistingContentOnProtectionLevelUpgrade() throws AttributeException {
+        // given: metadata registered without protection — plaintext content at rest (the legacy state)
+        MetadataAttributeV3 metadataAttribute = new MetadataAttributeV3();
+        metadataAttribute.setUuid(UUID.randomUUID().toString());
+        metadataAttribute.setName("upgradedMeta");
+        metadataAttribute.setType(AttributeType.META);
+        metadataAttribute.setContentType(AttributeContentType.STRING);
+        MetadataAttributeProperties props = new MetadataAttributeProperties();
+        props.setLabel("Upgraded Meta");
+        props.setVisible(true);
+        // an explicitly null declared level must be treated as NONE
+        props.setProtectionLevel(null);
+        metadataAttribute.setProperties(props);
+        metadataAttribute.setContent(List.of(new StringAttributeContentV3("previously-plaintext")));
+
+        ObjectAttributeContentInfo contentInfo = ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(connectorAuthority.getUuid()).build();
+        attributeEngine.updateMetadataAttribute(metadataAttribute, contentInfo);
+
+        AttributeDefinition definition = attributeDefinitionRepository.findByConnectorUuidAndAttributeUuid(connectorAuthority.getUuid(), UUID.fromString(metadataAttribute.getUuid())).orElseThrow();
+        AttributeContentItem plaintextItem = attributeContentItemRepository.findByAttributeDefinitionUuid(definition.getUuid()).getFirst();
+        Assertions.assertNull(plaintextItem.getEncryptedData());
+        Assertions.assertEquals("previously-plaintext", plaintextItem.getJson().getData());
+
+        // when: the connector re-registers the same metadata now declaring ENCRYPTED
+        props.setProtectionLevel(ProtectionLevel.ENCRYPTED);
+        attributeEngine.updateMetadataAttributeDefinition(metadataAttribute, connectorAuthority.getUuid());
+
+        // then: the definition carries the new level and already-stored plaintext is encrypted
+        definition = attributeDefinitionRepository.findByConnectorUuidAndAttributeUuid(connectorAuthority.getUuid(), UUID.fromString(metadataAttribute.getUuid())).orElseThrow();
+        Assertions.assertEquals(ProtectionLevel.ENCRYPTED, definition.getProtectionLevel());
+        AttributeContentItem healedItem = attributeContentItemRepository.findByAttributeDefinitionUuid(definition.getUuid()).getFirst();
+        Assertions.assertNotNull(healedItem.getEncryptedData(), "already-stored plaintext must be encrypted on protection-level upgrade");
+        Assertions.assertNull(healedItem.getJson().getData(), "plaintext json must be replaced by the encrypted-content placeholder");
+
+        // and: the value still reads back decrypted
+        MetadataAttribute readAttribute = attributeEngine.getMetadataAttributesDefinitionContent(contentInfo).stream()
+                .filter(a -> a.getName().equals(metadataAttribute.getName())).findFirst().orElseThrow();
+        List<AttributeContent> readContent = readAttribute.getContent();
+        Assertions.assertEquals("previously-plaintext", readContent.getFirst().getData());
+    }
+
+    @Test
+    void getDefinitionObjectAttributeContentDecryptsEncryptedContent() throws AttributeException, NotFoundException {
+        DataAttributeV3 secretAttribute = new DataAttributeV3();
+        secretAttribute.setUuid(UUID.randomUUID().toString());
+        secretAttribute.setName("encryptedDefinitionContent");
+        secretAttribute.setType(AttributeType.DATA);
+        secretAttribute.setContentType(AttributeContentType.STRING);
+        DataAttributeProperties properties = new DataAttributeProperties();
+        properties.setProtectionLevel(ProtectionLevel.ENCRYPTED);
+        properties.setLabel("Encrypted Definition Content");
+        secretAttribute.setProperties(properties);
+        attributeEngine.updateDataAttributeDefinitions(connectorAuthority.getUuid(), null, List.of(secretAttribute));
+
+        RequestAttributeV3 requestAttribute = new RequestAttributeV3();
+        requestAttribute.setUuid(UUID.fromString(secretAttribute.getUuid()));
+        requestAttribute.setName(secretAttribute.getName());
+        requestAttribute.setContentType(secretAttribute.getContentType());
+        requestAttribute.setContent(List.of(new StringAttributeContentV3("encrypted-at-rest")));
+        attributeEngine.updateObjectDataAttributesContent(
+                ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(connectorAuthority.getUuid()).build(),
+                List.of(requestAttribute));
+
+        DataAttribute readAttribute = attributeEngine.getDefinitionObjectAttributeContent(AttributeType.DATA, connectorAuthority.getUuid(), null, Resource.CERTIFICATE, certificate.getUuid()).stream()
+                .filter(a -> a.getName().equals(secretAttribute.getName())).findFirst().orElseThrow();
+        List<AttributeContent> readContent = readAttribute.getContent();
+        Assertions.assertEquals("encrypted-at-rest", readContent.getFirst().getData(), "definition object content read must return the decrypted value");
+    }
+
+    @Test
     void getRequestDataAttributesContentReturnsCorrectResponse() throws AttributeException {
         // Arrange
         DataAttributeV2 dataAttribute = new DataAttributeV2();

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
@@ -1262,6 +1262,16 @@ class AttributeEngineITest extends BaseSpringBootTest {
                 .filter(a -> a.getName().equals(secretAttribute.getName())).findFirst().orElseThrow();
         List<AttributeContent> readContent = readAttribute.getContent();
         Assertions.assertEquals("encrypted-at-rest", readContent.getFirst().getData(), "definition object content read must return the decrypted value");
+
+        // an undecryptable ciphertext must not fail the read or surface the null-data placeholder
+        AttributeDefinition definition = attributeDefinitionRepository.findByConnectorUuidAndAttributeUuid(connectorAuthority.getUuid(), UUID.fromString(secretAttribute.getUuid())).orElseThrow();
+        AttributeContentItem contentItem = attributeContentItemRepository.findByAttributeDefinitionUuid(definition.getUuid()).getFirst();
+        contentItem.setEncryptedData("not-a-valid-secret");
+        attributeContentItemRepository.save(contentItem);
+
+        List<DataAttribute> degradedRead = Assertions.assertDoesNotThrow(() -> attributeEngine.getDefinitionObjectAttributeContent(AttributeType.DATA, connectorAuthority.getUuid(), null, Resource.CERTIFICATE, certificate.getUuid()));
+        Assertions.assertTrue(degradedRead.stream().noneMatch(a -> a.getName().equals(secretAttribute.getName())),
+                "the item with undecryptable ciphertext must be skipped, not returned with null data");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
@@ -1207,6 +1207,36 @@ class AttributeEngineITest extends BaseSpringBootTest {
     }
 
     @Test
+    void metadataReadsSkipContentItemsWithUndecryptableCiphertext() throws AttributeException {
+        MetadataAttributeV3 metadataAttribute = new MetadataAttributeV3();
+        metadataAttribute.setUuid(UUID.randomUUID().toString());
+        metadataAttribute.setName("corruptCiphertextMeta");
+        metadataAttribute.setType(AttributeType.META);
+        metadataAttribute.setContentType(AttributeContentType.STRING);
+        MetadataAttributeProperties props = new MetadataAttributeProperties();
+        props.setLabel("Corrupt Ciphertext Meta");
+        props.setVisible(true);
+        props.setProtectionLevel(ProtectionLevel.ENCRYPTED);
+        metadataAttribute.setProperties(props);
+        metadataAttribute.setContent(List.of(new StringAttributeContentV3("will-be-corrupted")));
+
+        ObjectAttributeContentInfo contentInfo = ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(connectorAuthority.getUuid()).build();
+        attributeEngine.updateMetadataAttribute(metadataAttribute, contentInfo);
+
+        AttributeDefinition definition = attributeDefinitionRepository.findByConnectorUuidAndAttributeUuid(connectorAuthority.getUuid(), UUID.fromString(metadataAttribute.getUuid())).orElseThrow();
+        AttributeContentItem contentItem = attributeContentItemRepository.findByAttributeDefinitionUuid(definition.getUuid()).getFirst();
+        contentItem.setEncryptedData("not-a-valid-secret");
+        attributeContentItemRepository.save(contentItem);
+
+        // a single undecryptable ciphertext must not fail the whole read; the item degrades to the placeholder and is skipped
+        List<MetadataAttribute> definitionContent = Assertions.assertDoesNotThrow(() -> attributeEngine.getMetadataAttributesDefinitionContent(contentInfo));
+        Assertions.assertTrue(definitionContent.stream().noneMatch(a -> a.getName().equals(metadataAttribute.getName())));
+
+        List<MetadataResponseDto> mappedMetadata = Assertions.assertDoesNotThrow(() -> attributeEngine.getMappedMetadataContent(contentInfo));
+        Assertions.assertTrue(mappedMetadata.stream().flatMap(dto -> dto.getItems().stream()).noneMatch(item -> item.getName().equals(metadataAttribute.getName())));
+    }
+
+    @Test
     void getDefinitionObjectAttributeContentDecryptsEncryptedContent() throws AttributeException, NotFoundException {
         DataAttributeV3 secretAttribute = new DataAttributeV3();
         secretAttribute.setUuid(UUID.randomUUID().toString());

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
@@ -1146,6 +1146,8 @@ class AttributeEngineITest extends BaseSpringBootTest {
         attributeEngine.updateMetadataAttribute(metadataAttribute, contentInfo);
 
         AttributeDefinition definition = attributeDefinitionRepository.findByConnectorUuidAndAttributeUuid(connectorAuthority.getUuid(), UUID.fromString(metadataAttribute.getUuid())).orElseThrow();
+        Assertions.assertEquals(ProtectionLevel.NONE, ((MetadataAttribute) definition.getDefinition()).getProperties().getProtectionLevel(),
+                "persisted definition must carry the normalized protection level, not the declared null");
         AttributeContentItem plaintextItem = attributeContentItemRepository.findByAttributeDefinitionUuid(definition.getUuid()).getFirst();
         Assertions.assertNull(plaintextItem.getEncryptedData());
         Assertions.assertEquals("previously-plaintext", plaintextItem.getJson().getData());
@@ -1166,6 +1168,42 @@ class AttributeEngineITest extends BaseSpringBootTest {
                 .filter(a -> a.getName().equals(metadataAttribute.getName())).findFirst().orElseThrow();
         List<AttributeContent> readContent = readAttribute.getContent();
         Assertions.assertEquals("previously-plaintext", readContent.getFirst().getData());
+    }
+
+    @Test
+    void updateMetadataAttributeDefinition_encryptsExistingContentWithVersionAwarePlaceholderForV2() throws AttributeException {
+        // given: a version 2 metadata attribute registered without protection — plaintext at rest
+        MetadataAttributeV2 metadataAttribute = new MetadataAttributeV2();
+        metadataAttribute.setUuid(UUID.randomUUID().toString());
+        metadataAttribute.setName("upgradedMetaV2");
+        metadataAttribute.setType(AttributeType.META);
+        metadataAttribute.setContentType(AttributeContentType.STRING);
+        MetadataAttributeProperties props = new MetadataAttributeProperties();
+        props.setLabel("Upgraded Meta V2");
+        props.setVisible(true);
+        metadataAttribute.setProperties(props);
+        metadataAttribute.setContent(List.of(new StringAttributeContentV2("v2-plaintext")));
+
+        ObjectAttributeContentInfo contentInfo = ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(connectorAuthority.getUuid()).build();
+        attributeEngine.updateMetadataAttribute(metadataAttribute, contentInfo);
+
+        // when: the connector re-registers the same metadata declaring ENCRYPTED
+        props.setProtectionLevel(ProtectionLevel.ENCRYPTED);
+        attributeEngine.updateMetadataAttributeDefinition(metadataAttribute, connectorAuthority.getUuid());
+
+        // then: the placeholder matches the definition version instead of being hard-coded to v3
+        AttributeDefinition definition = attributeDefinitionRepository.findByConnectorUuidAndAttributeUuid(connectorAuthority.getUuid(), UUID.fromString(metadataAttribute.getUuid())).orElseThrow();
+        AttributeContentItem healedItem = attributeContentItemRepository.findByAttributeDefinitionUuid(definition.getUuid()).getFirst();
+        Assertions.assertNotNull(healedItem.getEncryptedData());
+        Assertions.assertInstanceOf(BaseAttributeContentV2.class, healedItem.getJson(),
+                "encrypted-content placeholder of a v2 definition must be a v2 content item");
+        Assertions.assertNull(healedItem.getJson().getData());
+
+        // and: the value still reads back decrypted
+        MetadataAttribute readAttribute = attributeEngine.getMetadataAttributesDefinitionContent(contentInfo).stream()
+                .filter(a -> a.getName().equals(metadataAttribute.getName())).findFirst().orElseThrow();
+        List<AttributeContent> readContent = readAttribute.getContent();
+        Assertions.assertEquals("v2-plaintext", readContent.getFirst().getData());
     }
 
     @Test


### PR DESCRIPTION
The protection level declared in metadata attribute properties is now persisted on the attribute definition when the definition is created or updated, so metadata content declared as encrypted is stored encrypted at rest. A declared level of null is treated as none.

When the declared protection level diverges from the persisted one, already stored content items of the definition are re-protected accordingly: encrypted on upgrade to encrypted, decrypted on downgrade.

The metadata read projections now carry the content item ciphertext, and encrypted content is decrypted when returning metadata content, mapped metadata, and definition object attribute content.