### PR TITLE
Reject token profile deletion with dependent keys or signing profiles

### DIFF
--- a/src/main/java/com/otilm/core/dao/repository/CryptographicKeyRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CryptographicKeyRepository.java
@@ -20,4 +20,6 @@ public interface CryptographicKeyRepository extends SecurityFilterRepository<Cry
 
     @EntityGraph(attributePaths = {"tokenProfile", "items"})
     List<CryptographicKey> findByUuidIn(List<UUID> uuids);
+
+    long countByTokenProfileUuid(UUID tokenProfileUuid);
 }

--- a/src/main/java/com/otilm/core/dao/repository/signing/SigningProfileVersionRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/signing/SigningProfileVersionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -27,6 +28,9 @@ public interface SigningProfileVersionRepository extends JpaRepository<SigningPr
     @Query("DELETE FROM SigningProfileVersion v WHERE v.signingProfileUuid = :signingProfileUuid")
     void deleteAllBySigningProfileUuid(UUID signingProfileUuid);
 
-    @Query("SELECT COUNT(DISTINCT v.signingProfileUuid) FROM SigningProfileVersion v WHERE v.tokenProfileUuid = :tokenProfileUuid")
-    long countDistinctSigningProfilesByTokenProfileUuid(UUID tokenProfileUuid);
+    @Query("SELECT DISTINCT v.signingProfile.name FROM SigningProfileVersion v WHERE v.tokenProfileUuid = :tokenProfileUuid ORDER BY v.signingProfile.name")
+    List<String> findDistinctSigningProfileNamesByTokenProfileUuid(UUID tokenProfileUuid);
+
+    @Query("SELECT DISTINCT v.signingProfile.name FROM SigningProfileVersion v WHERE v.tokenProfileUuid = :tokenProfileUuid AND v.version = v.signingProfile.latestVersion ORDER BY v.signingProfile.name")
+    List<String> findSigningProfileNamesUsingTokenProfileInLatestVersion(UUID tokenProfileUuid);
 }

--- a/src/main/java/com/otilm/core/dao/repository/signing/SigningProfileVersionRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/signing/SigningProfileVersionRepository.java
@@ -26,4 +26,7 @@ public interface SigningProfileVersionRepository extends JpaRepository<SigningPr
     @Modifying
     @Query("DELETE FROM SigningProfileVersion v WHERE v.signingProfileUuid = :signingProfileUuid")
     void deleteAllBySigningProfileUuid(UUID signingProfileUuid);
+
+    @Query("SELECT COUNT(DISTINCT v.signingProfileUuid) FROM SigningProfileVersion v WHERE v.tokenProfileUuid = :tokenProfileUuid")
+    long countDistinctSigningProfilesByTokenProfileUuid(UUID tokenProfileUuid);
 }

--- a/src/main/java/com/otilm/core/service/impl/TokenProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TokenProfileServiceImpl.java
@@ -227,6 +227,8 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
                 deleteProfileInternal(uuid, false);
             } catch (NotFoundException e) {
                 logger.warn("Unable to find Token Profile with uuid {}. It may have already been deleted", uuid);
+            } catch (ValidationException e) {
+                logger.warn(e.getMessage());
             }
         }
     }

--- a/src/main/java/com/otilm/core/service/impl/TokenProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TokenProfileServiceImpl.java
@@ -201,7 +201,6 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
     public void deleteTokenProfile(SecuredUUID tokenProfileUuid) throws NotFoundException {
         logger.info("Deleting token profile with uuid: {}", tokenProfileUuid);
         deleteProfileInternal(tokenProfileUuid, true);
-
     }
 
     @Override
