### PR TITLE
Add connector WebClient tuning configuration

### DIFF
--- a/src/main/java/com/otilm/core/config/ApplicationConfig.java
+++ b/src/main/java/com/otilm/core/config/ApplicationConfig.java
@@ -4,6 +4,7 @@ import com.otilm.api.clients.AttributeApiClient;
 import com.otilm.api.clients.AuthorityInstanceApiClient;
 import com.otilm.api.clients.BaseApiClient;
 import com.otilm.api.clients.CertificateApiClient;
+import com.otilm.api.clients.ClientTuning;
 import com.otilm.api.clients.ComplianceApiClient;
 import com.otilm.api.clients.ConnectorApiClient;
 import com.otilm.api.clients.DiscoveryApiClient;
@@ -42,7 +43,7 @@ import javax.net.ssl.TrustManager;
 
 @Configuration
 @EnableJpaAuditing(auditorAwareRef = "auditorAware")
-@EnableConfigurationProperties(DiscoveryProperties.class)
+@EnableConfigurationProperties({DiscoveryProperties.class, ConnectorClientProperties.class})
 @ComponentScan(basePackages = "com.otilm.core",
         excludeFilters = @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class))
 public class ApplicationConfig {
@@ -73,8 +74,12 @@ public class ApplicationConfig {
     }
 
     @Bean
-    public WebClient webClient() {
-        return BaseApiClient.prepareWebClient();
+    public WebClient webClient(ConnectorClientProperties connectorClientProperties) {
+        return BaseApiClient.prepareWebClient(new ClientTuning(
+                connectorClientProperties.connectTimeout(),
+                connectorClientProperties.responseTimeout(),
+                connectorClientProperties.maxConnections(),
+                connectorClientProperties.pendingAcquireTimeout()));
     }
 
     @Bean

--- a/src/main/java/com/otilm/core/config/ApplicationConfig.java
+++ b/src/main/java/com/otilm/core/config/ApplicationConfig.java
@@ -43,7 +43,7 @@ import javax.net.ssl.TrustManager;
 
 @Configuration
 @EnableJpaAuditing(auditorAwareRef = "auditorAware")
-@EnableConfigurationProperties({DiscoveryProperties.class, ConnectorClientProperties.class})
+@EnableConfigurationProperties({DiscoveryProperties.class, ConnectorApiClientProperties.class})
 @ComponentScan(basePackages = "com.otilm.core",
         excludeFilters = @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class))
 public class ApplicationConfig {
@@ -74,12 +74,12 @@ public class ApplicationConfig {
     }
 
     @Bean
-    public WebClient webClient(ConnectorClientProperties connectorClientProperties) {
+    public WebClient webClient(ConnectorApiClientProperties connectorApiClientProperties) {
         return BaseApiClient.prepareWebClient(new ClientTuning(
-                connectorClientProperties.connectTimeout(),
-                connectorClientProperties.responseTimeout(),
-                connectorClientProperties.maxConnections(),
-                connectorClientProperties.pendingAcquireTimeout()));
+                connectorApiClientProperties.connectTimeout(),
+                connectorApiClientProperties.responseTimeout(),
+                connectorApiClientProperties.maxConnections(),
+                connectorApiClientProperties.pendingAcquireTimeout()));
     }
 
     @Bean

--- a/src/main/java/com/otilm/core/config/ConnectorApiClientProperties.java
+++ b/src/main/java/com/otilm/core/config/ConnectorApiClientProperties.java
@@ -8,21 +8,21 @@ import java.time.Duration;
 
 /**
  * Tuning for the shared WebClient — response/connect timeouts and the connection pool — used for all
- * outbound API-client calls. Bound from {@code connector.client.*}; validated at startup so
+ * outbound API-client calls. Bound from {@code connector.api-client.*}; validated at startup so
  * misconfiguration fails fast with a clear error rather than a runtime NPE or an invalid pool.
  *
  * <p>The {@code application.yml} defaults mirror {@code ClientTuning.defaults()} in interfaces
  * (tests and untuned callers use those; deployments use these). Keep the two in sync.
  */
-@ConfigurationProperties(prefix = "connector.client")
+@ConfigurationProperties(prefix = "connector.api-client")
 @Validated
-public record ConnectorClientProperties(
+public record ConnectorApiClientProperties(
         Duration connectTimeout,
         Duration responseTimeout,
         @Positive int maxConnections,
         Duration pendingAcquireTimeout) {
 
-    public ConnectorClientProperties {
+    public ConnectorApiClientProperties {
         // Strictly positive, not merely non-null: 0s/negative would disable timeouts or fail deeper
         // in WebClient setup — fail fast at binding instead.
         requirePositive(connectTimeout, "connect-timeout");
@@ -32,7 +32,7 @@ public record ConnectorClientProperties(
 
     private static void requirePositive(Duration value, String name) {
         if (value == null || value.isNegative() || value.isZero()) {
-            throw new IllegalArgumentException("connector.client." + name + " must be a positive duration, was " + value);
+            throw new IllegalArgumentException("connector.api-client." + name + " must be a positive duration, was " + value);
         }
     }
 }

--- a/src/main/java/com/otilm/core/config/ConnectorClientProperties.java
+++ b/src/main/java/com/otilm/core/config/ConnectorClientProperties.java
@@ -1,0 +1,17 @@
+package com.otilm.core.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * Tuning for the shared connector WebClient — response/connect timeouts and the connection pool
+ * used for all HTTP calls to connectors and authorities. Bound from {@code connector.client.*}.
+ */
+@ConfigurationProperties(prefix = "connector.client")
+public record ConnectorClientProperties(
+        Duration connectTimeout,
+        Duration responseTimeout,
+        int maxConnections,
+        Duration pendingAcquireTimeout) {
+}

--- a/src/main/java/com/otilm/core/config/ConnectorClientProperties.java
+++ b/src/main/java/com/otilm/core/config/ConnectorClientProperties.java
@@ -1,17 +1,22 @@
 package com.otilm.core.config;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import java.time.Duration;
 
 /**
- * Tuning for the shared connector WebClient — response/connect timeouts and the connection pool
- * used for all HTTP calls to connectors and authorities. Bound from {@code connector.client.*}.
+ * Tuning for the shared WebClient — response/connect timeouts and the connection pool — used for all
+ * outbound API-client calls. Bound from {@code connector.client.*}; validated at startup so
+ * misconfiguration fails fast with a clear error rather than a runtime NPE or an invalid pool.
  */
 @ConfigurationProperties(prefix = "connector.client")
+@Validated
 public record ConnectorClientProperties(
-        Duration connectTimeout,
-        Duration responseTimeout,
-        int maxConnections,
-        Duration pendingAcquireTimeout) {
+        @NotNull Duration connectTimeout,
+        @NotNull Duration responseTimeout,
+        @Positive int maxConnections,
+        @NotNull Duration pendingAcquireTimeout) {
 }

--- a/src/main/java/com/otilm/core/config/ConnectorClientProperties.java
+++ b/src/main/java/com/otilm/core/config/ConnectorClientProperties.java
@@ -1,6 +1,5 @@
 package com.otilm.core.config;
 
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -11,12 +10,29 @@ import java.time.Duration;
  * Tuning for the shared WebClient — response/connect timeouts and the connection pool — used for all
  * outbound API-client calls. Bound from {@code connector.client.*}; validated at startup so
  * misconfiguration fails fast with a clear error rather than a runtime NPE or an invalid pool.
+ *
+ * <p>The {@code application.yml} defaults mirror {@code ClientTuning.defaults()} in interfaces
+ * (tests and untuned callers use those; deployments use these). Keep the two in sync.
  */
 @ConfigurationProperties(prefix = "connector.client")
 @Validated
 public record ConnectorClientProperties(
-        @NotNull Duration connectTimeout,
-        @NotNull Duration responseTimeout,
+        Duration connectTimeout,
+        Duration responseTimeout,
         @Positive int maxConnections,
-        @NotNull Duration pendingAcquireTimeout) {
+        Duration pendingAcquireTimeout) {
+
+    public ConnectorClientProperties {
+        // Strictly positive, not merely non-null: 0s/negative would disable timeouts or fail deeper
+        // in WebClient setup — fail fast at binding instead.
+        requirePositive(connectTimeout, "connect-timeout");
+        requirePositive(responseTimeout, "response-timeout");
+        requirePositive(pendingAcquireTimeout, "pending-acquire-timeout");
+    }
+
+    private static void requirePositive(Duration value, String name) {
+        if (value == null || value.isNegative() || value.isZero()) {
+            throw new IllegalArgumentException("connector.client." + name + " must be a positive duration, was " + value);
+        }
+    }
 }

--- a/src/main/java/com/otilm/core/service/v2/impl/ConnectorServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ConnectorServiceImpl.java
@@ -1,6 +1,7 @@
 package com.otilm.core.service.v2.impl;
 
 import com.otilm.api.clients.ApiClientConnectorInfo;
+import com.otilm.api.clients.BaseApiClient;
 import com.otilm.api.exception.*;
 import com.otilm.api.model.client.certificate.SearchFilterRequestDto;
 import com.otilm.api.model.client.certificate.SearchRequestDto;
@@ -685,6 +686,10 @@ public class ConnectorServiceImpl implements ConnectorExternalService, Connector
 
     void evictConnectorCache(UUID uuid) {
         cacheEvictor.evict(CacheConfig.CONNECTOR_API_CLIENT_CACHE, uuid);
+        // Drop any cached CERTIFICATE WebClient built for this connector so a deleted or reconfigured
+        // connector does not retain its client (and parsed key material). Keyed by the UUID string,
+        // matching mapToApiClientDtoV2().
+        BaseApiClient.evictCertificateClient(uuid.toString());
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -331,6 +331,17 @@ validation:
     read-timeout: 1000
     connect-timeout: 1000
 
+# Shared connector WebClient tuning (all HTTP calls to connectors and authorities)
+connector:
+  client:
+    # Fail fast when a connector does not respond; ~ authority per-call budget (30s) + margin
+    response-timeout: ${CONNECTOR_CLIENT_RESPONSE_TIMEOUT:35s}
+    connect-timeout: ${CONNECTOR_CLIENT_CONNECT_TIMEOUT:3s}
+    # Per remote host. Sized above the actions-listener concurrency (messaging.concurrency.actions)
+    max-connections: ${CONNECTOR_CLIENT_MAX_CONNECTIONS:20}
+    # Shed load fast under pool saturation instead of queueing behind the response timeout
+    pending-acquire-timeout: ${CONNECTOR_CLIENT_PENDING_ACQUIRE_TIMEOUT:10s}
+
 cbom:
   client:
     max-buffer-size: ${CBOM_CLIENT_MAX_BUFFER_SIZE:20971520}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -331,15 +331,15 @@ validation:
     read-timeout: 1000
     connect-timeout: 1000
 
-# Shared connector WebClient tuning (all HTTP calls to connectors and authorities)
+# Shared WebClient tuning applied to every outbound API-client call (any provider implementation)
 connector:
   client:
-    # Fail fast when a connector does not respond; ~ authority per-call budget (30s) + margin
+    # Fail fast when a remote endpoint stops responding instead of blocking the caller indefinitely
     response-timeout: ${CONNECTOR_CLIENT_RESPONSE_TIMEOUT:35s}
     connect-timeout: ${CONNECTOR_CLIENT_CONNECT_TIMEOUT:3s}
-    # Per remote host. Sized above the actions-listener concurrency (messaging.concurrency.actions)
+    # Connection-pool limit per remote host; size to the expected concurrent load
     max-connections: ${CONNECTOR_CLIENT_MAX_CONNECTIONS:20}
-    # Shed load fast under pool saturation instead of queueing behind the response timeout
+    # Shed load quickly under pool saturation rather than queueing behind the response timeout
     pending-acquire-timeout: ${CONNECTOR_CLIENT_PENDING_ACQUIRE_TIMEOUT:10s}
 
 cbom:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -333,14 +333,14 @@ validation:
 
 # Shared WebClient tuning applied to every outbound API-client call (any provider implementation)
 connector:
-  client:
-    # Fail fast when a remote endpoint stops responding instead of blocking the caller indefinitely
-    response-timeout: ${CONNECTOR_CLIENT_RESPONSE_TIMEOUT:35s}
-    connect-timeout: ${CONNECTOR_CLIENT_CONNECT_TIMEOUT:3s}
+  api-client:
+    # Fail fast on unresponsive endpoints; keep connect + response timeouts below the 120s transaction timeout.
+    response-timeout: ${CONNECTOR_API_CLIENT_RESPONSE_TIMEOUT:35s}
+    connect-timeout: ${CONNECTOR_API_CLIENT_CONNECT_TIMEOUT:3s}
     # Connection-pool limit per remote host; size to the expected concurrent load
-    max-connections: ${CONNECTOR_CLIENT_MAX_CONNECTIONS:20}
+    max-connections: ${CONNECTOR_API_CLIENT_MAX_CONNECTIONS:20}
     # Shed load quickly under pool saturation rather than queueing behind the response timeout
-    pending-acquire-timeout: ${CONNECTOR_CLIENT_PENDING_ACQUIRE_TIMEOUT:10s}
+    pending-acquire-timeout: ${CONNECTOR_API_CLIENT_PENDING_ACQUIRE_TIMEOUT:10s}
 
 cbom:
   client:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,6 +27,13 @@ caching:
     ttl-minutes: 5
     max-size: 100
 
+connector:
+  api-client:
+    response-timeout: 35s
+    connect-timeout: 3s
+    max-connections: 20
+    pending-acquire-timeout: 10s
+
 auth-service:
   base-url: http://authservice.dev
 opa:


### PR DESCRIPTION
## What

Expose the connector `WebClient` tuning as configuration and wire it into the shared `webClient` bean.

- New `connector.api-client.*` properties (`ConnectorApiClientProperties`): `response-timeout` (35s), `connect-timeout` (3s), `max-connections` (20), `pending-acquire-timeout` (10s) — all env-overridable, following the `provisioning.api` / `validation.crl` precedent. Validated at startup (durations strictly positive, `max-connections` positive) so misconfiguration fails fast.
- `ApplicationConfig.webClient()` maps them to `BaseApiClient.prepareWebClient(ClientTuning)`.
- `ConnectorServiceImpl.evictConnectorCache` also evicts the interfaces-side CERTIFICATE WebClient cache, so a deleted or reconfigured connector does not retain its TLS client.

## Why yml/env, not a Settings-UI tunable

This is boot-time infrastructure sizing by design. The interfaces side applies tuning **write-once per JVM** — the Reactor-Netty `ConnectionProvider` (and the timeouts baked into the shared `HttpClient`) cannot be swapped live once the pool is in use — so these values genuinely cannot be a runtime setting. They belong in yml/env, applied at startup.

## Follow-up

The four `CONNECTOR_API_CLIENT_*` env overrides still need wiring into the Helm charts (values + deployment env, same pattern as `CBOM_CLIENT_MAX_BUFFER_SIZE`) to be reachable in deployments — separate `helm-charts` PR. Defaults apply until then, so deployments remain functional.

## Depends on

Requires the `interfaces` change that adds `ClientTuning`, `prepareWebClient(ClientTuning)`, and `evictCertificateClient`: OmniTrustILM/interfaces#788. Merge and publish that first, or CI here will not resolve them.

Relates to #1878

