### PR TITLE
Certificate registration: attribute persistence and lifecycle hardening

### DIFF
--- a/src/main/java/com/otilm/core/api/v2/client/ClientOperationControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/v2/client/ClientOperationControllerImpl.java
@@ -112,6 +112,14 @@ public class ClientOperationControllerImpl implements ClientOperationController 
     }
 
     @Override
+    @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "register", affiliatedResource = Resource.RA_PROFILE, operation = Operation.LIST_ATTRIBUTES)
+    public List<BaseAttribute> listRegisterCertificateAttributes(
+            String authorityUuid,
+            @LogResource(uuid = true, affiliated = true) String raProfileUuid) throws ConnectorException, NotFoundException {
+        return clientOperationService.listRegisterCertificateAttributes(SecuredParentUUID.fromString(authorityUuid), SecuredUUID.fromString(raProfileUuid));
+    }
+
+    @Override
     @AuditLogged(module = Module.CERTIFICATES, resource = Resource.ATTRIBUTE, name = "revoke", affiliatedResource = Resource.RA_PROFILE, operation = Operation.VALIDATE_ATTRIBUTES)
     public void validateRevokeCertificateAttributes(
             String authorityUuid,

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeOperation.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeOperation.java
@@ -4,6 +4,7 @@ public class AttributeOperation {
 
     public static final String CERTIFICATE_ISSUE = "issue";
     public static final String CERTIFICATE_REVOKE = "revoke";
+    public static final String CERTIFICATE_REGISTER = "register";
     public static final String CERTIFICATE_REQUEST_SIGN = "sign"; // legacy usage in database migration
     public static final String SIGN = "sign";
     public static final String ENCRYPT = "encrypt";

--- a/src/main/java/com/otilm/core/dao/repository/CertificateRegistrationAuthorizationRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CertificateRegistrationAuthorizationRepository.java
@@ -48,4 +48,8 @@ public interface CertificateRegistrationAuthorizationRepository extends JpaRepos
     @Modifying
     @Query("UPDATE CertificateRegistrationAuthorization r SET r.state = :state, r.updated = CURRENT_TIMESTAMP WHERE r.certificateUuid = :certificateUuid")
     void updateStateByCertificateUuid(@Param("certificateUuid") UUID certificateUuid, @Param("state") RegistrationState state);
+
+    @Modifying
+    @Query("UPDATE CertificateRegistrationAuthorization r SET r.expiresAt = null, r.updated = CURRENT_TIMESTAMP WHERE r.certificateUuid = :certificateUuid")
+    void clearIssuanceWindowByCertificateUuid(@Param("certificateUuid") UUID certificateUuid);
 }

--- a/src/main/java/com/otilm/core/service/CertificateInternalService.java
+++ b/src/main/java/com/otilm/core/service/CertificateInternalService.java
@@ -62,7 +62,7 @@ public interface CertificateInternalService extends ResourceExtensionService {
      * for issuance. The registration identity already on the row (subject DN / SAN) is preserved; the issued
      * certificate's identity is written from the CA response at issuance.
      */
-    void addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateIssueRequestDto issueRequest)
+    UUID addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateIssueRequestDto issueRequest)
             throws CertificateRequestException, NoSuchAlgorithmException, NotFoundException;
 
     CertificateChainResponseDto getCertificateChain(SecuredUUID uuid, boolean withEndCertificate) throws NotFoundException;

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -490,7 +490,11 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
         if (certificate.getRaProfile() != null && certificate.getRaProfile().getAuthorityInstanceReference() != null && certificate.getRaProfile().getAuthorityInstanceReference().getConnectorUuid() != null) {
             dto.setIssueAttributes(attributeEngine.getObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(certificate.getRaProfile().getAuthorityInstanceReference().getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_ISSUE).build()));
             dto.setRevokeAttributes(attributeEngine.getObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(certificate.getRaProfile().getAuthorityInstanceReference().getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_REVOKE).build()));
+            dto.setRegisterAttributes(attributeEngine.getObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(certificate.getRaProfile().getAuthorityInstanceReference().getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_REGISTER).build()));
         }
+        // Register request-attribute values are stored connectorless at operation=null (see registerCertificate);
+        // read unconditionally so a REGISTERED placeholder (which has no certificate request) still exposes them.
+        dto.setRegistrationRequestAttributes(attributeEngine.getObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).build()));
         // TODO: originally showing only metadata from discovery resource, should it be like that?
         dto.setMetadata(attributeEngine.getMappedMetadataContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).build()));
         dto.setCustomAttributes(attributeEngine.getObjectCustomAttributesContent(Resource.CERTIFICATE, certificate.getUuid()));
@@ -1229,6 +1233,25 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
             // Preserve the hybrid/PQC alternative key's inventory linkage, mirroring the canonical
             // CSR-attach path; the request entity is managed here, so its alt-key fields flush at commit.
             setCertificateRequestAltKey(certificateRequestEntity, request.getAltPublicKey());
+        }
+        // Persist the operator-supplied request-attribute values from the completion on the request entity,
+        // connectorless at operation=null — the same slot direct issue uses, read back into certificateRequest.attributes.
+        // Write-if-empty so a fingerprint-shared CSR's attributes are not clobbered. Best-effort: this audit capture
+        // must not fail completion (the CSR itself carries the identity). The resolve is local under STATIC_ONLY (no
+        // connector call); hoist pre-lock if connector-set merge is later enabled.
+        List<RequestAttribute> completionRequestAttributes = issueRequest.getCsrAttributes() == null ? List.of()
+                : issueRequest.getCsrAttributes().stream().filter(a -> a != null).toList();
+        if (!completionRequestAttributes.isEmpty()) {
+            ObjectAttributeContentInfo info = ObjectAttributeContentInfo.builder(Resource.CERTIFICATE_REQUEST, certificateRequestEntity.getUuid()).build();
+            List<ResponseAttribute> existing = attributeEngine.getObjectDataAttributesContent(info);
+            if (existing == null || existing.isEmpty()) {
+                try {
+                    attributeEngine.validateUpdateDataAttributes(null, null, issuanceDefinitionResolver.resolve(certificate.getRaProfile()), completionRequestAttributes);
+                    attributeEngine.updateObjectDataAttributesContent(info, completionRequestAttributes);
+                } catch (Exception e) {
+                    log.debug("Skipping completion request-attribute persistence for certificate {}: {}", certificateUuid, e.getMessage());
+                }
+            }
         }
         certificateRepository.save(certificate);
     }

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -501,8 +501,9 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
             dto.setRevokeAttributes(attributeEngine.getObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(certificate.getRaProfile().getAuthorityInstanceReference().getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_REVOKE).build()));
             dto.setRegisterAttributes(attributeEngine.getObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(certificate.getRaProfile().getAuthorityInstanceReference().getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_REGISTER).build()));
         }
-        // Register request-attribute values are stored connectorless at operation=null (see registerCertificate);
-        // read unconditionally so a REGISTERED placeholder (which has no certificate request) still exposes them.
+        // Registration request-attribute values are persisted without a connector under the null operation slot by
+        // the register flow, and read here for every certificate so a registered placeholder that has no certificate
+        // request still exposes them.
         dto.setRegistrationRequestAttributes(attributeEngine.getObjectDataAttributesContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).build()));
         // TODO: originally showing only metadata from discovery resource, should it be like that?
         dto.setMetadata(attributeEngine.getMappedMetadataContent(ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).build()));
@@ -1171,7 +1172,8 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
     }
 
     @Override