@@ -353,8 +352,8 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
 
     private void deleteProfileInternal(SecuredUUID uuid, boolean throwWhenAssociated) throws NotFoundException {
         TokenProfile tokenProfile = getTokenProfileEntity(uuid);
-        if (throwWhenAssociated && tokenProfile.getTokenInstanceReference() == null) {
-            throw new ValidationException(ValidationError.create("Token Profile has associated Token Instance. Use other API"));
+        if (throwWhenAssociated && tokenProfile.getTokenInstanceReference() != null) {
+            throw new ValidationException(ValidationError.create("Token Profile has associated Token Instance. Use the token instance scoped API to delete the Token Profile."));
         }
         validateNoDependentObjects(tokenProfile);
         attributeEngine.deleteObjectAttributeContent(Resource.TOKEN_PROFILE, tokenProfile.getUuid());

--- a/src/main/java/com/otilm/core/service/impl/TokenProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TokenProfileServiceImpl.java
@@ -365,17 +365,28 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
 
         long keyCount = cryptographicKeyRepository.countByTokenProfileUuid(tokenProfile.getUuid());
         if (keyCount > 0) {
-            blockers.add(keyCount + " dependent Keys");
+            blockers.add(keyCount + " dependent Key(s)");
         }
 
-        long signingProfileCount = signingProfileVersionRepository.countDistinctSigningProfilesByTokenProfileUuid(tokenProfile.getUuid());
-        if (signingProfileCount > 0) {
-            blockers.add(signingProfileCount + " dependent Signing Profiles");
+        List<String> latestVersionNames = signingProfileVersionRepository.findSigningProfileNamesUsingTokenProfileInLatestVersion(tokenProfile.getUuid());
+        if (!latestVersionNames.isEmpty()) {
+            blockers.add("dependent Signing Profile(s): " + String.join(", ", latestVersionNames));
+        }
+
+        // Superseded versions are retained for audit and cannot be edited, so these references
+        // can only be released by deleting the Signing Profile itself.
+        List<String> supersededOnlyNames = new ArrayList<>(signingProfileVersionRepository.findDistinctSigningProfileNamesByTokenProfileUuid(tokenProfile.getUuid()));
+        supersededOnlyNames.removeAll(latestVersionNames);
+        if (!supersededOnlyNames.isEmpty()) {
+            blockers.add("Signing Profile(s) referencing it only in superseded versions (released only by deleting the Signing Profile): "
+                    + String.join(", ", supersededOnlyNames));
         }
 
         if (!blockers.isEmpty()) {
+            // Single placeholder: sequential {} substitution would garble the message when the
+            // profile name itself contains a literal "{}".
             throw new ValidationException(ValidationError.create(
-                    "Cannot delete Token Profile {}: {}", tokenProfile.getName(), String.join(", ", blockers)));
+                    "Cannot delete Token Profile {}", tokenProfile.getName() + ": " + String.join("; ", blockers)));
         }
     }
 

--- a/src/main/java/com/otilm/core/service/impl/TokenProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TokenProfileServiceImpl.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -357,7 +358,17 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
         }
         validateNoDependentObjects(tokenProfile);
         attributeEngine.deleteObjectAttributeContent(Resource.TOKEN_PROFILE, tokenProfile.getUuid());
