### PR TITLE
Tolerate null grouping value in dashboard statistics

### DIFF
--- a/src/main/java/com/otilm/core/dao/AggregateResultDto.java
+++ b/src/main/java/com/otilm/core/dao/AggregateResultDto.java
@@ -2,13 +2,17 @@ package com.otilm.core.dao;
 
 import com.otilm.api.model.common.enums.IPlatformEnum;
 
+/**
+ * Grouping on a nullable column yields a NULL group, so the convenience constructors must tolerate a null
+ * grouping value and pass it through — callers decide which placeholder label represents it.
+ */
 public record AggregateResultDto(String aggregatedValue, Number aggregation) {
 
     public AggregateResultDto(Integer aggregatedValue, Number aggregation) {
-        this(aggregatedValue.toString(), aggregation);
+        this(aggregatedValue == null ? null : aggregatedValue.toString(), aggregation);
     }
 
     public AggregateResultDto(IPlatformEnum aggregatedValue, Number aggregation) {
-        this(aggregatedValue.getCode(), aggregation);
+        this(aggregatedValue == null ? null : aggregatedValue.getCode(), aggregation);
     }
 }

--- a/src/test/java/com/otilm/core/dao/AggregateResultDtoTest.java
+++ b/src/test/java/com/otilm/core/dao/AggregateResultDtoTest.java
@@ -1,0 +1,44 @@
+package com.otilm.core.dao;
+
+import com.otilm.api.model.common.enums.IPlatformEnum;
+import com.otilm.api.model.core.certificate.CertificateState;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AggregateResultDtoTest {
+
+    @Test
+    void integerConstructorConvertsValueToString() {
+        AggregateResultDto result = new AggregateResultDto(Integer.valueOf(2048), 5L);
+
+        Assertions.assertEquals("2048", result.aggregatedValue());
+        Assertions.assertEquals(5L, result.aggregation());
+    }
+
+    @Test
+    void enumConstructorUsesCode() {
+        AggregateResultDto result = new AggregateResultDto(CertificateState.ISSUED, 5L);
+
+        Assertions.assertEquals(CertificateState.ISSUED.getCode(), result.aggregatedValue());
+    }
+
+    /**
+     * Grouping on a nullable column produces a NULL group; Hibernate instantiates the DTO with a null
+     * grouping value, and callers map that null to their own placeholder label.
+     */
+    @Test
+    void integerConstructorAcceptsNullValue() {
+        AggregateResultDto result = new AggregateResultDto((Integer) null, 5L);
+
+        Assertions.assertNull(result.aggregatedValue());
+        Assertions.assertEquals(5L, result.aggregation());
+    }
+
+    @Test
+    void enumConstructorAcceptsNullValue() {
+        AggregateResultDto result = new AggregateResultDto((IPlatformEnum) null, 5L);
+
+        Assertions.assertNull(result.aggregatedValue());
+        Assertions.assertEquals(5L, result.aggregation());
+    }
+}


### PR DESCRIPTION
## Problem

Dashboard statistics (`GET /api/v1/statistics`) fail for several certificate tiles:

```
org.springframework.orm.jpa.JpaSystemException: Error instantiating class 'com.otilm.core.dao.AggregateResultDto'
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.Integer.toString()" because "aggregatedValue" is null
    at com.otilm.core.dao.AggregateResultDto.<init>(AggregateResultDto.java:8)
```

The failures are swallowed per-future in `CertificateServiceImpl.processFutures`, so the endpoint returns 200 with the affected tiles missing.

## Root cause

`SecurityFilterRepositoryImpl.countGroupedUsingSecurityFilter` builds a `multiselect(groupBySelection, countDistinct(root))` against `AggregateResultDto`. Hibernate picks the constructor overload by static argument type.

Grouping on a nullable column produces a NULL group, and both convenience constructors dereferenced the value unguarded — `aggregatedValue.toString()` and `aggregatedValue.getCode()`.

The caller already anticipates the null group (`i.aggregatedValue() == null ? "Unassigned" : ...`), but the constructor threw before that mapping could run.

Affected `Certificate` columns, all nullable: `key_size`, `state`, `validation_status`, `certificate_type`. Secret statistics were unaffected — every grouped `Secret` enum column is `nullable = false` — but both dashboards surface the error because they share the one `/api/v1/statistics` endpoint.

## Fix

Pass the null through in both convenience constructors so the caller's `"Unassigned"` mapping applies.

## Testing

New `AggregateResultDtoTest` covers both null paths plus the existing non-null behaviour. Against the unfixed constructors the two null cases reproduce the exact production NPE messages; all four pass with the fix.