-    @Transactional
+    // Roll back the partial CSR attach when completion parsing or validation fails; Spring's default keeps writes on a checked exception.
+    @Transactional(rollbackFor = Exception.class)
     public UUID addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateIssueRequestDto issueRequest)
             throws CertificateRequestException, NoSuchAlgorithmException, NotFoundException {
         if (issueRequest == null || issueRequest.getRequest() == null || issueRequest.getRequest().isBlank()) {

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -1172,7 +1172,7 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
 
     @Override
     @Transactional
-    public void addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateIssueRequestDto issueRequest)
+    public UUID addCertificateRequestToExisting(UUID certificateUuid, ClientCertificateIssueRequestDto issueRequest)
             throws CertificateRequestException, NoSuchAlgorithmException, NotFoundException {
         if (issueRequest == null || issueRequest.getRequest() == null || issueRequest.getRequest().isBlank()) {
             throw new CertificateRequestException("A certificate signing request is required to complete a registered certificate");
@@ -1247,26 +1247,10 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
             // CSR-attach path; the request entity is managed here, so its alt-key fields flush at commit.
             setCertificateRequestAltKey(certificateRequestEntity, request.getAltPublicKey());
         }
-        // Persist the operator-supplied request-attribute values from the completion on the request entity,
-        // connectorless at operation=null — the same slot direct issue uses, read back into certificateRequest.attributes.
-        // Write-if-empty so a fingerprint-shared CSR's attributes are not clobbered. Best-effort: this audit capture
-        // must not fail completion (the CSR itself carries the identity). The resolve is local under STATIC_ONLY (no
-        // connector call); hoist pre-lock if connector-set merge is later enabled.
-        List<RequestAttribute> completionRequestAttributes = issueRequest.getCsrAttributes() == null ? List.of()
-                : issueRequest.getCsrAttributes().stream().filter(a -> a != null).toList();
-        if (!completionRequestAttributes.isEmpty()) {
-            ObjectAttributeContentInfo info = ObjectAttributeContentInfo.builder(Resource.CERTIFICATE_REQUEST, certificateRequestEntity.getUuid()).build();
-            List<ResponseAttribute> existing = attributeEngine.getObjectDataAttributesContent(info);
-            if (existing == null || existing.isEmpty()) {
-                try {
-                    attributeEngine.validateUpdateDataAttributes(null, null, issuanceDefinitionResolver.resolve(certificate.getRaProfile()), completionRequestAttributes);
-                    attributeEngine.updateObjectDataAttributesContent(info, completionRequestAttributes);
-                } catch (Exception e) {
-                    log.debug("Skipping completion request-attribute persistence for certificate {}: {}", certificateUuid, e.getMessage());
-                }
-            }
-        }
         certificateRepository.save(certificate);
+        // Completion request-attribute values are persisted by the caller (issueExistingCertificate) outside this
+        // locked transaction; return the request entity so it can key the write.
+        return certificateRequestEntity.getUuid();
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -75,6 +75,7 @@ import com.otilm.core.service.handler.authority.AuthorityProviderAdapter;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
 import com.otilm.core.service.handler.authority.lifecycle.CertificateStateMachine;
 import com.otilm.core.service.writer.CertificateValidationWriter;
+import com.otilm.core.service.writer.registration.CertificateRegistrationAuthorizationWriter;
 import com.otilm.core.service.v2.ExtendedAttributeService;
 import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.util.*;
@@ -222,6 +223,13 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
     @Autowired
     public void setRegistrationAuthorizationRepository(CertificateRegistrationAuthorizationRepository registrationAuthorizationRepository) {
         this.registrationAuthorizationRepository = registrationAuthorizationRepository;
+    }
+
+    private CertificateRegistrationAuthorizationWriter registrationAuthorizationWriter;
+
+    @Autowired
+    public void setRegistrationAuthorizationWriter(CertificateRegistrationAuthorizationWriter registrationAuthorizationWriter) {
+        this.registrationAuthorizationWriter = registrationAuthorizationWriter;
     }
 
     @Autowired
@@ -1945,6 +1953,9 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
 
         stateMachine.transition(certificate, CertificateState.ISSUED, CertificateEvent.ISSUE,
                 "Issued using RA Profile " + certificate.getRaProfile().getName());
+        // A pre-registered certificate's issuance window governed only this initial issuance; clear it so the
+        // authorization retained for a later renew/rekey carries no stale deadline. No-op for non-registered certs.
+        registrationAuthorizationWriter.clearIssuanceWindow(uuid);
 
         for (CertificateRelation relation : certificate.getPredecessorRelations()) {
             relation.setRelationType(determineRelationType(certificate, relation.getPredecessorCertificate()));

--- a/src/main/java/com/otilm/core/service/v2/ClientOperationExternalService.java
+++ b/src/main/java/com/otilm/core/service/v2/ClientOperationExternalService.java
@@ -73,6 +73,10 @@ public interface ClientOperationExternalService {
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid) throws ConnectorException, NotFoundException;
 
+    List<BaseAttribute> listRegisterCertificateAttributes(
+            SecuredParentUUID authorityUuid,
+            SecuredUUID raProfileUuid) throws ConnectorException, NotFoundException;
+
     void validateRevokeCertificateAttributes(
             SecuredParentUUID authorityUuid,
             SecuredUUID raProfileUuid,

--- a/src/main/java/com/otilm/core/service/v2/ExtendedAttributeService.java
+++ b/src/main/java/com/otilm/core/service/v2/ExtendedAttributeService.java
@@ -22,6 +22,9 @@ public interface ExtendedAttributeService {
     List<BaseAttribute> listRevokeCertificateAttributes(
             RaProfile raProfile) throws ConnectorException, NotFoundException;
 
+    List<BaseAttribute> listRegisterCertificateAttributes(
+            RaProfile raProfile) throws ConnectorException, NotFoundException;
+
     void validateRevokeCertificateAttributes(
             RaProfile raProfile,
             List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException;
@@ -29,6 +32,8 @@ public interface ExtendedAttributeService {
     void mergeAndValidateIssueAttributes(RaProfile raProfile, List<RequestAttribute> attributes) throws ConnectorException, AttributeException, NotFoundException;
 
     void mergeAndValidateRevokeAttributes(RaProfile raProfile, List<RequestAttribute> attributes) throws ConnectorException, AttributeException, NotFoundException;
+
+    void mergeAndValidateRegisterAttributes(RaProfile raProfile, List<RequestAttribute> attributes) throws ConnectorException, AttributeException, NotFoundException;
 
     void validateLegacyConnector(Connector connector) throws NotFoundException;
 }

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -116,7 +116,9 @@ import java.util.*;
 import java.util.function.BooleanSupplier;
 
 @Service("clientOperationServiceImplV2")
-@Transactional
+// Roll back on any exception, checked included, so a connector or attribute failure never commits partial state.
+// Write methods override this with their own NOT_SUPPORTED boundary; the methods governed here are reads.
+@Transactional(rollbackFor = Exception.class)
 public class ClientOperationServiceImpl implements ClientOperationExternalService, ClientOperationInternalService {
     private static final Logger logger = LoggerFactory.getLogger(ClientOperationServiceImpl.class);
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -336,6 +336,14 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
     @Override
     @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
+    public List<BaseAttribute> listRegisterCertificateAttributes(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid) throws ConnectorException, NotFoundException {
+        RaProfile raProfile = raProfileRepository.findByUuidAndEnabledIsTrue(raProfileUuid.getValue())
+                .orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
+        return extendedAttributeService.listRegisterCertificateAttributes(raProfile);
+    }
+
+    @Override
+    @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.ANY, parentResource = Resource.AUTHORITY, parentAction = ResourceAction.DETAIL)
     public void validateIssueCertificateAttributes(SecuredParentUUID authorityUuid, SecuredUUID raProfileUuid, List<RequestAttribute> attributes) throws ConnectorException, ValidationException, NotFoundException {
         RaProfile raProfile = raProfileRepository.findByUuidAndEnabledIsTrue(raProfileUuid.getValue())
                 .orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
@@ -494,6 +502,16 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             if (createCustomAttributes && request.getCustomAttributes() != null && !request.getCustomAttributes().isEmpty()) {
                 attributeEngine.updateObjectCustomAttributesContent(Resource.CERTIFICATE, certificate.getUuid(), request.getCustomAttributes());
             }
+            persistRegistrationRequestValues(certificate, request);
+            // Persist the connector's register-operation attributes (register + connector), symmetric with how
+            // issue/revoke store their operation attributes, so they surface as registerAttributes on the detail.
+            if (request.getAttributes() != null && !request.getAttributes().isEmpty()) {
+                extendedAttributeService.mergeAndValidateRegisterAttributes(raProfile, request.getAttributes());
+                attributeEngine.updateObjectDataAttributesContent(
+                        ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid())
+                                .connector(authority.getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_REGISTER).build(),
+                        request.getAttributes());
+            }
             // Apply owner/groups before the connector call, alongside custom attributes: an invalid owner/group
             // UUID fails the placeholder here (pre-acceptance) rather than after a connector has already accepted.
             applyRegistrationAssociations(certificate, request);
@@ -580,6 +598,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             if (createCustomAttributes && request.getCustomAttributes() != null && !request.getCustomAttributes().isEmpty()) {
                 attributeEngine.updateObjectCustomAttributesContent(Resource.CERTIFICATE, certificate.getUuid(), request.getCustomAttributes());
             }
+            persistRegistrationRequestValues(certificate, request);
             applyRegistrationAssociations(certificate, request);
             maybeCreateRegistrationAuthorization(certificate, request);
             // Write the register->issue binding (no connector meta) so a platform-level placeholder carries the same
@@ -678,6 +697,22 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
             RegisterWireBuilder.assertFlatRepresentable(content);
         }
         return content;
+    }
+
+    /**
+     * Persists the operator-supplied request-attribute values of a structured registration on the certificate,
+     * connectorless at operation=null — the key {@code getCertificate} reads into {@code registrationRequestAttributes}.
+     * The definitions were materialised by {@link #buildStructuredRegistrationContent} (operation=null), so this only
+     * writes content. A flat registration carries no csrAttributes and stores nothing.
+     */
+    private void persistRegistrationRequestValues(Certificate certificate, ClientCertificateRegistrationDto request)
+            throws AttributeException, NotFoundException {
+        if (!hasStructuredIdentity(request.getCsrAttributes())) {
+            return;
+        }
+        List<RequestAttribute> csrAttributes = request.getCsrAttributes().stream().filter(Objects::nonNull).toList();
+        attributeEngine.updateObjectDataAttributesContent(
+                ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).build(), csrAttributes);
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -800,7 +800,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     /**
      * Challenge gate for completing a pre-registered certificate. Issue is the only challenge-verified completion
      * path; renew and rekey of a registered certificate are fail-closed instead (see
-     * rejectRenewOrRekeyOfActiveRegistration). A certificate with no authorization row is not self-service and
+     * rejectRenewOrRekeyOfLiveRegistration). A certificate with no authorization row is not self-service and
      * passes untouched. On an ACTIVE authorization it
      * enforces, under a per-row pessimistic lock, the issuance window then the operator challenge; LOCKED/EXPIRED
      * deny; CLOSED passes as unregistered. The failed-attempt increment and lockout are committed before the caller
@@ -875,18 +875,20 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
     }
 
     /**
-     * Fail-closed guard: a certificate with an ACTIVE registration authorization must not be renewed or rekeyed
+     * Fail-closed guard: a certificate whose registration authorization is not CLOSED must not be renewed or rekeyed
      * until those paths are challenge-gated (together with copying the authorization to the successor), so neither
-     * can silently exit the challenge regime. This also denies platform-automation renewals (locations, workflows,
-     * scheduled renew) of such certificates. Issue completion remains the challenge-verified path
-     * (verifyRegistrationChallenge).
+     * can silently exit the challenge regime. Keying on {@code != CLOSED} rather than {@code == ACTIVE} keeps the
+     * guard fail-closed if a retained authorization is ever left EXPIRED (e.g. a passed-window sweep) or LOCKED:
+     * only a deliberately CLOSED (retired) registration renews freely as unregistered. This also denies
+     * platform-automation renewals (locations, workflows, scheduled renew) of such certificates. Issue completion
+     * remains the challenge-verified path (verifyRegistrationChallenge).
      */
-    private void rejectRenewOrRekeyOfActiveRegistration(UUID certificateUuid) {
+    private void rejectRenewOrRekeyOfLiveRegistration(UUID certificateUuid) {
         registrationAuthorizationRepository.findByCertificateUuid(certificateUuid)
-                .filter(authorization -> authorization.getState() == RegistrationState.ACTIVE)
+                .filter(authorization -> authorization.getState() != RegistrationState.CLOSED)
                 .ifPresent(authorization -> {
                     throw new ValidationException(ValidationError.create(
-                            "This certificate has an active registration; renew and rekey of registered certificates are not supported yet."));
+                            "This certificate has a live registration; renew and rekey of registered certificates are not supported yet."));
                 });
     }
 
@@ -1571,7 +1573,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
         // Fail-closed: renew is not challenge-gated yet, so refuse to renew a certificate whose registration is
         // still ACTIVE rather than let a secretless renew silently exit the challenge regime.
-        rejectRenewOrRekeyOfActiveRegistration(oldCertificate.getUuid());
+        rejectRenewOrRekeyOfLiveRegistration(oldCertificate.getUuid());
 
         // CSR decision making
         CertificateRequest certificateRequest;
@@ -1739,7 +1741,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
 
         // Fail-closed: rekey is not challenge-gated yet (its verification and successor copy come later), so
         // refuse to rekey a certificate whose registration is still ACTIVE.
-        rejectRenewOrRekeyOfActiveRegistration(oldCertificate.getUuid());
+        rejectRenewOrRekeyOfLiveRegistration(oldCertificate.getUuid());
 
         // CSR decision making
         ClientCertificateRequestDto certificateRequestDto = new ClientCertificateRequestDto();

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -459,6 +459,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         }
         rejectAmbiguousRegistrationIdentity(request);
         rejectPastRegistrationWindow(request);
+        rejectWindowWithoutChallenge(request);
         // Connector call below holds no transaction (NOT_SUPPORTED), so load the authority graph eagerly —
         // every association the adapter dereferences must be initialized before the session closes.
         RaProfile raProfile = raProfileRepository.findWithAuthorityByUuid(raProfileUuid.getValue())
@@ -726,6 +727,20 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         OffsetDateTime expiresAt = request.getExpiresAt();
         if (secret != null && !secret.isBlank() && expiresAt != null && !expiresAt.isAfter(OffsetDateTime.now(ZoneOffset.UTC))) {
             throw new ValidationException("The registration issuance window (expiresAt) must be in the future.");
+        }
+    }
+
+    /**
+     * Rejects an issuance window supplied without a challenge. The window is enforced only within the challenge
+     * regime — it lives on the {@link CertificateRegistrationAuthorization}, which is created only when a secret is
+     * present — so a window without an {@code authorizationSecret} would be silently dropped. Reject it up front
+     * rather than accept a deadline that has no effect.
+     */
+    private static void rejectWindowWithoutChallenge(ClientCertificateRegistrationDto request) {
+        String secret = request.getAuthorizationSecret();
+        if ((secret == null || secret.isBlank()) && request.getExpiresAt() != null) {
+            throw new ValidationException(
+                    "A registration issuance window (expiresAt) requires an authorization secret; a registration without a challenge has no completion deadline.");
         }
     }
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -511,10 +511,11 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
                 attributeEngine.updateObjectCustomAttributesContent(Resource.CERTIFICATE, certificate.getUuid(), request.getCustomAttributes());
             }
             persistRegistrationRequestValues(certificate, request);