-        tokenProfileRepository.delete(tokenProfile);
+        try {
+            tokenProfileRepository.delete(tokenProfile);
+            // Force the DELETE to execute here; without the flush it runs at commit,
+            // outside this try, and a concurrent FK violation would surface as HTTP 500.
+            tokenProfileRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            // The aborted transaction cannot be re-queried for the dependency counts.
+            throw new ValidationException(ValidationError.create(
+                    "Cannot delete Token Profile {}: dependent Key(s) or Signing Profile(s) were created concurrently. Retry to see current dependencies.",
+                    tokenProfile.getName()));
+        }
     }
 
     private void validateNoDependentObjects(TokenProfile tokenProfile) {

--- a/src/main/java/com/otilm/core/service/impl/TokenProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/TokenProfileServiceImpl.java
@@ -19,8 +19,10 @@ import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.dao.entity.TokenInstanceReference;
 import com.otilm.core.dao.entity.TokenProfile;
 import com.otilm.core.dao.entity.TokenProfile_;
+import com.otilm.core.dao.repository.CryptographicKeyRepository;
 import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
 import com.otilm.core.dao.repository.TokenProfileRepository;
+import com.otilm.core.dao.repository.signing.SigningProfileVersionRepository;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.AuthorizationEnforcer;
 import com.otilm.core.security.authz.ExternalAuthorization;
@@ -37,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -61,6 +64,18 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
     // --------------------------------------------------------------------------------
     private TokenProfileRepository tokenProfileRepository;
     private TokenInstanceReferenceRepository tokenInstanceReferenceRepository;
+    private CryptographicKeyRepository cryptographicKeyRepository;
+    private SigningProfileVersionRepository signingProfileVersionRepository;
+
+    @Autowired
+    public void setSigningProfileVersionRepository(SigningProfileVersionRepository signingProfileVersionRepository) {
+        this.signingProfileVersionRepository = signingProfileVersionRepository;
+    }
+
+    @Autowired
+    public void setCryptographicKeyRepository(CryptographicKeyRepository cryptographicKeyRepository) {
+        this.cryptographicKeyRepository = cryptographicKeyRepository;
+    }
 
     @Autowired
     public void setAttributeEngine(AttributeEngine attributeEngine) {
@@ -341,8 +356,28 @@ public class TokenProfileServiceImpl implements TokenProfileExternalService, Tok
         if (throwWhenAssociated && tokenProfile.getTokenInstanceReference() == null) {
             throw new ValidationException(ValidationError.create("Token Profile has associated Token Instance. Use other API"));
         }
+        validateNoDependentObjects(tokenProfile);
         attributeEngine.deleteObjectAttributeContent(Resource.TOKEN_PROFILE, tokenProfile.getUuid());
         tokenProfileRepository.delete(tokenProfile);
+    }
+
+    private void validateNoDependentObjects(TokenProfile tokenProfile) {
+        List<String> blockers = new ArrayList<>();
+
+        long keyCount = cryptographicKeyRepository.countByTokenProfileUuid(tokenProfile.getUuid());
+        if (keyCount > 0) {
+            blockers.add(keyCount + " dependent Keys");
+        }
+
+        long signingProfileCount = signingProfileVersionRepository.countDistinctSigningProfilesByTokenProfileUuid(tokenProfile.getUuid());
+        if (signingProfileCount > 0) {
+            blockers.add(signingProfileCount + " dependent Signing Profiles");
+        }
+
+        if (!blockers.isEmpty()) {
+            throw new ValidationException(ValidationError.create(
+                    "Cannot delete Token Profile {}: {}", tokenProfile.getName(), String.join(", ", blockers)));
+        }
     }
 
     private void disableProfileInternal(SecuredUUID uuid) throws NotFoundException {

--- a/src/main/resources/db/migration/V202607271557__cryptographic_key_token_profile_index.sql
+++ b/src/main/resources/db/migration/V202607271557__cryptographic_key_token_profile_index.sql
@@ -1,0 +1,6 @@
+-- Backs the FK cryptographic_key -> token_profile, which Postgres does not index automatically:
+-- the dependent-key count and FK check on token profile deletion, and the key inventory filter
+-- by token profile (FilterField.CK_TOKEN_PROFILE), all scan this column. Mirrors
+-- idx_spv_token_profile_uuid on signing_profile_version.
+CREATE INDEX IF NOT EXISTS "idx_cryptographic_key_token_profile_uuid"
+    ON "cryptographic_key" ("token_profile_uuid");

--- a/src/test/java/com/otilm/core/integration/service/TokenProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/TokenProfileServiceITest.java
@@ -8,12 +8,20 @@ import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.core.cryptography.tokenprofile.TokenProfileDetailDto;
 import com.otilm.api.model.core.cryptography.tokenprofile.TokenProfileDto;
+import com.otilm.api.model.client.signing.profile.scheme.SigningScheme;
+import com.otilm.api.model.client.signing.profile.workflow.SigningWorkflowType;
 import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.entity.CryptographicKey;
 import com.otilm.core.dao.entity.TokenInstanceReference;
 import com.otilm.core.dao.entity.TokenProfile;
+import com.otilm.core.dao.entity.signing.SigningProfile;
+import com.otilm.core.dao.entity.signing.SigningProfileVersion;
 import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.dao.repository.CryptographicKeyRepository;
 import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
 import com.otilm.core.dao.repository.TokenProfileRepository;
+import com.otilm.core.dao.repository.signing.SigningProfileRepository;
+import com.otilm.core.dao.repository.signing.SigningProfileVersionRepository;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.TokenProfileExternalService;
@@ -32,6 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @SpringBootTest
 @Transactional
@@ -50,6 +59,12 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
     private TokenInstanceReferenceRepository tokenInstanceReferenceRepository;
     @Autowired
     private ConnectorRepository connectorRepository;
+    @Autowired
+    private CryptographicKeyRepository cryptographicKeyRepository;
+    @Autowired
+    private SigningProfileRepository signingProfileRepository;
+    @Autowired
+    private SigningProfileVersionRepository signingProfileVersionRepository;
 
     private TokenProfile tokenProfile;
     private TokenInstanceReference tokenInstanceReference;
@@ -217,6 +232,47 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
     }
 
     @Test
+    void testRemoveTokenProfile_withDependentKeys() {
+        createKey("testKey1");
+        createKey("testKey2");
+
+        ValidationException e = Assertions.assertThrows(
+                ValidationException.class,
+                () -> tokenProfileService.deleteTokenProfile(tokenProfile.getSecuredUuid())
+        );
+
+        String errors = joinErrorDescriptions(e);
+        Assertions.assertTrue(errors.contains("Cannot delete Token Profile " + TOKEN_PROFILE_NAME + ": 2 dependent Keys"), errors);
+        Assertions.assertTrue(tokenProfileRepository.findByUuid(tokenProfile.getSecuredUuid()).isPresent());
+    }
+
+    @Test
+    void testRemoveTokenProfile_withDependentSigningProfile() {
+        SigningProfile signingProfile = new SigningProfile();
+        signingProfile.setName("testSigningProfile");
+        signingProfile.setSigningScheme(SigningScheme.DELEGATED);
+        signingProfile.setWorkflowType(SigningWorkflowType.RAW_SIGNING);
+        signingProfile.setLatestVersion(1);
+        signingProfile = signingProfileRepository.save(signingProfile);
+
+        SigningProfileVersion version = new SigningProfileVersion();
+        version.setSigningProfile(signingProfile);
+        version.setVersion(1);
+        version.setSigningScheme(SigningScheme.DELEGATED);
+        version.setWorkflowType(SigningWorkflowType.RAW_SIGNING);
+        version.setTokenProfile(tokenProfile);
+        signingProfileVersionRepository.save(version);
+
+        ValidationException e = Assertions.assertThrows(
+                ValidationException.class,
+                () -> tokenProfileService.deleteTokenProfile(tokenProfile.getSecuredUuid())
+        );
+
+        String errors = joinErrorDescriptions(e);
+        Assertions.assertTrue(errors.contains("Cannot delete Token Profile " + TOKEN_PROFILE_NAME + ": 1 dependent Signing Profiles"), errors);
+    }
+
+    @Test
     void testRemoveTokenProfile_notFound() {
         Assertions.assertThrows(
                 NotFoundException.class,
@@ -311,5 +367,19 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
         nameAndUuidDto = tokenProfileInternalService.getResourceObjectExternal(tokenProfile.getSecuredUuid());
         Assertions.assertEquals(tokenProfile.getUuid().toString(), nameAndUuidDto.getUuid());
         Assertions.assertEquals(tokenProfile.getName(), nameAndUuidDto.getName());
+    }
+
+    private CryptographicKey createKey(String name) {
+        CryptographicKey key = new CryptographicKey();
+        key.setName(name);
+        key.setTokenProfile(tokenProfile);
+        key.setTokenInstanceReference(tokenInstanceReference);
+        return cryptographicKeyRepository.save(key);
+    }
+
+    private static String joinErrorDescriptions(ValidationException e) {
+        return e.getErrors().stream()
+                .map(ValidationError::getErrorDescription)
+                .collect(Collectors.joining("; "));
     }
 }

--- a/src/test/java/com/otilm/core/integration/service/TokenProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/TokenProfileServiceITest.java
@@ -371,6 +371,44 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
     }
 
     @Test
