### PR TITLE
Accept platform RDN codes such as EMAIL in subject DNs

### DIFF
--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -33,27 +33,48 @@ public class OidHandler {
     private static final AtomicReference<Map<String, String>> rdnCodeToOid =
             new AtomicReference<>(Collections.emptyMap());
 
+    /**
+     * Serializes writers so that the read-copy-publish of a per-category map and the rebuild of the
+     * derived {@link #rdnCodeToOid} index happen as one unit. A private monitor is used rather than
+     * the {@code OidHandler.class} object so foreign code cannot contend on the same lock.
+     */
+    private static final Object WRITE_LOCK = new Object();
+
     public static Map<String, OidRecord> getOidCache(OidCategory oidCategory) {
         return oidCache.get(oidCategory);
     }
 
-    public static synchronized void cacheOidCategory(OidCategory category, Map<String, OidRecord> oidRecordMap) {
-        oidCache.put(category, oidRecordMap);
-        refreshRdnCodeLookup(category);
+    public static void cacheOidCategory(OidCategory category, Map<String, OidRecord> oidRecordMap) {
+        synchronized (WRITE_LOCK) {
+            oidCache.put(category, oidRecordMap);
+            refreshRdnCodeLookup(category);
+        }
     }
 
-    public static synchronized void cacheOid(OidCategory category, String oid, OidRecord oidRecord) {
-        // Copy-on-write: published per-category maps are iterated lock-free by readers
-        // (getCodeToOidMap, style snapshots), so never mutate one in place.
-        Map<String, OidRecord> next = new HashMap<>(oidCache.get(category));
-        next.put(oid, oidRecord);
-        oidCache.put(category, next);
-        refreshRdnCodeLookup(category);
+    public static void cacheOid(OidCategory category, String oid, OidRecord oidRecord) {
+        synchronized (WRITE_LOCK) {
+            // Copy-on-write: published per-category maps are iterated lock-free by readers
+            // (getCodeToOidMap, style snapshots), so never mutate one in place. getOrDefault
+            // keeps the first write to an as-yet-uncached category from throwing.
+            Map<String, OidRecord> next = new HashMap<>(oidCache.getOrDefault(category, Map.of()));
+            next.put(oid, oidRecord);
+            oidCache.put(category, next);
+            refreshRdnCodeLookup(category);
+        }
     }
 
     /** OID for an RDN code or alternative code, matched case-insensitively; {@code null} when unknown. */
     public static String getOidForRdnCode(String code) {
         return code == null ? null : rdnCodeToOid.get().get(code);
+    }
+
+    /**
+     * The published, immutable, case-insensitive RDN code/altCode → OID snapshot. Capture it once
+     * and reuse it for a whole DN so every RDN of one subject resolves against the same registry
+     * state, rather than re-reading the reference per attribute.
+     */
+    public static Map<String, String> getRdnCodeToOidMap() {
+        return rdnCodeToOid.get();
     }
 
     private static void refreshRdnCodeLookup(OidCategory category) {
@@ -93,10 +114,12 @@ public class OidHandler {
     }
 
 
-    public static synchronized void removeCachedOid(OidCategory category, String oid) {
-        Map<String, OidRecord> next = new HashMap<>(oidCache.get(category));
-        next.remove(oid);
-        oidCache.put(category, next);
-        refreshRdnCodeLookup(category);
+    public static void removeCachedOid(OidCategory category, String oid) {
+        synchronized (WRITE_LOCK) {
+            Map<String, OidRecord> next = new HashMap<>(oidCache.getOrDefault(category, Map.of()));
+            next.remove(oid);
+            oidCache.put(category, next);
+            refreshRdnCodeLookup(category);
+        }
     }
 }

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -40,25 +40,30 @@ public class OidHandler {
      */
     private static final Object WRITE_LOCK = new Object();
 
+    /** The published per-category map, or {@code null} when the category is not loaded. Immutable — see {@link #cacheOidCategory}. */
     public static Map<String, OidRecord> getOidCache(OidCategory oidCategory) {
         return oidCache.get(oidCategory);
     }
 
     public static void cacheOidCategory(OidCategory category, Map<String, OidRecord> oidRecordMap) {
         synchronized (WRITE_LOCK) {
-            oidCache.put(category, oidRecordMap);
+            // Publish an immutable defensive copy: per-category maps are iterated lock-free by
+            // readers (getCodeToOidMap, style snapshots), so a caller mutating the passed map
+            // after publish would desync oidCache from the derived rdnCodeToOid index. Copying
+            // here makes the copy-on-write contract structural rather than convention-only.
+            oidCache.put(category, Collections.unmodifiableMap(new HashMap<>(oidRecordMap)));
             refreshRdnCodeLookup(category);
         }
     }
 
     public static void cacheOid(OidCategory category, String oid, OidRecord oidRecord) {
         synchronized (WRITE_LOCK) {
-            // Copy-on-write: published per-category maps are iterated lock-free by readers
-            // (getCodeToOidMap, style snapshots), so never mutate one in place. getOrDefault
-            // keeps the first write to an as-yet-uncached category from throwing.
+            // Copy-on-write: build the next map fresh, then publish it immutable so readers never
+            // observe a map another thread might mutate. getOrDefault keeps the first write to an
+            // as-yet-uncached category from throwing.
             Map<String, OidRecord> next = new HashMap<>(oidCache.getOrDefault(category, Map.of()));
             next.put(oid, oidRecord);
-            oidCache.put(category, next);
+            oidCache.put(category, Collections.unmodifiableMap(next));
             refreshRdnCodeLookup(category);
         }
     }
@@ -124,7 +129,7 @@ public class OidHandler {
             }
             Map<String, OidRecord> next = new HashMap<>(current);
             next.remove(oid);
-            oidCache.put(category, next);
+            oidCache.put(category, Collections.unmodifiableMap(next));
             refreshRdnCodeLookup(category);
         }
     }

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -116,7 +116,13 @@ public class OidHandler {
 
     public static void removeCachedOid(OidCategory category, String oid) {
         synchronized (WRITE_LOCK) {
-            Map<String, OidRecord> next = new HashMap<>(oidCache.getOrDefault(category, Map.of()));
+            Map<String, OidRecord> current = oidCache.get(category);
+            // Removing from a never-loaded category is a no-op: don't materialize an empty entry,
+            // so getOidCache(category) stays null for callers that read null as "not loaded yet".
+            if (current == null) {
+                return;
+            }
+            Map<String, OidRecord> next = new HashMap<>(current);
             next.remove(oid);
             oidCache.put(category, next);
             refreshRdnCodeLookup(category);

--- a/src/main/java/com/otilm/core/util/X509RequestContentRenderer.java
+++ b/src/main/java/com/otilm/core/util/X509RequestContentRenderer.java
@@ -51,11 +51,12 @@ public final class X509RequestContentRenderer {
      * RDN types are resolved via the OID registry cache, then as dotted-decimal OIDs directly.
      */
     public static X500Principal toX500Principal(X509RequestContent x509) throws IOException {
-        Map<String, String> codeToOid = OidHandler.getCodeToOidMap();
+        // One registry snapshot for the whole subject, so all RDNs resolve against the same state.
+        Map<String, String> rdnCodeToOid = OidHandler.getRdnCodeToOidMap();
         X500NameBuilder builder = new X500NameBuilder();
         List<RdnEntry> subject = x509.getSubject() == null ? List.of() : x509.getSubject();
         for (RdnEntry rdn : subject) {
-            builder.addRDN(resolveOid(rdn.getType(), codeToOid), rdn.getValue());
+            builder.addRDN(resolveOid(rdn.getType(), rdnCodeToOid), rdn.getValue());
         }
         return new X500Principal(builder.build().getEncoded());
     }
@@ -200,15 +201,18 @@ public final class X509RequestContentRenderer {
         }
     }
 
-    private static ASN1ObjectIdentifier resolveOid(String type, Map<String, String> codeToOid) {
+    private static ASN1ObjectIdentifier resolveOid(String type, Map<String, String> rdnCodeToOid) {
         if (type == null || type.isBlank()) {
             throw new IllegalArgumentException("RDN type is required");
         }
         if (OidHandler.isOid(type)) {
             return new ASN1ObjectIdentifier(type);
         }
-        if (codeToOid != null && codeToOid.containsKey(type)) {
-            return new ASN1ObjectIdentifier(codeToOid.get(type));
+        // Case-insensitive registry lookup against the captured snapshot — the same rule the parse
+        // path uses (PlatformX500NameStyle.attrNameToOID), so any code that parses in renders back out.
+        String oid = rdnCodeToOid.get(type);
+        if (oid != null) {
+            return new ASN1ObjectIdentifier(oid);
         }
         throw new IllegalArgumentException("Unknown RDN type/code: " + type);
     }

--- a/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
+++ b/src/test/java/com/otilm/core/integration/attribute/AttributeEngineITest.java
@@ -190,12 +190,9 @@ class AttributeEngineITest extends BaseSpringBootTest {
     }
 
     private static void ensureOidCached(OidCategory category, String oid, OidRecord oidRecord) {
-        Map<String, OidRecord> cache = OidHandler.getOidCache(category);
-        if (cache == null) {
-            OidHandler.cacheOidCategory(category, new HashMap<>());
-            cache = OidHandler.getOidCache(category);
-        }
-        cache.put(oid, oidRecord);
+        // Route through cacheOid so the copy-on-write contract holds and the derived RDN code
+        // lookup is refreshed — mutating the map from getOidCache() directly bypasses both.
+        OidHandler.cacheOid(category, oid, oidRecord);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/oid/OidHandlerTest.java
+++ b/src/test/java/com/otilm/core/oid/OidHandlerTest.java
@@ -104,12 +104,15 @@ class OidHandlerTest {
     }
 
     @Test
-    void removeCachedOid_onUncachedCategory_doesNotThrow() {
+    void removeCachedOid_onUncachedCategory_isNoOpAndLeavesCategoryNull() {
         evictCategory(OidCategory.EXTENDED_KEY_USAGE);
         assertThat(OidHandler.getOidCache(OidCategory.EXTENDED_KEY_USAGE)).isNull();
 
         assertThatCode(() -> OidHandler.removeCachedOid(OidCategory.EXTENDED_KEY_USAGE, "9.9.9"))
                 .doesNotThrowAnyException();
+
+        // Must not materialize an empty entry: callers read null as "category not loaded yet".
+        assertThat(OidHandler.getOidCache(OidCategory.EXTENDED_KEY_USAGE)).isNull();
     }
 
     /**

--- a/src/test/java/com/otilm/core/oid/OidHandlerTest.java
+++ b/src/test/java/com/otilm/core/oid/OidHandlerTest.java
@@ -1,0 +1,130 @@
+package com.otilm.core.oid;
+
+import com.otilm.api.model.core.oid.OidCategory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Pure unit coverage for the {@link OidHandler} RDN-code lookup and copy-on-write mutators —
+ * no Spring context.
+ *
+ * <p>The OID cache is process-wide static state shared across the surefire JVM, so this class
+ * snapshots every category it touches in {@code @BeforeAll} and restores it in {@code @AfterAll}
+ * (mirroring {@code X509RequestContentRendererTest.ToX500Principal}) rather than leaking state
+ * into other test classes.
+ */
+class OidHandlerTest {
+
+    private static final OidCategory[] TOUCHED =
+            {OidCategory.RDN_ATTRIBUTE_TYPE, OidCategory.GENERIC, OidCategory.EXTENDED_KEY_USAGE};
+
+    private static final Map<OidCategory, Map<String, OidRecord>> saved = new EnumMap<>(OidCategory.class);
+
+    @BeforeAll
+    static void snapshotTouchedCategories() {
+        for (OidCategory category : TOUCHED) {
+            Map<String, OidRecord> existing = OidHandler.getOidCache(category);
+            saved.put(category, existing == null ? null : new HashMap<>(existing));
+        }
+    }
+
+    @AfterAll
+    static void restoreTouchedCategories() {
+        for (OidCategory category : TOUCHED) {
+            Map<String, OidRecord> original = saved.get(category);
+            if (original == null) {
+                evictCategory(category);
+            } else {
+                OidHandler.cacheOidCategory(category, original);
+            }
+        }
+    }
+
+    @BeforeEach
+    void resetRdnCache() {
+        OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, new HashMap<>());
+    }
+
+    @Test
+    void getOidForRdnCode_returnsNullForNullInput() {
+        assertThat(OidHandler.getOidForRdnCode(null)).isNull();
+    }
+
+    @Test
+    void getOidForRdnCode_returnsNullForUnknownCode() {
+        assertThat(OidHandler.getOidForRdnCode("NOPE")).isNull();
+    }
+
+    @Test
+    void getOidForRdnCode_matchesCodeAndAltCodesCaseInsensitively() {
+        OidHandler.cacheOid(OidCategory.RDN_ATTRIBUTE_TYPE, "1.2.840.113549.1.9.1",
+                OidRecord.builder().displayName("Email").code("EMAIL")
+                        .altCodes(List.of("E", "EMAILADDRESS")).build());
+
+        assertThat(OidHandler.getOidForRdnCode("EMAIL")).isEqualTo("1.2.840.113549.1.9.1");
+        assertThat(OidHandler.getOidForRdnCode("email")).isEqualTo("1.2.840.113549.1.9.1");
+        assertThat(OidHandler.getOidForRdnCode("e")).isEqualTo("1.2.840.113549.1.9.1");
+        assertThat(OidHandler.getOidForRdnCode("EmailAddress")).isEqualTo("1.2.840.113549.1.9.1");
+    }
+
+    @Test
+    void removeCachedOid_deregistersRdnCode() {
+        OidHandler.cacheOid(OidCategory.RDN_ATTRIBUTE_TYPE, "2.5.4.3",
+                OidRecord.builder().displayName("Common Name").code("CN").build());
+        assertThat(OidHandler.getOidForRdnCode("cn")).isEqualTo("2.5.4.3");
+
+        OidHandler.removeCachedOid(OidCategory.RDN_ATTRIBUTE_TYPE, "2.5.4.3");
+
+        assertThat(OidHandler.getOidForRdnCode("cn")).isNull();
+        assertThat(OidHandler.getOidCache(OidCategory.RDN_ATTRIBUTE_TYPE)).doesNotContainKey("2.5.4.3");
+    }
+
+    @Test
+    void cacheOid_onUncachedCategory_doesNotThrow() {
+        // Enforce the uncached precondition so the getOrDefault guard path is actually exercised,
+        // rather than assuming the category happens to be absent in the shared JVM.
+        evictCategory(OidCategory.GENERIC);
+        assertThat(OidHandler.getOidCache(OidCategory.GENERIC)).isNull();
+
+        assertThatCode(() -> OidHandler.cacheOid(OidCategory.GENERIC, "1.2.3.4",
+                OidRecord.builder().displayName("x").build()))
+                .doesNotThrowAnyException();
+        assertThat(OidHandler.getOidCache(OidCategory.GENERIC)).containsKey("1.2.3.4");
+    }
+
+    @Test
+    void removeCachedOid_onUncachedCategory_doesNotThrow() {
+        evictCategory(OidCategory.EXTENDED_KEY_USAGE);
+        assertThat(OidHandler.getOidCache(OidCategory.EXTENDED_KEY_USAGE)).isNull();
+
+        assertThatCode(() -> OidHandler.removeCachedOid(OidCategory.EXTENDED_KEY_USAGE, "9.9.9"))
+                .doesNotThrowAnyException();
+    }
+
+    /**
+     * Removes a category from the private static cache so an uncached ({@code null}) precondition
+     * is deterministic. There is no public API to drop a whole category, so the guard tests reach
+     * into the field directly — acceptable for white-box unit coverage in the same package.
+     */
+    @SuppressWarnings("unchecked")
+    private static void evictCategory(OidCategory category) {
+        try {
+            Field field = OidHandler.class.getDeclaredField("oidCache");
+            field.setAccessible(true);
+            ((Map<OidCategory, ?>) field.get(null)).remove(category);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Could not evict OID category for test setup", e);
+        }
+    }
+}

--- a/src/test/java/com/otilm/core/oid/OidHandlerTest.java
+++ b/src/test/java/com/otilm/core/oid/OidHandlerTest.java
@@ -44,6 +44,10 @@ class OidHandlerTest {
         for (OidCategory category : TOUCHED) {
             Map<String, OidRecord> original = saved.get(category);
             if (original == null) {
+                // Refresh the derived rdnCodeToOid index to empty before dropping the entry —
+                // evictCategory bypasses refreshRdnCodeLookup, so a bare remove would leave the
+                // index holding phantom codes from tests in this class. No-op for non-RDN categories.
+                OidHandler.cacheOidCategory(category, new HashMap<>());
                 evictCategory(category);
             } else {
                 OidHandler.cacheOidCategory(category, original);

--- a/src/test/java/com/otilm/core/util/X509RequestContentRendererTest.java
+++ b/src/test/java/com/otilm/core/util/X509RequestContentRendererTest.java
@@ -98,6 +98,21 @@ class X509RequestContentRendererTest {
         }
 
         @Test
+        void resolvesRdnType_caseInsensitively() throws IOException {
+            // given — registered codes supplied in lower case; RFC 4514 keywords are case-insensitive
+            // and the parse path (PlatformX500NameStyle.attrNameToOID) already matches case-insensitively,
+            // so the wire renderer must resolve the same codes rather than reject them.
+            var x509 = subjectOf(rdn("cn", "host.example.com"), rdn("mycode", "val"));
+
+            // when
+            X500Principal name = X509RequestContentRenderer.toX500Principal(x509);
+
+            // then — resolved to the registered OIDs despite the lower-case codes
+            assertThat(name.toString()).contains("CN=host.example.com");
+            assertThat(name.toString()).contains("1.2.3.4.5.6=val");
+        }
+
+        @Test
         void returnsEmptyDn_whenSubjectIsEmpty() throws IOException {
             // given
             var x509 = subjectOf();


### PR DESCRIPTION
## What

Follow-up hardening to the strict-wire-DN / registry-first-OID change (merged into `main` via #1839's merge commit). Addresses correctness, concurrency, and test-hygiene items surfaced in review.

### `OidHandler`
- Serialize writers on a private `WRITE_LOCK` monitor instead of the public `OidHandler.class` object, so foreign code cannot contend on the same lock.
- Guard `cacheOid` / `removeCachedOid` with `getOrDefault(category, Map.of())` so the first write to an as-yet-uncached category cannot NPE.
- Expose `getRdnCodeToOidMap()` — the published immutable, case-insensitive snapshot — so callers can capture it once.

### Wire DN rendering
- `X509RequestContentRenderer.toX500Principal` captures one registry snapshot per subject and resolves every RDN against it, and `resolveOid` now matches RDN codes **case-insensitively** — the same rule the parse path uses (`PlatformX500NameStyle.attrNameToOID`). A code that parses in now also renders back out, and all RDNs of one subject resolve against a single, consistent snapshot.

### Tests
- `AttributeEngineITest.ensureOidCached` routes through `cacheOid` instead of mutating the `getOidCache()` map in place, honoring the copy-on-write contract.
- New `OidHandlerTest`: null and case-insensitive code/altCode lookup, code de-registration via `removeCachedOid`, and uncached-category NPE-guard coverage (with the uncached precondition enforced).
- New case-insensitive wire-rendering test.

## Why

The render path resolved RDN codes case-sensitively while the parse path was case-insensitive, so a lower-case structured code could parse but fail to render. The per-RDN live lookup also let one subject resolve against multiple registry snapshots. The lock and NPE-guard changes tighten the copy-on-write registry the platform relies on.

## Testing

`mvn test` for the affected unit tests passes (`OidHandlerTest`, `X509RequestContentRendererTest`, `RegisterWireBuilderTest`, `X509RequestContentParserTest`, `CertificateRequestContentValidatorTest`). Spring integration tests (`PlatformX500NameStyleITest`, `AttributeEngineITest`, `CustomOidEntryServiceITest`) were not run locally — please run the ITest suite in CI before merge.