### PR TITLE
Disable object-level permissions for Signing Records and Trusted Certificates

### DIFF
--- a/src/main/java/com/otilm/core/api/web/SigningRecordControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/SigningRecordControllerImpl.java
@@ -12,7 +12,6 @@ import com.otilm.api.model.core.logging.enums.Operation;
 import com.otilm.api.model.core.signing.signingrecord.SigningRecordDto;
 import com.otilm.api.model.core.signing.signingrecord.SigningRecordListDto;
 import com.otilm.core.aop.AuditLogged;
-import com.otilm.core.auth.AuthEndpoint;
 import com.otilm.core.logging.LogResource;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
@@ -34,7 +33,6 @@ public class SigningRecordControllerImpl implements SigningRecordController {
     }
 
     @Override
-    @AuthEndpoint(resourceName = Resource.SIGNING_RECORD)
     @AuditLogged(module = Module.SIGNING, resource = Resource.SIGNING_RECORD, operation = Operation.LIST)
     public List<SearchFieldDataByGroupDto> getSearchableFieldInformation() {
         return signingRecordService.getSearchableFieldInformation();

--- a/src/main/java/com/otilm/core/api/web/TrustedCertificateControllerImpl.java
+++ b/src/main/java/com/otilm/core/api/web/TrustedCertificateControllerImpl.java
@@ -9,7 +9,6 @@ import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.logging.enums.Module;
 import com.otilm.api.model.core.logging.enums.Operation;
 import com.otilm.core.aop.AuditLogged;
-import com.otilm.core.auth.AuthEndpoint;
 import com.otilm.core.logging.LogResource;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.service.TrustedCertificateExternalService;
@@ -31,7 +30,6 @@ public class TrustedCertificateControllerImpl implements TrustedCertificateContr
     private final TrustedCertificateExternalService trustedCertificateService;
 
     @Override
-    @AuthEndpoint(resourceName = Resource.TRUSTED_CERTIFICATE)
     @AuditLogged(module = Module.CORE, resource = Resource.TRUSTED_CERTIFICATE, operation = Operation.LIST)
     public List<TrustedCertificateDto> listTrustedCertificates() {
         return trustedCertificateService.listTrustedCertificates();

--- a/src/test/java/com/otilm/core/architecture/AuthEndpointResourceExtensionArchTest.java
+++ b/src/test/java/com/otilm/core/architecture/AuthEndpointResourceExtensionArchTest.java
@@ -22,10 +22,18 @@ import java.util.stream.Collectors;
  * permissions editor then calls {@code GET /api/v1/auth/resources/{resource}/objects}, which
  * {@code ResourceServiceImpl} serves by looking up a {@link ResourceExtensionService} bean keyed by the
  * resource code. A resource advertised via {@code @AuthEndpoint} but without a matching extension-service
- * bean fails that call with HTTP 501 (issue #1873, Signing Records and Trusted Certificates).
+ * bean fails that call with HTTP 501 (Signing Records and Trusted Certificates).
  *
- * <p>This rule fails the build when the two sets diverge, keeping the advertised-object-access contract and
- * the object-listing capability in lockstep.
+ * <p>This rule fails the build when a resource advertises object access via {@code @AuthEndpoint} but has no
+ * {@link ResourceExtensionService} bean to serve the object listing. The reverse is allowed: a
+ * {@link ResourceExtensionService} without {@code @AuthEndpoint} (e.g. CERTIFICATE) is legitimate and not
+ * flagged.
+ *
+ * <p>The guard resolves the served resources from {@code @Service}-annotated {@link ResourceExtensionService}
+ * classes whose annotation value is the resource code — the registration convention every extension service
+ * follows ({@code @Service(Resource.Codes.X)}, a compile-time constant). A bean registered another way
+ * ({@code @Component}, a {@code @Bean} factory method, or a value-less {@code @Service}) would not be seen
+ * here even though the runtime lookup would resolve it, so keep this convention when adding an extension service.
  */
 @AnalyzeClasses(packages = "com.otilm.core", importOptions = ImportOption.DoNotIncludeTests.class)
 public class AuthEndpointResourceExtensionArchTest {

--- a/src/test/java/com/otilm/core/architecture/AuthEndpointResourceExtensionArchTest.java
+++ b/src/test/java/com/otilm/core/architecture/AuthEndpointResourceExtensionArchTest.java
@@ -1,0 +1,64 @@
+package com.otilm.core.architecture;
+
+import com.otilm.core.auth.AuthEndpoint;
+import com.otilm.core.service.ResourceExtensionService;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+/**
+ * A resource advertises object-level (per-object) permissions when a controller method carries
+ * {@link AuthEndpoint}: {@code ContextRefreshListener} turns that into the resource's
+ * {@code listObjectsEndpoint}, which the auth service exposes as {@code objectAccess=true}. The Role
+ * permissions editor then calls {@code GET /api/v1/auth/resources/{resource}/objects}, which
+ * {@code ResourceServiceImpl} serves by looking up a {@link ResourceExtensionService} bean keyed by the
+ * resource code. A resource advertised via {@code @AuthEndpoint} but without a matching extension-service
+ * bean fails that call with HTTP 501 (issue #1873, Signing Records and Trusted Certificates).
+ *
+ * <p>This rule fails the build when the two sets diverge, keeping the advertised-object-access contract and
+ * the object-listing capability in lockstep.
+ */
+@AnalyzeClasses(packages = "com.otilm.core", importOptions = ImportOption.DoNotIncludeTests.class)
+public class AuthEndpointResourceExtensionArchTest {
+
+    @ArchTest
+    static void every_auth_endpoint_resource_has_a_resource_extension_service(JavaClasses classes) {
+        Set<String> advertised = new TreeSet<>();
+        for (JavaClass clazz : classes) {
+            for (JavaMethod method : clazz.getMethods()) {
+                if (method.isAnnotatedWith(AuthEndpoint.class)) {
+                    advertised.add(method.getAnnotationOfType(AuthEndpoint.class).resourceName().getCode());
+                }
+            }
+        }
+
+        Set<String> served = classes.stream()
+                .filter(clazz -> !clazz.isInterface())
+                .filter(clazz -> clazz.isAssignableTo(ResourceExtensionService.class))
+                .filter(clazz -> clazz.isAnnotatedWith(Service.class))
+                .map(clazz -> clazz.getAnnotationOfType(Service.class).value())
+                .filter(beanName -> !beanName.isEmpty())
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        List<String> missing = advertised.stream()
+                .filter(code -> !served.contains(code))
+                .toList();
+
+        if (!missing.isEmpty()) {
+            throw new AssertionError(
+                    "Resources advertise object-level permissions via @AuthEndpoint but have no ResourceExtensionService "
+                            + "bean to serve GET /api/v1/auth/resources/{resource}/objects (the call would fail with HTTP 501): "
+                            + missing + ". Either register a @Service(<resource code>) bean implementing ResourceExtensionService, "
+                            + "or remove @AuthEndpoint from the resource's controller if it must not expose per-object permissions.");
+        }
+    }
+}

--- a/src/test/java/com/otilm/core/integration/service/AuthServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AuthServiceITest.java
@@ -749,8 +749,7 @@ class AuthServiceITest extends BaseSpringBootTest {
                         "uuid": "f3f2f6e1-6c8b-4f7c-9a9b-4d6e9b5c3e2a",
                         "name": "trustedCertificates",
                         "displayName": "Trusted Certificates",
-                        "listObjectsEndpoint": "/v1/trustedCertificates",
-                        "objectAccess": true,
+                        "objectAccess": false,
                         "actions": [
                             {
                                 "uuid": "53421445-5d6e-4257-b59d-235aaf26e61e",
@@ -828,8 +827,7 @@ class AuthServiceITest extends BaseSpringBootTest {
                         "uuid": "d1c8e5b4-9c3a-4c8e-9b0c-1f2a5e6f7896",
                         "name": "signingRecords",
                         "displayName": "Signing Record",
-                        "listObjectsEndpoint": "/v1/signingRecords/search",
-                        "objectAccess": true,
+                        "objectAccess": false,
                         "actions": [
                             {
                                 "uuid": "b31b0ea1-d97f-4ade-895c-a982f4544e1b",


### PR DESCRIPTION
## Problem

In **Access Control → Roles → Edit Role permissions**, selecting **Signing Records** or **Trusted Certificates** triggered `GET /api/v1/auth/resources/{resource}/objects` → **HTTP 501** (`Cannot list objects for requested resource: …`). The Object Action Permissions table stayed empty and a red error toast appeared. Per-object permissions could not be configured for these two resources; resource-level permissions worked.

## Root cause

A resource advertises per-object permissions to the auth service (and thus the Role editor) when a controller method carries `@AuthEndpoint`: `ContextRefreshListener` turns that into the resource's `listObjectsEndpoint`, which the auth service exposes as `objectAccess=true`. The editor then calls the generic `/objects` endpoint, which `ResourceServiceImpl` serves by looking up a `ResourceExtensionService` bean keyed by the resource code.

`SigningRecordControllerImpl` and `TrustedCertificateControllerImpl` both carried `@AuthEndpoint`, but **neither resource has a `ResourceExtensionService`** — so the lookup returned `null` and the endpoint threw `NotSupportedException` → 501. Every other `@AuthEndpoint` resource has an extension service; these two broke the invariant.

## Fix

These resources have no meaningful per-object ACL model:

- **Signing Records** — row access is delegated to the parent **Signing Profile**; per-record ACLs would be redundant, and the object picker would enumerate audit-scale rows.
- **Trusted Certificates** — remote provisioning-backed, no local table, so the list can't be `SecurityFilter` object-filtered like local resources.

So instead of implementing object listing, **remove `@AuthEndpoint` from both controllers**. On the next core startup sync, the auth service updates each resource's `listObjectsEndpoint` to null → `objectAccess=false`, and the Role editor no longer renders the Object Action Permissions panel or calls `/objects`. Resource-level permissions are unaffected (`@ExternalAuthorization` actions are untouched).

## Regression guard

New ArchUnit rule `AuthEndpointResourceExtensionArchTest` pins the invariant: **every `@AuthEndpoint` resource must have a `ResourceExtensionService` bean.** A resource can never again advertise object access it cannot serve (the rule fails the build if so).

## Testing

- `AuthEndpointResourceExtensionArchTest` — fails on `main` listing exactly `[signingRecords, trustedCertificates]`; passes with this change.
- Full `*ArchTest` suite: 20/20 pass.
- `AuthServiceITest`: 5/5 pass (mock resource fixture updated to `objectAccess=false` for both).

Fixes #1873