-            // Persist the connector's register-operation attributes (register + connector), symmetric with how
-            // issue/revoke store their operation attributes, so they surface as registerAttributes on the detail.
+            // Validate the connector's register-operation attributes against the schema — always, so a required
+            // register attribute is enforced even when the client sends none — then persist the supplied ones on the
+            // certificate (register + connector), symmetric with issue/revoke, so they surface as registerAttributes.
+            extendedAttributeService.mergeAndValidateRegisterAttributes(raProfile, request.getAttributes());
             if (request.getAttributes() != null && !request.getAttributes().isEmpty()) {
-                extendedAttributeService.mergeAndValidateRegisterAttributes(raProfile, request.getAttributes());
                 attributeEngine.updateObjectDataAttributesContent(
                         ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid())
                                 .connector(authority.getConnectorUuid()).operation(AttributeOperation.CERTIFICATE_REGISTER).build(),
@@ -727,6 +728,36 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         List<RequestAttribute> csrAttributes = request.getCsrAttributes().stream().filter(Objects::nonNull).toList();
         attributeEngine.updateObjectDataAttributesContent(
                 ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).build(), csrAttributes);
+    }
+
+    /**
+     * Persists the operator-supplied completion request-attribute values on the certificate request, connectorless at
+     * operation=null (the slot direct issue uses; read back into {@code certificateRequest.attributes}). Called from
+     * {@code issueExistingCertificate} (NOT_SUPPORTED), so it runs outside the CSR-attach row lock: the resolve — which
+     * can reach the connector for a non-STATIC_ONLY profile — and each attribute-engine write execute in their own
+     * transaction, so an invalid attribute or an unreachable connector is skipped (WARN) without failing the completed
+     * certificate. Write-if-empty so a fingerprint-shared CSR's attributes are not clobbered.
+     */
+    private void persistCompletionRequestValues(RaProfile raProfile, UUID certificateRequestUuid, ClientCertificateIssueRequestDto request) {
+        if (certificateRequestUuid == null || request.getCsrAttributes() == null) {
+            return;
+        }
+        List<RequestAttribute> csrAttributes = request.getCsrAttributes().stream().filter(Objects::nonNull).toList();
+        if (csrAttributes.isEmpty()) {
+            return;
+        }
+        ObjectAttributeContentInfo info = ObjectAttributeContentInfo.builder(Resource.CERTIFICATE_REQUEST, certificateRequestUuid).build();
+        try {
+            var existing = attributeEngine.getObjectDataAttributesContent(info);
+            if (existing != null && !existing.isEmpty()) {
+                return;
+            }
+            attributeEngine.validateUpdateDataAttributes(null, null, issuanceDefinitionResolver.resolve(raProfile), csrAttributes);
+            attributeEngine.updateObjectDataAttributesContent(info, csrAttributes);
+        } catch (ValidationException | AttributeException | ConnectorException | NotFoundException e) {
+            logger.warn("Skipping completion request-attribute persistence for certificate request {}: {}",
+                    certificateRequestUuid, safeMessage(e, "completion attribute persistence failed"));
+        }
     }
 
     /**
@@ -1548,11 +1579,16 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
                 request != null ? request.getAuthorizationSecret() : null);
 
         if (registered) {
+            UUID certificateRequestUuid;
             try {
-                certificateService.addCertificateRequestToExisting(certificate.getUuid(), request);
+                certificateRequestUuid = certificateService.addCertificateRequestToExisting(certificate.getUuid(), request);
             } catch (CertificateRequestException | NoSuchAlgorithmException e) {
                 throw new ValidationException(ValidationError.create("Invalid certificate signing request: " + e.getMessage()));
             }
+            // Persist the completion request-attribute values outside the CSR-attach transaction and its row lock
+            // (this method is NOT_SUPPORTED), so the resolve and the attribute-engine writes run in their own
+            // transactions and cannot mark the completed certificate's transaction rollback-only.
+            persistCompletionRequestValues(raProfile, certificateRequestUuid, request);
         }
 
         final ActionMessage actionMessage = new ActionMessage();

--- a/src/main/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImpl.java
@@ -2,6 +2,7 @@ package com.otilm.core.service.v2.impl;
 
 import com.otilm.api.exception.*;
 import com.otilm.api.model.client.attribute.RequestAttribute;
+import com.otilm.api.model.client.connector.v2.FeatureFlag;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeOperation;
@@ -9,8 +10,10 @@ import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.Connector2FunctionGroup;
 import com.otilm.core.dao.entity.RaProfile;
 import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.service.handler.ConnectorCapabilityService;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapter;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
+import com.otilm.core.service.handler.authority.RegisterCapability;
 import com.otilm.core.service.v2.ExtendedAttributeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -40,6 +43,13 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
     @Autowired
     public void setAttributeEngine(AttributeEngine attributeEngine) {
         this.attributeEngine = attributeEngine;
+    }
+
+    private ConnectorCapabilityService capabilityService;
+
+    @Autowired
+    public void setCapabilityService(ConnectorCapabilityService capabilityService) {
+        this.capabilityService = capabilityService;
     }
 
     @Override
@@ -96,6 +106,44 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
         validateLegacyConnector(connector);
         AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
         return adapter.listRevokeAttributes(authorityRef, raProfile);
+    }
+
+    @Override
+    public List<BaseAttribute> listRegisterCertificateAttributes(RaProfile raProfile) throws ConnectorException, NotFoundException {
+        var authorityRef = raProfile.getAuthorityInstanceReference();
+        var connector = authorityRef.getConnector();
+        if (connector == null) {
+            throw new NotFoundException("Connector of the Authority is not available / deleted");
+        }
+        // No legacy-connector check here (unlike issue/revoke): registration is a v3-only capability, so a legacy
+        // or v2 authority simply routes to a non-RegisterCapability adapter and the guard below returns an empty
+        // set — uniform "no register support" behaviour rather than a v2-framed 404.
+        AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(authorityRef);
+        if (adapter instanceof RegisterCapability registerCapability
+                && capabilityService.supports(authorityRef, FeatureFlag.CERTIFICATE_REGISTRATION)) {
+            return registerCapability.listRegisterAttributes(authorityRef, raProfile);
+        }
+        return List.of();
+    }
+
+    @Override
+    public void mergeAndValidateRegisterAttributes(RaProfile raProfile, List<RequestAttribute> attributes) throws ConnectorException, AttributeException, NotFoundException {
+        var authorityRef = raProfile.getAuthorityInstanceReference();
+        if (authorityRef.getConnector() == null) {
+            throw new ValidationException(ValidationError.create("Connector of the Authority is not available / deleted"));
+        }
+        AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(authorityRef);
+        // Registration is v3-only; a non-register-capable authority carries no register attributes to validate.
+        if (!(adapter instanceof RegisterCapability registerCapability)
+                || !capabilityService.supports(authorityRef, FeatureFlag.CERTIFICATE_REGISTRATION)) {
+            return;
+        }
+        if (attributes == null) {
+            attributes = new ArrayList<>();
+        }
+        // v3 has no connector-side validate; materialize the register schema and validate structurally via the engine.
+        List<BaseAttribute> definitions = registerCapability.listRegisterAttributes(authorityRef, raProfile);
+        attributeEngine.validateUpdateDataAttributes(authorityRef.getConnectorUuid(), AttributeOperation.CERTIFICATE_REGISTER, definitions, attributes);
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImpl.java
@@ -24,6 +24,8 @@ import java.util.List;
 @Service("extendedAcmeServiceImpl")
 public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
 
+    private static final String CONNECTOR_UNAVAILABLE_MESSAGE = "Connector of the Authority is not available / deleted";
+
     private ConnectorRepository connectorRepository;
 
     @Autowired
@@ -57,7 +59,7 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
         var authorityRef = raProfile.getAuthorityInstanceReference();
         var connector = authorityRef.getConnector();
         if (connector == null) {
-            throw new NotFoundException("Connector of the Authority is not available / deleted");
+            throw new NotFoundException(CONNECTOR_UNAVAILABLE_MESSAGE);
         }
         validateLegacyConnector(connector);
         return authorityProviderAdapterFactory.forAuthority(authorityRef).listIssueAttributes(authorityRef, raProfile);
@@ -68,7 +70,7 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
         var authorityRef = raProfile.getAuthorityInstanceReference();
         var connector = authorityRef.getConnector();
         if (connector == null) {
-            throw new NotFoundException("Connector of the Authority is not available / deleted");
+            throw new NotFoundException(CONNECTOR_UNAVAILABLE_MESSAGE);
         }
         validateLegacyConnector(connector);
 
@@ -79,7 +81,7 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
     @Override
     public void mergeAndValidateIssueAttributes(RaProfile raProfile, List<RequestAttribute> attributes) throws ConnectorException, AttributeException, NotFoundException {
         if (raProfile.getAuthorityInstanceReference().getConnector() == null) {
-            throw new ValidationException(ValidationError.create("Connector of the Authority is not available / deleted"));
+            throw new ValidationException(ValidationError.create(CONNECTOR_UNAVAILABLE_MESSAGE));
         }
         AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
 
@@ -101,7 +103,7 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
         var authorityRef = raProfile.getAuthorityInstanceReference();
         var connector = authorityRef.getConnector();
         if (connector == null) {
-            throw new NotFoundException("Connector of the Authority is not available / deleted");
+            throw new NotFoundException(CONNECTOR_UNAVAILABLE_MESSAGE);
         }
         validateLegacyConnector(connector);
         AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
@@ -113,7 +115,7 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
         var authorityRef = raProfile.getAuthorityInstanceReference();
         var connector = authorityRef.getConnector();
         if (connector == null) {
-            throw new NotFoundException("Connector of the Authority is not available / deleted");
+            throw new NotFoundException(CONNECTOR_UNAVAILABLE_MESSAGE);
         }
         // No legacy-connector check here (unlike issue/revoke): registration is a v3-only capability, so a legacy
         // or v2 authority simply routes to a non-RegisterCapability adapter and the guard below returns an empty
@@ -130,7 +132,7 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
     public void mergeAndValidateRegisterAttributes(RaProfile raProfile, List<RequestAttribute> attributes) throws ConnectorException, AttributeException, NotFoundException {
         var authorityRef = raProfile.getAuthorityInstanceReference();
         if (authorityRef.getConnector() == null) {
-            throw new ValidationException(ValidationError.create("Connector of the Authority is not available / deleted"));
+            throw new ValidationException(ValidationError.create(CONNECTOR_UNAVAILABLE_MESSAGE));
         }
         AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(authorityRef);
         // Registration is v3-only; a non-register-capable authority carries no register attributes to validate.
@@ -151,7 +153,7 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
         var authorityRef = raProfile.getAuthorityInstanceReference();
         var connector = authorityRef.getConnector();
         if (connector == null) {
-            throw new NotFoundException("Connector of the Authority is not available / deleted");
+            throw new NotFoundException(CONNECTOR_UNAVAILABLE_MESSAGE);
         }
         validateLegacyConnector(connector);
         AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
@@ -161,7 +163,7 @@ public class ExtendedAttributeServiceImpl implements ExtendedAttributeService {
     @Override
     public void mergeAndValidateRevokeAttributes(RaProfile raProfile, List<RequestAttribute> attributes) throws ConnectorException, AttributeException, NotFoundException {
         if (raProfile.getAuthorityInstanceReference().getConnector() == null) {
-            throw new ValidationException(ValidationError.create("Connector of the Authority is not available / deleted"));
+            throw new ValidationException(ValidationError.create(CONNECTOR_UNAVAILABLE_MESSAGE));
         }
         AuthorityProviderAdapter adapter = authorityProviderAdapterFactory.forAuthority(raProfile.getAuthorityInstanceReference());
 

--- a/src/main/java/com/otilm/core/service/writer/registration/CertificateRegistrationAuthorizationWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/registration/CertificateRegistrationAuthorizationWriter.java
@@ -34,4 +34,15 @@ public class CertificateRegistrationAuthorizationWriter {
     public void close(UUID certificateUuid) {
         authorizationRepository.updateStateByCertificateUuid(certificateUuid, RegistrationState.CLOSED);
     }
+
+    /**
+     * Clears the issuance window (expiresAt to null) once the pre-registration's initial issuance completes: the
+     * deadline governed only that first issuance, so an authorization retained for a later renew/rekey carries no
+     * stale deadline — a passed window must never flip a still-live authorization to EXPIRED. State is left
+     * unchanged. Idempotent (no-op when no row exists).
+     */
+    @Transactional
+    public void clearIssuanceWindow(UUID certificateUuid) {
+        authorizationRepository.clearIssuanceWindowByCertificateUuid(certificateUuid);
+    }
 }

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterCustomAttributeITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterCustomAttributeITest.java
@@ -1,5 +1,6 @@
 package com.otilm.core.integration.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.attribute.RequestAttributeV3;
 import com.otilm.api.model.client.attribute.ResponseAttribute;
