### PR TITLE
Validate fieldMapping regardless of operation

### DIFF
--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -592,12 +592,10 @@ public class AttributeEngine {
     private void updateDataAttributeDefinition(UUID connectorUuid, String operation, DataAttribute dataAttribute, Supplier<Map<String, String>> codeToOidMap) throws AttributeException {
         validateAttributeDefinition(dataAttribute, connectorUuid);
         if (dataAttribute instanceof DataAttributeV3 v3 && v3.getFieldMapping() != null) {
-            if (isRequestOperation(operation)) {
-                validateFieldMapping(v3, connectorUuid != null ? connectorUuid.toString() : null, codeToOidMap);
-            } else {
-                logger.warn("DataAttribute '{}' has fieldMapping but is registered outside a request operation context (operation={}); fieldMapping validation skipped",
-                        dataAttribute.getName(), operation);
-            }
+            // A fieldMapping declares projection intent; a malformed one is an authoring error whatever
+            // operation the definition registers under (issuance definitions register with operation=null),
+            // so validity is intrinsic to the definition and not gated on the operation.
+            validateFieldMapping(v3, connectorUuid != null ? connectorUuid.toString() : null, codeToOidMap);
         }
 
         // find by connector uuid and name only because attribute uuid could be generated when data attribute was migrated from RequestAttribute
@@ -1242,11 +1240,6 @@ public class AttributeEngine {
             if (!hasCallback && !hasCoreValueSource)
                 throw new AttributeException("Attribute with Resource Content Type is missing callback", attribute.getUuid(), attribute.getName(), attribute.getType(), connectorUuidStr);
         }
-    }
-
-    private static boolean isRequestOperation(String operation) {
-        return AttributeOperation.CERTIFICATE_ISSUE.equals(operation)
-                || AttributeOperation.SIGN.equals(operation);
     }
 
     private static Supplier<Map<String, String>> lazyCodeToOidMap() {

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
@@ -1622,11 +1622,13 @@ class AttributeEngineITest extends BaseSpringBootTest {
             Assertions.assertTrue(ex.getMessage().contains("fieldMapping is only valid for attributes with STRING or TEXT content type"), ex::getMessage);
         }
 
-        // ── isRequestOperation gating ─────────────────────────────────────────────
+        // ── fieldMapping validated regardless of operation ───────────────────────
 
         @Test
-        void testFieldMapping_nonRequestOperation_skipsValidation() {
-            // Invalid fieldMapping (no objectType) should NOT throw when operation is not a request operation
+        void testFieldMapping_nonRequestOperation_validatesFieldMapping() {
+            // A fieldMapping declares projection intent; a malformed one is an authoring error
+            // whatever operation the definition registers under (issuance definitions register
+            // with operation=null), so validation must not be gated on the operation
             DataAttributeV3 attr = fieldMappingAttribute("fm_non_req_op");
             FieldMapping fm = new FieldMapping();
             fm.setObjectType(null);
@@ -1634,9 +1636,9 @@ class AttributeEngineITest extends BaseSpringBootTest {
             attr.setFieldMapping(fm);
 
             UUID connectorUuid = connectorAuthority.getUuid();
-            // null operation → skips validateFieldMapping, so no exception
-            Assertions.assertDoesNotThrow(
+            AttributeException ex = Assertions.assertThrows(AttributeException.class,
                     () -> attributeEngine.updateDataAttributeDefinitions(connectorUuid, null, List.of(attr)));
+            Assertions.assertTrue(ex.getMessage().contains("fieldMapping.objectType is required"), ex::getMessage);
         }
 
         @Test

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
@@ -1642,6 +1642,18 @@ class AttributeEngineITest extends BaseSpringBootTest {
         }
 
         @Test
+        void testFieldMapping_nonRequestOperation_acceptsValidMapping() {
+            // The register build registers issuance definitions with operation=null; a well-formed
+            // mapping must be accepted there, not merely rejected when malformed
+            DataAttributeV3 attr = fieldMappingAttribute("fm_non_req_op_valid");
+            attr.setFieldMapping(fieldMappingWith(rdnField("CN")));
+
+            UUID connectorUuid = connectorAuthority.getUuid();
+            Assertions.assertDoesNotThrow(
+                    () -> attributeEngine.updateDataAttributeDefinitions(connectorUuid, null, List.of(attr)));
+        }
+
+        @Test
         void testFieldMapping_signOperation_validatesFieldMapping() {
             DataAttributeV3 attr = fieldMappingAttribute("fm_sign_op");
             FieldMapping fm = new FieldMapping();


### PR DESCRIPTION
Fixes #1850.

### Problem

`validateFieldMapping` was gated on `isRequestOperation(operation)` — only `certificateIssue` and `sign` triggered it. The register build (and the platform-built CSR path) call `validateUpdateDataAttributes(null, null, definitions, csrAttributes)` with a null operation, so a malformed `fieldMapping` on an issuance definition passed silently through pre-registration, and every structured registration logged a "fieldMapping validation skipped" warning.

### Fix

Validate `fieldMapping` unconditionally whenever a registered definition carries one. The operation gate, the skip-branch warning, and `isRequestOperation` are removed.

The rationale: whether a `fieldMapping` is well-formed is intrinsic to the definition — a malformed mapping is an authoring error regardless of which operation the definition registers under. Gating validation on caller-supplied context is exactly what caused this bug, and any variant of it keeps the failure mode.

### Why not the alternatives

- **Passing a request operation on the register path** (the fix suggested in the issue) is unsafe. The `operation` value is persisted: new definition rows are created with it, and `validateDataAttributesContent` overwrites the stored operation on definitions it loads by request attribute. The stored operation is load-bearing — `AttributeContent2ObjectRepository` joins content reads through `ad.operation`, and csrAttributes content on `CERTIFICATE_REQUEST` is written and read with `operation=null`. Retagging the issuance definitions would make those null-operation reads come back empty.

### Behavior change

Registration of any fieldMapping-bearing definition — including connector-supplied attributes under non-request operations — now rejects a malformed mapping instead of warn-and-tolerate. `fieldMapping` is a recent v3 feature (gate introduced in #1655), so no deployed connectors are expected to be affected; if one is, the failure is loud and names the attribute and defect, and the mapping would have misbehaved at projection time anyway.

### Tests

`testFieldMapping_nonRequestOperation_skipsValidation` is flipped to `testFieldMapping_nonRequestOperation_validatesFieldMapping`: a malformed mapping now throws under `operation=null`, which is the register path's exact shape. The remaining `ValidateMappedField` suite is unchanged and still passes.