### PR TITLE
Persist registered SAN and surface dropped extensions on pre-registration

### DIFF
--- a/src/main/java/com/otilm/core/certificate/request/RegisterWireBuilder.java
+++ b/src/main/java/com/otilm/core/certificate/request/RegisterWireBuilder.java
@@ -56,9 +56,7 @@ public final class RegisterWireBuilder {
      */
     public static X509RequestContent buildContent(String subjectDn, String subjectAltName,
                                                   List<CertificateExtension> extensions) {
-        X509RequestContent content = new X509RequestContent();
-        content.setCertificateType(CertificateType.X509);
-        content.setSubject(parseSubject(subjectDn));
+        X509RequestContent content = buildIdentityContent(subjectDn);
         content.setSubjectAltNames(parseSubjectAltName(subjectAltName));
         content.setExtensions(mapExtensions(extensions));
         return content;
@@ -173,12 +171,14 @@ public final class RegisterWireBuilder {
             return result;
         }
         for (CertificateExtension extension : extensions) {
-            RequestedExtension mapped = new RequestedExtension();
-            mapped.setOid(extension.getOid());
-            mapped.setCritical(extension.isCritical());
-            mapped.setEncoding(ExtensionValueEncoding.DER);
-            mapped.setValue(extension.getValueBase64());
-            result.add(mapped);
+            if (extension != null) {
+                RequestedExtension mapped = new RequestedExtension();
+                mapped.setOid(extension.getOid());
+                mapped.setCritical(extension.isCritical());
+                mapped.setEncoding(ExtensionValueEncoding.DER);
+                mapped.setValue(extension.getValueBase64());
+                result.add(mapped);
+            }
         }
         return result;
     }

--- a/src/main/java/com/otilm/core/mapper/certificate/CertificateDetailDtoMapper.java
+++ b/src/main/java/com/otilm/core/mapper/certificate/CertificateDetailDtoMapper.java
@@ -30,7 +30,9 @@ public class CertificateDetailDtoMapper {
         final CertificateDetailDto dto = new CertificateDetailDto();
         dto.setCommonName(CertificateUtil.formatCommonName(certificate.getCommonName()));
         dto.setIssuerCommonName(resolveIssuerCommonName(certificate));
-        dto.setSubjectAlternativeNames(CertificateUtil.deserializeSans(certificate.getSubjectAlternativeNames()));
+        if (certificate.getSubjectAlternativeNames() != null) {
+            dto.setSubjectAlternativeNames(CertificateUtil.deserializeSans(certificate.getSubjectAlternativeNames()));
+        }
         if (certificate.getCertificateContent() != null) {
             dto.setCertificateContent(certificate.getCertificateContent().getContent());
             dto.setIssuerDn(certificate.getIssuerDn());

--- a/src/main/java/com/otilm/core/mapper/certificate/CertificateDetailDtoMapper.java
+++ b/src/main/java/com/otilm/core/mapper/certificate/CertificateDetailDtoMapper.java
@@ -30,6 +30,7 @@ public class CertificateDetailDtoMapper {
         final CertificateDetailDto dto = new CertificateDetailDto();
         dto.setCommonName(CertificateUtil.formatCommonName(certificate.getCommonName()));
         dto.setIssuerCommonName(resolveIssuerCommonName(certificate));
+        dto.setSubjectAlternativeNames(CertificateUtil.deserializeSans(certificate.getSubjectAlternativeNames()));
         if (certificate.getCertificateContent() != null) {
             dto.setCertificateContent(certificate.getCertificateContent().getContent());
             dto.setIssuerDn(certificate.getIssuerDn());
@@ -39,7 +40,6 @@ public class CertificateDetailDtoMapper {
             dto.setExtendedKeyUsage(MetaDefinitions.deserializeArrayString(certificate.getExtendedKeyUsage()));
             dto.setKeyUsage(certificate.getKeyUsage().stream().toList());
             dto.setFingerprint(certificate.getFingerprint());
-            dto.setSubjectAlternativeNames(CertificateUtil.deserializeSans(certificate.getSubjectAlternativeNames()));
             dto.setIssuerSerialNumber(certificate.getIssuerSerialNumber());
             dto.setSerialNumber(certificate.getSerialNumber());
 

--- a/src/main/java/com/otilm/core/service/CertificateInternalService.java
+++ b/src/main/java/com/otilm/core/service/CertificateInternalService.java
@@ -5,6 +5,7 @@ import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.client.dashboard.StatisticsDto;
 import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
 import com.otilm.api.model.common.attribute.common.MetadataAttribute;
+import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
 import com.otilm.api.model.core.certificate.*;
 import com.otilm.api.model.core.enums.CertificateRequestFormat;
 import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
@@ -50,8 +51,11 @@ public interface CertificateInternalService extends ResourceExtensionService {
      * @param effectiveSubjectDn the subject DN to persist — the flat {@code subjectDn} for a flat request,
      *                           or the DN rendered from projected {@code csrAttributes} for a structured one
      *                           (resolved by the caller so the placeholder matches the register wire identity)
+     * @param registrationContent the projected registration identity content; its subject alternative
+     *                            names are persisted on the placeholder alongside the subject DN, so the
+     *                            platform record carries the full registered identity (may be null)
      */
-    Certificate createRegistrationPlaceholder(RaProfile raProfile, String effectiveSubjectDn);
+    Certificate createRegistrationPlaceholder(RaProfile raProfile, String effectiveSubjectDn, X509RequestContent registrationContent);
 
     /**
      * Attaches an operator-supplied CSR to an existing certificate (a REGISTERED placeholder), preparing it

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderV3Adapter.java
@@ -280,8 +280,8 @@ public class AuthorityProviderV3Adapter
         AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
         ApiClientConnectorInfo connectorDto = connectorForApiClient(authority);
 
-        // Structured csrAttributes are projected once by the orchestrator (identityContent); a flat request
-        // carries no pre-built content, so build the identity here from subjectDn/subjectAltName/extensions.
+        // The orchestrator projects the identity once (structured csrAttributes or the flat fields) and passes
+        // it as identityContent; the flat build below is a defensive fallback for callers supplying no content.
         X509RequestContent content;
         if (identityContent != null) {
             content = identityContent;

--- a/src/main/java/com/otilm/core/service/handler/authority/RegisterCapability.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/RegisterCapability.java
@@ -29,8 +29,10 @@ public interface RegisterCapability {
      * {@link com.otilm.core.exception.ConnectorAcceptedButLocalFailureException}; a raw {@link RuntimeException}
      * signals a pre-acceptance failure.
      *
-     * @param identityContent the structured identity projected once by the orchestrator (from {@code csrAttributes}),
-     *                         or null for a flat request — the adapter then builds it from subjectDn/subjectAltName/extensions
+     * @param identityContent the registration identity projected once by the orchestrator — from structured
+     *                         {@code csrAttributes} or from the flat subjectDn/subjectAltName/extensions — so the
+     *                         persisted placeholder and the wire derive from the same content; when null the
+     *                         adapter builds it from the request's flat fields defensively
      * @return SYNC_OK when the CA confirmed immediately, ASYNC_ACCEPTED when polling is needed.
      */
     AdapterOperationResult register(Certificate cert, ClientCertificateRegistrationDto req,

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -13,6 +13,7 @@ import com.otilm.api.model.common.attribute.common.MetadataAttribute;
 import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.v3.content.data.ResourceCertificateContentData;
 import com.otilm.api.model.common.attribute.v3.content.data.ResourceObjectContentData;
+import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.auth.UserDto;
 import com.otilm.api.model.core.certificate.*;
@@ -1139,12 +1140,16 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
 
     @Override
     @Transactional
-    public Certificate createRegistrationPlaceholder(RaProfile raProfile, String effectiveSubjectDn) {
-        // Identity-only placeholder: no key/CSR/content yet. The authoritative subject, SAN and key
-        // material are recorded when the follow-up CSR issuance completes against this record, so only
-        // the subject DN identity from the registration request is captured here.
+    public Certificate createRegistrationPlaceholder(RaProfile raProfile, String effectiveSubjectDn, X509RequestContent registrationContent) {
+        // Identity-only placeholder: no key/CSR/content yet. The registered identity — subject DN plus any
+        // subject alternative names from the projected registration content — is captured here; the
+        // authoritative subject, SAN and key material are overwritten when the follow-up CSR issuance
+        // completes against this record.
         Certificate certificate = new Certificate();
         CertificateUtil.applyRegistrationSubject(certificate, effectiveSubjectDn);
+        if (registrationContent != null) {
+            CertificateUtil.applyRegistrationSan(certificate, registrationContent.getSubjectAltNames());
+        }
         certificate.setState(CertificateState.REQUESTED);
         certificate.setComplianceStatus(ComplianceStatus.NOT_CHECKED);
         certificate.setValidationStatus(CertificateValidationStatus.NOT_CHECKED);

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -11,6 +11,7 @@ import com.otilm.api.model.client.location.PushToLocationRequestDto;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateRequestContent;
+import com.otilm.api.model.connector.v3.certificate.RequestedExtension;
 import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
 import com.otilm.api.exception.ConnectorClientException;
 import com.otilm.api.exception.ConnectorCommunicationException;
@@ -114,6 +115,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
 import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
 
 @Service("clientOperationServiceImplV2")
 @Transactional
@@ -463,21 +465,28 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         AuthorityInstanceReference authority = raProfile.getAuthorityInstanceReference();
         AuthorityProviderAdapter adapter = adapterFactory.forAuthority(authority);
 
-        // Project structured csrAttributes once (validated) so the placeholder DN and the connector wire derive
-        // from the same content; a flat request yields null here and the adapter builds its identity itself.
+        // Project the registration identity once (validated) so the placeholder row and the connector wire
+        // derive from the same content: structured csrAttributes through the issuance-definition projector,
+        // a flat request through the same builder the adapter uses for the wire. The placeholder DN keeps its
+        // historical derivation (rendered for structured, the raw request DN for flat).
         X509RequestContent registrationContent = buildStructuredRegistrationContent(raProfile, request);
-        String effectiveSubjectDn = registrationContent != null
-                ? RegisterWireBuilder.renderSubjectDn(registrationContent)
-                : request.getSubjectDn();
+        String effectiveSubjectDn;
+        if (registrationContent != null) {
+            effectiveSubjectDn = RegisterWireBuilder.renderSubjectDn(registrationContent);
+        } else {
+            effectiveSubjectDn = request.getSubjectDn();
+            registrationContent = RegisterWireBuilder.buildContent(
+                    request.getSubjectDn(), request.getSubjectAltName(), request.getExtensions());
+        }
 
         // No connector-backed registration for this authority (not a RegisterCapability, or the flag is not
         // advertised) -> platform-level pre-registration (see registerPlatformLevel); otherwise connector-backed below.
         if (!(adapter instanceof RegisterCapability registerCapability)
                 || !capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REGISTRATION)) {
-            return registerPlatformLevel(raProfile, request, effectiveSubjectDn, createCustomAttributes);
+            return registerPlatformLevel(raProfile, request, effectiveSubjectDn, registrationContent, createCustomAttributes);
         }
 
-        Certificate placeholder = certificateService.createRegistrationPlaceholder(raProfile, effectiveSubjectDn);
+        Certificate placeholder = certificateService.createRegistrationPlaceholder(raProfile, effectiveSubjectDn, registrationContent);
         // Re-load with the full adapter graph for the transaction-less connector call, as the poll listener does.
         // No pessimistic lock here (unlike the cancel/poll paths): the placeholder was just created and its UUID
         // is not yet known to any concurrent actor, so the read-modify-write below cannot race.
@@ -556,7 +565,11 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
      *
      * <p><b>Behaviour.</b> The placeholder, its register-&gt;issue binding, and (when a secret is supplied) its
      * challenge authorization are created and owned entirely by the platform, with no connector {@code /register}
-     * call. The certificate reaches {@code REGISTERED} directly.</p>
+     * call. The certificate reaches {@code REGISTERED} directly. The placeholder records the full registered
+     * identity the platform can represent — subject DN and subject alternative names from the projected
+     * {@code registrationContent}; requested extensions have nowhere to be stored or forwarded on this path,
+     * so their drop is recorded to the certificate event history instead (see
+     * {@link #noteUnrecordedPlatformLevelExtensions}).</p>
      *
      * <p><b>Completion.</b> Runs later through the normal issue path; {@code issueCertificateAction} routes to the
      * register-bound path only for a {@code RegisterCapability} adapter that advertises the flag, so a platform-level
@@ -568,8 +581,9 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     private ClientCertificateDataResponseDto registerPlatformLevel(RaProfile raProfile,
                                                                    ClientCertificateRegistrationDto request,
                                                                    String effectiveSubjectDn,
+                                                                   X509RequestContent registrationContent,
                                                                    boolean createCustomAttributes) throws NotFoundException, AttributeException {
-        Certificate placeholder = certificateService.createRegistrationPlaceholder(raProfile, effectiveSubjectDn);
+        Certificate placeholder = certificateService.createRegistrationPlaceholder(raProfile, effectiveSubjectDn, registrationContent);
         Certificate certificate = certificateRepository.findForPollingByUuid(placeholder.getUuid())
                 .orElseThrow(() -> new NotFoundException(Certificate.class, placeholder.getUuid()));
         stateMachine.transition(certificate, CertificateState.PENDING_REGISTRATION);
@@ -586,6 +600,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             // marker as a connector-backed one — the discriminator both the issue routing and the approval-reject
             // restore key on, which makes a no-secret placeholder restorable.
             certificateRegistrationWriter.upsert(certificate.getUuid(), List.of());
+            noteUnrecordedPlatformLevelExtensions(certificate.getUuid(), registrationContent);
         } catch (RuntimeException | AttributeException | NotFoundException e) {
             // A challenge store/save, binding-write, or custom-attribute persistence failure must fail the
             // placeholder rather than orphan it in PENDING_REGISTRATION.
@@ -601,6 +616,31 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         response.setUuid(certificate.getUuid().toString());
         response.setCertificateData("");
         return response;
+    }
+
+    /**
+     * Records requested extensions that a platform-level pre-registration cannot carry. The certificate row
+     * records only the subject DN and subject alternative names, and with no connector {@code /register} call
+     * there is no wire to forward extensions to. Failing the registration would be disproportionate — the
+     * extensions that reach the issued certificate arrive with the CSR at issuance — but dropping them
+     * silently hid the reduction, so the drop is made operator-visible: a certificate event-history entry
+     * (logs are not an operator surface under SaaS) plus a warn log. Written inside the placeholder
+     * try-block, so a history-write failure fails the placeholder like any other local setup step.
+     */
+    private void noteUnrecordedPlatformLevelExtensions(UUID certificateUuid, X509RequestContent registrationContent) {
+        if (registrationContent == null || registrationContent.getExtensions() == null
+                || registrationContent.getExtensions().isEmpty()) {
+            return;
+        }
+        String oids = registrationContent.getExtensions().stream()
+                .map(RequestedExtension::getOid)
+                .collect(Collectors.joining(", "));
+        certificateEventHistoryService.addEventHistory(certificateUuid, CertificateEvent.REQUEST, CertificateEventStatus.SUCCESS,
+                ("Requested certificate extensions (%s) are not recorded on a platform-level pre-registration "
+                        + "(no connector-backed registration for this authority); supply them with the CSR at issuance")
+                        .formatted(oids), "");
+        logger.warn("Certificate {} pre-registered at the platform level; requested extensions ({}) are not recorded "
+                + "and must be supplied with the CSR at issuance", certificateUuid, oids);
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -624,23 +624,28 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
      * there is no wire to forward extensions to. Failing the registration would be disproportionate — the
      * extensions that reach the issued certificate arrive with the CSR at issuance — but dropping them
      * silently hid the reduction, so the drop is made operator-visible: a certificate event-history entry
-     * (logs are not an operator surface under SaaS) plus a warn log. Written inside the placeholder
-     * try-block, so a history-write failure fails the placeholder like any other local setup step.
+     * (logs are not an operator surface under SaaS) plus a warn log. Best-effort, mirroring
+     * {@link #deleteRegistrationAuthorizationBestEffort}: the note is advisory, so a history-write failure
+     * is swallowed (warn-logged) rather than allowed to fail a registration whose essential setup succeeded.
      */
     private void noteUnrecordedPlatformLevelExtensions(UUID certificateUuid, X509RequestContent registrationContent) {
         if (registrationContent == null || registrationContent.getExtensions() == null
                 || registrationContent.getExtensions().isEmpty()) {
             return;
         }
-        String oids = registrationContent.getExtensions().stream()
-                .map(RequestedExtension::getOid)
-                .collect(Collectors.joining(", "));
-        certificateEventHistoryService.addEventHistory(certificateUuid, CertificateEvent.REQUEST, CertificateEventStatus.SUCCESS,
-                ("Requested certificate extensions (%s) are not recorded on a platform-level pre-registration "
-                        + "(no connector-backed registration for this authority); supply them with the CSR at issuance")
-                        .formatted(oids), "");
-        logger.warn("Certificate {} pre-registered at the platform level; requested extensions ({}) are not recorded "
-                + "and must be supplied with the CSR at issuance", certificateUuid, oids);
+        try {
+            String oids = registrationContent.getExtensions().stream()
+                    .map(RequestedExtension::getOid)
+                    .collect(Collectors.joining(", "));
+            certificateEventHistoryService.addEventHistory(certificateUuid, CertificateEvent.REQUEST, CertificateEventStatus.SUCCESS,
+                    ("Requested certificate extensions (%s) are not recorded on a platform-level pre-registration "
+                            + "(no connector-backed registration for this authority); supply them with the CSR at issuance")
+                            .formatted(oids), "");
+            logger.warn("Certificate {} pre-registered at the platform level; requested extensions ({}) are not recorded "
+                    + "and must be supplied with the CSR at issuance", certificateUuid, oids);
+        } catch (Exception e) {
+            logger.warn("Failed to record unrecorded platform-level extensions for certificate {}: {}", certificateUuid, e.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -11,7 +11,6 @@ import com.otilm.api.model.client.location.PushToLocationRequestDto;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.connector.v3.certificate.CertificateRequestContent;
-import com.otilm.api.model.connector.v3.certificate.RequestedExtension;
 import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
 import com.otilm.api.exception.ConnectorClientException;
 import com.otilm.api.exception.ConnectorCommunicationException;
@@ -115,7 +114,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
 import java.util.function.BooleanSupplier;
-import java.util.stream.Collectors;
 
 @Service("clientOperationServiceImplV2")
 @Transactional
@@ -567,9 +565,10 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
      * challenge authorization are created and owned entirely by the platform, with no connector {@code /register}
      * call. The certificate reaches {@code REGISTERED} directly. The placeholder records the full registered
      * identity the platform can represent — subject DN and subject alternative names from the projected
-     * {@code registrationContent}; requested extensions have nowhere to be stored or forwarded on this path,
-     * so their drop is recorded to the certificate event history instead (see
-     * {@link #noteUnrecordedPlatformLevelExtensions}).</p>
+     * {@code registrationContent}. Requested extensions are not persisted on the row (it has no column for
+     * them and there is no wire to forward them to); the operator-visible record of what was requested is
+     * the certificate's request attributes, and the extensions that reach the issued certificate arrive
+     * with the CSR at issuance.</p>
      *
      * <p><b>Completion.</b> Runs later through the normal issue path; {@code issueCertificateAction} routes to the
      * register-bound path only for a {@code RegisterCapability} adapter that advertises the flag, so a platform-level
@@ -600,7 +599,6 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             // marker as a connector-backed one — the discriminator both the issue routing and the approval-reject
             // restore key on, which makes a no-secret placeholder restorable.
             certificateRegistrationWriter.upsert(certificate.getUuid(), List.of());
-            noteUnrecordedPlatformLevelExtensions(certificate.getUuid(), registrationContent);
         } catch (RuntimeException | AttributeException | NotFoundException e) {
             // A challenge store/save, binding-write, or custom-attribute persistence failure must fail the
             // placeholder rather than orphan it in PENDING_REGISTRATION.
@@ -616,36 +614,6 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         response.setUuid(certificate.getUuid().toString());
         response.setCertificateData("");
         return response;
-    }
-
-    /**
-     * Records requested extensions that a platform-level pre-registration cannot carry. The certificate row
-     * records only the subject DN and subject alternative names, and with no connector {@code /register} call
-     * there is no wire to forward extensions to. Failing the registration would be disproportionate — the
-     * extensions that reach the issued certificate arrive with the CSR at issuance — but dropping them
-     * silently hid the reduction, so the drop is made operator-visible: a certificate event-history entry
-     * (logs are not an operator surface under SaaS) plus a warn log. Best-effort, mirroring
-     * {@link #deleteRegistrationAuthorizationBestEffort}: the note is advisory, so a history-write failure
-     * is swallowed (warn-logged) rather than allowed to fail a registration whose essential setup succeeded.
-     */
-    private void noteUnrecordedPlatformLevelExtensions(UUID certificateUuid, X509RequestContent registrationContent) {
-        if (registrationContent == null || registrationContent.getExtensions() == null
-                || registrationContent.getExtensions().isEmpty()) {
-            return;
-        }
-        try {
-            String oids = registrationContent.getExtensions().stream()
-                    .map(RequestedExtension::getOid)
-                    .collect(Collectors.joining(", "));
-            certificateEventHistoryService.addEventHistory(certificateUuid, CertificateEvent.REQUEST, CertificateEventStatus.SUCCESS,
-                    ("Requested certificate extensions (%s) are not recorded on a platform-level pre-registration "
-                            + "(no connector-backed registration for this authority); supply them with the CSR at issuance")
-                            .formatted(oids), "");
-            logger.warn("Certificate {} pre-registered at the platform level; requested extensions ({}) are not recorded "
-                    + "and must be supplied with the CSR at issuance", certificateUuid, oids);
-        } catch (Exception e) {
-            logger.warn("Failed to record unrecorded platform-level extensions for certificate {}: {}", certificateUuid, e.getMessage());
-        }
     }
 
     /**

--- a/src/main/java/com/otilm/core/util/CertificateUtil.java
+++ b/src/main/java/com/otilm/core/util/CertificateUtil.java
@@ -4,6 +4,7 @@ import com.otilm.api.exception.CertificateRequestException;
 import com.otilm.api.exception.ValidationError;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.otilm.api.model.connector.v3.certificate.GeneralNameEntry;
 import com.otilm.api.model.core.certificate.*;
 import com.otilm.api.model.core.compliance.ComplianceStatus;
 import com.otilm.api.model.core.oid.SystemOid;
@@ -248,7 +249,7 @@ public class CertificateUtil {
             DLSequence otherNameSeq = (DLSequence) GeneralName.getInstance(value).getName();
             var oidSeq = otherNameSeq.getObjectAt(0).toString();
             var valueSeq = ((DLTaggedObject) otherNameSeq.getObjectAt(1)).getBaseObject().toString();
-            return "%s=%s".formatted(oidSeq, valueSeq);
+            return formatOtherNameSan(oidSeq, valueSeq);
         }
         if (sanType == GeneralName.ediPartyName) {
             DLSequence ediPartySeq = (DLSequence) GeneralName.getInstance(value).getName();
@@ -603,6 +604,37 @@ public class CertificateUtil {
         } catch (IllegalArgumentException e) {
             throw new ValidationException(ValidationError.create("Invalid subject DN '%s': %s".formatted(subjectDn, e.getMessage())));
         }
+    }
+
+    /**
+     * Records the SAN identity of a no-CSR registration placeholder from the projected registration
+     * content, serialized in the same map format used for issued certificates. No entries is a no-op,
+     * leaving the column null exactly as for a DN-only registration.
+     */
+    public static void applyRegistrationSan(Certificate modal, List<GeneralNameEntry> subjectAltNames) {
+        if (subjectAltNames == null || subjectAltNames.isEmpty()) {
+            return;
+        }
+        Map<String, List<String>> sans = buildEmptySans();
+        for (GeneralNameEntry entry : subjectAltNames) {
+            // Projected entries carry a validated type; guard anyway so a malformed persisted mapping
+            // surfaces as a controlled rejection instead of an NPE inside the placeholder transaction.
+            if (entry.getType() == null) {
+                throw new ValidationException(ValidationError.create(
+                        "A projected subject alternative name entry carries no type; check the SAN field mappings of the issuance attributes"));
+            }
+            String value = entry.getType() == GeneralNameType.OTHER_NAME
+                    ? formatOtherNameSan(entry.getOtherNameOid(), entry.getValue())
+                    : entry.getValue();
+            sans.get(SAN_TYPE_MAP.get(entry.getType().getBcTag())).add(value);
+        }
+        modal.setSubjectAlternativeNames(serializeSans(sans));
+    }
+
+    /** Single source of the persisted otherName SAN form, shared by issued-certificate parsing and
+     * registration placeholders so the two can never drift. */
+    private static String formatOtherNameSan(String oid, String value) {
+        return "%s=%s".formatted(oid, value);
     }
 
     private static void setSubjectDNParams(Certificate modal, X500Name subjectDN) {

--- a/src/main/java/com/otilm/core/util/CertificateUtil.java
+++ b/src/main/java/com/otilm/core/util/CertificateUtil.java
@@ -617,11 +617,17 @@ public class CertificateUtil {
         }
         Map<String, List<String>> sans = buildEmptySans();
         for (GeneralNameEntry entry : subjectAltNames) {
-            // Projected entries carry a validated type; guard anyway so a malformed persisted mapping
-            // surfaces as a controlled rejection instead of an NPE inside the placeholder transaction.
+            // Projected entries carry a validated type and otherName OID; guard anyway so a malformed
+            // persisted mapping surfaces as a controlled rejection instead of an NPE or a literal
+            // "null=value" SAN inside the placeholder transaction.
             if (entry.getType() == null) {
                 throw new ValidationException(ValidationError.create(
                         "A projected subject alternative name entry carries no type; check the SAN field mappings of the issuance attributes"));
+            }
+            if (entry.getType() == GeneralNameType.OTHER_NAME
+                    && (entry.getOtherNameOid() == null || entry.getOtherNameOid().isBlank())) {
+                throw new ValidationException(ValidationError.create(
+                        "A projected otherName subject alternative name entry carries no OID; check the SAN field mappings of the issuance attributes"));
             }
             String value = entry.getType() == GeneralNameType.OTHER_NAME
                     ? formatOtherNameSan(entry.getOtherNameOid(), entry.getValue())

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -10,6 +10,7 @@ import com.otilm.api.model.client.attribute.RequestAttributeV3;
 import com.otilm.api.model.client.connector.v2.ConnectorVersion;
 import com.otilm.api.model.client.connector.v2.FeatureFlag;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.certificate.CertificateEvent;
 import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.certificate.CertificateType;
 import com.otilm.api.model.core.other.ResourceEvent;
@@ -71,6 +72,7 @@ import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authn.client.UserManagementApiClient;
+import com.otilm.core.service.CertificateEventHistoryInternalService;
 import com.otilm.core.service.CertificateExternalService;
 import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.ResourceObjectAssociationService;
@@ -165,6 +167,10 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     // post-acceptance divergence branch.
     @MockitoSpyBean
     private CertificateRegistrationWriter registrationWriter;
+    // Spied (not mocked) so state-transition history really persists; one test stubs the advisory
+    // unrecorded-extensions note to fail, asserting the best-effort contract.
+    @MockitoSpyBean
+    private CertificateEventHistoryInternalService certificateEventHistoryService;
     @MockitoBean
     private AuthorityProviderAdapterFactory adapterFactory;
 
@@ -993,6 +999,31 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
                         && event.getMessage().contains("not recorded on a platform-level pre-registration"));
         Assertions.assertTrue(noted,
                 "the dropped extensions must be recorded to the certificate event history with their OIDs");
+    }
+
+    @Test
+    void platformLevelRegistrationSurvivesAdvisoryNoteFailure() throws Exception {
+        // The unrecorded-extensions note is advisory (best-effort, mirroring
+        // deleteRegistrationAuthorizationBestEffort): a failure writing it must not fail a registration
+        // whose essential setup already succeeded. Only the note's event is stubbed to throw — the
+        // state-transition history keeps working, so the flow under test is otherwise the real one.
+        when(adapterFactory.forAuthority(Mockito.any())).thenReturn(mock(AuthorityProviderAdapter.class));
+        Mockito.doThrow(new RuntimeException("event-history write failed"))
+                .when(certificateEventHistoryService)
+                .addEventHistory(Mockito.any(UUID.class), Mockito.eq(CertificateEvent.REQUEST), Mockito.any(),
+                        Mockito.contains("not recorded on a platform-level pre-registration"), Mockito.anyString());
+        ClientCertificateRegistrationDto request = registrationRequest();
+        CertificateExtension extension = new CertificateExtension();
+        extension.setOid("1.3.6.1.5.5.7.1.1");
+        extension.setValueBase64(Base64.getEncoder().encodeToString(new byte[]{0x30, 0x00}));
+        request.setExtensions(List.of(extension));
+
+        ClientCertificateDataResponseDto response =
+                clientOperationService.registerCertificate(authorityParent, securedRaProfile, request);
+
+        Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
+        Assertions.assertEquals(CertificateState.REGISTERED, cert.getState(),
+                "a failure writing the advisory extensions note must not fail the registration");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -28,7 +28,11 @@ import com.otilm.api.model.common.attribute.v3.content.StringAttributeContentV3;
 import com.otilm.api.model.common.attribute.v3.mapping.FieldMapping;
 import com.otilm.api.model.common.attribute.v3.mapping.FieldType;
 import com.otilm.api.model.common.attribute.v3.mapping.RdnMappedField;
+import com.otilm.api.model.common.attribute.v3.mapping.SanMappedField;
+import com.otilm.api.model.connector.v3.certificate.CertificateExtension;
 import com.otilm.api.model.connector.v3.certificate.X509RequestContent;
+import com.otilm.api.model.core.certificate.CertificateDetailDto;
+import com.otilm.api.model.core.certificate.GeneralNameType;
 import com.otilm.api.model.core.v2.AvailableOperationsDto;
 import com.otilm.api.model.core.v2.CertificateOperationKind;
 import com.otilm.api.model.core.v2.ClientCertificateDataResponseDto;
@@ -51,6 +55,7 @@ import com.otilm.core.dao.entity.RegistrationState;
 import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.CertificateRegistrationAuthorizationRepository;
 import com.otilm.core.dao.repository.CertificateRegistrationRepository;
+import com.otilm.core.dao.repository.CertificateEventHistoryRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.GroupRepository;
@@ -66,6 +71,7 @@ import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authn.client.UserManagementApiClient;
+import com.otilm.core.service.CertificateExternalService;
 import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.ResourceObjectAssociationService;
 import com.otilm.core.service.handler.ConnectorCapabilityService;
@@ -84,6 +90,7 @@ import com.otilm.core.service.writer.registration.CertificateRegistrationWriter;
 import com.otilm.core.service.writer.statuspoll.CertificateStatusPollWriter;
 import com.otilm.core.util.AuthHelper;
 import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.CertificateUtil;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
@@ -104,6 +111,7 @@ import java.security.KeyPairGenerator;
 import java.time.OffsetDateTime;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -130,7 +138,11 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     @Autowired
     private CertificateInternalService certificateService;
     @Autowired
+    private CertificateExternalService certificateExternalService;
+    @Autowired
     private CertificateRepository certificateRepository;
+    @Autowired
+    private CertificateEventHistoryRepository certificateEventHistoryRepository;
     @Autowired
     private RaProfileRepository raProfileRepository;
     @Autowired
@@ -880,6 +892,121 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
         Assertions.assertEquals("device-9", contentCaptor.getValue().getSubject().get(0).getValue());
         Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
         Assertions.assertEquals(CertificateState.REGISTERED, cert.getState());
+    }
+
+    // ── registered identity (SAN / extensions) on the placeholder ────────────
+
+    @Test
+    void registerPersistsProjectedSanOnPlaceholder() throws Exception {
+        // A csrAttribute mapped to a DNS SAN must be recorded on the placeholder row, not reduced to the
+        // subject DN. SAN-only identities are permitted (RFC 5280 §4.1.2.6), so the DN stays empty here.
+        UUID sanUuid = UUID.randomUUID();
+        DataAttributeV3 sanDef = new DataAttributeV3();
+        sanDef.setUuid(sanUuid.toString());
+        sanDef.setName("dnsName");
+        SanMappedField san = new SanMappedField();
+        san.setFieldType(FieldType.SAN);
+        san.setGeneralNameType(GeneralNameType.DNS);
+        FieldMapping fieldMapping = new FieldMapping();
+        fieldMapping.setFields(List.of(san));
+        sanDef.setFieldMapping(fieldMapping);
+        when(issuanceDefinitionResolver.resolve(Mockito.any())).thenReturn(List.of(sanDef));
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, List.of(), CertificateType.X509));
+
+        ClientCertificateRegistrationDto request = new ClientCertificateRegistrationDto();
+        request.setCsrAttributes(List.of(new RequestAttributeV3(sanUuid, "dnsName",
+                AttributeContentType.STRING, List.<BaseAttributeContentV3<?>>of(new StringAttributeContentV3("device-9.example.com")))));
+
+        ClientCertificateDataResponseDto response = clientOperationService.registerCertificate(
+                authorityParent, securedRaProfile, request);
+
+        Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
+        Map<String, List<String>> sans = CertificateUtil.deserializeSans(cert.getSubjectAlternativeNames());
+        Assertions.assertEquals(List.of("device-9.example.com"), sans.get("dNSName"),
+                "the projected DNS SAN must be persisted on the placeholder row");
+    }
+
+    @Test
+    void registerPersistsFlatSanOnPlaceholder() throws Exception {
+        // The flat subjectAltName string must be recorded on the placeholder row, same as the projected form.
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
+        ClientCertificateRegistrationDto request = registrationRequest();
+        request.setSubjectAltName("DNS:device-1.example.com,IP:10.0.0.1");
+
+        ClientCertificateDataResponseDto response = clientOperationService.registerCertificate(
+                authorityParent, securedRaProfile, request);
+
+        Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
+        Map<String, List<String>> sans = CertificateUtil.deserializeSans(cert.getSubjectAlternativeNames());
+        Assertions.assertEquals(List.of("device-1.example.com"), sans.get("dNSName"),
+                "the flat DNS SAN must be persisted on the placeholder row");
+        Assertions.assertEquals(List.of("10.0.0.1"), sans.get("iPAddress"),
+                "the flat IP SAN must be persisted on the placeholder row");
+    }
+
+    @Test
+    void platformLevelRegistrationPersistsSanOnPlaceholder() throws Exception {
+        // Platform-level path (no connector-backed registration): the requested SAN must be stored on the
+        // placeholder, not silently dropped — before this fix the identity was reduced to the subject DN.
+        when(adapterFactory.forAuthority(Mockito.any())).thenReturn(mock(AuthorityProviderAdapter.class));
+        ClientCertificateRegistrationDto request = registrationRequest();
+        request.setSubjectAltName("DNS:device-1.example.com");
+
+        ClientCertificateDataResponseDto response = clientOperationService.registerCertificate(
+                authorityParent, securedRaProfile, request);
+
+        Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
+        Assertions.assertEquals(CertificateState.REGISTERED, cert.getState());
+        Map<String, List<String>> sans = CertificateUtil.deserializeSans(cert.getSubjectAlternativeNames());
+        Assertions.assertEquals(List.of("device-1.example.com"), sans.get("dNSName"),
+                "the platform-level placeholder must record the requested SAN");
+        // The certificate detail must expose the SAN for a content-less placeholder too — the detail mapper
+        // reads the SAN column unconditionally, not only for certificates that already carry issued content.
+        CertificateDetailDto detail = certificateExternalService.getCertificate(SecuredUUID.fromString(response.getUuid()));
+        Assertions.assertEquals(List.of("device-1.example.com"), detail.getSubjectAlternativeNames().get("dNSName"),
+                "the certificate detail of a placeholder must expose the registered SAN");
+    }
+
+    @Test
+    void platformLevelRegistrationRecordsUnrecordedExtensions() throws Exception {
+        // No connector /register call exists to forward extensions to, and the placeholder row cannot record
+        // them. The registration still succeeds (the authoritative extensions arrive with the CSR at issuance),
+        // but the drop must be operator-visible as a certificate event-history entry — not silent.
+        when(adapterFactory.forAuthority(Mockito.any())).thenReturn(mock(AuthorityProviderAdapter.class));
+        ClientCertificateRegistrationDto request = registrationRequest();
+        CertificateExtension extension = new CertificateExtension();
+        extension.setOid("1.3.6.1.5.5.7.1.1");
+        extension.setValueBase64(Base64.getEncoder().encodeToString(new byte[]{0x30, 0x00}));
+        request.setExtensions(List.of(extension));
+
+        ClientCertificateDataResponseDto response =
+                clientOperationService.registerCertificate(authorityParent, securedRaProfile, request);
+
+        Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
+        Assertions.assertEquals(CertificateState.REGISTERED, cert.getState(),
+                "extensions must not fail a platform-level pre-registration");
+        boolean noted = certificateEventHistoryRepository.findByCertificateOrderByCreatedDesc(cert).stream()
+                .anyMatch(event -> event.getMessage() != null
+                        && event.getMessage().contains("1.3.6.1.5.5.7.1.1")
+                        && event.getMessage().contains("not recorded on a platform-level pre-registration"));
+        Assertions.assertTrue(noted,
+                "the dropped extensions must be recorded to the certificate event history with their OIDs");
+    }
+
+    @Test
+    void registerRejectsMalformedFlatSanBeforePlaceholder() {
+        // The flat identity is now projected in the orchestrator, before the placeholder — a malformed SAN
+        // rejects with no row, uniform with the sibling register validations.
+        registeringAdapter();
+        ClientCertificateRegistrationDto request = registrationRequest();
+        request.setSubjectAltName("BOGUS:device-1");
+
+        Assertions.assertThrows(ValidationException.class, () -> clientOperationService.registerCertificate(
+                authorityParent, securedRaProfile, request));
+        Assertions.assertEquals(0, certificateRepository.count(),
+                "a malformed flat SAN must be rejected before the placeholder is created");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -10,7 +10,6 @@ import com.otilm.api.model.client.attribute.RequestAttributeV3;
 import com.otilm.api.model.client.connector.v2.ConnectorVersion;
 import com.otilm.api.model.client.connector.v2.FeatureFlag;
 import com.otilm.api.model.core.auth.Resource;
-import com.otilm.api.model.core.certificate.CertificateEvent;
 import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.certificate.CertificateType;
 import com.otilm.api.model.core.other.ResourceEvent;
@@ -56,7 +55,6 @@ import com.otilm.core.dao.entity.RegistrationState;
 import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.CertificateRegistrationAuthorizationRepository;
 import com.otilm.core.dao.repository.CertificateRegistrationRepository;
-import com.otilm.core.dao.repository.CertificateEventHistoryRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.GroupRepository;
@@ -72,7 +70,6 @@ import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authn.client.UserManagementApiClient;
-import com.otilm.core.service.CertificateEventHistoryInternalService;
 import com.otilm.core.service.CertificateExternalService;
 import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.ResourceObjectAssociationService;
@@ -144,8 +141,6 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     @Autowired
     private CertificateRepository certificateRepository;
     @Autowired
-    private CertificateEventHistoryRepository certificateEventHistoryRepository;
-    @Autowired
     private RaProfileRepository raProfileRepository;
     @Autowired
     private AuthorityInstanceReferenceRepository authorityInstanceReferenceRepository;
@@ -167,10 +162,6 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     // post-acceptance divergence branch.
     @MockitoSpyBean
     private CertificateRegistrationWriter registrationWriter;
-    // Spied (not mocked) so state-transition history really persists; one test stubs the advisory
-    // unrecorded-extensions note to fail, asserting the best-effort contract.
-    @MockitoSpyBean
-    private CertificateEventHistoryInternalService certificateEventHistoryService;
     @MockitoBean
     private AuthorityProviderAdapterFactory adapterFactory;
 
@@ -994,10 +985,10 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     }
 
     @Test
-    void platformLevelRegistrationRecordsUnrecordedExtensions() throws Exception {
-        // No connector /register call exists to forward extensions to, and the placeholder row cannot record
-        // them. The registration still succeeds (the authoritative extensions arrive with the CSR at issuance),
-        // but the drop must be operator-visible as a certificate event-history entry — not silent.
+    void platformLevelRegistrationAcceptsExtensions() throws Exception {
+        // Extensions cannot be stored on the placeholder row or forwarded (no connector /register call), but
+        // they must not fail a platform-level pre-registration: the request attributes returned for the
+        // certificate carry what was requested, and the authoritative extensions arrive with the CSR at issuance.
         when(adapterFactory.forAuthority(Mockito.any())).thenReturn(mock(AuthorityProviderAdapter.class));
         ClientCertificateRegistrationDto request = registrationRequest();
         CertificateExtension extension = new CertificateExtension();
@@ -1011,37 +1002,6 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
         Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
         Assertions.assertEquals(CertificateState.REGISTERED, cert.getState(),
                 "extensions must not fail a platform-level pre-registration");
-        boolean noted = certificateEventHistoryRepository.findByCertificateOrderByCreatedDesc(cert).stream()
-                .anyMatch(event -> event.getMessage() != null
-                        && event.getMessage().contains("1.3.6.1.5.5.7.1.1")
-                        && event.getMessage().contains("not recorded on a platform-level pre-registration"));
-        Assertions.assertTrue(noted,
-                "the dropped extensions must be recorded to the certificate event history with their OIDs");
-    }
-
-    @Test
-    void platformLevelRegistrationSurvivesAdvisoryNoteFailure() throws Exception {
-        // The unrecorded-extensions note is advisory (best-effort, mirroring
-        // deleteRegistrationAuthorizationBestEffort): a failure writing it must not fail a registration
-        // whose essential setup already succeeded. Only the note's event is stubbed to throw — the
-        // state-transition history keeps working, so the flow under test is otherwise the real one.
-        when(adapterFactory.forAuthority(Mockito.any())).thenReturn(mock(AuthorityProviderAdapter.class));
-        Mockito.doThrow(new RuntimeException("event-history write failed"))
-                .when(certificateEventHistoryService)
-                .addEventHistory(Mockito.any(UUID.class), Mockito.eq(CertificateEvent.REQUEST), Mockito.any(),
-                        Mockito.contains("not recorded on a platform-level pre-registration"), Mockito.anyString());
-        ClientCertificateRegistrationDto request = registrationRequest();
-        CertificateExtension extension = new CertificateExtension();
-        extension.setOid("1.3.6.1.5.5.7.1.1");
-        extension.setValueBase64(Base64.getEncoder().encodeToString(new byte[]{0x30, 0x00}));
-        request.setExtensions(List.of(extension));
-
-        ClientCertificateDataResponseDto response =
-                clientOperationService.registerCertificate(authorityParent, securedRaProfile, request);
-
-        Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
-        Assertions.assertEquals(CertificateState.REGISTERED, cert.getState(),
-                "a failure writing the advisory extensions note must not fail the registration");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -953,9 +953,27 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     }
 
     @Test
+    void registerPersistsOtherNameSanOnPlaceholder() throws Exception {
+        // otherName rides the flat form as 'otherName:<oid>;UTF8:<value>' and must persist in the same
+        // 'oid=value' serialized form used for issued certificates (the shared formatOtherNameSan).
+        when(registeringAdapter().register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
+        ClientCertificateRegistrationDto request = registrationRequest();
+        request.setSubjectAltName("otherName:1.3.6.1.4.1.311.20.2.3;UTF8:device-9@acme.test");
+
+        ClientCertificateDataResponseDto response = clientOperationService.registerCertificate(
+                authorityParent, securedRaProfile, request);
+
+        Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
+        Map<String, List<String>> sans = CertificateUtil.deserializeSans(cert.getSubjectAlternativeNames());
+        Assertions.assertEquals(List.of("1.3.6.1.4.1.311.20.2.3=device-9@acme.test"), sans.get("otherName"),
+                "the otherName SAN must persist on the placeholder in the oid=value serialized form");
+    }
+
+    @Test
     void platformLevelRegistrationPersistsSanOnPlaceholder() throws Exception {
         // Platform-level path (no connector-backed registration): the requested SAN must be stored on the
-        // placeholder, not silently dropped — before this fix the identity was reduced to the subject DN.
+        // placeholder, not silently dropped
         when(adapterFactory.forAuthority(Mockito.any())).thenReturn(mock(AuthorityProviderAdapter.class));
         ClientCertificateRegistrationDto request = registrationRequest();
         request.setSubjectAltName("DNS:device-1.example.com");

--- a/src/test/java/com/otilm/core/util/CertificateUtilTest.java
+++ b/src/test/java/com/otilm/core/util/CertificateUtilTest.java
@@ -256,4 +256,18 @@ class CertificateUtilTest {
         assertNull(cert.getSubjectAlternativeNames());
     }
 
+    @Test
+    void applyRegistrationSan_rejectsOtherNameWithoutOid() {
+        // An OID-less otherName would serialize a literal "null=value" SAN; reject it as a controlled
+        // ValidationException instead, and persist nothing on the certificate.
+        Certificate cert = new Certificate();
+        GeneralNameEntry otherName = new GeneralNameEntry();
+        otherName.setType(GeneralNameType.OTHER_NAME);
+        otherName.setValue("device-9");
+
+        assertThrows(ValidationException.class,
+                () -> CertificateUtil.applyRegistrationSan(cert, List.of(otherName)));
+        assertNull(cert.getSubjectAlternativeNames());
+    }
+
 }

--- a/src/test/java/com/otilm/core/util/CertificateUtilTest.java
+++ b/src/test/java/com/otilm/core/util/CertificateUtilTest.java
@@ -1,6 +1,9 @@
 package com.otilm.core.util;
 
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.connector.v3.certificate.GeneralNameEntry;
 import com.otilm.api.model.core.certificate.CertificateState;
+import com.otilm.api.model.core.certificate.GeneralNameType;
 import com.otilm.api.model.core.certificate.QcType;
 import com.otilm.api.model.core.oid.OidCategory;
 import com.otilm.core.dao.entity.Certificate;
@@ -222,6 +225,35 @@ class CertificateUtilTest {
 
         assertEquals(CertificateState.ISSUED, cert.getState());
         assertNotNull(cert.getSerialNumber());
+    }
+
+    @Test
+    void applyRegistrationSan_persistsOtherNameAsOidEqualsValue() {
+        // The otherName serialized form must match the one written for issued certificates
+        // (getSanValueString) — both go through the shared formatOtherNameSan.
+        Certificate cert = new Certificate();
+        GeneralNameEntry otherName = new GeneralNameEntry();
+        otherName.setType(GeneralNameType.OTHER_NAME);
+        otherName.setOtherNameOid("1.2.3.4");
+        otherName.setValue("example othername");
+
+        CertificateUtil.applyRegistrationSan(cert, List.of(otherName));
+
+        Map<String, List<String>> sans = CertificateUtil.deserializeSans(cert.getSubjectAlternativeNames());
+        assertEquals(List.of("1.2.3.4=example othername"), sans.get("otherName"));
+    }
+
+    @Test
+    void applyRegistrationSan_rejectsEntryWithoutType() {
+        // A type-less entry cannot be bucketed; it must surface as a controlled ValidationException
+        // (not an NPE), and nothing may be persisted on the certificate.
+        Certificate cert = new Certificate();
+        GeneralNameEntry typeless = new GeneralNameEntry();
+        typeless.setValue("device-9");
+
+        assertThrows(ValidationException.class,
+                () -> CertificateUtil.applyRegistrationSan(cert, List.of(typeless)));
+        assertNull(cert.getSubjectAlternativeNames());
     }
 
 }


### PR DESCRIPTION
 Fixes #1851

 ## Problem
The register flow projected the full structured identity (subject DN + SAN + extensions) into `X509RequestContent`, then collapsed it to the DN. The placeholder row never recorded the SAN, and the platform-level path dropped the SAN and extensions entirely — silently, with no error and no record.
>
 ## Changes
> - **Single identity projection for both request forms.** Structured `csrAttributes` go through the issuance-definition projector as before; flat requests now go through the same `RegisterWireBuilder.buildContent` the adapter uses for the wire, in the orchestrator. The adapter receives the pre-built content on both forms (its flat fallback remains as a defensive contract). The placeholder DN keeps its historical derivation, so no stored DN formats change.
> - **The placeholder persists the SAN.** `createRegistrationPlaceholder` takes the projected content; new `CertificateUtil.applyRegistrationSan` writes `subject_alternative_names` in the same serialized map format used for issued certificates (shared otherName formatter, so the two can't drift). The stored SAN is the platform's record of the pre-registered identity until issuance overwrites it from the CA response.
> - **The certificate detail maps the SAN unconditionally**, not only when `certificateContent` is present, so a content-less REGISTERED placeholder exposes its registered SAN.
> - **Platform-level extensions are recorded, not dropped silently.** On the platform-level path there is no connector wire to forward extensions to and no column to record them, and the authoritative extensions arrive with the CSR at issuance — so the registration succeeds, and the drop is made operator-visible: a certificate event-history entry listing the extension OIDs with guidance to supply them in the CSR, plus a warn log. (Event history rather than logs alone, since SaaS operators can't read server logs.)
>
 ## Behavior changes
> - Malformed flat SAN/DN now rejects **before** the placeholder exists (no FAILED row), uniform with the sibling register validations.
> - Platform-level registrations with an unparsable SAN string now return a validation error instead of silently dropping it.
> - Platform-level registrations with extensions remain accepted, now with an audit record in the certificate event history.

## Deliberate scope limits
> - Requested extensions are still not persisted: the certificate row has no extensions column and there is no generic per-certificate extensions view even for issued certificates — storing them would write data nothing can display. Possible follow-up (schema + detail surface).
> - The identity override at register-bound issue stays subject-only; the CA re-derives SAN/extensions from the replayed handle. Extending the override to carry the now-persisted SAN would be a connector-contract change.
>
## Testing
> Six new integration tests in `ClientOperationServiceRegisterITest`: projected (structured) SAN persisted; flat SAN persisted; platform-level SAN persisted and exposed via the certificate detail; platform-level extensions accepted with the event-history record; malformed flat SAN rejected pre-placeholder. Full `ClientOperationServiceRegisterITest` and `V3RegisterLifecycleITest` suites green locally.