@@ -95,7 +96,7 @@ class ClientOperationServiceRegisterCustomAttributeITest extends BaseSpringBootT
     @Autowired
     private RaProfileCertificateRequestAttributeWriter requestAttributeWriter;
     @Autowired
-    private com.fasterxml.jackson.databind.ObjectMapper objectMapper;
+    private ObjectMapper objectMapper;
 
     @MockitoBean
     private AuthorityProviderAdapterFactory adapterFactory;
@@ -297,6 +298,44 @@ class ClientOperationServiceRegisterCustomAttributeITest extends BaseSpringBootT
         Assertions.assertEquals("device-complete",
                 ((StringAttributeContentV3) ((ResponseAttributeV3) reqAttrs.getFirst()).getContent().getFirst()).getData(),
                 "the completion request-attribute value must be readable from the detail");
+    }
+
+    @Test
+    void completionWithUnpersistableRequestAttributeStillCompletes() throws Exception {
+        // Author a required CN attribute (STATIC_ONLY so resolve is local), then complete with that attribute EMPTY.
+        // Validation fails (a required value is missing) — a ValidationException (RuntimeException) that, before the
+        // fix, marked the completion transaction rollback-only. The persistence must now be skipped best-effort and
+        // the certificate must still complete.
+        DataAttributeV3 cnDef = aMappedDataAttribute().withName("commonName").required().mappingRdn("2.5.4.3").build();
+        ((RdnMappedField) cnDef.getFieldMapping().getFields().getFirst()).setFieldType(FieldType.RDN);
+        UUID cnUuid = UUID.randomUUID();
+        cnDef.setUuid(cnUuid.toString());
+        requestAttributeWriter.saveStaticSet(raProfile,
+                objectMapper.writeValueAsString(List.of(cnDef)), AttributeSetMergeMode.STATIC_ONLY, null);
+
+        AuthorityProviderAdapter adapter = mock(AuthorityProviderAdapter.class,
+                Mockito.withSettings().extraInterfaces(RegisterCapability.class));
+        when(adapterFactory.forAuthority(Mockito.any())).thenReturn(adapter);
+        when(((RegisterCapability) adapter).register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
+        ClientCertificateRegistrationDto registration = new ClientCertificateRegistrationDto();
+        registration.setSubjectDn("CN=device-badattr,O=Acme");
+        String certUuid = clientOperationService.registerCertificate(authorityParent, securedRaProfile, registration).getUuid();
+
+        ClientCertificateIssueRequestDto completion = new ClientCertificateIssueRequestDto();
+        completion.setRequest(generateCsrBase64());
+        completion.setFormat(CertificateRequestFormat.PKCS10);
+        // Required attribute submitted with no content -> validation fails; the persistence is skipped, not fatal.
+        completion.setCsrAttributes(List.of(new RequestAttributeV3(cnUuid, "commonName",
+                AttributeContentType.STRING, List.<BaseAttributeContentV3<?>>of())));
+
+        // Must not throw — the completion succeeds despite the unpersistable request attribute.
+        clientOperationService.issueExistingCertificate(authorityParent, securedRaProfile, certUuid, completion);
+
+        CertificateDetailDto detail = certificateExternalService.getCertificate(SecuredUUID.fromString(certUuid));
+        Assertions.assertNotNull(detail.getCertificateRequest(), "the CSR must be attached even though the attribute was skipped");
+        Assertions.assertTrue(detail.getCertificateRequest().getAttributes().isEmpty(),
+                "the unpersistable completion attribute must be skipped, not persisted");
     }
 
     private String generateCsrBase64() throws Exception {

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterCustomAttributeITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterCustomAttributeITest.java
@@ -12,6 +12,8 @@ import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.v3.content.StringAttributeContentV3;
 import com.otilm.api.model.core.v2.ClientCertificateDataResponseDto;
+import com.otilm.api.model.core.enums.CertificateRequestFormat;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
@@ -42,6 +44,10 @@ import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
 import com.otilm.core.service.handler.authority.RegisterCapability;
 import com.otilm.core.service.v2.ClientOperationExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,6 +56,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 
@@ -252,5 +261,50 @@ class ClientOperationServiceRegisterCustomAttributeITest extends BaseSpringBootT
         Assertions.assertEquals("device-rt",
                 ((StringAttributeContentV3) attr.getContent().getFirst()).getData(),
                 "the submitted registration request-attribute value must be readable from the detail");
+    }
+
+    @Test
+    void completionPersistsRequestAttributeValuesOnTheRequestEntity() throws Exception {
+        // Author the CN request attribute so the completion can resolve + validate it.
+        DataAttributeV3 cnDef = aMappedDataAttribute().withName("commonName").mappingRdn("2.5.4.3").build();
+        ((RdnMappedField) cnDef.getFieldMapping().getFields().getFirst()).setFieldType(FieldType.RDN);
+        UUID cnUuid = UUID.randomUUID();
+        cnDef.setUuid(cnUuid.toString());
+        requestAttributeWriter.saveStaticSet(raProfile,
+                objectMapper.writeValueAsString(List.of(cnDef)), AttributeSetMergeMode.STATIC_ONLY, null);
+
+        // Register a flat placeholder (no csrAttributes → no registrationRequestAttributes), then complete it with a
+        // CSR carrying request attributes; the completion values are persisted on the request entity.
+        AuthorityProviderAdapter adapter = mock(AuthorityProviderAdapter.class,
+                Mockito.withSettings().extraInterfaces(RegisterCapability.class));
+        when(adapterFactory.forAuthority(Mockito.any())).thenReturn(adapter);
+        when(((RegisterCapability) adapter).register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
+        ClientCertificateRegistrationDto registration = new ClientCertificateRegistrationDto();
+        registration.setSubjectDn("CN=device-complete,O=Acme");
+        String certUuid = clientOperationService.registerCertificate(authorityParent, securedRaProfile, registration).getUuid();
+
+        ClientCertificateIssueRequestDto completion = new ClientCertificateIssueRequestDto();
+        completion.setRequest(generateCsrBase64());
+        completion.setFormat(CertificateRequestFormat.PKCS10);
+        completion.setCsrAttributes(List.of(new RequestAttributeV3(cnUuid, "commonName",
+                AttributeContentType.STRING, List.<BaseAttributeContentV3<?>>of(new StringAttributeContentV3("device-complete")))));
+        clientOperationService.issueExistingCertificate(authorityParent, securedRaProfile, certUuid, completion);
+
+        CertificateDetailDto detail = certificateExternalService.getCertificate(SecuredUUID.fromString(certUuid));
+        List<ResponseAttribute> reqAttrs = detail.getCertificateRequest().getAttributes();
+        Assertions.assertEquals(1, reqAttrs.size(), "the completion request attribute must be persisted on the request entity");
+        Assertions.assertEquals("device-complete",
+                ((StringAttributeContentV3) ((ResponseAttributeV3) reqAttrs.getFirst()).getContent().getFirst()).getData(),
+                "the completion request-attribute value must be readable from the detail");
+    }
+
+    private String generateCsrBase64() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        PKCS10CertificationRequest csr = new JcaPKCS10CertificationRequestBuilder(new X500Name("CN=device-complete,O=Acme"), keyPair.getPublic())
+                .build(new JcaContentSignerBuilder("SHA256withRSA").build(keyPair.getPrivate()));
+        return Base64.getEncoder().encodeToString(csr.getEncoded());
     }
 }

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterCustomAttributeITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterCustomAttributeITest.java
@@ -13,6 +13,14 @@ import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.v3.content.StringAttributeContentV3;
 import com.otilm.api.model.core.v2.ClientCertificateDataResponseDto;
 import com.otilm.api.model.core.v2.ClientCertificateRegistrationDto;