+    void testBulkRemove_skipsProfilesWithDependents() {
+        TokenProfile cleanProfile = new TokenProfile();
+        cleanProfile.setName("testTokenProfile2");
+        cleanProfile.setTokenInstanceReference(tokenInstanceReference);
+        cleanProfile.setEnabled(true);
+        cleanProfile = tokenProfileRepository.save(cleanProfile);
+        createKey("testKey1");
+
+        tokenProfileService.deleteTokenProfile(
+                List.of(cleanProfile.getSecuredUuid(), tokenProfile.getSecuredUuid()));
+
+        // Best-effort semantics: deletable profiles are removed, blocked ones are skipped (logged),
+        // consistent with how the bulk loop treats NotFoundException. Per-item error reporting
+        // (BulkActionMessageDto contract) is tracked as a follow-up.
+        Assertions.assertTrue(tokenProfileRepository.findByUuid(cleanProfile.getSecuredUuid()).isEmpty());
+        Assertions.assertTrue(tokenProfileRepository.findByUuid(tokenProfile.getSecuredUuid()).isPresent());
+    }
+
+    @Test
+    void testRemoveTokenProfile_withMultipleBlockerTypes() {
+        createKey("testKey1");
+        SigningProfile signingProfile = createSigningProfile("testSigningProfile", 1);
+        createSigningProfileVersion(signingProfile, 1, tokenProfile);
+
+        SecuredUUID tokenProfileUuid = tokenProfile.getSecuredUuid();
+        SecuredParentUUID tokenInstanceUuid = tokenInstanceReference.getSecuredParentUuid();
+        ValidationException e = Assertions.assertThrows(
+                ValidationException.class,
+                () -> tokenProfileService.deleteTokenProfile(tokenInstanceUuid, tokenProfileUuid)
+        );
+
+        String errors = joinErrorDescriptions(e);
+        Assertions.assertTrue(errors.contains(
+                "Cannot delete Token Profile " + TOKEN_PROFILE_NAME
+                        + ": 1 dependent Key(s); dependent Signing Profile(s): testSigningProfile"), errors);
+    }
+
+    @Test
     void testBulkEnable() {
         tokenProfileService.enableTokenProfile(List.of(tokenProfile.getSecuredUuid()));
         Assertions.assertTrue(tokenProfile.getEnabled());

--- a/src/test/java/com/otilm/core/integration/service/TokenProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/TokenProfileServiceITest.java
@@ -245,26 +245,15 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
         );
 
         String errors = joinErrorDescriptions(e);
