### PR TITLE
Use strict wire DN and registry-first OID parse

### DIFF
--- a/src/main/java/com/otilm/core/certificate/request/RegisterWireBuilder.java
+++ b/src/main/java/com/otilm/core/certificate/request/RegisterWireBuilder.java
@@ -82,7 +82,7 @@ public final class RegisterWireBuilder {
     public static CertificateRegistrationRequestDtoV3 buildRegistration(X509RequestContent content,
                                                                         boolean connectorSupportsStructured) {
         CertificateRegistrationRequestDtoV3 dto = new CertificateRegistrationRequestDtoV3();
-        dto.setSubjectDn(renderSubjectDn(content));
+        dto.setSubjectDn(renderWireSubjectDn(content));
         dto.setSubjectAltName(renderSubjectAltName(content.getSubjectAltNames()));
         if (connectorSupportsStructured) {
             dto.setRequestContent(content);
@@ -186,8 +186,11 @@ public final class RegisterWireBuilder {
     // ── flat-wire rendering ─────────────────────────────────────────────────
 
     /**
-     * Renders the RFC 4514 subject DN string for the given content, or null when it carries no subject.
-     * Shared with the register orchestrator so the persisted placeholder DN matches the wire anchor exactly.
+     * Renders the subject DN in the platform display form (registry codes such as {@code EMAIL}), or null
+     * when the content carries no subject. Used by the register orchestrator for the persisted placeholder
+     * DN and the UI; the connector wire uses {@link #renderWireSubjectDn(X509RequestContent)} instead, so
+     * the two strings differ in dialect while deriving from the same content. DN identity comparisons use
+     * the separate normalized form, never these display strings.
      */
     public static String renderSubjectDn(X509RequestContent content) {
         if (content.getSubject() == null || content.getSubject().isEmpty()) {
@@ -196,6 +199,25 @@ public final class RegisterWireBuilder {
         try {
             X500Principal principal = X509RequestContentRenderer.toX500Principal(content);
             return X500Name.getInstance(PlatformX500NameStyle.DEFAULT, principal.getEncoded()).toString();
+        } catch (IOException | IllegalArgumentException e) {
+            // Keep the renderer/encoder message off the wire-facing exception (info-leak rule).
+            throw new ValidationException("Unable to render subject DN from the certificate request content");
+        }
+    }
+
+    /**
+     * Renders the subject DN for the connector wire in strict RFC 2253/4514 form: registered short
+     * keywords (CN, L, ST, O, OU, C, STREET, DC, UID), dotted-decimal OIDs with hexstring values for
+     * every other attribute, and full value escaping. Platform registry codes (e.g. {@code EMAIL})
+     * never reach the wire — connectors parse this field with standards-strict parsers that are
+     * entitled to reject unregistered keywords. Returns null when the content carries no subject.
+     */
+    public static String renderWireSubjectDn(X509RequestContent content) {
+        if (content.getSubject() == null || content.getSubject().isEmpty()) {
+            return null;
+        }
+        try {
+            return X509RequestContentRenderer.toX500Principal(content).getName(X500Principal.RFC2253);
         } catch (IOException | IllegalArgumentException e) {
             // Keep the renderer/encoder message off the wire-facing exception (info-leak rule).
             throw new ValidationException("Unable to render subject DN from the certificate request content");

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -2,8 +2,10 @@ package com.otilm.core.oid;
 
 import com.otilm.api.model.core.oid.OidCategory;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
@@ -22,16 +24,43 @@ public class OidHandler {
 
     private static final Map<OidCategory, Map<String, OidRecord>> oidCache = new ConcurrentHashMap<>();
 
+    /**
+     * Case-insensitive RDN code/altCode → OID lookup. Rebuilt on every RDN cache mutation and
+     * published via volatile write, so readers on hot paths (DN parsing) never iterate a map
+     * another thread may be mutating.
+     */
+    private static volatile Map<String, String> rdnCodeToOid = Collections.emptyMap();
+
     public static Map<String, OidRecord> getOidCache(OidCategory oidCategory) {
         return oidCache.get(oidCategory);
     }
 
-    public static void cacheOidCategory(OidCategory category, Map<String, OidRecord> oidRecordMap) {
+    public static synchronized void cacheOidCategory(OidCategory category, Map<String, OidRecord> oidRecordMap) {
         oidCache.put(category, oidRecordMap);
+        refreshRdnCodeLookup(category);
     }
 
-    public static void cacheOid(OidCategory category, String oid, OidRecord oidRecord) {
-        oidCache.get(category).put(oid, oidRecord);
+    public static synchronized void cacheOid(OidCategory category, String oid, OidRecord oidRecord) {
+        // Copy-on-write: published per-category maps are iterated lock-free by readers
+        // (getCodeToOidMap, style snapshots), so never mutate one in place.
+        Map<String, OidRecord> next = new HashMap<>(oidCache.get(category));
+        next.put(oid, oidRecord);
+        oidCache.put(category, next);
+        refreshRdnCodeLookup(category);
+    }
+
+    /** OID for an RDN code or alternative code, matched case-insensitively; {@code null} when unknown. */
+    public static String getOidForRdnCode(String code) {
+        return code == null ? null : rdnCodeToOid.get(code);
+    }
+
+    private static void refreshRdnCodeLookup(OidCategory category) {
+        if (category != OidCategory.RDN_ATTRIBUTE_TYPE) {
+            return;
+        }
+        Map<String, String> lookup = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        lookup.putAll(getCodeToOidMap());
+        rdnCodeToOid = Collections.unmodifiableMap(lookup);
     }
 
     public static Map<String, String> getCodeToOidMap() {
@@ -62,7 +91,10 @@ public class OidHandler {
     }
 
 
-    public static void removeCachedOid(OidCategory category, String oid) {
-        oidCache.get(category).remove(oid);
+    public static synchronized void removeCachedOid(OidCategory category, String oid) {
+        Map<String, OidRecord> next = new HashMap<>(oidCache.get(category));
+        next.remove(oid);
+        oidCache.put(category, next);
+        refreshRdnCodeLookup(category);
     }
 }

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 public class OidHandler {
@@ -26,10 +27,11 @@ public class OidHandler {
 
     /**
      * Case-insensitive RDN code/altCode → OID lookup. Rebuilt on every RDN cache mutation and
-     * published via volatile write, so readers on hot paths (DN parsing) never iterate a map
-     * another thread may be mutating.
+     * republished as an immutable snapshot, so readers on hot paths (DN parsing) never iterate
+     * a map another thread may be mutating.
      */
-    private static volatile Map<String, String> rdnCodeToOid = Collections.emptyMap();
+    private static final AtomicReference<Map<String, String>> rdnCodeToOid =
+            new AtomicReference<>(Collections.emptyMap());
 
     public static Map<String, OidRecord> getOidCache(OidCategory oidCategory) {
         return oidCache.get(oidCategory);
@@ -51,7 +53,7 @@ public class OidHandler {
 
     /** OID for an RDN code or alternative code, matched case-insensitively; {@code null} when unknown. */
     public static String getOidForRdnCode(String code) {
-        return code == null ? null : rdnCodeToOid.get(code);
+        return code == null ? null : rdnCodeToOid.get().get(code);
     }
 
     private static void refreshRdnCodeLookup(OidCategory category) {
@@ -60,7 +62,7 @@ public class OidHandler {
         }
         Map<String, String> lookup = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         lookup.putAll(getCodeToOidMap());
-        rdnCodeToOid = Collections.unmodifiableMap(lookup);
+        rdnCodeToOid.set(Collections.unmodifiableMap(lookup));
     }
 
     public static Map<String, String> getCodeToOidMap() {

--- a/src/main/java/com/otilm/core/util/PlatformX500NameStyle.java
+++ b/src/main/java/com/otilm/core/util/PlatformX500NameStyle.java
@@ -35,6 +35,21 @@ public class PlatformX500NameStyle extends BCStrictStyle {
                 ));
     }
 
+    /**
+     * Resolves an RDN code to its OID, consulting the platform OID registry before BouncyCastle's
+     * built-in keyword table so that every code this style renders (default and alternative codes)
+     * parses back. The registry lookup is live — unlike the {@link #oidToCodeMap} snapshot —
+     * because the shared {@link #DEFAULT}/{@link #NORMALIZED} instances outlive runtime
+     * registrations of custom OID entries. Codes match case-insensitively (RFC 4514 keywords are
+     * case-insensitive); unknown codes fall through to BouncyCastle, which also handles the
+     * dotted-decimal form.
+     */
+    @Override
+    public ASN1ObjectIdentifier attrNameToOID(String attrName) {
+        String oid = OidHandler.getOidForRdnCode(attrName);
+        return oid != null ? new ASN1ObjectIdentifier(oid) : super.attrNameToOID(attrName);
+    }
+
     @Override
     public String toString(X500Name x500Name) {
         StringBuilder stringBuilder = new StringBuilder();

--- a/src/test/java/com/otilm/core/certificate/request/RegisterWireBuilderTest.java
+++ b/src/test/java/com/otilm/core/certificate/request/RegisterWireBuilderTest.java
@@ -41,6 +41,8 @@ class RegisterWireBuilderTest {
                 OidRecord.builder().displayName("Common Name").code("CN").build());
         OidHandler.cacheOid(OidCategory.RDN_ATTRIBUTE_TYPE, "2.5.4.10",
                 OidRecord.builder().displayName("Organization").code("O").build());
+        OidHandler.cacheOid(OidCategory.RDN_ATTRIBUTE_TYPE, "1.2.840.113549.1.9.1",
+                OidRecord.builder().displayName("Email").code("EMAIL").altCodes(List.of("E", "EMAILADDRESS")).build());
     }
 
     @AfterAll
@@ -263,8 +265,8 @@ class RegisterWireBuilderTest {
             // when
             CertificateRegistrationRequestDtoV3 dto = RegisterWireBuilder.buildRegistration(fullContent(), true);
 
-            // then — flat subjectDn stays the validation anchor (platform canonical display order)
-            assertThat(dto.getSubjectDn()).isEqualTo("O=Acme, CN=device-7");
+            // then — flat subjectDn stays the validation anchor (strict RFC 2253/4514 wire form)
+            assertThat(dto.getSubjectDn()).isEqualTo("O=Acme,CN=device-7");
             assertThat(dto.getSubjectAltName()).isEqualTo("DNS:device-7.acme.test");
         }
 
@@ -275,6 +277,31 @@ class RegisterWireBuilderTest {
 
             // then — extensions ride the structured wire only (no duplicate source)
             assertThat(dto.getExtensions()).isNull();
+        }
+
+        @Test
+        void wireSubjectDn_rendersNonStandardAttributesAsDottedOidHex() {
+            // given — EMAIL is a platform registry code, not an RFC 4514 registered keyword; strict
+            // connector parsers only accept registered keywords or dotted OIDs with hexstring values.
+            X509RequestContent content = RegisterWireBuilder.buildContent("CN=reg,EMAIL=mail@mail.com", null, null);
+
+            // when
+            CertificateRegistrationRequestDtoV3 dto = RegisterWireBuilder.buildRegistration(content, false);
+
+            // then — #160d… is the DER IA5String of "mail@mail.com"
+            assertThat(dto.getSubjectDn()).isEqualTo("1.2.840.113549.1.9.1=#160d6d61696c406d61696c2e636f6d,CN=reg");
+        }
+
+        @Test
+        void wireSubjectDn_escapesSpecialCharacters() {
+            // given — a value containing the RDN separator must be escaped on the wire
+            X509RequestContent content = RegisterWireBuilder.buildContent("CN=x,O=Org\\, s.r.o.", null, null);
+
+            // when
+            CertificateRegistrationRequestDtoV3 dto = RegisterWireBuilder.buildRegistration(content, false);
+
+            // then
+            assertThat(dto.getSubjectDn()).isEqualTo("O=Org\\, s.r.o.,CN=x");
         }
 
         @Test
@@ -292,7 +319,7 @@ class RegisterWireBuilderTest {
             CertificateRegistrationRequestDtoV3 dto = RegisterWireBuilder.buildRegistration(fullContent(), false);
 
             // then
-            assertThat(dto.getSubjectDn()).isEqualTo("O=Acme, CN=device-7");
+            assertThat(dto.getSubjectDn()).isEqualTo("O=Acme,CN=device-7");
             assertThat(dto.getSubjectAltName()).isEqualTo("DNS:device-7.acme.test");
             assertThat(dto.getExtensions()).hasSize(1);
             CertificateExtension flat = dto.getExtensions().get(0);

--- a/src/test/java/com/otilm/core/integration/util/PlatformX500NameStyleITest.java
+++ b/src/test/java/com/otilm/core/integration/util/PlatformX500NameStyleITest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PlatformX500NameStyleITest extends BaseSpringBootTest {
 
@@ -88,6 +89,47 @@ class PlatformX500NameStyleITest extends BaseSpringBootTest {
 
         assertThat(rendered).as("OID should be rendered as code for Location").contains(code + "=Location");
         assertThat(rendered).as("OID should be rendered as code for US").contains(code2 + "=US");
+    }
+
+    @Test
+    void parsesRegistryDefaultCodesUnknownToBouncyCastle() {
+        // EMAIL is the platform's default code for the email OID (SystemOid.EMAIL) but not a
+        // BouncyCastle keyword — every code the platform renders must parse back.
+        X500Name parsed = new X500Name(PlatformX500NameStyle.DEFAULT, "EMAIL=mail@mail.com, CN=reg");
+        assertThat(getOidByValueFromRDNs(parsed, "mail@mail.com")).isEqualTo(SystemOid.EMAIL.getOid());
+        assertThat(getOidByValueFromRDNs(parsed, "reg")).isEqualTo(SystemOid.COMMON_NAME.getOid());
+    }
+
+    @Test
+    void parsesRegistryCodesCaseInsensitively() {
+        X500Name parsed = new X500Name(PlatformX500NameStyle.DEFAULT, "email=mail@mail.com, CN=reg");
+        assertThat(getOidByValueFromRDNs(parsed, "mail@mail.com")).isEqualTo(SystemOid.EMAIL.getOid());
+    }
+
+    @Test
+    void parsesCustomCodesRegisteredAtRuntime() {
+        // DEFAULT is a shared instance created before runtime registrations — parsing must see them.
+        String oid = "1.2.3.4.5.7";
+        OidHandler.cacheOid(OidCategory.RDN_ATTRIBUTE_TYPE, oid,
+                OidRecord.builder().displayName("d").code("FOO").altCodes(List.of("BAR")).build());
+        X500Name parsed = new X500Name(PlatformX500NameStyle.DEFAULT, "FOO=a, BAR=b");
+        assertThat(getOidByValueFromRDNs(parsed, "a")).isEqualTo(oid);
+        assertThat(getOidByValueFromRDNs(parsed, "b")).isEqualTo(oid);
+    }
+
+    @Test
+    void parsesSnAsSurnamePerRegistry() {
+        // Registry-first is deliberate: the platform renders 2.5.4.4 (SystemOid.SURNAME) as "SN",
+        // so "SN" must parse back to surname even though BouncyCastle's keyword table would read
+        // it as serialNumber (2.5.4.5).
+        X500Name parsed = new X500Name(PlatformX500NameStyle.DEFAULT, "SN=Doe, CN=reg");
+        assertThat(getOidByValueFromRDNs(parsed, "Doe")).isEqualTo(SystemOid.SURNAME.getOid());
+    }
+
+    @Test
+    void rejectsCodesInNeitherRegistryNorBouncyCastle() {
+        assertThatThrownBy(() -> new X500Name(PlatformX500NameStyle.DEFAULT, "NOPE=x, CN=reg"))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     private static String getOidByValueFromRDNs(X500Name normalizedX500Name, String value) {


### PR DESCRIPTION
**Review-only PR — do not merge.**

The "strict wire DN and registry-first OID parse" change was unintentionally swept into `main` inside the #1839 squash-merge (the branch had merged a local main carrying it), so it never got its own review. This PR reconstructs it for review:

- **Base** (`wire-dn-review-base`): current `main` with the change reverted
- **Head**: base + the original change (`047e46d5a`) + its volatile→AtomicReference follow-up, so the reviewed `OidHandler` state is identical to what `main` has today

Review and comment as usual; when done, close this PR (the content is already in `main`) and delete both branches.