+import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
+import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
+import com.otilm.api.model.common.attribute.v3.mapping.FieldType;
+import com.otilm.api.model.common.attribute.v3.mapping.RdnMappedField;
+import com.otilm.api.model.core.certificate.CertificateDetailDto;
+import com.otilm.api.model.core.raprofile.AttributeSetMergeMode;
+import com.otilm.core.service.CertificateExternalService;
+import com.otilm.core.service.writer.RaProfileCertificateRequestAttributeWriter;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.Certificate;
@@ -45,6 +53,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import java.util.List;
 import java.util.UUID;
 
+import static com.otilm.core.util.builders.MappedDataAttributeV3Builder.aMappedDataAttribute;
 import static com.otilm.core.util.builders.RequestAttributeV3Builder.aCustomAttribute;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -72,6 +81,12 @@ class ClientOperationServiceRegisterCustomAttributeITest extends BaseSpringBootT
     private ConnectorRepository connectorRepository;
     @Autowired
     private CertificateRepository certificateRepository;
+    @Autowired
+    private CertificateExternalService certificateExternalService;
+    @Autowired
+    private RaProfileCertificateRequestAttributeWriter requestAttributeWriter;
+    @Autowired
+    private com.fasterxml.jackson.databind.ObjectMapper objectMapper;
 
     @MockitoBean
     private AuthorityProviderAdapterFactory adapterFactory;