-        Assertions.assertTrue(errors.contains("Cannot delete Token Profile " + TOKEN_PROFILE_NAME + ": 2 dependent Keys"), errors);
+        Assertions.assertTrue(errors.contains("Cannot delete Token Profile " + TOKEN_PROFILE_NAME + ": 2 dependent Key(s)"), errors);
         Assertions.assertTrue(tokenProfileRepository.findByUuid(tokenProfileUuid).isPresent());
+        Assertions.assertEquals(2, cryptographicKeyRepository.countByTokenProfileUuid(tokenProfileUuid.getValue()));
     }
 
     @Test
     void testRemoveTokenProfile_withDependentSigningProfile() {
-        SigningProfile signingProfile = new SigningProfile();
-        signingProfile.setName("testSigningProfile");
-        signingProfile.setSigningScheme(SigningScheme.DELEGATED);
-        signingProfile.setWorkflowType(SigningWorkflowType.RAW_SIGNING);
-        signingProfile.setLatestVersion(1);
-        signingProfile = signingProfileRepository.save(signingProfile);
-
-        SigningProfileVersion version = new SigningProfileVersion();
-        version.setSigningProfile(signingProfile);
-        version.setVersion(1);
-        version.setSigningScheme(SigningScheme.DELEGATED);
-        version.setWorkflowType(SigningWorkflowType.RAW_SIGNING);
-        version.setTokenProfile(tokenProfile);
-        signingProfileVersionRepository.save(version);
+        SigningProfile signingProfile = createSigningProfile("testSigningProfile", 1);
+        createSigningProfileVersion(signingProfile, 1, tokenProfile);
 
         SecuredUUID tokenProfileUuid = tokenProfile.getSecuredUuid();
         SecuredParentUUID tokenInstanceUuid = tokenInstanceReference.getSecuredParentUuid();
@@ -274,7 +263,43 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
         );
 
         String errors = joinErrorDescriptions(e);
