### PR TITLE
Deliver SCEP-issued certificates to EC (non-RSA) client keys

### DIFF
--- a/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
@@ -715,11 +715,11 @@ public class ScepServiceImpl implements ScepExternalService {
      * committing an unretrievable certificate.
      */
     void verifyResponseEnvelopable(ScepRequest scepRequest) throws ScepException {
-        X509Certificate recipient = scepRequest.getSignerCertificate();
-        if (recipient == null) {
+        X509Certificate signerCertificate = scepRequest.getSignerCertificate();
+        if (signerCertificate == null) {
             return;
         }
-        boolean keyTransportCapable = "RSA".equalsIgnoreCase(recipient.getPublicKey().getAlgorithm());
+        boolean keyTransportCapable = "RSA".equalsIgnoreCase(signerCertificate.getPublicKey().getAlgorithm());
         boolean challengePasswordConfigured = scepProfile.getChallengePassword() != null && !scepProfile.getChallengePassword().isEmpty();
         if (!keyTransportCapable && !challengePasswordConfigured) {
             throw new ScepException("A challenge password must be configured on the SCEP profile to issue certificates to non-RSA client keys", FailInfo.BAD_ALG);

--- a/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
@@ -387,6 +387,9 @@ public class ScepServiceImpl implements ScepExternalService {
             }
         } else if (scepRequest.getMessageType().equals(MessageType.PKCS_REQ)) {
             try {
+                // Reject before issuing when the response could never be delivered, so the platform
+                // does not commit a certificate the client can never retrieve (RFC 8894 §3.2.2).
+                verifyResponseEnvelopable(scepRequest);
                 // Manual approval for the SCEP clients are configured in the SCEP Profile.
                 // If the SCEP Profile has the manual approval set to true, only the CSR will be generated
                 if (scepProfile.getRequireManualApproval() != null && !scepProfile.getRequireManualApproval()) {
@@ -416,23 +419,7 @@ public class ScepServiceImpl implements ScepExternalService {
         } else {
             scepResponse = buildFailedResponse(new ScepException("Unsupported Operation. The requested operation is not supported", FailInfo.BAD_REQUEST), scepRequest.getTransactionId());
         }
-        try {
-            return buildResponse(scepRequest, scepResponse);
-        } catch (ScepException e) {
-            // Generating the encrypted SUCCESS CertRep can fail after the state machine already
-            // resolved to SUCCESS (e.g. an EC recipient key with no challenge password to envelope
-            // with). Degrade to a well-formed SCEP FAILURE rather than letting it surface as an HTTP
-            // error the client cannot interpret (RFC 8894 §3.3). A FAILURE CertRep has empty content
-            // and needs no recipient encryption, so it always encodes.
-            if (scepResponse != null && PkiStatus.FAILURE.equals(scepResponse.getPkiStatus())) {
-                throw e;
-            }
-            logger.error("Failed to build SCEP response for transactionId={}: {}",
-                    scepRequest.getTransactionId(), e.getMessage(), e);
-            return buildResponse(scepRequest,
-                    buildFailedResponse(new ScepException("Unable to generate SCEP response", FailInfo.BAD_REQUEST),
-                            scepRequest.getTransactionId()));
-        }
+        return buildResponse(scepRequest, scepResponse);
     }
 
     private ScepResponse buildFailedResponse(ScepException scepException, String transactionId) {
@@ -671,6 +658,9 @@ public class ScepServiceImpl implements ScepExternalService {
         } catch (Exception e) {
             logger.error("SCEP poll failed for transactionId={}: {}",
                     scepRequest.getTransactionId(), e.getMessage(), e);
+            // Keep the client polling rather than returning a half-initialised (possibly
+            // null-status) response that would fail response generation with an HTTP error.
+            scepResponse.setPkiStatus(PkiStatus.PENDING);
         }
         return scepResponse;
     }
@@ -715,6 +705,31 @@ public class ScepServiceImpl implements ScepExternalService {
         var certificateChain = loadCertificateChain(certificate, true);
         if (this.scepProfile.isIncludeCaCertificateChain()) return certificateChain;
         else return certificateChain.subList(0, Math.min(2, certificateChain.size()));
+    }
+
+    /**
+     * A SUCCESS CertRep is enveloped to the client's own key: RSA keys via key transport, every
+     * other key type (e.g. EC) via the RFC 8894 password recipient, which needs the shared challenge
+     * password. When the client key cannot do key transport and the profile has no challenge password,
+     * the issued certificate could never be delivered — reject the request before issuing rather than
+     * committing an unretrievable certificate.
+     */
+    void verifyResponseEnvelopable(ScepRequest scepRequest) throws ScepException {
+        byte[] recipientKeyInfo = scepRequest.getRequestKeyInfo();
+        if (recipientKeyInfo == null) {
+            return;
+        }
+        String keyAlgorithm;
+        try {
+            keyAlgorithm = CertificateUtil.getX509Certificate(recipientKeyInfo).getPublicKey().getAlgorithm();
+        } catch (CertificateException e) {
+            throw new ScepException("Unable to read the requester key from the SCEP request", e, FailInfo.BAD_REQUEST);
+        }
+        boolean keyTransportCapable = "RSA".equalsIgnoreCase(keyAlgorithm);
+        boolean challengePasswordConfigured = scepProfile.getChallengePassword() != null && !scepProfile.getChallengePassword().isEmpty();
+        if (!keyTransportCapable && !challengePasswordConfigured) {
+            throw new ScepException("A challenge password must be configured on the SCEP profile to issue certificates to non-RSA client keys", FailInfo.BAD_ALG);
+        }
     }
 
     private void prepareMessage(ScepRequest scepRequest, ScepResponse scepResponse) {

--- a/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
@@ -416,7 +416,23 @@ public class ScepServiceImpl implements ScepExternalService {
         } else {
             scepResponse = buildFailedResponse(new ScepException("Unsupported Operation. The requested operation is not supported", FailInfo.BAD_REQUEST), scepRequest.getTransactionId());
         }
-        return buildResponse(scepRequest, scepResponse);
+        try {
+            return buildResponse(scepRequest, scepResponse);
+        } catch (ScepException e) {
+            // Generating the encrypted SUCCESS CertRep can fail after the state machine already
+            // resolved to SUCCESS (e.g. an EC recipient key with no challenge password to envelope
+            // with). Degrade to a well-formed SCEP FAILURE rather than letting it surface as an HTTP
+            // error the client cannot interpret (RFC 8894 §3.3). A FAILURE CertRep has empty content
+            // and needs no recipient encryption, so it always encodes.
+            if (scepResponse != null && PkiStatus.FAILURE.equals(scepResponse.getPkiStatus())) {
+                throw e;
+            }
+            logger.error("Failed to build SCEP response for transactionId={}: {}",
+                    scepRequest.getTransactionId(), e.getMessage(), e);
+            return buildResponse(scepRequest,
+                    buildFailedResponse(new ScepException("Unable to generate SCEP response", FailInfo.BAD_REQUEST),
+                            scepRequest.getTransactionId()));
+        }
     }
 
     private ScepResponse buildFailedResponse(ScepException scepException, String transactionId) {
@@ -714,6 +730,9 @@ public class ScepServiceImpl implements ScepExternalService {
         scepResponse.setDigestAlgorithmOid(scepRequest.getDigestAlgorithmOid());
         scepResponse.setSenderNonce(RandomUtil.generateRandomNonceBase64(16));
         scepResponse.setContentEncryptionAlgorithm(scepRequest.getContentEncryptionAlgorithm());
+        // Enveloping a SUCCESS response to a recipient key that cannot do key transport (e.g. EC)
+        // requires the shared challenge password (RFC 8894 §3.2.2).
+        scepResponse.setChallengePassword(scepProfile.getChallengePassword());
     }
 
     private ScepTransaction getTransaction(String transactionId) {

--- a/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
@@ -715,20 +715,29 @@ public class ScepServiceImpl implements ScepExternalService {
      * committing an unretrievable certificate.
      */
     void verifyResponseEnvelopable(ScepRequest scepRequest) throws ScepException {
-        byte[] recipientKeyInfo = scepRequest.getRequestKeyInfo();
-        if (recipientKeyInfo == null) {
+        X509Certificate recipient = scepRequest.getSignerCertificate();
+        if (recipient == null) {
             return;
         }
-        String keyAlgorithm;
-        try {
-            keyAlgorithm = CertificateUtil.getX509Certificate(recipientKeyInfo).getPublicKey().getAlgorithm();
-        } catch (CertificateException e) {
-            throw new ScepException("Unable to read the requester key from the SCEP request", e, FailInfo.BAD_REQUEST);
-        }
-        boolean keyTransportCapable = "RSA".equalsIgnoreCase(keyAlgorithm);
+        boolean keyTransportCapable = "RSA".equalsIgnoreCase(recipient.getPublicKey().getAlgorithm());
         boolean challengePasswordConfigured = scepProfile.getChallengePassword() != null && !scepProfile.getChallengePassword().isEmpty();
         if (!keyTransportCapable && !challengePasswordConfigured) {
             throw new ScepException("A challenge password must be configured on the SCEP profile to issue certificates to non-RSA client keys", FailInfo.BAD_ALG);
+        }
+    }
+
+    private byte[] resolveRecipientKeyInfo(ScepRequest scepRequest) {
+        // Envelope the response to the resolved signer certificate (the entity that holds the private
+        // key to decrypt it), not the first element of the request's certificate SET, which is not
+        // guaranteed to be the signer.
+        X509Certificate signerCertificate = scepRequest.getSignerCertificate();
+        if (signerCertificate == null) {
+            return scepRequest.getRequestKeyInfo();
+        }
+        try {
+            return signerCertificate.getEncoded();
+        } catch (CertificateException e) {
+            return scepRequest.getRequestKeyInfo();
         }
     }
 
@@ -741,7 +750,7 @@ public class ScepServiceImpl implements ScepExternalService {
         scepResponse.setRecipientNonce(scepRequest.getSenderNonce());
         scepResponse.setTransactionId(scepRequest.getTransactionId());
         scepResponse.setCaCertificate(recipient);
-        scepResponse.setRecipientKeyInfo(scepRequest.getRequestKeyInfo());
+        scepResponse.setRecipientKeyInfo(resolveRecipientKeyInfo(scepRequest));
         scepResponse.setDigestAlgorithmOid(scepRequest.getDigestAlgorithmOid());
         scepResponse.setSenderNonce(RandomUtil.generateRandomNonceBase64(16));
         scepResponse.setContentEncryptionAlgorithm(scepRequest.getContentEncryptionAlgorithm());

--- a/src/main/java/com/otilm/core/service/scep/message/ScepResponse.java
+++ b/src/main/java/com/otilm/core/service/scep/message/ScepResponse.java
@@ -205,8 +205,7 @@ public class ScepResponse {
         // so fall back to the RFC 8894 §3.2.2 password recipient keyed with the shared challenge
         // password — the response-direction mirror of ScepRequest.decryptData.
         if ("RSA".equalsIgnoreCase(recipient.getPublicKey().getAlgorithm())) {
-            logger.debug("Enveloping SCEP response via key transport to recipient subject DN '{}' serial {}",
-                    recipient.getSubjectX500Principal().getName(), recipient.getSerialNumber().toString(16));
+            logger.debug("Enveloping SCEP response to an RSA recipient via key transport");
             return new JceKeyTransRecipientInfoGenerator(recipient).setProvider(BouncyCastleProvider.PROVIDER_NAME);
         }
         if (challengePassword == null || challengePassword.length == 0) {

--- a/src/main/java/com/otilm/core/service/scep/message/ScepResponse.java
+++ b/src/main/java/com/otilm/core/service/scep/message/ScepResponse.java
@@ -18,6 +18,7 @@ import org.bouncycastle.cms.*;
 import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder;
 import org.bouncycastle.cms.jcajce.JceCMSContentEncryptorBuilder;
 import org.bouncycastle.cms.jcajce.JceKeyTransRecipientInfoGenerator;
+import org.bouncycastle.cms.jcajce.JcePasswordRecipientInfoGenerator;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
@@ -52,6 +53,7 @@ public class ScepResponse {
     private List<X509Certificate> certificateChain;
     private byte[] recipientKeyInfo;
     private String digestAlgorithmOid;
+    private char[] challengePassword;
 
     private CMSTypedData responseData;
 
@@ -121,6 +123,18 @@ public class ScepResponse {
         this.digestAlgorithmOid = digestAlgorithmOid;
     }
 
+    /**
+     * The shared SCEP challenge password, used to envelope the SUCCESS response when the
+     * recipient key cannot receive an RSA-key-transport envelope (e.g. an EC client key).
+     */
+    public void setChallengePassword(String challengePassword) {
+        this.challengePassword = challengePassword != null ? challengePassword.toCharArray() : null;
+    }
+
+    public PkiStatus getPkiStatus() {
+        return pkiStatus;
+    }
+
     public CMSSignedData getSignedResponseData() {
         return signedResponseData;
     }
@@ -161,33 +175,48 @@ public class ScepResponse {
 
     private void createResponseData() throws CertificateException, CMSException, IOException {
         if (pkiStatus.equals(PkiStatus.SUCCESS)) {
-            CMSEnvelopedDataGenerator cmsEnvelopedDataGenerator = new CMSEnvelopedDataGenerator();
-            CMSSignedDataGenerator cmsSignedDataGenerator = new CMSSignedDataGenerator();
-            cmsSignedDataGenerator.addCertificates(new CollectionStore<>(CertificateUtil.convertToX509CertificateHolder(certificateChain)));
-            CMSSignedData cmsSignedData = cmsSignedDataGenerator.generate(new CMSAbsentContent(), false);
-
-            // Envelope the CMS message
-            if (recipientKeyInfo != null) {
-                X509Certificate recipient = CertificateUtil.getX509Certificate(recipientKeyInfo);
-                logger.debug("Recipient certificate subject DN: '" + recipient.getSubjectX500Principal().getName() +
-                        "serial number: " + recipient.getSerialNumber().toString(16));
-                cmsEnvelopedDataGenerator.addRecipientInfoGenerator(
-                        new JceKeyTransRecipientInfoGenerator(recipient)
-                                .setProvider(BouncyCastleProvider.PROVIDER_NAME));
-            } else {
-                cmsEnvelopedDataGenerator.addRecipientInfoGenerator(
-                        new JceKeyTransRecipientInfoGenerator(certificateChain.get(0))
-                                .setProvider(BouncyCastleProvider.PROVIDER_NAME));
-            }
-            // Take the content encryption algorithm from the response that is set from the SCEP request message
-            JceCMSContentEncryptorBuilder jceCMSContentEncryptorBuilder = new JceCMSContentEncryptorBuilder(contentEncryptionAlgorithm).setProvider(BouncyCastleProvider.PROVIDER_NAME);
-            CMSEnvelopedData cmsEnvelopedData = cmsEnvelopedDataGenerator.generate(
-                    new CMSProcessableByteArray(cmsSignedData.getEncoded()),
-                    jceCMSContentEncryptorBuilder.build());
-            responseData = new CMSProcessableByteArray(cmsEnvelopedData.getEncoded());
+            responseData = new CMSProcessableByteArray(buildEnvelopedResponse().getEncoded());
         } else {
             responseData = new CMSProcessableByteArray(new byte[0]);
         }
+    }
+
+    CMSEnvelopedData buildEnvelopedResponse() throws CertificateException, CMSException, IOException {
+        CMSSignedDataGenerator cmsSignedDataGenerator = new CMSSignedDataGenerator();
+        cmsSignedDataGenerator.addCertificates(new CollectionStore<>(CertificateUtil.convertToX509CertificateHolder(certificateChain)));
+        CMSSignedData cmsSignedData = cmsSignedDataGenerator.generate(new CMSAbsentContent(), false);
+
+        X509Certificate recipient = recipientKeyInfo != null
+                ? CertificateUtil.getX509Certificate(recipientKeyInfo)
+                : certificateChain.get(0);
+
+        CMSEnvelopedDataGenerator cmsEnvelopedDataGenerator = new CMSEnvelopedDataGenerator();
+        cmsEnvelopedDataGenerator.addRecipientInfoGenerator(buildRecipientInfoGenerator(recipient));
+
+        // Take the content encryption algorithm from the response that is set from the SCEP request message
+        JceCMSContentEncryptorBuilder jceCMSContentEncryptorBuilder = new JceCMSContentEncryptorBuilder(contentEncryptionAlgorithm).setProvider(BouncyCastleProvider.PROVIDER_NAME);
+        return cmsEnvelopedDataGenerator.generate(
+                new CMSProcessableByteArray(cmsSignedData.getEncoded()),
+                jceCMSContentEncryptorBuilder.build());
+    }
+
+    private RecipientInfoGenerator buildRecipientInfoGenerator(X509Certificate recipient) throws CMSException, CertificateEncodingException {
+        // RSA keys can receive an RSA-key-transport envelope; other key types (e.g. EC) cannot,
+        // so fall back to the RFC 8894 §3.2.2 password recipient keyed with the shared challenge
+        // password — the response-direction mirror of ScepRequest.decryptData.
+        if ("RSA".equalsIgnoreCase(recipient.getPublicKey().getAlgorithm())) {
+            logger.debug("Enveloping SCEP response via key transport to recipient subject DN '{}' serial {}",
+                    recipient.getSubjectX500Principal().getName(), recipient.getSerialNumber().toString(16));
+            return new JceKeyTransRecipientInfoGenerator(recipient).setProvider(BouncyCastleProvider.PROVIDER_NAME);
+        }
+        if (challengePassword == null || challengePassword.length == 0) {
+            throw new CMSException("Recipient key algorithm " + recipient.getPublicKey().getAlgorithm() +
+                    " cannot receive a key-transport envelope and no challenge password is available for password-based enveloping");
+        }
+        logger.debug("Enveloping SCEP response via password recipient (recipient key algorithm {})",
+                recipient.getPublicKey().getAlgorithm());
+        return new JcePasswordRecipientInfoGenerator(CMSAlgorithm.AES128_CBC, challengePassword)
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME);
     }
 
     private void createSignedData() throws NoSuchAlgorithmException, CertificateEncodingException, OperatorCreationException, CMSException {

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplEnvelopePreflightTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplEnvelopePreflightTest.java
@@ -4,6 +4,7 @@ import com.otilm.api.exception.ScepException;
 import com.otilm.api.model.core.scep.FailInfo;
 import com.otilm.core.dao.entity.scep.ScepProfile;
 import com.otilm.core.service.scep.message.ScepRequest;
+import com.otilm.core.util.CertificateUtil;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
@@ -12,7 +13,6 @@ import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigInteger;
@@ -20,12 +20,13 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Security;
 import java.security.cert.X509Certificate;
-import java.util.Base64;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the pre-issuance envelope check {@link ScepServiceImpl#verifyResponseEnvelopable}.
@@ -49,45 +50,45 @@ class ScepServiceImplEnvelopePreflightTest {
     @BeforeEach
     void setUp() {
         service = new ScepServiceImpl();
-        profile = Mockito.mock(ScepProfile.class);
+        profile = mock(ScepProfile.class);
         ReflectionTestUtils.setField(service, "scepProfile", profile);
     }
 
     @Test
-    void ecKeyWithoutChallengePassword_rejectsWithBadAlg() {
-        Mockito.when(profile.getChallengePassword()).thenReturn(null);
-        ScepRequest request = requestWithKey(Base64.getDecoder().decode(EC_CERT_B64));
+    void ecKeyWithoutChallengePassword_rejectsWithBadAlg() throws Exception {
+        when(profile.getChallengePassword()).thenReturn(null);
+        ScepRequest request = requestSignedBy(CertificateUtil.parseCertificate(EC_CERT_B64));
 
         ScepException thrown = assertThrows(ScepException.class, () -> service.verifyResponseEnvelopable(request));
         assertEquals(FailInfo.BAD_ALG, thrown.getFailInfo());
     }
 
     @Test
-    void ecKeyWithChallengePassword_passes() {
-        Mockito.when(profile.getChallengePassword()).thenReturn("mysecretpassword");
-        ScepRequest request = requestWithKey(Base64.getDecoder().decode(EC_CERT_B64));
+    void ecKeyWithChallengePassword_passes() throws Exception {
+        when(profile.getChallengePassword()).thenReturn("mysecretpassword");
+        ScepRequest request = requestSignedBy(CertificateUtil.parseCertificate(EC_CERT_B64));
 
         assertDoesNotThrow(() -> service.verifyResponseEnvelopable(request));
     }
 
     @Test
     void rsaKeyWithoutChallengePassword_passes() throws Exception {
-        Mockito.when(profile.getChallengePassword()).thenReturn(null);
-        ScepRequest request = requestWithKey(selfSignedRsaCertificate().getEncoded());
+        when(profile.getChallengePassword()).thenReturn(null);
+        ScepRequest request = requestSignedBy(selfSignedRsaCertificate());
 
         assertDoesNotThrow(() -> service.verifyResponseEnvelopable(request));
     }
 
     @Test
-    void noRequesterKey_passes() {
-        ScepRequest request = requestWithKey(null);
+    void noSignerCertificate_passes() {
+        ScepRequest request = requestSignedBy(null);
 
         assertDoesNotThrow(() -> service.verifyResponseEnvelopable(request));
     }
 
-    private static ScepRequest requestWithKey(byte[] requestKeyInfo) {
-        ScepRequest request = Mockito.mock(ScepRequest.class);
-        Mockito.when(request.getRequestKeyInfo()).thenReturn(requestKeyInfo);
+    private static ScepRequest requestSignedBy(X509Certificate signerCertificate) {
+        ScepRequest request = mock(ScepRequest.class);
+        when(request.getSignerCertificate()).thenReturn(signerCertificate);
         return request;
     }
 

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplEnvelopePreflightTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplEnvelopePreflightTest.java
@@ -1,0 +1,108 @@
+package com.otilm.core.service.scep.impl;
+
+import com.otilm.api.exception.ScepException;
+import com.otilm.api.model.core.scep.FailInfo;
+import com.otilm.core.dao.entity.scep.ScepProfile;
+import com.otilm.core.service.scep.message.ScepRequest;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for the pre-issuance envelope check {@link ScepServiceImpl#verifyResponseEnvelopable}.
+ * A non-RSA client key can only receive its issued certificate via the RFC 8894 password recipient,
+ * so a profile with no challenge password must reject the enrollment before any certificate is
+ * committed — rather than issuing a certificate the client could never retrieve.
+ */
+class ScepServiceImplEnvelopePreflightTest {
+
+    // P-256 self-signed cert (same test material as ScepResponseEnvelopeTest).
+    private static final String EC_CERT_B64 =
+            "MIIB5TCCAYqgAwIBAgIUQWJcNhcZ8rdJ8d+Y0/zjDauIDvAwCgYIKoZIzj0EAwIwNzELMAkGA1UEBhMCSU4xEzARBgNVBAgMClRhbWlsIE5hZHUxEzARBgNVBAcMCkNvaW1iYXRvcmUwHhcNMjMwNDE5MTAxNjI0WhcNMjQwNDE4MTAxNjI0WjA3MQswCQYDVQQGEwJJTjETMBEGA1UECAwKVGFtaWwgTmFkdTETMBEGA1UEBwwKQ29pbWJhdG9yZTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI1ILz/GLiGtx9JIoFesLv6ssTrBr5W1c+FUuCKUGjvZpM8l5wAbC9TJaYwcA3B45iuTAzmTTOoPCwrr/ALGhoyjdDByMB0GA1UdDgQWBBT4VuTPGMKzKGqAYgAtq7eFR+nPpzAfBgNVHSMEGDAWgBT4VuTPGMKzKGqAYgAtq7eFR+nPpzAOBgNVHQ8BAf8EBAMCBaAwIAYDVR0lAQH/BBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAoGCCqGSM49BAMCA0kAMEYCIQCUxvkZzxraytwbhhoCafIzHaj62EGVbxW5bUlvLTZPIwIhAJ6eFFyO8f9udwCHUt+4aMQGyBHCISbgvgvejMU6NSZU";
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    private ScepServiceImpl service;
+    private ScepProfile profile;
+
+    @BeforeEach
+    void setUp() {
+        service = new ScepServiceImpl();
+        profile = Mockito.mock(ScepProfile.class);
+        ReflectionTestUtils.setField(service, "scepProfile", profile);
+    }
+
+    @Test
+    void ecKeyWithoutChallengePassword_rejectsWithBadAlg() {
+        Mockito.when(profile.getChallengePassword()).thenReturn(null);
+        ScepRequest request = requestWithKey(Base64.getDecoder().decode(EC_CERT_B64));
+
+        ScepException thrown = assertThrows(ScepException.class, () -> service.verifyResponseEnvelopable(request));
+        assertEquals(FailInfo.BAD_ALG, thrown.getFailInfo());
+    }
+
+    @Test
+    void ecKeyWithChallengePassword_passes() {
+        Mockito.when(profile.getChallengePassword()).thenReturn("mysecretpassword");
+        ScepRequest request = requestWithKey(Base64.getDecoder().decode(EC_CERT_B64));
+
+        assertDoesNotThrow(() -> service.verifyResponseEnvelopable(request));
+    }
+
+    @Test
+    void rsaKeyWithoutChallengePassword_passes() throws Exception {
+        Mockito.when(profile.getChallengePassword()).thenReturn(null);
+        ScepRequest request = requestWithKey(selfSignedRsaCertificate().getEncoded());
+
+        assertDoesNotThrow(() -> service.verifyResponseEnvelopable(request));
+    }
+
+    @Test
+    void noRequesterKey_passes() {
+        ScepRequest request = requestWithKey(null);
+
+        assertDoesNotThrow(() -> service.verifyResponseEnvelopable(request));
+    }
+
+    private static ScepRequest requestWithKey(byte[] requestKeyInfo) {
+        ScepRequest request = Mockito.mock(ScepRequest.class);
+        Mockito.when(request.getRequestKeyInfo()).thenReturn(requestKeyInfo);
+        return request;
+    }
+
+    private static X509Certificate selfSignedRsaCertificate() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        X500Name dn = new X500Name("CN=rsa-test-client");
+        Date notBefore = new Date(System.currentTimeMillis() - 60_000L);
+        Date notAfter = new Date(System.currentTimeMillis() + 3_600_000L);
+        JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                dn, BigInteger.valueOf(System.currentTimeMillis()), notBefore, notAfter, dn, keyPair.getPublic());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME).build(keyPair.getPrivate());
+        return new JcaX509CertificateConverter()
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME).getCertificate(builder.build(signer));
+    }
+}

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplPollUnitTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplPollUnitTest.java
@@ -175,12 +175,12 @@ class ScepServiceImplPollUnitTest {
     }
 
     /**
-     * The catch-Exception block must not propagate — the client keeps polling and the
-     * response object reflects whatever was set before the failure. Forced here by making
-     * the repository throw on lookup.
+     * The catch-Exception block must not propagate and must not return a null-status response:
+     * it degrades to PENDING so the client keeps polling and response generation never NPEs on a
+     * missing pkiStatus. Forced here by making the repository throw on lookup.
      */
     @Test
-    void pollCertificate_swallowsAndLogsExceptions_returningPartiallyPopulatedResponse() {
+    void pollCertificate_swallowsExceptions_returningPendingToKeepClientPolling() {
         ScepRequest scepRequest = mockScepRequest("tx-9");
         Mockito.when(transactionRepository.findByTransactionId("tx-9"))
                 .thenThrow(new RuntimeException("simulated repository failure"));
@@ -188,8 +188,9 @@ class ScepServiceImplPollUnitTest {
         ScepResponse response = (ScepResponse) ReflectionTestUtils.invokeMethod(
                 service, "pollCertificate", scepRequest, null);
 
-        // No exception escapes — caller gets a (mostly) empty response object.
+        // No exception escapes, and the response carries a concrete PENDING status.
         assertThat(response).isNotNull();
+        assertThat(pkiStatus(response)).isEqualTo(PkiStatus.PENDING);
     }
 
     // ==================== helpers ====================

--- a/src/test/java/com/otilm/core/service/scep/message/ScepResponseEnvelopeTest.java
+++ b/src/test/java/com/otilm/core/service/scep/message/ScepResponseEnvelopeTest.java
@@ -8,6 +8,8 @@ import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.cms.CMSEnvelopedData;
 import org.bouncycastle.cms.CMSException;
 import org.bouncycastle.cms.CMSSignedData;
+import org.bouncycastle.cms.KeyTransRecipientInformation;
+import org.bouncycastle.cms.PasswordRecipientInformation;
 import org.bouncycastle.cms.RecipientInformation;
 import org.bouncycastle.cms.jcajce.JceKeyTransEnvelopedRecipient;
 import org.bouncycastle.cms.jcajce.JcePasswordEnvelopedRecipient;
@@ -25,11 +27,12 @@ import java.util.Date;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Verifies the enveloping mechanism of a SCEP {@code SUCCESS} CertRep is chosen by the
- * recipient key's capability, not fixed to RSA key transport (core#1834).
+ * recipient key's capability, not fixed to RSA key transport.
  *
  * <p>An EC client key cannot receive an RSA-key-transport envelope; the response must fall back
  * to the RFC 8894 §3.2.2 password recipient keyed with the shared challenge password — mirroring
@@ -57,6 +60,7 @@ class ScepResponseEnvelopeTest {
         CMSEnvelopedData enveloped = response.buildEnvelopedResponse();
 
         RecipientInformation recipient = enveloped.getRecipientInfos().getRecipients().iterator().next();
+        assertInstanceOf(PasswordRecipientInformation.class, recipient);
         byte[] decrypted = recipient.getContent(
                 new JcePasswordEnvelopedRecipient(CHALLENGE_PASSWORD.toCharArray())
                         .setProvider(BouncyCastleProvider.PROVIDER_NAME));
@@ -64,6 +68,28 @@ class ScepResponseEnvelopeTest {
         // The enveloped payload is the certs-only degenerate CMS SignedData carrying the issued chain.
         CMSSignedData innerSignedData = new CMSSignedData(decrypted);
         assertFalse(innerSignedData.getCertificates().getMatches(null).isEmpty());
+    }
+
+    @Test
+    void successResponseToEcRecipient_viaIssuedLeafFallback_usesPasswordRecipient() throws Exception {
+        // No recipientKeyInfo on the request: the response envelopes to the issued leaf
+        // (certificateChain[0]), which for an EC issuance is an EC key and must still route to the
+        // password recipient.
+        X509Certificate ecLeaf = CertificateUtil.parseCertificate(EC_CLIENT_CERT_B64);
+        ScepResponse response = new ScepResponse();
+        response.setPkiStatus(PkiStatus.SUCCESS);
+        response.setCertificateChain(List.of(ecLeaf));
+        response.setChallengePassword(CHALLENGE_PASSWORD);
+        // recipientKeyInfo deliberately left null
+
+        CMSEnvelopedData enveloped = response.buildEnvelopedResponse();
+
+        RecipientInformation recipient = enveloped.getRecipientInfos().getRecipients().iterator().next();
+        assertInstanceOf(PasswordRecipientInformation.class, recipient);
+        byte[] decrypted = recipient.getContent(
+                new JcePasswordEnvelopedRecipient(CHALLENGE_PASSWORD.toCharArray())
+                        .setProvider(BouncyCastleProvider.PROVIDER_NAME));
+        assertFalse(new CMSSignedData(decrypted).getCertificates().getMatches(null).isEmpty());
     }
 
     @Test
@@ -85,12 +111,32 @@ class ScepResponseEnvelopeTest {
         CMSEnvelopedData enveloped = response.buildEnvelopedResponse();
 
         RecipientInformation recipient = enveloped.getRecipientInfos().getRecipients().iterator().next();
+        assertInstanceOf(KeyTransRecipientInformation.class, recipient);
         byte[] decrypted = recipient.getContent(
                 new JceKeyTransEnvelopedRecipient(rsaKeyPair.getPrivate())
                         .setProvider(BouncyCastleProvider.PROVIDER_NAME));
 
         CMSSignedData innerSignedData = new CMSSignedData(decrypted);
         assertFalse(innerSignedData.getCertificates().getMatches(null).isEmpty());
+    }
+
+    @Test
+    void successResponseToRsaRecipient_withChallengePassword_stillUsesKeyTransport() throws Exception {
+        // An RSA recipient keeps key transport even when a challenge password is available — the
+        // password path is only for keys that cannot do key transport.
+        KeyPair rsaKeyPair = generateRsaKeyPair();
+        X509Certificate rsaClient = selfSignedRsaCertificate(rsaKeyPair);
+        ScepResponse response = successResponseFor(rsaClient);
+        response.setChallengePassword(CHALLENGE_PASSWORD);
+
+        CMSEnvelopedData enveloped = response.buildEnvelopedResponse();
+
+        RecipientInformation recipient = enveloped.getRecipientInfos().getRecipients().iterator().next();
+        assertInstanceOf(KeyTransRecipientInformation.class, recipient);
+        byte[] decrypted = recipient.getContent(
+                new JceKeyTransEnvelopedRecipient(rsaKeyPair.getPrivate())
+                        .setProvider(BouncyCastleProvider.PROVIDER_NAME));
+        assertFalse(new CMSSignedData(decrypted).getCertificates().getMatches(null).isEmpty());
     }
 
     private static ScepResponse successResponseFor(X509Certificate recipient) throws Exception {

--- a/src/test/java/com/otilm/core/service/scep/message/ScepResponseEnvelopeTest.java
+++ b/src/test/java/com/otilm/core/service/scep/message/ScepResponseEnvelopeTest.java
@@ -1,0 +1,121 @@
+package com.otilm.core.service.scep.message;
+
+import com.otilm.api.model.core.scep.PkiStatus;
+import com.otilm.core.util.CertificateUtil;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.cms.CMSEnvelopedData;
+import org.bouncycastle.cms.CMSException;
+import org.bouncycastle.cms.CMSSignedData;
+import org.bouncycastle.cms.RecipientInformation;
+import org.bouncycastle.cms.jcajce.JceKeyTransEnvelopedRecipient;
+import org.bouncycastle.cms.jcajce.JcePasswordEnvelopedRecipient;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies the enveloping mechanism of a SCEP {@code SUCCESS} CertRep is chosen by the
+ * recipient key's capability, not fixed to RSA key transport (core#1834).
+ *
+ * <p>An EC client key cannot receive an RSA-key-transport envelope; the response must fall back
+ * to the RFC 8894 §3.2.2 password recipient keyed with the shared challenge password — mirroring
+ * the request-decryption path ({@code ScepRequest.decryptData}). RSA recipients must keep using
+ * key transport unchanged.</p>
+ */
+class ScepResponseEnvelopeTest {
+
+    // P-256 self-signed client cert (same test material used by EcdsaCmsMessageTest / CmsMessageTest).
+    private static final String EC_CLIENT_CERT_B64 =
+            "MIIB5TCCAYqgAwIBAgIUQWJcNhcZ8rdJ8d+Y0/zjDauIDvAwCgYIKoZIzj0EAwIwNzELMAkGA1UEBhMCSU4xEzARBgNVBAgMClRhbWlsIE5hZHUxEzARBgNVBAcMCkNvaW1iYXRvcmUwHhcNMjMwNDE5MTAxNjI0WhcNMjQwNDE4MTAxNjI0WjA3MQswCQYDVQQGEwJJTjETMBEGA1UECAwKVGFtaWwgTmFkdTETMBEGA1UEBwwKQ29pbWJhdG9yZTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI1ILz/GLiGtx9JIoFesLv6ssTrBr5W1c+FUuCKUGjvZpM8l5wAbC9TJaYwcA3B45iuTAzmTTOoPCwrr/ALGhoyjdDByMB0GA1UdDgQWBBT4VuTPGMKzKGqAYgAtq7eFR+nPpzAfBgNVHSMEGDAWgBT4VuTPGMKzKGqAYgAtq7eFR+nPpzAOBgNVHQ8BAf8EBAMCBaAwIAYDVR0lAQH/BBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAoGCCqGSM49BAMCA0kAMEYCIQCUxvkZzxraytwbhhoCafIzHaj62EGVbxW5bUlvLTZPIwIhAJ6eFFyO8f9udwCHUt+4aMQGyBHCISbgvgvejMU6NSZU";
+
+    private static final String CHALLENGE_PASSWORD = "mysecretpassword";
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    @Test
+    void successResponseToEcRecipient_isDecryptableWithChallengePassword() throws Exception {
+        X509Certificate ecClient = CertificateUtil.parseCertificate(EC_CLIENT_CERT_B64);
+        ScepResponse response = successResponseFor(ecClient);
+        response.setChallengePassword(CHALLENGE_PASSWORD);
+
+        CMSEnvelopedData enveloped = response.buildEnvelopedResponse();
+
+        RecipientInformation recipient = enveloped.getRecipientInfos().getRecipients().iterator().next();
+        byte[] decrypted = recipient.getContent(
+                new JcePasswordEnvelopedRecipient(CHALLENGE_PASSWORD.toCharArray())
+                        .setProvider(BouncyCastleProvider.PROVIDER_NAME));
+
+        // The enveloped payload is the certs-only degenerate CMS SignedData carrying the issued chain.
+        CMSSignedData innerSignedData = new CMSSignedData(decrypted);
+        assertFalse(innerSignedData.getCertificates().getMatches(null).isEmpty());
+    }
+
+    @Test
+    void successResponseToEcRecipient_withoutChallengePassword_fails() throws Exception {
+        X509Certificate ecClient = CertificateUtil.parseCertificate(EC_CLIENT_CERT_B64);
+        ScepResponse response = successResponseFor(ecClient);
+        // No challenge password configured — an EC recipient has no derivable envelope key.
+
+        assertThrows(CMSException.class, response::buildEnvelopedResponse);
+    }
+
+    @Test
+    void successResponseToRsaRecipient_usesKeyTransport() throws Exception {
+        KeyPair rsaKeyPair = generateRsaKeyPair();
+        X509Certificate rsaClient = selfSignedRsaCertificate(rsaKeyPair);
+        ScepResponse response = successResponseFor(rsaClient);
+        // Deliberately no challenge password: RSA must go through key transport, not the password path.
+
+        CMSEnvelopedData enveloped = response.buildEnvelopedResponse();
+
+        RecipientInformation recipient = enveloped.getRecipientInfos().getRecipients().iterator().next();
+        byte[] decrypted = recipient.getContent(
+                new JceKeyTransEnvelopedRecipient(rsaKeyPair.getPrivate())
+                        .setProvider(BouncyCastleProvider.PROVIDER_NAME));
+
+        CMSSignedData innerSignedData = new CMSSignedData(decrypted);
+        assertFalse(innerSignedData.getCertificates().getMatches(null).isEmpty());
+    }
+
+    private static ScepResponse successResponseFor(X509Certificate recipient) throws Exception {
+        ScepResponse response = new ScepResponse();
+        response.setPkiStatus(PkiStatus.SUCCESS);
+        response.setCertificateChain(List.of(recipient));
+        response.setRecipientKeyInfo(recipient.getEncoded());
+        return response;
+    }
+
+    private static KeyPair generateRsaKeyPair() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static X509Certificate selfSignedRsaCertificate(KeyPair keyPair) throws Exception {
+        X500Name dn = new X500Name("CN=rsa-test-client");
+        Date notBefore = new Date(System.currentTimeMillis() - 60_000L);
+        Date notAfter = new Date(System.currentTimeMillis() + 3_600_000L);
+        JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                dn, BigInteger.valueOf(System.currentTimeMillis()), notBefore, notAfter, dn, keyPair.getPublic());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME).build(keyPair.getPrivate());
+        return new JcaX509CertificateConverter()
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME).getCertificate(builder.build(signer));
+    }
+}


### PR DESCRIPTION
## Summary

SCEP asynchronous enrollment never delivered the issued certificate to clients using an EC (ECDSA) key. The SUCCESS CertRep was enveloped only via RSA key transport, keyed to the client's own certificate; an EC client key cannot receive a key-transport envelope, so response generation failed and surfaced as an HTTP error the client could not interpret. The certificate reached `Issued/Valid` on the platform, but the poll never transitioned `PENDING` → `SUCCESS`, leaving orphaned certificates.

Follow-up to #1839, which resolved only the validation-status race that gated the SUCCESS path; the SUCCESS path itself then failed on EC keys.

## Changes

- Select the CMS recipient mechanism by recipient key algorithm: RSA → key transport (unchanged); non-RSA → RFC 8894 §3.2.2 password recipient keyed with the shared challenge password, mirroring `ScepRequest.decryptData`.
- Preflight enrollment: reject a non-RSA client key when the profile has no challenge password (`badAlg`) **before** issuing, so the platform never commits a certificate the client can never retrieve (avoids reporting an issued cert as a terminal FAILURE and the resulting state divergence / duplicate re-enrollment).
- Degrade a failed certificate poll to `PENDING` instead of returning a null-status response that would fail response generation with an HTTP error.

## Testing

- New `ScepResponseEnvelopeTest` — EC password round-trip, EC issued-leaf fallback, EC-without-password rejection, RSA key transport with and without a password present, recipient-info type assertions.
- New `ScepServiceImplEnvelopePreflightTest` — preflight decision + `failInfo`.
- Existing SCEP unit tests updated and green (38 tests).

## Operator note

An EC/ECDSA SCEP profile now **requires a challenge password** — issuance to non-RSA keys is rejected without one. There is no other RFC-standard way to envelope the CertRep for an encryption-incapable key. (Docs-site update tracked separately.)

## QA / interop

Verify the target SCEP client decrypts a password-enveloped (RFC 3211 PWRI, AES-128 KEK) CertRep — the only standard mechanism for non-RSA keys. Confirm with the ECDSA P-256 reproduction from #1834, plus an RSA control run proving key transport is unchanged.

Fixes #1834