@@ -201,5 +216,41 @@ class ClientOperationServiceRegisterCustomAttributeITest extends BaseSpringBootT
         List<Certificate> certs = certificateRepository.findAll();
         Assertions.assertTrue(certs.isEmpty(),
                 "an up-front custom-attribute validation failure must leave no placeholder certificate behind");
+    }
+
+    @Test
+    void registerPersistsRequestAttributeValuesVisibleOnTheCertificateDetail() throws Exception {
+        // Author an RA-profile request attribute mapping the CN RDN, so the real resolver returns it and the
+        // submitted value projects to the placeholder identity and is persisted as a registration request attribute.
+        DataAttributeV3 cnDef = aMappedDataAttribute().withName("commonName").mappingRdn("2.5.4.3").build();
+        // fieldType is the serialized type discriminator for MappedField; the builder leaves it unset, so set it
+        // here or the RA-profile set can't be deserialized back by the real resolver.
+        ((RdnMappedField) cnDef.getFieldMapping().getFields().getFirst()).setFieldType(FieldType.RDN);
+        UUID cnUuid = UUID.randomUUID();
+        cnDef.setUuid(cnUuid.toString());
+        requestAttributeWriter.saveStaticSet(raProfile,
+                objectMapper.writeValueAsString(List.of(cnDef)), AttributeSetMergeMode.STATIC_ONLY, null);
+
+        AuthorityProviderAdapter adapter = mock(AuthorityProviderAdapter.class,
+                Mockito.withSettings().extraInterfaces(RegisterCapability.class));
+        when(adapterFactory.forAuthority(Mockito.any())).thenReturn(adapter);
+        when(((RegisterCapability) adapter).register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
+
+        ClientCertificateRegistrationDto request = new ClientCertificateRegistrationDto();
+        request.setCsrAttributes(List.of(new RequestAttributeV3(cnUuid, "commonName",
+                AttributeContentType.STRING, List.<BaseAttributeContentV3<?>>of(new StringAttributeContentV3("device-rt")))));
+
+        ClientCertificateDataResponseDto response = clientOperationService.registerCertificate(
+                authorityParent, securedRaProfile, request);
+
+        CertificateDetailDto detail = certificateExternalService.getCertificate(SecuredUUID.fromString(response.getUuid()));
+        List<ResponseAttribute> persisted = detail.getRegistrationRequestAttributes();
+        Assertions.assertEquals(1, persisted.size(), "the submitted request attribute must round-trip to the certificate detail");
+        ResponseAttributeV3 attr = (ResponseAttributeV3) persisted.getFirst();
+        Assertions.assertEquals("commonName", attr.getName());
+        Assertions.assertEquals("device-rt",
+                ((StringAttributeContentV3) attr.getContent().getFirst()).getData(),
+                "the submitted registration request-attribute value must be readable from the detail");
     }
 }

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -153,6 +153,8 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     @Autowired
     private CertificateRegistrationAuthorizationRepository authorizationRepository;
     @Autowired
+    private com.otilm.core.service.writer.registration.CertificateRegistrationAuthorizationWriter registrationAuthorizationWriter;
+    @Autowired
     private SettingsCache settingsCache;
     @Autowired
     private SettingExternalService settingService;
@@ -1096,6 +1098,22 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
         Assertions.assertEquals(AttributeOperation.CERTIFICATE_REGISTER, info.operation(),
                 "connector register attributes are stored under the register operation");
         Assertions.assertNotNull(info.connectorUuid(), "connector register attributes are connector-scoped");