-        Assertions.assertTrue(errors.contains("Cannot delete Token Profile " + TOKEN_PROFILE_NAME + ": 1 dependent Signing Profiles"), errors);
+        Assertions.assertTrue(errors.contains("Cannot delete Token Profile " + TOKEN_PROFILE_NAME + ": dependent Signing Profile(s): testSigningProfile"), errors);
+    }
+
+    @Test
+    void testRemoveTokenProfile_withSupersededSigningProfileVersion() {
+        SigningProfile signingProfile = createSigningProfile("testSigningProfile", 2);
+        createSigningProfileVersion(signingProfile, 1, tokenProfile);
+        createSigningProfileVersion(signingProfile, 2, null);
+
+        SecuredUUID tokenProfileUuid = tokenProfile.getSecuredUuid();
+        SecuredParentUUID tokenInstanceUuid = tokenInstanceReference.getSecuredParentUuid();
+        ValidationException e = Assertions.assertThrows(
+                ValidationException.class,
+                () -> tokenProfileService.deleteTokenProfile(tokenInstanceUuid, tokenProfileUuid)
+        );
+
+        String errors = joinErrorDescriptions(e);
+        Assertions.assertTrue(errors.contains("Signing Profile(s) referencing it only in superseded versions (released only by deleting the Signing Profile): testSigningProfile"), errors);
+        Assertions.assertFalse(errors.contains("dependent Signing Profile(s)"), errors);
+    }
+
+    @Test
+    void testRemoveTokenProfile_signingProfileReferencingInLatestAndSupersededVersion() {
+        SigningProfile signingProfile = createSigningProfile("testSigningProfile", 2);
+        createSigningProfileVersion(signingProfile, 1, tokenProfile);
+        createSigningProfileVersion(signingProfile, 2, tokenProfile);
+
+        SecuredUUID tokenProfileUuid = tokenProfile.getSecuredUuid();
+        SecuredParentUUID tokenInstanceUuid = tokenInstanceReference.getSecuredParentUuid();
+        ValidationException e = Assertions.assertThrows(
+                ValidationException.class,
+                () -> tokenProfileService.deleteTokenProfile(tokenInstanceUuid, tokenProfileUuid)
+        );
+
+        String errors = joinErrorDescriptions(e);
+        Assertions.assertTrue(errors.contains("dependent Signing Profile(s): testSigningProfile"), errors);
+        Assertions.assertFalse(errors.contains("superseded"), errors);
     }
 
     @Test
@@ -372,6 +397,25 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
         nameAndUuidDto = tokenProfileInternalService.getResourceObjectExternal(tokenProfile.getSecuredUuid());
         Assertions.assertEquals(tokenProfile.getUuid().toString(), nameAndUuidDto.getUuid());
         Assertions.assertEquals(tokenProfile.getName(), nameAndUuidDto.getName());
+    }
+
+    private SigningProfile createSigningProfile(String name, int latestVersion) {
+        SigningProfile signingProfile = new SigningProfile();
+        signingProfile.setName(name);
+        signingProfile.setSigningScheme(SigningScheme.DELEGATED);
+        signingProfile.setWorkflowType(SigningWorkflowType.RAW_SIGNING);
+        signingProfile.setLatestVersion(latestVersion);
+        return signingProfileRepository.save(signingProfile);
+    }
+
+    private SigningProfileVersion createSigningProfileVersion(SigningProfile signingProfile, int version, TokenProfile referencedTokenProfile) {
+        SigningProfileVersion profileVersion = new SigningProfileVersion();
+        profileVersion.setSigningProfile(signingProfile);
+        profileVersion.setVersion(version);
+        profileVersion.setSigningScheme(SigningScheme.DELEGATED);
+        profileVersion.setWorkflowType(SigningWorkflowType.RAW_SIGNING);
+        profileVersion.setTokenProfile(referencedTokenProfile);
+        return signingProfileVersionRepository.save(profileVersion);
     }
 
     private CryptographicKey createKey(String name) {

--- a/src/test/java/com/otilm/core/integration/service/TokenProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/TokenProfileServiceITest.java
@@ -22,6 +22,7 @@ import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
 import com.otilm.core.dao.repository.TokenProfileRepository;
 import com.otilm.core.dao.repository.signing.SigningProfileRepository;
 import com.otilm.core.dao.repository.signing.SigningProfileVersionRepository;
+import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.TokenProfileExternalService;
@@ -73,7 +74,7 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
     private WireMockServer mockServer;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         mockServer = new WireMockServer(0);
         mockServer.start();
 
@@ -98,7 +99,7 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         mockServer.stop();
     }
 
