### PR TITLE
Return a CMP rejection instead of crashing on protection mismatch

### DIFF
--- a/src/main/java/com/otilm/core/service/cmp/impl/CmpServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/cmp/impl/CmpServiceImpl.java
@@ -335,19 +335,20 @@ public class CmpServiceImpl implements CmpExternalService {
      * with the profile's response strategy when possible; if that construction itself fails (e.g. a misconfigured
      * profile), it falls back to an unprotected CMP error carrying the same domain body. RFC 4210 permits
      * unprotected error messages, and this guarantees the endpoint always answers with {@code application/pkixcmp}
-     * rather than leaking to the generic JSON error handler (issue #1885).
+     * rather than leaking to the generic JSON error handler.
      */
     private PKIMessage buildProcessingErrorResponse(ConfigurationContext configuration, PKIMessage pkiRequest,
                                                     CmpBaseException e) {
+        PKIBody errorBody = e.toPKIBody();
         try {
             return new PkiMessageBuilder(configuration)
                     .addHeader(PkiMessageBuilder.buildBasicHeaderTemplate(pkiRequest))
-                    .addBody(e.toPKIBody())
+                    .addBody(errorBody)
                     .addExtraCerts(null)
                     .build();
         } catch (Exception buildError) {
             LOG.error("failed to build protected CMP error response; falling back to unprotected error", buildError);
-            return PkiMessageError.unprotectedMessage(pkiRequest.getHeader(), e.toPKIBody());
+            return PkiMessageError.unprotectedMessage(pkiRequest.getHeader(), errorBody);
         }
     }
 

--- a/src/main/java/com/otilm/core/service/cmp/impl/CmpServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/cmp/impl/CmpServiceImpl.java
@@ -299,11 +299,7 @@ public class CmpServiceImpl implements CmpExternalService {
             return buildOk(pkiResponse);
         } catch (CmpBaseException e) {
             return errorResponse(tid, logPrefix, requestAsString, "processing", e,
-                    new PkiMessageBuilder(configuration)
-                            .addHeader(PkiMessageBuilder.buildBasicHeaderTemplate(pkiRequest))
-                            .addBody(e.toPKIBody())
-                            .addExtraCerts(null)
-                            .build());
+                    buildProcessingErrorResponse(configuration, pkiRequest, e));
         } catch (IOException e) {
             return errorResponse(tid, logPrefix, requestAsString, "parsing", e,
                     PkiMessageError.unprotectedMessage(pkiRequest.getHeader(),
@@ -334,6 +330,27 @@ public class CmpServiceImpl implements CmpExternalService {
         return buildBadRequest(pkiResponse);
     }
 
+    /**
+     * Builds the CMP error response for a domain exception raised during processing. The response is protected
+     * with the profile's response strategy when possible; if that construction itself fails (e.g. a misconfigured
+     * profile), it falls back to an unprotected CMP error carrying the same domain body. RFC 4210 permits
+     * unprotected error messages, and this guarantees the endpoint always answers with {@code application/pkixcmp}
+     * rather than leaking to the generic JSON error handler (issue #1885).
+     */
+    private PKIMessage buildProcessingErrorResponse(ConfigurationContext configuration, PKIMessage pkiRequest,
+                                                    CmpBaseException e) {
+        try {
+            return new PkiMessageBuilder(configuration)
+                    .addHeader(PkiMessageBuilder.buildBasicHeaderTemplate(pkiRequest))
+                    .addBody(e.toPKIBody())
+                    .addExtraCerts(null)
+                    .build();
+        } catch (Exception buildError) {
+            LOG.error("failed to build protected CMP error response; falling back to unprotected error", buildError);
+            return PkiMessageError.unprotectedMessage(pkiRequest.getHeader(), e.toPKIBody());
+        }
+    }
+
     // Should it be handled in new transaction? It wqs made private since it was called intra class so Transactional annotation was ignored anyway
     //    @Transactional(propagation = Propagation.REQUIRES_NEW)
     private void handleTrxError(ASN1OctetString tid, Exception e) {
@@ -341,7 +358,7 @@ public class CmpServiceImpl implements CmpExternalService {
         if (!trx.isEmpty()) {
             for (CmpTransaction updatedTransaction : trx) {
                 updatedTransaction.setState(CmpTransactionState.FAILED);
-                String customReason = e.getMessage();
+                String customReason = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
                 updatedTransaction.setCustomReason(customReason.substring(0, Math.min(254, customReason.length())));
                 cmpTransactionService.save(updatedTransaction);
             }

--- a/src/main/java/com/otilm/core/service/cmp/message/protection/impl/PasswordBasedMacProtectionStrategy.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/protection/impl/PasswordBasedMacProtectionStrategy.java
@@ -102,9 +102,8 @@ public class PasswordBasedMacProtectionStrategy extends BaseProtectionStrategy i
     }
 
     private AlgorithmIdentifier getDigestAlgorithm() throws CmpConfigurationException {
-        PBMParameter pbmParameter = PBMParameter.getInstance(
-                headerProtectionAlgorithm.getParameters());
-        AlgorithmIdentifier algorithmIdentifier = pbmParameter.getOwf();
+        PBMParameter pbmParameter = resolveRequestPbmParameter();
+        AlgorithmIdentifier algorithmIdentifier = pbmParameter == null ? null : pbmParameter.getOwf();
         if (algorithmIdentifier == null) {
             algorithmIdentifier = DIGEST_ALGORITHM_IDENTIFIER_FINDER.find("SHA256");//db query/cmp profile.getSignatureName
             if (algorithmIdentifier == null) {
@@ -121,9 +120,8 @@ public class PasswordBasedMacProtectionStrategy extends BaseProtectionStrategy i
      * @throws CmpConfigurationException if algorithm cannot be found (e.g. wrong mac name).
      */
     private AlgorithmIdentifier getMacAlgorithm() throws CmpConfigurationException {
-        PBMParameter pbmParameter = PBMParameter.getInstance(
-                headerProtectionAlgorithm.getParameters());
-        AlgorithmIdentifier algorithmIdentifier = pbmParameter.getMac();
+        PBMParameter pbmParameter = resolveRequestPbmParameter();
+        AlgorithmIdentifier algorithmIdentifier = pbmParameter == null ? null : pbmParameter.getMac();
         if (algorithmIdentifier == null) {
             algorithmIdentifier = MAC_ALGORITHM_IDENTIFIER_FINDER.find("HMACSHA256");//db query/cmp profile.getSignatureName
             if (algorithmIdentifier == null) {
@@ -131,5 +129,21 @@ public class PasswordBasedMacProtectionStrategy extends BaseProtectionStrategy i
             }
         }
         return algorithmIdentifier;
+    }
+
+    /**
+     * Extracts the {@link PBMParameter} carried by the request's protection algorithm, or {@code null} when the
+     * request was not PBM-protected (e.g. signature- or DH-based). A non-PBM request carries no OWF/MAC template
+     * to echo into the shared-secret response, so callers fall back to the platform defaults (SHA-256 /
+     * HMAC-SHA256). Never dereference a non-PBM algorithm here — see issue #1885, where a signature-protected
+     * KUR against a sharedSecret profile made {@code PBMParameter.getInstance(...)} return {@code null} and the
+     * subsequent {@code getOwf()} throw an NPE that escaped as a generic JSON error.
+     */
+    private PBMParameter resolveRequestPbmParameter() {
+        if (headerProtectionAlgorithm == null
+                || !CMPObjectIdentifiers.passwordBasedMac.equals(headerProtectionAlgorithm.getAlgorithm())) {
+            return null;
+        }
+        return PBMParameter.getInstance(headerProtectionAlgorithm.getParameters());
     }
 }

--- a/src/main/java/com/otilm/core/service/cmp/message/protection/impl/PasswordBasedMacProtectionStrategy.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/protection/impl/PasswordBasedMacProtectionStrategy.java
@@ -48,7 +48,8 @@ public class PasswordBasedMacProtectionStrategy extends BaseProtectionStrategy i
         System.arraycopy(protectionSalt, 0, calculatingBaseKey, sharedSecret.length, protectionSalt.length);
 
         try {
-            AlgorithmIdentifier digestAlgorithm = getDigestAlgorithm();
+            PBMParameter requestPbmParameter = resolveRequestPbmParameter();
+            AlgorithmIdentifier digestAlgorithm = getDigestAlgorithm(requestPbmParameter);
             MessageDigest digest = MessageDigest.getInstance(digestAlgorithm.getAlgorithm().getId(),
                     BouncyCastleProvider.PROVIDER_NAME);
             for (int i = 0; i < iterationCount; i++) {
@@ -56,7 +57,7 @@ public class PasswordBasedMacProtectionStrategy extends BaseProtectionStrategy i
                 digest.reset();
             }
 
-            AlgorithmIdentifier macAlgorithm = getMacAlgorithm();
+            AlgorithmIdentifier macAlgorithm = getMacAlgorithm(requestPbmParameter);
             this.mac = Mac.getInstance(macAlgorithm.getAlgorithm().getId(),
                     BouncyCastleProvider.PROVIDER_NAME);
             this.mac.init(new SecretKeySpec(calculatingBaseKey, mac.getAlgorithm()));
@@ -101,8 +102,7 @@ public class PasswordBasedMacProtectionStrategy extends BaseProtectionStrategy i
         return configuration.getSenderKID();
     }
 
-    private AlgorithmIdentifier getDigestAlgorithm() throws CmpConfigurationException {
-        PBMParameter pbmParameter = resolveRequestPbmParameter();
+    private AlgorithmIdentifier getDigestAlgorithm(PBMParameter pbmParameter) throws CmpConfigurationException {
         AlgorithmIdentifier algorithmIdentifier = pbmParameter == null ? null : pbmParameter.getOwf();
         if (algorithmIdentifier == null) {
             algorithmIdentifier = DIGEST_ALGORITHM_IDENTIFIER_FINDER.find("SHA256");//db query/cmp profile.getSignatureName
@@ -119,8 +119,7 @@ public class PasswordBasedMacProtectionStrategy extends BaseProtectionStrategy i
      * @return algorithm for mac (for PKI Protection field)
      * @throws CmpConfigurationException if algorithm cannot be found (e.g. wrong mac name).
      */
-    private AlgorithmIdentifier getMacAlgorithm() throws CmpConfigurationException {
-        PBMParameter pbmParameter = resolveRequestPbmParameter();
+    private AlgorithmIdentifier getMacAlgorithm(PBMParameter pbmParameter) throws CmpConfigurationException {
         AlgorithmIdentifier algorithmIdentifier = pbmParameter == null ? null : pbmParameter.getMac();
         if (algorithmIdentifier == null) {
             algorithmIdentifier = MAC_ALGORITHM_IDENTIFIER_FINDER.find("HMACSHA256");//db query/cmp profile.getSignatureName
@@ -135,9 +134,9 @@ public class PasswordBasedMacProtectionStrategy extends BaseProtectionStrategy i
      * Extracts the {@link PBMParameter} carried by the request's protection algorithm, or {@code null} when the
      * request was not PBM-protected (e.g. signature- or DH-based). A non-PBM request carries no OWF/MAC template
      * to echo into the shared-secret response, so callers fall back to the platform defaults (SHA-256 /
-     * HMAC-SHA256). Never dereference a non-PBM algorithm here — see issue #1885, where a signature-protected
-     * KUR against a sharedSecret profile made {@code PBMParameter.getInstance(...)} return {@code null} and the
-     * subsequent {@code getOwf()} throw an NPE that escaped as a generic JSON error.
+     * HMAC-SHA256). Never dereference a non-PBM algorithm here: for a signature-protected request (e.g. a KUR)
+     * against a sharedSecret profile {@code PBMParameter.getInstance(...)} returns {@code null}, so a direct
+     * {@code getOwf()} would throw a NullPointerException.
      */
     private PBMParameter resolveRequestPbmParameter() {
         if (headerProtectionAlgorithm == null

--- a/src/main/java/com/otilm/core/service/cmp/message/validator/impl/ProtectionValidator.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/validator/impl/ProtectionValidator.java
@@ -88,6 +88,7 @@ public class ProtectionValidator implements BiValidator<Void, Void> {
                     ImplFailureInfo.CMPVALPRO532);
         }
 
+        assertMessageProtectionMatchesProfile(tid, protectionAlg, configuration.getProtectionMethod());
         checkProtectionMatrix(configuration, request);
         if (CMPObjectIdentifiers.passwordBasedMac.equals(protectionAlg.getAlgorithm())) {
             new ProtectionMacValidator().validate(request, configuration);
@@ -142,6 +143,37 @@ public class ProtectionValidator implements BiValidator<Void, Void> {
         }
 
         return null;
+    }
+
+    /**
+     * Rejects a request whose actual protection type contradicts the profile's configured
+     * {@code Requested Protection Method}. A sharedSecret profile must receive PBM-protected
+     * messages ({@code passwordBasedMac} / {@code id_PBMAC1}); a signature profile must receive
+     * signature-protected messages. On mismatch a {@link PKIFailureInfo#badMessageCheck} rejection
+     * is raised (RFC 4210 §5.2.7) so the client gets a parseable CMP error instead of the platform
+     * dereferencing PBM-specific fields on a non-PBM message (issue #1885).
+     *
+     * <p>When the profile does not constrain the request method ({@code expectedRequestMethod == null})
+     * no check is applied.</p>
+     *
+     * @throws CmpProcessingException if the message protection type is not accepted by the profile
+     */
+    static void assertMessageProtectionMatchesProfile(ASN1OctetString tid, AlgorithmIdentifier protectionAlg,
+                                                      ProtectionMethod expectedRequestMethod)
+            throws CmpProcessingException {
+        if (expectedRequestMethod == null) {
+            return;
+        }
+        boolean messageIsPbm = CMPObjectIdentifiers.passwordBasedMac.equals(protectionAlg.getAlgorithm())
+                || PKCSObjectIdentifiers.id_PBMAC1.equals(protectionAlg.getAlgorithm());
+        if (ProtectionMethod.SHARED_SECRET.equals(expectedRequestMethod) && !messageIsPbm) {
+            throw new CmpProcessingException(tid, PKIFailureInfo.badMessageCheck,
+                    "this CMP profile only accepts PBM (shared secret) protected messages");
+        }
+        if (ProtectionMethod.SIGNATURE.equals(expectedRequestMethod) && messageIsPbm) {
+            throw new CmpProcessingException(tid, PKIFailureInfo.badMessageCheck,
+                    "this CMP profile only accepts signature-protected messages");
+        }
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/cmp/message/validator/impl/ProtectionValidator.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/validator/impl/ProtectionValidator.java
@@ -57,7 +57,10 @@ import org.springframework.transaction.annotation.Transactional;
  * @see <a href="https://www.rfc-editor.org/rfc/rfc4210#section-5.1.3">PKI message protection</a>
  */
 @Component
-@Transactional
+// noRollbackFor keeps Spring's default (no rollback on checked exceptions): CMP surfaces
+// CmpBaseException as a protocol error response, and this validator shares the caller's
+// transaction, so rolling back on it would mark that transaction rollback-only.
+@Transactional(noRollbackFor = CmpBaseException.class)
 public class ProtectionValidator implements BiValidator<Void, Void> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProtectionValidator.class.getName());

--- a/src/main/java/com/otilm/core/service/cmp/message/validator/impl/ProtectionValidator.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/validator/impl/ProtectionValidator.java
@@ -151,7 +151,7 @@ public class ProtectionValidator implements BiValidator<Void, Void> {
      * messages ({@code passwordBasedMac} / {@code id_PBMAC1}); a signature profile must receive
      * signature-protected messages. On mismatch a {@link PKIFailureInfo#badMessageCheck} rejection
      * is raised (RFC 4210 §5.2.7) so the client gets a parseable CMP error instead of the platform
-     * dereferencing PBM-specific fields on a non-PBM message (issue #1885).
+     * dereferencing PBM-specific fields on a non-PBM message.
      *
      * <p>When the profile does not constrain the request method ({@code expectedRequestMethod == null})
      * no check is applied.</p>

--- a/src/test/java/com/otilm/core/service/cmp/impl/CmpServiceImplHandlePostTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/impl/CmpServiceImplHandlePostTest.java
@@ -205,7 +205,7 @@ class CmpServiceImplHandlePostTest {
     @Test
     void handlePost_returnsCmpRejection_whenSignatureMessageHitsSharedSecretProfile() throws Exception {
         // given: a shared-secret profile (both request and response protection are sharedSecret) that receives a
-        // signature-protected message — the scenario from issue #1885 (a KUR against a PBM-only profile)
+        // signature-protected message — e.g. a KUR against a PBM-only profile
         CmpProfile cmpProfile = resolvedCmpProfile();
         when(cmpProfile.getRequestProtectionMethod()).thenReturn(ProtectionMethod.SHARED_SECRET);
         when(cmpProfile.getSharedSecret()).thenReturn("shared-secret-value");
@@ -228,6 +228,61 @@ class CmpServiceImplHandlePostTest {
         assertThat(responseMessage.getBody().getType()).isEqualTo(PKIBody.TYPE_ERROR);
         assertThat(responseMessage.getProtection()).isNotNull();
         assertThat(wireStatusText(response.getBody())).contains("only accepts PBM");
+    }
+
+    @Test
+    void handlePost_returnsUnprotectedError_whenProtectedErrorResponseCannotBeBuilt() throws Exception {
+        // given: a sharedSecret-response profile whose shared secret is null, so building the *protected* error
+        // response throws while handling a domain exception — the endpoint must still answer with a CMP error
+        CmpProfile cmpProfile = resolvedCmpProfile();
+        when(cmpProfile.getSharedSecret()).thenReturn(null);
+        RaProfile raProfile = resolvedRaProfile(cmpProfile);
+        RaProfileRepository raProfileRepository = mock(RaProfileRepository.class);
+        when(raProfileRepository.findByName(anyString())).thenReturn(Optional.of(raProfile));
+
+        // and: a domain exception is raised during processing so the catch path builds the error response
+        HeaderValidator headerValidator = mock(HeaderValidator.class);
+        when(headerValidator.validate(any(), any()))
+                .thenThrow(new CmpProcessingException(PKIFailureInfo.badRequest, "sender name is not trusted"));
+        CmpServiceImpl service = newService(raProfileRepository, mock(CmpProfileRepository.class), headerValidator, false);
+
+        // when
+        ResponseEntity<byte[]> response = service.handlePost(PROFILE_NAME, revocationRequest());
+
+        // then: the endpoint falls back to an unprotected CMP error rather than leaking to the JSON handler
+        assertThat(response.getBody()).isNotNull();
+        PKIMessage responseMessage = PKIMessage.getInstance(response.getBody());
+        assertThat(responseMessage.getBody().getType()).isEqualTo(PKIBody.TYPE_ERROR);
+        assertThat(responseMessage.getProtection()).isNull();
+        assertThat(wireStatusText(response.getBody())).contains("sender name is not trusted");
+    }
+
+    @Test
+    void handlePost_failsTransactionWithoutNpe_whenExceptionMessageIsNull() throws Exception {
+        // given: a resolved profile, a matching in-flight transaction, and processing that throws an exception
+        // carrying a null message (the branch that previously NPE'd in handleTrxError's substring call)
+        CmpProfile cmpProfile = resolvedCmpProfile();
+        RaProfile raProfile = resolvedRaProfile(cmpProfile);
+        RaProfileRepository raProfileRepository = mock(RaProfileRepository.class);
+        when(raProfileRepository.findByName(anyString())).thenReturn(Optional.of(raProfile));
+
+        HeaderValidator headerValidator = mock(HeaderValidator.class);
+        when(headerValidator.validate(any(), any())).thenThrow(new RuntimeException());
+        CmpServiceImpl service = newService(raProfileRepository, mock(CmpProfileRepository.class), headerValidator, false);
+
+        CmpTransaction transaction = new CmpTransaction();
+        CmpTransactionService cmpTransactionService =
+                (CmpTransactionService) ReflectionTestUtils.getField(service, "cmpTransactionService");
+        when(cmpTransactionService.findByTransactionId(anyString())).thenReturn(List.of(transaction));
+
+        // when
+        ResponseEntity<byte[]> response = service.handlePost(PROFILE_NAME, revocationRequest());
+
+        // then: no NPE escapes; the transaction is marked FAILED with the exception's class name as the reason
+        assertThat(response.getBody()).isNotNull();
+        verify(cmpTransactionService).save(transaction);
+        assertThat(transaction.getState()).isEqualTo(CmpTransactionState.FAILED);
+        assertThat(transaction.getCustomReason()).isEqualTo("RuntimeException");
     }
 
     private CmpServiceImpl newService(RaProfileRepository raProfileRepository,

--- a/src/test/java/com/otilm/core/service/cmp/impl/CmpServiceImplHandlePostTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/impl/CmpServiceImplHandlePostTest.java
@@ -12,7 +12,9 @@ import com.otilm.core.dao.repository.RaProfileRepository;
 import com.otilm.core.dao.repository.cmp.CmpProfileRepository;
 import com.otilm.core.service.cmp.CmpTestUtil;
 import com.otilm.core.service.cmp.message.CmpTransactionService;
+import com.otilm.core.service.cmp.message.validator.impl.BodyValidator;
 import com.otilm.core.service.cmp.message.validator.impl.HeaderValidator;
+import com.otilm.core.service.cmp.message.validator.impl.ProtectionValidator;
 import org.bouncycastle.asn1.cmp.PKIBody;
 import org.bouncycastle.asn1.cmp.PKIFailureInfo;
 import org.bouncycastle.asn1.cmp.PKIHeader;
@@ -200,6 +202,34 @@ class CmpServiceImplHandlePostTest {
         assertThat(captor.getValue().getState()).isEqualTo(CmpTransactionState.FAILED);
     }
 
+    @Test
+    void handlePost_returnsCmpRejection_whenSignatureMessageHitsSharedSecretProfile() throws Exception {
+        // given: a shared-secret profile (both request and response protection are sharedSecret) that receives a
+        // signature-protected message — the scenario from issue #1885 (a KUR against a PBM-only profile)
+        CmpProfile cmpProfile = resolvedCmpProfile();
+        when(cmpProfile.getRequestProtectionMethod()).thenReturn(ProtectionMethod.SHARED_SECRET);
+        when(cmpProfile.getSharedSecret()).thenReturn("shared-secret-value");
+        RaProfile raProfile = resolvedRaProfile(cmpProfile);
+        RaProfileRepository raProfileRepository = mock(RaProfileRepository.class);
+        when(raProfileRepository.findByName(anyString())).thenReturn(Optional.of(raProfile));
+
+        // and: header/body validation pass, so the real ProtectionValidator runs
+        CmpServiceImpl service = newService(raProfileRepository, mock(CmpProfileRepository.class),
+                mock(HeaderValidator.class), false);
+        ReflectionTestUtils.setField(service, "bodyValidator", mock(BodyValidator.class));
+        ReflectionTestUtils.setField(service, "protectionValidator", new ProtectionValidator());
+
+        // when: instead of an NPE escaping to the JSON error handler, handlePost returns a CMP response
+        ResponseEntity<byte[]> response = service.handlePost(PROFILE_NAME, signatureProtectedRevocationRequest());
+
+        // then: the response is a well-formed, protected CMP rejection carrying a badMessageCheck status string
+        assertThat(response.getBody()).isNotNull();
+        PKIMessage responseMessage = PKIMessage.getInstance(response.getBody());
+        assertThat(responseMessage.getBody().getType()).isEqualTo(PKIBody.TYPE_ERROR);
+        assertThat(responseMessage.getProtection()).isNotNull();
+        assertThat(wireStatusText(response.getBody())).contains("only accepts PBM");
+    }
+
     private CmpServiceImpl newService(RaProfileRepository raProfileRepository,
                                       CmpProfileRepository cmpProfileRepository,
                                       HeaderValidator headerValidator,
@@ -252,6 +282,13 @@ class CmpServiceImplHandlePostTest {
     private static byte[] macProtectedRevocationRequest() throws Exception {
         PKIBody body = CmpTestUtil.createRevocationBody(BigInteger.ONE);
         return CmpTestUtil.createMacBasedMessage("transaction1", "shared-secret-value", body)
+                .toASN1Structure().getEncoded();
+    }
+
+    private static byte[] signatureProtectedRevocationRequest() throws Exception {
+        PKIBody body = CmpTestUtil.createRevocationBody(BigInteger.ONE);
+        var keyPair = CmpTestUtil.generateKeyPairEC();
+        return CmpTestUtil.createSignatureBasedMessage("transaction1", keyPair.getPrivate(), body)
                 .toASN1Structure().getEncoded();
     }
 

--- a/src/test/java/com/otilm/core/service/cmp/message/protection/impl/PasswordBasedMacProtectionStrategyTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/protection/impl/PasswordBasedMacProtectionStrategyTest.java
@@ -1,0 +1,93 @@
+package com.otilm.core.service.cmp.message.protection.impl;
+
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERNull;
+import org.bouncycastle.asn1.cmp.CMPObjectIdentifiers;
+import org.bouncycastle.asn1.cmp.PBMParameter;
+import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.security.Security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Unit tests for {@link PasswordBasedMacProtectionStrategy}.
+ *
+ * <p>Regression coverage for issue #1885: when a CMP profile has {@code Response Protection Method = sharedSecret}
+ * and the incoming request is <em>not</em> PBM-protected (signature- or DH-based), the response PBM strategy is
+ * still built from the request's protection algorithm. That algorithm carries no {@link PBMParameter}, so the
+ * strategy must fall back to platform defaults (SHA-256 / HMAC-SHA256) instead of dereferencing a {@code null}
+ * {@code PBMParameter} and throwing an NPE.</p>
+ */
+class PasswordBasedMacProtectionStrategyTest {
+
+    private static final ASN1ObjectIdentifier ECDSA_WITH_SHA384 = new ASN1ObjectIdentifier("1.2.840.10045.4.3.3");
+    private static final ASN1ObjectIdentifier SHA1_OWF = new ASN1ObjectIdentifier("1.3.14.3.2.26");
+    private static final ASN1ObjectIdentifier HMAC_SHA1 = new ASN1ObjectIdentifier("1.2.840.113549.2.7");
+
+    private static final byte[] SHARED_SECRET = "shared-secret-value".getBytes();
+    private static final byte[] SALT = "0123456789012345678901234".getBytes();
+    private static final int ITERATION_COUNT = 1000;
+
+    @BeforeAll
+    static void registerBouncyCastle() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    @Test
+    void buildsWithDefaultAlgorithms_whenRequestUsesSignatureAlgorithmWithoutParameters() throws Exception {
+        // given: an ECDSA signature algorithm identifier with no parameters (getParameters() == null),
+        // which is exactly what a signature-protected KUR carries — no PBMParameter to echo
+        AlgorithmIdentifier signatureAlg = new AlgorithmIdentifier(ECDSA_WITH_SHA384);
+
+        // when / then: constructing the PBM response strategy must not throw an NPE
+        PasswordBasedMacProtectionStrategy strategy = new PasswordBasedMacProtectionStrategy(
+                null, signatureAlg, SHARED_SECRET, SALT, ITERATION_COUNT);
+
+        // and: the produced protection uses the platform default digest (SHA-256) and MAC (HMAC-SHA256)
+        assertThat(strategy.getProtectionAlg().getAlgorithm()).isEqualTo(CMPObjectIdentifiers.passwordBasedMac);
+        PBMParameter produced = PBMParameter.getInstance(strategy.getProtectionAlg().getParameters());
+        assertThat(produced.getOwf().getAlgorithm()).isEqualTo(NISTObjectIdentifiers.id_sha256);
+        assertThat(produced.getMac().getAlgorithm()).isEqualTo(PKCSObjectIdentifiers.id_hmacWithSHA256);
+    }
+
+    @Test
+    void buildsWithDefaultAlgorithms_whenRequestUsesSignatureAlgorithmWithNullParameters() {
+        // given: an RSA signature algorithm identifier whose parameters are ASN.1 NULL (not a PBMParameter sequence)
+        AlgorithmIdentifier signatureAlg =
+                new AlgorithmIdentifier(PKCSObjectIdentifiers.sha256WithRSAEncryption, DERNull.INSTANCE);
+
+        // when / then: constructing the PBM response strategy must not throw (pre-fix: IllegalArgumentException)
+        assertThatCode(() -> new PasswordBasedMacProtectionStrategy(
+                null, signatureAlg, SHARED_SECRET, SALT, ITERATION_COUNT))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void echoesRequestAlgorithms_whenRequestIsPbmProtected() throws Exception {
+        // given: a genuine PBM protection algorithm carrying SHA1 owf + HMAC-SHA1 mac
+        AlgorithmIdentifier pbmAlg = new AlgorithmIdentifier(
+                CMPObjectIdentifiers.passwordBasedMac,
+                new PBMParameter(SALT,
+                        new AlgorithmIdentifier(SHA1_OWF),
+                        ITERATION_COUNT,
+                        new AlgorithmIdentifier(HMAC_SHA1)));
+
+        // when
+        PasswordBasedMacProtectionStrategy strategy = new PasswordBasedMacProtectionStrategy(
+                null, pbmAlg, SHARED_SECRET, SALT, ITERATION_COUNT);
+
+        // then: the client's chosen digest/mac are echoed, not overridden by the defaults
+        PBMParameter produced = PBMParameter.getInstance(strategy.getProtectionAlg().getParameters());
+        assertThat(produced.getOwf().getAlgorithm()).isEqualTo(SHA1_OWF);
+        assertThat(produced.getMac().getAlgorithm()).isEqualTo(HMAC_SHA1);
+    }
+}

--- a/src/test/java/com/otilm/core/service/cmp/message/protection/impl/PasswordBasedMacProtectionStrategyTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/protection/impl/PasswordBasedMacProtectionStrategyTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 /**
  * Unit tests for {@link PasswordBasedMacProtectionStrategy}.
  *
- * <p>Regression coverage for issue #1885: when a CMP profile has {@code Response Protection Method = sharedSecret}
+ * <p>Regression coverage: when a CMP profile has {@code Response Protection Method = sharedSecret}
  * and the incoming request is <em>not</em> PBM-protected (signature- or DH-based), the response PBM strategy is
  * still built from the request's protection algorithm. That algorithm carries no {@link PBMParameter}, so the
  * strategy must fall back to platform defaults (SHA-256 / HMAC-SHA256) instead of dereferencing a {@code null}

--- a/src/test/java/com/otilm/core/service/cmp/message/validator/impl/ProtectionValidatorTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/validator/impl/ProtectionValidatorTest.java
@@ -1,0 +1,78 @@
+package com.otilm.core.service.cmp.message.validator.impl;
+
+import com.otilm.api.interfaces.core.cmp.error.CmpProcessingException;
+import com.otilm.api.model.core.cmp.ProtectionMethod;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.cmp.CMPObjectIdentifiers;
+import org.bouncycastle.asn1.cmp.PKIFailureInfo;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the protection-type consistency check in {@link ProtectionValidator}.
+ *
+ * <p>Regression coverage for issue #1885: a message whose actual protection type contradicts the profile's
+ * configured {@code Requested Protection Method} must be rejected with a proper CMP {@code badMessageCheck}
+ * rejection (RFC 4210 §5.2.7) rather than being allowed through to a strategy that assumes a different type.</p>
+ */
+class ProtectionValidatorTest {
+
+    private static final ASN1OctetString TID = new DEROctetString(new byte[]{1, 2, 3, 4});
+    private static final AlgorithmIdentifier SIGNATURE_ALG =
+            new AlgorithmIdentifier(new ASN1ObjectIdentifier("1.2.840.10045.4.3.3")); // ecdsa-with-SHA384
+    private static final AlgorithmIdentifier PBM_ALG =
+            new AlgorithmIdentifier(CMPObjectIdentifiers.passwordBasedMac);
+    private static final AlgorithmIdentifier PBMAC1_ALG =
+            new AlgorithmIdentifier(PKCSObjectIdentifiers.id_PBMAC1);
+
+    @Test
+    void rejectsSignatureMessage_whenProfileRequiresSharedSecret() {
+        assertThatThrownBy(() -> ProtectionValidator.assertMessageProtectionMatchesProfile(
+                TID, SIGNATURE_ALG, ProtectionMethod.SHARED_SECRET))
+                .isInstanceOfSatisfying(CmpProcessingException.class,
+                        e -> assertThat(e.getFailureInfo()).isEqualTo(PKIFailureInfo.badMessageCheck));
+    }
+
+    @Test
+    void rejectsPbmMessage_whenProfileRequiresSignature() {
+        assertThatThrownBy(() -> ProtectionValidator.assertMessageProtectionMatchesProfile(
+                TID, PBM_ALG, ProtectionMethod.SIGNATURE))
+                .isInstanceOfSatisfying(CmpProcessingException.class,
+                        e -> assertThat(e.getFailureInfo()).isEqualTo(PKIFailureInfo.badMessageCheck));
+    }
+
+    @Test
+    void acceptsPbmMessage_whenProfileRequiresSharedSecret() {
+        assertThatCode(() -> ProtectionValidator.assertMessageProtectionMatchesProfile(
+                TID, PBM_ALG, ProtectionMethod.SHARED_SECRET))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void acceptsPbmac1Message_whenProfileRequiresSharedSecret() {
+        assertThatCode(() -> ProtectionValidator.assertMessageProtectionMatchesProfile(
+                TID, PBMAC1_ALG, ProtectionMethod.SHARED_SECRET))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void acceptsSignatureMessage_whenProfileRequiresSignature() {
+        assertThatCode(() -> ProtectionValidator.assertMessageProtectionMatchesProfile(
+                TID, SIGNATURE_ALG, ProtectionMethod.SIGNATURE))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void acceptsAnyMessage_whenProfileDoesNotConstrainRequestMethod() {
+        assertThatCode(() -> ProtectionValidator.assertMessageProtectionMatchesProfile(
+                TID, SIGNATURE_ALG, null))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/otilm/core/service/cmp/message/validator/impl/ProtectionValidatorTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/validator/impl/ProtectionValidatorTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for the protection-type consistency check in {@link ProtectionValidator}.
  *
- * <p>Regression coverage for issue #1885: a message whose actual protection type contradicts the profile's
+ * <p>Regression coverage: a message whose actual protection type contradicts the profile's
  * configured {@code Requested Protection Method} must be rejected with a proper CMP {@code badMessageCheck}
  * rejection (RFC 4210 §5.2.7) rather than being allowed through to a strategy that assumes a different type.</p>
  */


### PR DESCRIPTION
## Summary

Fixes the crash where a signature-protected CMP message (e.g. `KUR`) sent to a profile with `sharedSecret` response protection caused a `NullPointerException` in `PBMParameter.getOwf()` that escaped as `application/json` instead of a CMP `application/pkixcmp` error (OpenSSL: `unexpected content type: expected=application/pkixcmp, actual=application/json`).

## Root cause

The `sharedSecret` response strategy was built from the **request's** protection algorithm. A signature-protected request carries no `PBMParameter`, so `PBMParameter.getInstance(...)` returned `null` and the subsequent `getOwf()` threw. The wrapped exception was then re-thrown while building the error response, so it escaped the CMP handler and fell through to the generic JSON error handler.

## Changes

- **PasswordBasedMacProtectionStrategy** — read the request `PBMParameter` only when the request algorithm is `passwordBasedMac`; otherwise fall back to the SHA-256 / HMAC-SHA256 defaults instead of dereferencing `null`. Resolved once per construction.
- **ProtectionValidator** — reject a message whose protection type contradicts the profile's configured Request Protection Method with a `badMessageCheck` rejection (RFC 4210 §5.2.7), so the client gets a parseable CMP error.
- **CmpServiceImpl** — build the processing error response defensively, falling back to an unprotected CMP error so the endpoint always answers `application/pkixcmp`; guard `handleTrxError` against a null exception message.

## Tests

- 12 new tests: strategy null-safety (incl. RSA/ECDSA algorithm shapes and the PBM echo path), the protection-mismatch kernel, the `handlePost` end-to-end rejection, the unprotected-error fallback, and the null-message guard.
- Verified the strategy test fails pre-fix with the exact reported NPE (`Cannot invoke "...PBMParameter.getOwf()" because "pbmParameter" is null`).
- CMP unit **79/79**, CMP integration **16/16** (PBM + signature `IR`/`KUR`/revocation/certConf) — no regressions.

## Review

Ran a multi-reviewer pass (Copilot CLI, guided, superpowers, hygiene): Copilot **SHIP**, no correctness or security defects. Review findings folded in — tests for the defensive branches, single `PBMParameter` parse, and comment cleanup.

Closes #1885