+    }
+
+    @Test
+    void clearIssuanceWindowNullsExpiryAndKeepsStateActive() {
+        // The window governs only the initial issuance; clearing it leaves the authorization ACTIVE and durable
+        // for a later renew/rekey, with no stale deadline a future sweep could flip to EXPIRED.
+        Certificate cert = seedIssuedCert();
+        activeAuthorizationFor(cert.getUuid());
+        Assertions.assertNotNull(authorizationRepository.findByCertificateUuid(cert.getUuid()).orElseThrow().getExpiresAt(),
+                "precondition: the authorization starts with an issuance window");
+
+        registrationAuthorizationWriter.clearIssuanceWindow(cert.getUuid());
+
+        CertificateRegistrationAuthorization after = authorizationRepository.findByCertificateUuid(cert.getUuid()).orElseThrow();
+        Assertions.assertNull(after.getExpiresAt(), "the issuance window must be cleared on completion");
+        Assertions.assertEquals(RegistrationState.ACTIVE, after.getState(), "the authorization stays ACTIVE for renew/rekey");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -53,6 +53,7 @@ import com.otilm.core.dao.entity.Group;
 import com.otilm.core.dao.entity.RaProfile;
 import com.otilm.core.dao.entity.CertificateRegistration;
 import com.otilm.core.dao.entity.CertificateRegistrationAuthorization;
+import com.otilm.core.service.writer.registration.CertificateRegistrationAuthorizationWriter;
 import com.otilm.core.dao.entity.RegistrationState;
 import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.CertificateRegistrationAuthorizationRepository;
@@ -153,7 +154,7 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     @Autowired
     private CertificateRegistrationAuthorizationRepository authorizationRepository;
     @Autowired
-    private com.otilm.core.service.writer.registration.CertificateRegistrationAuthorizationWriter registrationAuthorizationWriter;
+    private CertificateRegistrationAuthorizationWriter registrationAuthorizationWriter;
     @Autowired
     private SettingsCache settingsCache;
     @Autowired

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -38,6 +38,7 @@ import com.otilm.api.model.core.v2.ClientCertificateRekeyRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.OperationSupport;
 import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.certificate.request.IssuanceDefinitionResolver;
 import com.otilm.api.model.core.auth.UserDetailDto;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
@@ -880,6 +881,19 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
         Assertions.assertEquals("device-9", contentCaptor.getValue().getSubject().get(0).getValue());
         Certificate cert = certificateRepository.findByUuid(UUID.fromString(response.getUuid())).orElseThrow();
         Assertions.assertEquals(CertificateState.REGISTERED, cert.getState());
+
+        // The submitted request-attribute values are persisted on the certificate itself, connectorless at
+        // operation=null (the key getCertificate reads into registrationRequestAttributes).
+        ArgumentCaptor<ObjectAttributeContentInfo> infoCaptor = ArgumentCaptor.forClass(ObjectAttributeContentInfo.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<RequestAttribute>> valuesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(attributeEngine).updateObjectDataAttributesContent(infoCaptor.capture(), valuesCaptor.capture());
+        Assertions.assertEquals(Resource.CERTIFICATE, infoCaptor.getValue().objectType());
+        Assertions.assertEquals(cert.getUuid(), infoCaptor.getValue().objectUuid());
+        Assertions.assertNull(infoCaptor.getValue().operation(), "register request values are stored at operation=null");
+        Assertions.assertNull(infoCaptor.getValue().connectorUuid(), "register request values are stored connectorless");
+        Assertions.assertEquals(1, valuesCaptor.getValue().size());
+        Assertions.assertEquals(cnUuid, valuesCaptor.getValue().get(0).getUuid());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -916,6 +916,23 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
     }
 
     @Test
+    void registerRejectsIssuanceWindowWithoutChallenge() {
+        // An issuance window is enforced only within the challenge regime (it lives on the authorization, created
+        // only with a secret), so a window without an authorizationSecret must be rejected up front rather than
+        // silently dropped — before any placeholder is created.
+        ClientCertificateRegistrationDto request = new ClientCertificateRegistrationDto();
+        request.setSubjectDn("CN=device-nowindow,O=Test");
+        request.setExpiresAt(OffsetDateTime.now().plusDays(1));
+
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
+                () -> clientOperationService.registerCertificate(authorityParent, securedRaProfile, request));
+        Assertions.assertTrue(ex.getMessage().contains("requires an authorization secret"),
+                "an issuance window without a challenge must be rejected");
+        Assertions.assertEquals(0, certificateRepository.count(),
+                "no placeholder should be created when the window-without-challenge combination is rejected");
+    }
+
+    @Test
     void registerWrapsCsrAttributeValidationFailure() throws Exception {
         // An AttributeException from the attribute engine's validation must surface as a client-facing
         // ValidationException ("Invalid csrAttributes...") and leave no placeholder behind.

--- a/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
+++ b/src/test/java/com/otilm/core/integration/service/ClientOperationServiceRegisterITest.java
@@ -42,6 +42,7 @@ import com.otilm.api.model.core.v2.ClientCertificateRekeyRequestDto;
 import com.otilm.api.model.core.v2.ClientCertificateRenewRequestDto;
 import com.otilm.api.model.core.v2.OperationSupport;
 import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.AttributeOperation;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.certificate.request.IssuanceDefinitionResolver;
 import com.otilm.api.model.core.auth.UserDetailDto;
@@ -1066,6 +1067,35 @@ class ClientOperationServiceRegisterITest extends BaseSpringBootTest {
                 "an issuance window without a challenge must be rejected");
         Assertions.assertEquals(0, certificateRepository.count(),
                 "no placeholder should be created when the window-without-challenge combination is rejected");
+    }
+
+    @Test
+    void registerPersistsConnectorRegisterAttributesUnderTheRegisterOperation() throws Exception {
+        // A connector-backed registration carrying connector register attributes stores them on the certificate
+        // under the register operation (+ connector), so they surface as registerAttributes on the detail.
+        RegisterCapability adapter = registeringAdapter();
+        when(adapter.register(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(AdapterOperationResult.syncOk(null, null, CertificateType.X509));
+        when(adapter.listRegisterAttributes(Mockito.any(), Mockito.any())).thenReturn(List.of());
+
+        RequestAttribute registerAttr = new RequestAttributeV3(UUID.randomUUID(), "registerParam",
+                AttributeContentType.STRING, List.<BaseAttributeContentV3<?>>of(new StringAttributeContentV3("v")));
+        ClientCertificateRegistrationDto request = new ClientCertificateRegistrationDto();
+        request.setSubjectDn("CN=device-conn-attrs,O=Acme");
+        request.setAttributes(List.of(registerAttr));
+
+        ClientCertificateDataResponseDto response = clientOperationService.registerCertificate(
+                authorityParent, securedRaProfile, request);
+
+        UUID certUuid = UUID.fromString(response.getUuid());
+        ArgumentCaptor<ObjectAttributeContentInfo> infoCaptor = ArgumentCaptor.forClass(ObjectAttributeContentInfo.class);
+        verify(attributeEngine).updateObjectDataAttributesContent(infoCaptor.capture(), Mockito.anyList());
+        ObjectAttributeContentInfo info = infoCaptor.getValue();
+        Assertions.assertEquals(Resource.CERTIFICATE, info.objectType());
+        Assertions.assertEquals(certUuid, info.objectUuid());
+        Assertions.assertEquals(AttributeOperation.CERTIFICATE_REGISTER, info.operation(),
+                "connector register attributes are stored under the register operation");
+        Assertions.assertNotNull(info.connectorUuid(), "connector register attributes are connector-scoped");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImplTest.java
+++ b/src/test/java/com/otilm/core/service/v2/impl/ExtendedAttributeServiceImplTest.java
@@ -4,6 +4,7 @@ import com.otilm.api.exception.ConnectorException;
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.attribute.RequestAttribute;
+import com.otilm.api.model.client.connector.v2.FeatureFlag;
 import com.otilm.api.model.common.attribute.common.BaseAttribute;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.AttributeOperation;
@@ -13,8 +14,10 @@ import com.otilm.core.dao.entity.Connector2FunctionGroup;
 import com.otilm.core.dao.entity.FunctionGroup;
 import com.otilm.core.dao.entity.RaProfile;
 import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.service.handler.ConnectorCapabilityService;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapter;
 import com.otilm.core.service.handler.authority.AuthorityProviderAdapterFactory;
+import com.otilm.core.service.handler.authority.RegisterCapability;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,9 +56,16 @@ class ExtendedAttributeServiceImplTest {
     AuthorityProviderAdapter adapter;
     @Mock
     AttributeEngine attributeEngine;
+    @Mock
+    ConnectorCapabilityService capabilityService;
+    @Mock
+    RegisterAdapter registerAdapter;
 
     @InjectMocks
     ExtendedAttributeServiceImpl service;
+
+    /** A v3-style adapter that is both an authority provider and register-capable. */
+    private interface RegisterAdapter extends AuthorityProviderAdapter, RegisterCapability { }
 
     private Connector connector;
     private AuthorityInstanceReference authority;
@@ -212,5 +222,73 @@ class ExtendedAttributeServiceImplTest {
         order.verify(adapter).listRevokeAttributes(authority, raProfile);
         order.verify(attributeEngine).validateUpdateDataAttributes(
                 connector.getUuid(), AttributeOperation.CERTIFICATE_REVOKE, definitions, attrs);
+    }
+
+    // --- listRegisterCertificateAttributes ---
+
+    @Test
+    void listRegisterCertificateAttributes_returnsAttrsForRegisterCapableAuthority() throws Exception {
+        List<BaseAttribute> expected = List.of(mock(BaseAttribute.class));
+        when(adapterFactory.forAuthority(authority)).thenReturn(registerAdapter);
+        when(capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REGISTRATION)).thenReturn(true);
+        when(registerAdapter.listRegisterAttributes(authority, raProfile)).thenReturn(expected);
+
+        assertSame(expected, service.listRegisterCertificateAttributes(raProfile));
+    }
+
+    @Test
+    void listRegisterCertificateAttributes_emptyWhenAuthorityNotRegisterCapable() throws Exception {
+        // adapter from setUp is a plain AuthorityProviderAdapter, not a RegisterCapability
+        assertTrue(service.listRegisterCertificateAttributes(raProfile).isEmpty());
+        verifyNoInteractions(attributeEngine);
+    }
+
+    @Test
+    void listRegisterCertificateAttributes_emptyWhenRegistrationFlagNotAdvertised() throws Exception {
+        when(adapterFactory.forAuthority(authority)).thenReturn(registerAdapter);
+        when(capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REGISTRATION)).thenReturn(false);
+
+        assertTrue(service.listRegisterCertificateAttributes(raProfile).isEmpty());
+        verify(registerAdapter, never()).listRegisterAttributes(any(), any());
+    }
+
+    @Test
+    void listRegisterCertificateAttributes_throwsWhenConnectorMissing() {
+        authority.setConnector(null);
+
+        assertThrows(NotFoundException.class, () -> service.listRegisterCertificateAttributes(raProfile));
+        verifyNoInteractions(adapterFactory);
+    }
+
+    // --- mergeAndValidateRegisterAttributes ---
+
+    @Test
+    void mergeAndValidateRegisterAttributes_materializesRegisterSchemaAndValidates() throws Exception {
+        List<RequestAttribute> attrs = List.of(mock(RequestAttribute.class));
+        List<BaseAttribute> definitions = List.of(mock(BaseAttribute.class));
+        when(adapterFactory.forAuthority(authority)).thenReturn(registerAdapter);
+        when(capabilityService.supports(authority, FeatureFlag.CERTIFICATE_REGISTRATION)).thenReturn(true);
+        when(registerAdapter.listRegisterAttributes(authority, raProfile)).thenReturn(definitions);
+
+        service.mergeAndValidateRegisterAttributes(raProfile, attrs);
+
+        verify(attributeEngine).validateUpdateDataAttributes(
+                connector.getUuid(), AttributeOperation.CERTIFICATE_REGISTER, definitions, attrs);
+    }
+
+    @Test
+    void mergeAndValidateRegisterAttributes_noOpWhenNotRegisterCapable() throws Exception {
+        // adapter from setUp is a plain AuthorityProviderAdapter, not a RegisterCapability
+        service.mergeAndValidateRegisterAttributes(raProfile, List.of(mock(RequestAttribute.class)));
+
+        verifyNoInteractions(attributeEngine);
+    }
+
+    @Test
+    void mergeAndValidateRegisterAttributes_throwsWhenConnectorMissing() {
+        authority.setConnector(null);
+
+        assertThrows(ValidationException.class, () -> service.mergeAndValidateRegisterAttributes(raProfile, List.of()));
+        verifyNoInteractions(adapterFactory, attributeEngine);
     }
 }

--- a/src/test/java/com/otilm/core/util/builders/V3ConnectorStubs.java
+++ b/src/test/java/com/otilm/core/util/builders/V3ConnectorStubs.java
@@ -19,6 +19,7 @@ public final class V3ConnectorStubs {
     // ---- endpoint paths (from CertificateApiClient v3 constants) ----
 
     private static final String REGISTER_PATH   = "/v3/authorityProvider/certificates/register";
+    private static final String REGISTER_ATTRIBUTES_PATH = REGISTER_PATH + "/attributes";
     public static final String REGISTER_STATUS = "/v3/authorityProvider/certificates/register/status";
     private static final String ISSUE_PATH      = "/v3/authorityProvider/certificates/issue";
 
@@ -37,6 +38,7 @@ public final class V3ConnectorStubs {
      */
     public static void stubRegisterSync(WireMockServer wm, String metaJson) {
         String safeMetaJson = (metaJson == null || metaJson.isBlank()) ? "[]" : metaJson;
+        stubRegisterAttributesEmpty(wm);
         wm.stubFor(post(urlEqualTo(REGISTER_PATH))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -53,6 +55,7 @@ public final class V3ConnectorStubs {
      */
     public static void stubRegisterAsync(WireMockServer wm, String trackingMeta) {
         String safeMeta = (trackingMeta == null || trackingMeta.isBlank()) ? "[]" : trackingMeta;
+        stubRegisterAttributesEmpty(wm);
         wm.stubFor(post(urlEqualTo(REGISTER_PATH))
                 .willReturn(aResponse()
                         .withStatus(202)
@@ -60,6 +63,17 @@ public final class V3ConnectorStubs {
                         .withBody("""
                                 {"certificateData": null, "meta": %s}
                                 """.formatted(safeMeta))));
+    }
+
+    /**
+     * Stubs the connector's register-operation attribute-list endpoint to return an empty schema, so the
+     * unconditional {@code mergeAndValidateRegisterAttributes} on the register-capable path succeeds without real
+     * register-attribute data. Every register-capable stub needs this — a real register-capable connector exposes
+     * {@code /register/attributes} alongside {@code /register}.
+     */
+    private static void stubRegisterAttributesEmpty(WireMockServer wm) {
+        wm.stubFor(post(urlEqualTo(REGISTER_ATTRIBUTES_PATH)).willReturn(WireMock.okJson("[]")));
+        wm.stubFor(get(urlEqualTo(REGISTER_ATTRIBUTES_PATH)).willReturn(WireMock.okJson("[]")));
     }
 
     // ---- Register status (stateful scenario) ----------------------------


### PR DESCRIPTION
Closes #1867. Also bundles two registration-flow lifecycle hardenings discovered during review (no separate issues; related to the certificate registration flow, ilm#130).

## 1. Register-operation attributes (Gap A) — #1867
- New `GET /v2/operations/authorities/{a}/raProfiles/{r}/attributes/register` surfacing the connector's register schema (`listRegisterAttributes`), gated on a v3 register-capable authority (others return empty; deleted connector 404s). v2-only, mirroring `/attributes/issue`.
- `AttributeOperation.CERTIFICATE_REGISTER = "register"`.
- Submitted connector register attributes persisted on `CERTIFICATE` / `register` + connector; exposed as `registerAttributes` on the certificate detail.

## 2. Submitted request-attribute values (Gap B) — #1867
- **Register**: submitted `csrAttributes` values persisted connectorless at `operation=null` on the certificate (both connector-backed and platform-level paths), exposed as `registrationRequestAttributes` — read unconditionally, so a REGISTERED placeholder shows them.
- **Completion**: the completion CSR's request-attribute values persisted on the request entity (`operation=null`), write-if-empty and best-effort, surfaced via the existing `certificateRequest.attributes`.

Data-model note: request-attribute **values** are stored at `operation=null` and distinguished by resource+object (never a new operation) — `operation` lives on the shared `attribute_definition` row (last-writer-wins), so a second operation would contend and corrupt reads. `Resource.CERTIFICATE` is reused; `register` stays reserved for the connector register-operation attributes.

## 3. Renew/rekey guard hardening (registration lifecycle)
`rejectRenewOrRekeyOfLiveRegistration` now fails closed on any **non-CLOSED** registration authorization (was ACTIVE-only). If a retained post-issuance authorization is ever left EXPIRED (a future passed-window sweep, R1c) or LOCKED, renew/rekey still fail closed rather than silently exiting the challenge regime; only a deliberately CLOSED (retired) registration renews as unregistered. No behaviour change today (only ACTIVE reaches the guard on an issued cert); forward-proofs the invariant challenge-gated renew/rekey (core#1774) build on.

## 4. Reject issuance window without a challenge (registration lifecycle)
`expiresAt` lives on the registration authorization, which is created only when an `authorizationSecret` is supplied — so a window without a challenge was silently dropped and never enforced. Now rejected (422) at the registration boundary, alongside the past-window and ambiguous-identity guards.

## 5. Clear the issuance window on successful issuance (registration lifecycle)
The issuance window governs only the initial issuance. On successful issuance the authorization's `expiresAt` is now cleared, at the single ISSUED choke point (`issueRequestedCertificate`) so it covers the sync register-bound, async-poll, and platform-level completion paths (no-op for non-registered certs). The authorization then matches the null-window invariant renew/rekey copies use (core#1774), and a future passed-window sweep cannot flip a still-live authorization to EXPIRED. Complements the guard hardening in §3.

## Tests
Unit tests for the new service methods (register-capable / non-capable / flag-off / connector-missing); integration assertions that register values persist at `operation=null` and that a window-without-challenge is rejected before any placeholder. Further ITests (completion + detail round-trip, endpoint, op=null vs register coexistence) to follow. Integration tests compiled here; run under Docker/CI.

## Depends on
Interface contract OmniTrustILM/interfaces#787 (new endpoint + `registerAttributes` / `registrationRequestAttributes` DTO fields). CI needs that interfaces SNAPSHOT published before this resolves.