@@ -221,7 +222,7 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
 
     @Test
     void testRemoveTokenProfile() throws NotFoundException {
-        tokenProfileService.deleteTokenProfile(tokenProfile.getSecuredUuid());
+        tokenProfileService.deleteTokenProfile(tokenProfile.getTokenInstanceReference().getSecuredParentUuid(), tokenProfile.getSecuredUuid());
         Assertions.assertThrows(
                 NotFoundException.class,
                 () -> tokenProfileService.getTokenProfile(
@@ -236,14 +237,16 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
         createKey("testKey1");
         createKey("testKey2");
 
+        SecuredUUID tokenProfileUuid = tokenProfile.getSecuredUuid();
+        SecuredParentUUID tokenInstanceUuid = tokenInstanceReference.getSecuredParentUuid();
         ValidationException e = Assertions.assertThrows(
                 ValidationException.class,
-                () -> tokenProfileService.deleteTokenProfile(tokenProfile.getSecuredUuid())
+                () -> tokenProfileService.deleteTokenProfile(tokenInstanceUuid, tokenProfileUuid)
         );
 
         String errors = joinErrorDescriptions(e);
         Assertions.assertTrue(errors.contains("Cannot delete Token Profile " + TOKEN_PROFILE_NAME + ": 2 dependent Keys"), errors);
-        Assertions.assertTrue(tokenProfileRepository.findByUuid(tokenProfile.getSecuredUuid()).isPresent());
+        Assertions.assertTrue(tokenProfileRepository.findByUuid(tokenProfileUuid).isPresent());
     }
 
     @Test
@@ -263,9 +266,11 @@ class TokenProfileServiceITest extends BaseSpringBootTest {
         version.setTokenProfile(tokenProfile);
         signingProfileVersionRepository.save(version);
 
+        SecuredUUID tokenProfileUuid = tokenProfile.getSecuredUuid();
+        SecuredParentUUID tokenInstanceUuid = tokenInstanceReference.getSecuredParentUuid();
         ValidationException e = Assertions.assertThrows(
                 ValidationException.class,
-                () -> tokenProfileService.deleteTokenProfile(tokenProfile.getSecuredUuid())
+                () -> tokenProfileService.deleteTokenProfile(tokenInstanceUuid, tokenProfileUuid)
         );
 
         String errors = joinErrorDescriptions(e);


### PR DESCRIPTION
Fixes #1882

## Problem

Deleting a token profile that still has dependent objects failed with an HTTP 500 —
the delete hit the FK constraint on `cryptographic_key.token_profile_uuid` and the
raw `DataIntegrityViolationException` propagated. The operator got no indication of
what blocks the deletion.

While fixing this, a second blocker was found: `signing_profile_version` also
references `token_profile` with `ON DELETE RESTRICT`, so signing profiles bound to
the token profile caused the same 500.

## Change

`deleteProfileInternal` now validates dependents before deleting (all three delete
overloads — single, token-instance-scoped, and bulk — funnel through it) and rejects
with HTTP 422: `Cannot delete Token Profile <name>: 12 dependent Keys, 2 dependent
Signing Profiles`

The message reports **counts only, not names**. A token profile can have thousands
of dependent keys, so listing them in an error message doesn't scale; operators can
see the full set by filtering the Key inventory (or Signing Profiles) by token
profile in the UI. Signing profiles are counted by distinct profile
(`COUNT(DISTINCT signing_profile_uuid)`), not by version, so the count matches what
the operator sees in the profile list.

New repository methods: `CryptographicKeyRepository.countByTokenProfileUuid`,
`SigningProfileVersionRepository.countDistinctSigningProfilesByTokenProfileUuid`.

## Notes

- **Bulk delete stays all-or-nothing**: one blocked profile rolls back the whole
  batch (class-level `@Transactional`). This is pre-existing behavior — before this
  fix the FK violation caused the same zero-progress rollback, just as a 500.
  Per-item reporting (the `BulkActionMessageDto` pattern used by token instance bulk
  delete) would change the endpoint contract and is left out of scope.
- The check-then-delete pattern has a narrow race window (a key created between the
  check and commit still trips the FK), matching the existing SCEP/ACME profile
  delete convention.

## Testing

Two new integration tests in `TokenProfileServiceITest` (existing Spring context
signature, no new context): deletion blocked by dependent keys, and by a signing
profile version referencing the token profile.