### PR TITLE
Register system certificate extensions and resolve RDN code conflicts

### DIFF
--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -31,7 +31,6 @@ import com.otilm.api.model.core.oid.OidCategory;
 import com.otilm.api.model.core.oid.SystemOid;
 import com.otilm.core.oid.OidHandler;
 import com.otilm.core.oid.OidRecord;
-import org.bouncycastle.asn1.x509.Extension;
 import com.otilm.api.model.core.auth.AttributeResource;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.search.FilterFieldSource;
@@ -61,6 +60,7 @@ import jakarta.persistence.PersistenceContext;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.bouncycastle.asn1.x509.Extension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -1456,7 +1456,7 @@ public class AttributeEngine {
                     attribute.getUuid(), attribute.getName(), attribute.getType(), connectorUuidStr);
 
         // SAN is parsed out of the extension list into subjectAltNames, so an extension mapping on it
-        // would silently never match. Reject at authoring time and name the target that does work.
+        // would silently never match.
         if (Extension.subjectAlternativeName.getId().equals(extOid))
             throw new AttributeException(
                     "fieldMapping EXTENSION OID '%s' is the Subject Alternative Name; use the SAN mapping target instead".formatted(extOid),
@@ -1469,13 +1469,6 @@ public class AttributeEngine {
         Map<String, OidRecord> registry = OidHandler.getOidCache(OidCategory.CERTIFICATE_EXTENSION);
         if (!systemExtension && (registry == null || registry.get(extOid) == null))
             throw new AttributeException("fieldMapping EXTENSION OID '%s' is not registered in the OID registry".formatted(extOid),
-                    attribute.getUuid(), attribute.getName(), attribute.getType(), connectorUuidStr);
-
-        // The issuing CA owns these, so a requester-supplied value must never drive them.
-        if (systemExtension && systemOid.isCaControlled())
-            throw new AttributeException(
-                    "fieldMapping EXTENSION OID '%s' (%s) is controlled by the issuing CA and cannot be a request-attribute mapping target"
-                            .formatted(extOid, systemOid.getDisplayName()),
                     attribute.getUuid(), attribute.getName(), attribute.getType(), connectorUuidStr);
     }
 

--- a/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
+++ b/src/main/java/com/otilm/core/attribute/engine/AttributeEngine.java
@@ -30,6 +30,8 @@ import com.otilm.api.model.core.certificate.GeneralNameType;
 import com.otilm.api.model.core.oid.OidCategory;
 import com.otilm.api.model.core.oid.SystemOid;
 import com.otilm.core.oid.OidHandler;
+import com.otilm.core.oid.OidRecord;
+import org.bouncycastle.asn1.x509.Extension;
 import com.otilm.api.model.core.auth.AttributeResource;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.search.FilterFieldSource;
@@ -1439,22 +1441,42 @@ public class AttributeEngine {
                     throw new AttributeException("fieldMapping SAN field of type OTHER_NAME is missing otherNameOid or it is not a valid OID",
                             attribute.getUuid(), attribute.getName(), attribute.getType(), connectorUuidStr);
             }
-            case ExtensionMappedField ext -> {
-                if (ext.getExtensionOid() == null || ext.getExtensionOid().isBlank())
-                    throw new AttributeException("fieldMapping EXTENSION field is missing extensionOid",
-                            attribute.getUuid(), attribute.getName(), attribute.getType(), connectorUuidStr);
-                // Extension OID must be registered so the platform knows defaultCritical and valueEncoding
-                String extOid = ext.getExtensionOid();
-                SystemOid systemOid = SystemOid.fromOID(extOid);
-                if ((systemOid == null || systemOid.getCategory() != OidCategory.CERTIFICATE_EXTENSION)
-                        && (OidHandler.getOidCache(OidCategory.CERTIFICATE_EXTENSION) == null || OidHandler.getOidCache(OidCategory.CERTIFICATE_EXTENSION).get(extOid) == null))
-                    throw new AttributeException("fieldMapping EXTENSION OID '%s' is not registered in the OID registry".formatted(extOid),
-                            attribute.getUuid(), attribute.getName(), attribute.getType(), connectorUuidStr);
-            }
+            case ExtensionMappedField ext ->
+                validateExtensionMappedField(attribute, connectorUuidStr, ext);
             default ->
                     throw new AttributeException("Unexpected MappedField subtype: " + field.getClass().getSimpleName(),
                             attribute.getUuid(), attribute.getName(), attribute.getType(), connectorUuidStr);
         }
+    }
+
+    private static void validateExtensionMappedField(DataAttributeV3 attribute, String connectorUuidStr, ExtensionMappedField ext) throws AttributeException {
+        String extOid = ext.getExtensionOid();
+        if (extOid == null || extOid.isBlank())
+            throw new AttributeException("fieldMapping EXTENSION field is missing extensionOid",
+                    attribute.getUuid(), attribute.getName(), attribute.getType(), connectorUuidStr);
+
+        // SAN is parsed out of the extension list into subjectAltNames, so an extension mapping on it
+        // would silently never match. Reject at authoring time and name the target that does work.
+        if (Extension.subjectAlternativeName.getId().equals(extOid))
+            throw new AttributeException(
+                    "fieldMapping EXTENSION OID '%s' is the Subject Alternative Name; use the SAN mapping target instead".formatted(extOid),
+                    attribute.getUuid(), attribute.getName(), attribute.getType(), connectorUuidStr);
+
+        SystemOid systemOid = SystemOid.fromOID(extOid);
+        boolean systemExtension = systemOid != null && systemOid.getCategory() == OidCategory.CERTIFICATE_EXTENSION;
+
+        // Extension OID must be registered so the platform knows defaultCritical and valueEncoding
+        Map<String, OidRecord> registry = OidHandler.getOidCache(OidCategory.CERTIFICATE_EXTENSION);
+        if (!systemExtension && (registry == null || registry.get(extOid) == null))
+            throw new AttributeException("fieldMapping EXTENSION OID '%s' is not registered in the OID registry".formatted(extOid),
+                    attribute.getUuid(), attribute.getName(), attribute.getType(), connectorUuidStr);
+
+        // The issuing CA owns these, so a requester-supplied value must never drive them.
+        if (systemExtension && systemOid.isCaControlled())
+            throw new AttributeException(
+                    "fieldMapping EXTENSION OID '%s' (%s) is controlled by the issuing CA and cannot be a request-attribute mapping target"
+                            .formatted(extOid, systemOid.getDisplayName()),
+                    attribute.getUuid(), attribute.getName(), attribute.getType(), connectorUuidStr);
     }
 
     private static void validateRdnMappedField(DataAttributeV3 attribute, String connectorUuidStr, Supplier<Map<String, String>> codeToOidMap, RdnMappedField rdn) throws AttributeException {

--- a/src/main/java/com/otilm/core/mapper/oid/CustomOidEntryMapper.java
+++ b/src/main/java/com/otilm/core/mapper/oid/CustomOidEntryMapper.java
@@ -34,12 +34,16 @@ public class CustomOidEntryMapper {
         dto.setOid(systemOid.getOid());
         dto.setCategory(systemOid.getCategory());
         dto.setDisplayName(systemOid.getDisplayName());
-        // SystemOid only carries RDN code/altCodes; EKU and GENERIC entries have no additional
-        // properties, and the enum has no fields to represent a CERTIFICATE_EXTENSION's typed properties.
+        // EKU purposes and generic identifiers carry nothing beyond the base fields.
         if (systemOid.getCategory() == OidCategory.RDN_ATTRIBUTE_TYPE) {
             RdnAttributeTypeOidPropertiesDto props = new RdnAttributeTypeOidPropertiesDto();
             props.setCode(systemOid.getCode());
             props.setAltCodes(systemOid.getAltCodes());
+            dto.setAdditionalProperties(props);
+        } else if (systemOid.getCategory() == OidCategory.CERTIFICATE_EXTENSION) {
+            CertificateExtensionOidPropertiesDto props = new CertificateExtensionOidPropertiesDto();
+            props.setDefaultCritical(systemOid.getDefaultCritical());
+            props.setValueEncoding(systemOid.getValueEncoding());
             dto.setAdditionalProperties(props);
         }
         return dto;

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -1,15 +1,19 @@
 package com.otilm.core.oid;
 
 import com.otilm.api.model.core.oid.OidCategory;
+import com.otilm.api.model.core.oid.SystemOid;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
+@Slf4j
 public class OidHandler {
 
     private OidHandler() {
@@ -91,31 +95,54 @@ public class OidHandler {
         rdnCodeToOid.set(Collections.unmodifiableMap(lookup));
     }
 
+    /**
+     * RDN code/altCode → OID, matched case-insensitively so the authoring-time gate and request-time
+     * resolution agree. Codes and alt codes share one flat namespace, so two OIDs can claim the same
+     * token; see {@link #claimToken} for how that is resolved.
+     */
     public static Map<String, String> getCodeToOidMap() {
-        Map<String, String> reverseMap = new HashMap<>();
+        Map<String, String> reverseMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         Map<String, OidRecord> rdnCache = oidCache.get(OidCategory.RDN_ATTRIBUTE_TYPE);
         if (rdnCache == null) {
             return reverseMap;
         }
-        for (Map.Entry<String, OidRecord> entry : rdnCache.entrySet()) {
-            String oidKey = entry.getKey();
-            OidRecord oidRecord = entry.getValue();
-
-            // map the code to the oidKey
+        // Sorted so a contested token resolves the same way on every rebuild, rather than by the
+        // iteration order of the backing HashMap.
+        for (String oid : new TreeSet<>(rdnCache.keySet())) {
+            OidRecord oidRecord = rdnCache.get(oid);
             if (oidRecord.code() != null) {
-                reverseMap.put(oidRecord.code(), oidKey);
+                claimToken(reverseMap, oidRecord.code(), oid);
             }
-
-            // map all altCodes to the oidKey
             if (oidRecord.altCodes() != null) {
                 for (String altCode : oidRecord.altCodes()) {
                     if (altCode != null) {
-                        reverseMap.put(altCode, oidKey);
+                        claimToken(reverseMap, altCode, oid);
                     }
                 }
             }
         }
         return reverseMap;
+    }
+
+    /**
+     * Assigns one code token to an OID, resolving a contest in favour of the operator-registered
+     * entry. A custom OID entry was already resolving that token before its OID became a system OID,
+     * so an upgrade must not silently repoint it; the built-in entry stays reachable by its dotted
+     * OID. Contests between two entries of the same kind keep the lowest OID, purely for determinism.
+     */
+    private static void claimToken(Map<String, String> reverseMap, String token, String oid) {
+        String incumbent = reverseMap.get(token);
+        if (incumbent == null || incumbent.equals(oid)) {
+            reverseMap.put(token, oid);
+            return;
+        }
+        boolean incumbentIsSystem = SystemOid.fromOID(incumbent) != null;
+        boolean candidateIsSystem = SystemOid.fromOID(oid) != null;
+        String winner = incumbentIsSystem && !candidateIsSystem ? oid : incumbent;
+        reverseMap.put(token, winner);
+        log.warn("RDN code '{}' is claimed by OID {} and OID {}; resolving it to {}. "
+                        + "Rename the custom OID entry's code or alt code to remove the ambiguity.",
+                token, incumbent, oid, winner);
     }
 
 

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,6 +37,10 @@ public class OidHandler {
      */
     private static final AtomicReference<Map<String, String>> rdnCodeToOid =
             new AtomicReference<>(Collections.emptyMap());
+
+    /** Code tokens claimed by more than one OID, republished on every rebuild. See {@link #getRdnCodeConflicts}. */
+    private static final AtomicReference<Map<String, Set<String>>> rdnCodeConflicts =
+            new AtomicReference<>(Map.of());
 
     /**
      * Serializes writers so that the read-copy-publish of a per-category map and the rebuild of the
@@ -102,8 +107,10 @@ public class OidHandler {
      */
     public static Map<String, String> getCodeToOidMap() {
         Map<String, String> reverseMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        Map<String, Set<String>> conflicts = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         Map<String, OidRecord> rdnCache = oidCache.get(OidCategory.RDN_ATTRIBUTE_TYPE);
         if (rdnCache == null) {
+            publishRdnCodeConflicts(conflicts, reverseMap);
             return reverseMap;
         }
         // Sorted so a contested token resolves the same way on every rebuild, rather than by the
@@ -111,17 +118,47 @@ public class OidHandler {
         for (String oid : new TreeSet<>(rdnCache.keySet())) {
             OidRecord oidRecord = rdnCache.get(oid);
             if (oidRecord.code() != null) {
-                claimToken(reverseMap, oidRecord.code(), oid);
+                claimToken(reverseMap, conflicts, oidRecord.code(), oid);
             }
             if (oidRecord.altCodes() != null) {
                 for (String altCode : oidRecord.altCodes()) {
                     if (altCode != null) {
-                        claimToken(reverseMap, altCode, oid);
+                        claimToken(reverseMap, conflicts, altCode, oid);
                     }
                 }
             }
         }
+        publishRdnCodeConflicts(conflicts, reverseMap);
         return reverseMap;
+    }
+
+    /**
+     * RDN code tokens claimed by more than one OID, mapped to every claimant. Empty when the registry
+     * is unambiguous. Exposed so the condition can be surfaced to an operator rather than living only
+     * in the log — the cache rebuilds every few seconds, so a per-rebuild log line is not a report.
+     */
+    public static Map<String, Set<String>> getRdnCodeConflicts() {
+        return rdnCodeConflicts.get();
+    }
+
+    /**
+     * Publishes the current conflict set, logging only when it differs from the last one. The cache is
+     * rebuilt on a short schedule, so logging per rebuild would emit the same warning thousands of
+     * times a day until an operator resolved it.
+     */
+    private static void publishRdnCodeConflicts(Map<String, Set<String>> conflicts, Map<String, String> resolved) {
+        Map<String, Set<String>> published = Collections.unmodifiableMap(new TreeMap<>(conflicts));
+        Map<String, Set<String>> previous = rdnCodeConflicts.getAndSet(published);
+        if (published.equals(previous)) {
+            return;
+        }
+        if (published.isEmpty()) {
+            log.info("RDN code conflicts resolved; every code and alt code now maps to a single OID.");
+            return;
+        }
+        published.forEach((token, claimants) -> log.warn(
+                "RDN code '{}' is claimed by OIDs {}; resolving it to {}. Rename the custom OID entry's code "
+                        + "or alt code to remove the ambiguity.", token, claimants, resolved.get(token)));
     }
 
     /**
@@ -130,7 +167,8 @@ public class OidHandler {
      * so an upgrade must not silently repoint it; the built-in entry stays reachable by its dotted
      * OID. Contests between two entries of the same kind keep the lowest OID, purely for determinism.
      */
-    private static void claimToken(Map<String, String> reverseMap, String token, String oid) {
+    private static void claimToken(Map<String, String> reverseMap, Map<String, Set<String>> conflicts,
+                                   String token, String oid) {
         String incumbent = reverseMap.get(token);
         if (incumbent == null || incumbent.equals(oid)) {
             reverseMap.put(token, oid);
@@ -138,11 +176,8 @@ public class OidHandler {
         }
         boolean incumbentIsSystem = SystemOid.fromOID(incumbent) != null;
         boolean candidateIsSystem = SystemOid.fromOID(oid) != null;
-        String winner = incumbentIsSystem && !candidateIsSystem ? oid : incumbent;
-        reverseMap.put(token, winner);
-        log.warn("RDN code '{}' is claimed by OID {} and OID {}; resolving it to {}. "
-                        + "Rename the custom OID entry's code or alt code to remove the ambiguity.",
-                token, incumbent, oid, winner);
+        reverseMap.put(token, incumbentIsSystem && !candidateIsSystem ? oid : incumbent);
+        conflicts.computeIfAbsent(token, t -> new TreeSet<>()).addAll(Set.of(incumbent, oid));
     }
 
 

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -95,9 +95,12 @@ public class OidHandler {
         if (category != OidCategory.RDN_ATTRIBUTE_TYPE) {
             return;
         }
-        Map<String, String> lookup = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        lookup.putAll(getCodeToOidMap());
+        // The single writer of conflict state: this runs under WRITE_LOCK, so the published snapshot and
+        // the index it describes always come from the same rebuild. Readers never publish.
+        Map<String, Set<String>> conflicts = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        Map<String, String> lookup = buildCodeToOid(conflicts);
         rdnCodeToOid.set(Collections.unmodifiableMap(lookup));
+        publishRdnCodeConflicts(conflicts, lookup);
     }
 
     /**
@@ -106,11 +109,17 @@ public class OidHandler {
      * token; see {@link #claimToken} for how that is resolved.
      */
     public static Map<String, String> getCodeToOidMap() {
+        return buildCodeToOid(new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+    }
+
+    /**
+     * Builds the code → OID index, recording any contested token into {@code conflicts}. Side-effect
+     * free: publication is the caller's job, so request-path readers cannot race the writer.
+     */
+    private static Map<String, String> buildCodeToOid(Map<String, Set<String>> conflicts) {
         Map<String, String> reverseMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        Map<String, Set<String>> conflicts = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         Map<String, OidRecord> rdnCache = oidCache.get(OidCategory.RDN_ATTRIBUTE_TYPE);
         if (rdnCache == null) {
-            publishRdnCodeConflicts(conflicts, reverseMap);
             return reverseMap;
         }
         // Sorted so a contested token resolves the same way on every rebuild, rather than by the
@@ -128,23 +137,21 @@ public class OidHandler {
                 }
             }
         }
-        publishRdnCodeConflicts(conflicts, reverseMap);
         return reverseMap;
     }
 
     /**
      * RDN code tokens claimed by more than one OID, mapped to every claimant. Empty when the registry
-     * is unambiguous. Exposed so the condition can be surfaced to an operator rather than living only
-     * in the log — the cache rebuilds every few seconds, so a per-rebuild log line is not a report.
+     * is unambiguous.
      */
     public static Map<String, Set<String>> getRdnCodeConflicts() {
         return rdnCodeConflicts.get();
     }
 
     /**
-     * Publishes the current conflict set, logging only when it differs from the last one. The cache is
-     * rebuilt on a short schedule, so logging per rebuild would emit the same warning thousands of
-     * times a day until an operator resolved it.
+     * Publishes the current conflict set, logging only when it differs from the last one. The registry
+     * rebuilds on {@code settings.cache.refresh-interval} (30 s by default), so logging per rebuild
+     * would repeat the same warning thousands of times a day until an operator resolved it.
      */
     private static void publishRdnCodeConflicts(Map<String, Set<String>> conflicts, Map<String, String> resolved) {
         // Deep-immutable, and case-insensitive like every other code lookup here. Both matter because
@@ -158,7 +165,6 @@ public class OidHandler {
         if (published.equals(previous)) {
             return;
         }
-        // An empty set logs nothing: the state is queryable, and the log carries problems only.
         published.forEach((token, claimants) -> log.warn(
                 "RDN code '{}' is claimed by OIDs {}; resolving it to {}. Rename the custom OID entry's code "
                         + "or alt code to remove the ambiguity.", token, claimants, resolved.get(token)));
@@ -168,7 +174,8 @@ public class OidHandler {
      * Assigns one code token to an OID, resolving a contest in favour of the operator-registered
      * entry. A custom OID entry was already resolving that token before its OID became a system OID,
      * so an upgrade must not silently repoint it; the built-in entry stays reachable by its dotted
-     * OID. Contests between two entries of the same kind keep the lowest OID, purely for determinism.
+     * OID. Contests between two entries of the same kind keep the lexicographically first OID; determinism is
+     * the guarantee, not any numeric ordering of the arcs.
      */
     private static void claimToken(Map<String, String> reverseMap, Map<String, Set<String>> conflicts,
                                    String token, String oid) {

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -147,7 +147,13 @@ public class OidHandler {
      * times a day until an operator resolved it.
      */
     private static void publishRdnCodeConflicts(Map<String, Set<String>> conflicts, Map<String, String> resolved) {
-        Map<String, Set<String>> published = Collections.unmodifiableMap(new TreeMap<>(conflicts));
+        // Deep-immutable, and case-insensitive like every other code lookup here. Both matter because
+        // this is process-wide static state handed out through a public accessor: a mutable claimant set
+        // would let a caller corrupt it, and note that TreeMap(Map) would silently drop the comparator.
+        Map<String, Set<String>> snapshot = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        conflicts.forEach((token, claimants) ->
+                snapshot.put(token, Collections.unmodifiableSortedSet(new TreeSet<>(claimants))));
+        Map<String, Set<String>> published = Collections.unmodifiableMap(snapshot);
         Map<String, Set<String>> previous = rdnCodeConflicts.getAndSet(published);
         if (published.equals(previous)) {
             return;

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -38,6 +38,13 @@ public class OidHandler {
     private static final AtomicReference<Map<String, String>> rdnCodeToOid =
             new AtomicReference<>(Collections.emptyMap());
 
+    /**
+     * Bumped under {@link #WRITE_LOCK} by every publication. Lets a caller that read source data without
+     * holding the lock detect that the registry moved underneath it and abandon its now-stale snapshot,
+     * instead of holding the lock across those reads.
+     */
+    private static long generation;
+
     /** Code tokens claimed by more than one OID, republished on every rebuild. See {@link #getRdnCodeConflicts}. */
     private static final AtomicReference<Map<String, Set<String>>> rdnCodeConflicts =
             new AtomicReference<>(Map.of());
@@ -48,6 +55,40 @@ public class OidHandler {
      * the {@code OidHandler.class} object so foreign code cannot contend on the same lock.
      */
     private static final Object WRITE_LOCK = new Object();
+
+    /** Registry version, for the optimistic publish in {@link #cacheAllCategories}. */
+    public static long getGeneration() {
+        synchronized (WRITE_LOCK) {
+            return generation;
+        }
+    }
+
+    /**
+     * Replaces every supplied category and rebuilds the derived RDN index once, or publishes nothing if
+     * the registry moved since {@code expectedGeneration} was read.
+     *
+     * <p>The guard is what lets a full refresh read its source data without holding {@link #WRITE_LOCK}:
+     * a concurrent single-entry publication bumps the generation, so the refresh abandons a snapshot that
+     * would otherwise clobber a committed mutation. Categories absent from {@code byCategory} are left
+     * untouched — {@code null} means "not loaded" to every reader, so clearing them would break callers
+     * that dereference {@link #getOidCache} directly.
+     *
+     * @return {@code true} when published, {@code false} when abandoned as stale
+     */
+    public static boolean cacheAllCategories(long expectedGeneration, Map<OidCategory, Map<String, OidRecord>> byCategory) {
+        synchronized (WRITE_LOCK) {
+            if (generation != expectedGeneration) {
+                return false;
+            }
+            byCategory.forEach((category, records) ->
+                    oidCache.put(category, Collections.unmodifiableMap(new HashMap<>(records))));
+            generation++;
+            if (byCategory.containsKey(OidCategory.RDN_ATTRIBUTE_TYPE)) {
+                refreshRdnCodeLookup(OidCategory.RDN_ATTRIBUTE_TYPE);
+            }
+            return true;
+        }
+    }
 
     /** The published per-category map, or {@code null} when the category is not loaded. Immutable — see {@link #cacheOidCategory}. */
     public static Map<String, OidRecord> getOidCache(OidCategory oidCategory) {
@@ -61,6 +102,7 @@ public class OidHandler {
             // after publish would desync oidCache from the derived rdnCodeToOid index. Copying
             // here makes the copy-on-write contract structural rather than convention-only.
             oidCache.put(category, Collections.unmodifiableMap(new HashMap<>(oidRecordMap)));
+            generation++;
             refreshRdnCodeLookup(category);
         }
     }
@@ -73,6 +115,7 @@ public class OidHandler {
             Map<String, OidRecord> next = new HashMap<>(oidCache.getOrDefault(category, Map.of()));
             next.put(oid, oidRecord);
             oidCache.put(category, Collections.unmodifiableMap(next));
+            generation++;
             refreshRdnCodeLookup(category);
         }
     }
@@ -215,6 +258,7 @@ public class OidHandler {
             Map<String, OidRecord> next = new HashMap<>(current);
             next.remove(oid);
             oidCache.put(category, Collections.unmodifiableMap(next));
+            generation++;
             refreshRdnCodeLookup(category);
         }
     }

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -1,7 +1,9 @@
 package com.otilm.core.oid;
 
 import com.otilm.api.model.core.oid.OidCategory;
-import lombok.extern.slf4j.Slf4j;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -13,8 +15,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
-@Slf4j
 public class OidHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(OidHandler.class);
 
     private OidHandler() {
     }
@@ -208,7 +211,7 @@ public class OidHandler {
         if (published.equals(previous)) {
             return;
         }
-        published.forEach((token, claimants) -> log.warn(
+        published.forEach((token, claimants) -> logger.warn(
                 "RDN code '{}' is claimed by OIDs {}; resolving it to {}. Rename the custom OID entry's code "
                         + "or alt code to remove the ambiguity.", token, claimants, resolved.get(token)));
     }

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -5,6 +5,7 @@ import com.otilm.api.model.core.oid.OidCategory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,6 +47,10 @@ public class OidHandler {
      * instead of holding the lock across those reads.
      */
     private static long generation;
+
+    /** Keeps a lasting conflict visible in recent log output without repeating it on every rebuild. */
+    private static final PersistentWarningThrottle conflictWarnings =
+            new PersistentWarningThrottle(Duration.ofHours(1));
 
     /** Code tokens claimed by more than one OID, republished on every rebuild. See {@link #getRdnCodeConflicts}. */
     private static final AtomicReference<Map<String, Set<String>>> rdnCodeConflicts =
@@ -195,9 +200,10 @@ public class OidHandler {
     }
 
     /**
-     * Publishes the current conflict set, logging only when it differs from the last one. The registry
-     * rebuilds on {@code settings.cache.refresh-interval} (30 s by default), so logging per rebuild
-     * would repeat the same warning thousands of times a day until an operator resolved it.
+     * Publishes the current conflict set, warning when it changes and periodically while it persists.
+     * The registry rebuilds on {@code settings.cache.refresh-interval} (30 s by default), so warning per
+     * rebuild would repeat thousands of times a day, while warning only on change would make silence
+     * mean both "resolved" and "still broken, already reported".
      */
     private static void publishRdnCodeConflicts(Map<String, Set<String>> conflicts, Map<String, String> resolved) {
         // Deep-immutable, and case-insensitive like every other code lookup here. Both matter because
@@ -208,7 +214,7 @@ public class OidHandler {
                 snapshot.put(token, Collections.unmodifiableSortedSet(new TreeSet<>(claimants))));
         Map<String, Set<String>> published = Collections.unmodifiableMap(snapshot);
         Map<String, Set<String>> previous = rdnCodeConflicts.getAndSet(published);
-        if (published.equals(previous)) {
+        if (!conflictWarnings.shouldWarn(!published.equals(previous), !published.isEmpty())) {
             return;
         }
         published.forEach((token, claimants) -> logger.warn(

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -118,6 +118,7 @@ public class OidHandler {
      */
     private static Map<String, String> buildCodeToOid(Map<String, Set<String>> conflicts) {
         Map<String, String> reverseMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        Set<String> systemClaimants = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         Map<String, OidRecord> rdnCache = oidCache.get(OidCategory.RDN_ATTRIBUTE_TYPE);
         if (rdnCache == null) {
             return reverseMap;
@@ -127,12 +128,12 @@ public class OidHandler {
         for (String oid : new TreeSet<>(rdnCache.keySet())) {
             OidRecord oidRecord = rdnCache.get(oid);
             if (oidRecord.code() != null) {
-                claimToken(reverseMap, conflicts, oidRecord.code(), oid);
+                claimToken(reverseMap, systemClaimants, conflicts, oidRecord.code(), oid, oidRecord.system());
             }
             if (oidRecord.altCodes() != null) {
                 for (String altCode : oidRecord.altCodes()) {
                     if (altCode != null) {
-                        claimToken(reverseMap, conflicts, altCode, oid);
+                        claimToken(reverseMap, systemClaimants, conflicts, altCode, oid, oidRecord.system());
                     }
                 }
             }
@@ -156,7 +157,7 @@ public class OidHandler {
     private static void publishRdnCodeConflicts(Map<String, Set<String>> conflicts, Map<String, String> resolved) {
         // Deep-immutable, and case-insensitive like every other code lookup here. Both matter because
         // this is process-wide static state handed out through a public accessor: a mutable claimant set
-        // would let a caller corrupt it, and note that TreeMap(Map) would silently drop the comparator.
+        // would let a caller corrupt it,; TreeMap(Map) would drop the comparator.
         Map<String, Set<String>> snapshot = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         conflicts.forEach((token, claimants) ->
                 snapshot.put(token, Collections.unmodifiableSortedSet(new TreeSet<>(claimants))));
@@ -177,16 +178,28 @@ public class OidHandler {
      * OID. Contests between two entries of the same kind keep the lexicographically first OID; determinism is
      * the guarantee, not any numeric ordering of the arcs.
      */
-    private static void claimToken(Map<String, String> reverseMap, Map<String, Set<String>> conflicts,
-                                   String token, String oid) {
+    private static void claimToken(Map<String, String> reverseMap, Set<String> systemClaimants,
+                                   Map<String, Set<String>> conflicts, String token, String oid,
+                                   boolean candidateIsSystem) {
         String incumbent = reverseMap.get(token);
         if (incumbent == null || incumbent.equals(oid)) {
             reverseMap.put(token, oid);
+            if (candidateIsSystem) {
+                systemClaimants.add(token);
+            } else {
+                systemClaimants.remove(token);
+            }
             return;
         }
-        boolean incumbentIsSystem = SystemOid.fromOID(incumbent) != null;
-        boolean candidateIsSystem = SystemOid.fromOID(oid) != null;
-        reverseMap.put(token, incumbentIsSystem && !candidateIsSystem ? oid : incumbent);
+        // Decided on record provenance, not on whether the dotted OID happens to be built-in: a custom
+        // row can occupy a system OID (see getOidToRecordMap's putIfAbsent), and asking SystemOid.fromOID
+        // would misclassify that operator record as built-in and make it lose its own token.
+        boolean incumbentIsSystem = systemClaimants.contains(token);
+        boolean candidateWins = incumbentIsSystem && !candidateIsSystem;
+        reverseMap.put(token, candidateWins ? oid : incumbent);
+        if (candidateWins) {
+            systemClaimants.remove(token);
+        }
         conflicts.computeIfAbsent(token, t -> new TreeSet<>()).addAll(Set.of(incumbent, oid));
     }
 

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -1,7 +1,6 @@
 package com.otilm.core.oid;
 
 import com.otilm.api.model.core.oid.OidCategory;
-import com.otilm.api.model.core.oid.SystemOid;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
@@ -200,7 +199,7 @@ public class OidHandler {
     private static void publishRdnCodeConflicts(Map<String, Set<String>> conflicts, Map<String, String> resolved) {
         // Deep-immutable, and case-insensitive like every other code lookup here. Both matter because
         // this is process-wide static state handed out through a public accessor: a mutable claimant set
-        // would let a caller corrupt it,; TreeMap(Map) would drop the comparator.
+        // would let a caller corrupt it, and TreeMap(Map) would drop the comparator.
         Map<String, Set<String>> snapshot = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         conflicts.forEach((token, claimants) ->
                 snapshot.put(token, Collections.unmodifiableSortedSet(new TreeSet<>(claimants))));

--- a/src/main/java/com/otilm/core/oid/OidHandler.java
+++ b/src/main/java/com/otilm/core/oid/OidHandler.java
@@ -152,10 +152,7 @@ public class OidHandler {
         if (published.equals(previous)) {
             return;
         }
-        if (published.isEmpty()) {
-            log.info("RDN code conflicts resolved; every code and alt code now maps to a single OID.");
-            return;
-        }
+        // An empty set logs nothing: the state is queryable, and the log carries problems only.
         published.forEach((token, claimants) -> log.warn(
                 "RDN code '{}' is claimed by OIDs {}; resolving it to {}. Rename the custom OID entry's code "
                         + "or alt code to remove the ambiguity.", token, claimants, resolved.get(token)));

--- a/src/main/java/com/otilm/core/oid/OidRecord.java
+++ b/src/main/java/com/otilm/core/oid/OidRecord.java
@@ -12,6 +12,14 @@ public record OidRecord(
         String code,
         List<String> altCodes,
         Boolean defaultCritical,
-        ExtensionValueEncoding valueEncoding
+        ExtensionValueEncoding valueEncoding,
+        /** True only for a built-in {@code SystemOid} entry; a DB-backed custom row leaves it false. */
+        boolean system
 ) {
+    public OidRecord {
+        // Records live in the process-wide OID registry, which hands them out through getOidCache. A
+        // caller mutating the list it originally passed in would desync the cache from the derived
+        // rdnCodeToOid index — the same hazard cacheOidCategory's defensive copy exists to prevent.
+        altCodes = altCodes == null ? null : List.copyOf(altCodes);
+    }
 }

--- a/src/main/java/com/otilm/core/oid/PersistentWarningThrottle.java
+++ b/src/main/java/com/otilm/core/oid/PersistentWarningThrottle.java
@@ -1,0 +1,44 @@
+package com.otilm.core.oid;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Decides when a warning about a persistent condition should be re-emitted.
+ *
+ * <p>The OID registry rebuilds on a short schedule, so warning on every rebuild floods the log until
+ * it is filtered out. Warning only when the condition changes has the opposite problem: the log falls
+ * silent, and silence then means both "resolved" and "still broken, already reported". Re-emitting
+ * periodically while the condition lasts makes the log answer the question an operator actually has —
+ * whether the condition holds now — from any recent window, without needing to have seen the original
+ * warning. It also keeps the log carrying problems only, with no all-clear line to interpret.
+ */
+public final class PersistentWarningThrottle {
+
+    private final Duration repeatAfter;
+    private Instant lastWarned;
+
+    public PersistentWarningThrottle(Duration repeatAfter) {
+        this.repeatAfter = repeatAfter;
+    }
+
+    /**
+     * @param stateChanged whether the condition's detail differs from the last time it was published
+     * @param unresolved   whether the condition currently holds at all
+     * @return {@code true} when the caller should emit its warning now
+     */
+    public synchronized boolean shouldWarn(boolean stateChanged, boolean unresolved) {
+        if (!unresolved) {
+            // Reset, so a condition that recurs later is reported immediately rather than waiting out
+            // an interval started by the previous occurrence.
+            lastWarned = null;
+            return false;
+        }
+        Instant now = Instant.now();
+        if (stateChanged || lastWarned == null || !now.isBefore(lastWarned.plus(repeatAfter))) {
+            lastWarned = now;
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/otilm/core/service/CustomOidEntryExternalService.java
+++ b/src/main/java/com/otilm/core/service/CustomOidEntryExternalService.java
@@ -71,6 +71,11 @@ public interface CustomOidEntryExternalService {
     /**
      * OIDs held by a custom entry that a built-in system OID now shares. The custom entry wins, so the
      * built-in defaults do not apply; deleting it falls back to them. Empty when there is no conflict.
+     *
+     * <p>Such a row can only arise from an upgrade: creating one is rejected because the OID is reserved,
+     * so every entry here predates its OID's promotion to a system OID. The set therefore only grows at
+     * an upgrade and only shrinks as operators resolve entries, and an empty set on a fresh install is
+     * the expected state rather than an unexercised code path.
      */
     Set<String> getShadowedCustomOidEntries();
 

--- a/src/main/java/com/otilm/core/service/CustomOidEntryExternalService.java
+++ b/src/main/java/com/otilm/core/service/CustomOidEntryExternalService.java
@@ -66,13 +66,13 @@ public interface CustomOidEntryExternalService {
      * @param category optional category filter; when {@code null}, all system OIDs are returned
      * @return list of system OID entries
      */
+    List<CustomOidEntryDetailResponseDto> listSystemOidEntries(OidCategory category);
+
     /**
      * OIDs held by a custom entry that a built-in system OID now shares. The custom entry wins, so the
      * built-in defaults do not apply; deleting it falls back to them. Empty when there is no conflict.
      */
     Set<String> getShadowedCustomOidEntries();
-
-    List<CustomOidEntryDetailResponseDto> listSystemOidEntries(OidCategory category);
 
     /**
      * Returns a list of properties for filtering custom OID entries

--- a/src/main/java/com/otilm/core/service/CustomOidEntryExternalService.java
+++ b/src/main/java/com/otilm/core/service/CustomOidEntryExternalService.java
@@ -6,6 +6,7 @@ import com.otilm.api.model.core.oid.*;
 import com.otilm.api.model.core.search.SearchFieldDataByGroupDto;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Service for managing OID entries.
@@ -65,6 +66,12 @@ public interface CustomOidEntryExternalService {
      * @param category optional category filter; when {@code null}, all system OIDs are returned
      * @return list of system OID entries
      */
+    /**
+     * OIDs held by a custom entry that a built-in system OID now shares. The custom entry wins, so the
+     * built-in defaults do not apply; deleting it falls back to them. Empty when there is no conflict.
+     */
+    Set<String> getShadowedCustomOidEntries();
+
     List<CustomOidEntryDetailResponseDto> listSystemOidEntries(OidCategory category);
 
     /**

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -34,8 +34,9 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.transaction.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.lang3.function.TriFunction;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -48,10 +49,11 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service(Resource.Codes.OID)
 @Transactional
 public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService {
+
+    private static final Logger logger = LoggerFactory.getLogger(CustomOidEntryServiceImpl.class);
 
     public static final String OID_ENTRY = "OID Entry";
     private final CustomOidEntryRepository customOidEntryRepository;
@@ -84,7 +86,7 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
             byCategory.put(oidCategory, getOidToRecordMap(oidCategory));
         }
         if (!OidHandler.cacheAllCategories(expectedGeneration, byCategory)) {
-            log.debug("Skipped a registry refresh: a mutation published while its source data was being read.");
+            logger.debug("Skipped a registry refresh: a mutation published while its source data was being read.");
             return;
         }
         publishShadowedCustomOidEntries();
@@ -132,7 +134,7 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
             return;
         }
         shadowedCustomOidEntries = Collections.unmodifiableSet(shadowed);
-        shadowed.forEach(oid -> log.warn(
+        shadowed.forEach(oid -> logger.warn(
                 "Custom OID entry {} shares its OID with a built-in system OID. The custom entry wins, so the "
                         + "built-in defaults do not apply; delete the custom entry to fall back to them.", oid));
     }

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -54,6 +54,9 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     public static final String OID_ENTRY = "OID Entry";
     private final CustomOidEntryRepository customOidEntryRepository;
     private CertificateInternalService certificateService;
+    /** Rows shadowed by a built-in system OID; see {@link #getShadowedCustomOidEntries}. */
+    private volatile Set<String> shadowedCustomOidEntries = Collections.emptySet();
+
 
     @Autowired
     public void setCertificateService(CertificateInternalService certificateService) {
@@ -280,6 +283,44 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
         return searchFieldDataByGroupDtos;
     }
 
+    /**
+     * OIDs held by a {@code custom_oid_entry} row that a built-in system OID now shadows, so the row's
+     * configured properties no longer apply. Exposed so the condition can be surfaced to an operator;
+     * the resolution is to delete the row.
+     */
+    public Set<String> getShadowedCustomOidEntries() {
+        return shadowedCustomOidEntries;
+    }
+
+    /**
+     * Records the shadowed rows for one category and logs only when the set changes. The cache rebuilds
+     * on a short schedule, so logging per rebuild would repeat the same warning until it was ignored.
+     */
+    private void reportShadowedCustomEntries(OidCategory oidCategory, Set<String> customOids) {
+        Set<String> shadowed = Arrays.stream(SystemOid.values())
+                .filter(systemOid -> systemOid.getCategory() == oidCategory)
+                .map(SystemOid::getOid)
+                .filter(customOids::contains)
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        Set<String> others = shadowedCustomOidEntries.stream()
+                .filter(oid -> {
+                    SystemOid systemOid = SystemOid.fromOID(oid);
+                    return systemOid == null || systemOid.getCategory() != oidCategory;
+                })
+                .collect(Collectors.toCollection(TreeSet::new));
+        Set<String> merged = new TreeSet<>(others);
+        merged.addAll(shadowed);
+
+        if (merged.equals(shadowedCustomOidEntries)) {
+            return;
+        }
+        shadowedCustomOidEntries = Collections.unmodifiableSet(merged);
+        shadowed.forEach(oid -> log.warn(
+                "Custom OID entry {} is shadowed by the built-in system OID of the same value, so its configured "
+                        + "properties no longer apply. Delete the custom entry to resolve the conflict.", oid));
+    }
+
     private Map<String, OidRecord> getOidToRecordMap(OidCategory oidCategory) {
         // Cache DB OIDs
         Map<String, OidRecord> oidToDisplayNameMap = new HashMap<>(customOidEntryRepository.findAllByCategory(oidCategory)
@@ -294,16 +335,7 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
                             .valueEncoding(isExt ? ((CertificateExtensionCustomOidEntry) oid).getValueEncoding() : null)
                             .build();
                 })));
-        // A row whose OID has since become a system OID is shadowed by the built-in entry below, so its
-        // configured properties stop taking effect. Report it rather than let it fail silently — the
-        // operator resolves it by deleting the row.
-        Arrays.stream(SystemOid.values())
-                .filter(systemOid -> systemOid.getCategory() == oidCategory)
-                .map(SystemOid::getOid)
-                .filter(oidToDisplayNameMap::containsKey)
-                .forEach(shadowedOid -> log.warn(
-                        "Custom OID entry {} is shadowed by the built-in system OID of the same value; its configured "
-                                + "properties no longer apply. Delete the custom entry to resolve the conflict.", shadowedOid));
+        reportShadowedCustomEntries(oidCategory, oidToDisplayNameMap.keySet());
 
         // Cache System OIDs. defaultCritical and valueEncoding must be carried through: the projector
         // reads them from this cache, and an unset defaultCritical silently emits a critical extension

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -57,7 +57,6 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     /** Rows shadowed by a built-in system OID; see {@link #getShadowedCustomOidEntries}. */
     private volatile Set<String> shadowedCustomOidEntries = Collections.emptySet();
 
-
     @Autowired
     public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
@@ -76,6 +75,30 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
         for (OidCategory oidCategory : OidCategory.values()) {
             OidHandler.cacheOidCategory(oidCategory, getOidToRecordMap(oidCategory));
         }
+        publishShadowedCustomOidEntries();
+    }
+
+    /**
+     * Recomputes the shadowed-row set from one query and publishes it in a single assignment, logging
+     * only when the set changes. Derived in one shot rather than accumulated per category, because
+     * refreshCache is reachable concurrently from the scheduler and from bulkDeleteCustomOidEntry, and a
+     * read-modify-write across categories can drop a category's contribution however volatile the field.
+     */
+    private void publishShadowedCustomOidEntries() {
+        Set<String> shadowed = customOidEntryRepository.findAll().stream()
+                .filter(entry -> {
+                    SystemOid systemOid = SystemOid.fromOID(entry.getOid());
+                    return systemOid != null && systemOid.getCategory() == entry.getCategory();
+                })
+                .map(CustomOidEntry::getOid)
+                .collect(Collectors.toCollection(TreeSet::new));
+        if (shadowed.equals(shadowedCustomOidEntries)) {
+            return;
+        }
+        shadowedCustomOidEntries = Collections.unmodifiableSet(shadowed);
+        shadowed.forEach(oid -> log.warn(
+                "Custom OID entry {} shares its OID with a built-in system OID. The custom entry wins, so the "
+                        + "built-in defaults do not apply; delete the custom entry to fall back to them.", oid));
     }
 
     @Override
@@ -153,14 +176,6 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     @ExternalAuthorization(resource = Resource.OID, action = ResourceAction.UPDATE)
     public CustomOidEntryDetailResponseDto editCustomOidEntry(String oid, CustomOidEntryUpdateRequestDto request) throws NotFoundException {
         CustomOidEntry customOidEntry = customOidEntryRepository.findById(oid).orElseThrow(() -> new NotFoundException(OID_ENTRY, oid));
-        // A row can predate the OID's promotion to a system OID. The registry resolves that OID to the
-        // built-in entry, so an edit would persist and rewrite certificate DNs while never reaching the
-        // cache — a half-applied change reporting success. Refuse instead, and say what to do.
-        SystemOid shadowing = SystemOid.fromOID(oid);
-        if (shadowing != null)
-            throw new ValidationException(
-                    "OID %s is now reserved for system OID %s, so this custom entry no longer takes effect and cannot be edited. Delete it instead."
-                            .formatted(oid, shadowing.name()));
         String code = null;
         List<String> altCodes = null;
         Boolean defaultCritical = null;
@@ -200,15 +215,15 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
         customOidEntry.setDescription(request.getDescription());
         customOidEntryRepository.save(customOidEntry);
 
-        if (SystemOid.fromOID(oid) == null) {
-            OidHandler.cacheOid(customOidEntry.getCategory(), oid, OidRecord.builder()
-                    .displayName(customOidEntry.getDisplayName())
-                    .code(code)
-                    .altCodes(altCodes)
-                    .defaultCritical(defaultCritical)
-                    .valueEncoding(valueEncoding)
-                    .build());
-        }
+        // Cached unconditionally: a custom row wins over a same-OID built-in (see getOidToRecordMap),
+        // so skipping this would leave the DB and the registry disagreeing after a successful edit.
+        OidHandler.cacheOid(customOidEntry.getCategory(), oid, OidRecord.builder()
+                .displayName(customOidEntry.getDisplayName())
+                .code(code)
+                .altCodes(altCodes)
+                .defaultCritical(defaultCritical)
+                .valueEncoding(valueEncoding)
+                .build());
         return CustomOidEntryMapper.toDetailDto(customOidEntry);
     }
 
@@ -226,8 +241,22 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     @ExternalAuthorization(resource = Resource.OID, action = ResourceAction.DELETE)
     public void deleteCustomOidEntry(String oid) throws NotFoundException {
         CustomOidEntry customOidEntry = customOidEntryRepository.findById(oid).orElseThrow(() -> new NotFoundException(OID_ENTRY, oid));
-        if (SystemOid.fromOID(oid) == null) OidHandler.removeCachedOid(customOidEntry.getCategory(), oid);
         customOidEntryRepository.delete(customOidEntry);
+        // Deleting a row that shadowed a built-in must hand the OID back to the built-in rather than drop
+        // it from the registry, since the custom record was the effective one while it existed.
+        SystemOid shadowed = SystemOid.fromOID(oid);
+        if (shadowed != null && shadowed.getCategory() == customOidEntry.getCategory()) {
+            OidHandler.cacheOid(shadowed.getCategory(), oid, OidRecord.builder()
+                    .displayName(shadowed.getDisplayName())
+                    .code(shadowed.getCode())
+                    .altCodes(shadowed.getAltCodes())
+                    .defaultCritical(shadowed.getDefaultCritical())
+                    .valueEncoding(shadowed.getValueEncoding())
+                    .build());
+            publishShadowedCustomOidEntries();
+        } else {
+            OidHandler.removeCachedOid(customOidEntry.getCategory(), oid);
+        }
     }
 
     @Override
@@ -292,35 +321,6 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
         return shadowedCustomOidEntries;
     }
 
-    /**
-     * Records the shadowed rows for one category and logs only when the set changes. The cache rebuilds
-     * on a short schedule, so logging per rebuild would repeat the same warning until it was ignored.
-     */
-    private void reportShadowedCustomEntries(OidCategory oidCategory, Set<String> customOids) {
-        Set<String> shadowed = Arrays.stream(SystemOid.values())
-                .filter(systemOid -> systemOid.getCategory() == oidCategory)
-                .map(SystemOid::getOid)
-                .filter(customOids::contains)
-                .collect(Collectors.toCollection(TreeSet::new));
-
-        Set<String> others = shadowedCustomOidEntries.stream()
-                .filter(oid -> {
-                    SystemOid systemOid = SystemOid.fromOID(oid);
-                    return systemOid == null || systemOid.getCategory() != oidCategory;
-                })
-                .collect(Collectors.toCollection(TreeSet::new));
-        Set<String> merged = new TreeSet<>(others);
-        merged.addAll(shadowed);
-
-        if (merged.equals(shadowedCustomOidEntries)) {
-            return;
-        }
-        shadowedCustomOidEntries = Collections.unmodifiableSet(merged);
-        shadowed.forEach(oid -> log.warn(
-                "Custom OID entry {} is shadowed by the built-in system OID of the same value, so its configured "
-                        + "properties no longer apply. Delete the custom entry to resolve the conflict.", oid));
-    }
-
     private Map<String, OidRecord> getOidToRecordMap(OidCategory oidCategory) {
         // Cache DB OIDs
         Map<String, OidRecord> oidToDisplayNameMap = new HashMap<>(customOidEntryRepository.findAllByCategory(oidCategory)
@@ -335,20 +335,24 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
                             .valueEncoding(isExt ? ((CertificateExtensionCustomOidEntry) oid).getValueEncoding() : null)
                             .build();
                 })));
-        reportShadowedCustomEntries(oidCategory, oidToDisplayNameMap.keySet());
-
         // Cache System OIDs. defaultCritical and valueEncoding must be carried through: the projector
         // reads them from this cache, and an unset defaultCritical silently emits a critical extension
         // such as Name Constraints as non-critical.
-        oidToDisplayNameMap.putAll(Arrays.stream(SystemOid.values()).filter(oid -> oid.getCategory() == oidCategory)
-                .collect(Collectors.toMap(SystemOid::getOid, oid ->
-                        OidRecord.builder()
-                                .displayName(oid.getDisplayName())
-                                .code(oid.getCode())
-                                .altCodes(oid.getAltCodes())
-                                .defaultCritical(oid.getDefaultCritical())
-                                .valueEncoding(oid.getValueEncoding())
-                                .build())));
+        //
+        // putIfAbsent, not putAll: a custom row for the same OID predates the promotion, and overwriting
+        // it would drop the operator's code, alt codes, criticality and encoding wholesale — taking a
+        // code out of the registry entirely, so every DN carrying it fails to resolve at request time.
+        // The operator's record therefore wins and is reported as shadowed, matching how a contested
+        // code resolves. The built-in stays reachable by its dotted OID.
+        Arrays.stream(SystemOid.values())
+                .filter(oid -> oid.getCategory() == oidCategory)
+                .forEach(oid -> oidToDisplayNameMap.putIfAbsent(oid.getOid(), OidRecord.builder()
+                        .displayName(oid.getDisplayName())
+                        .code(oid.getCode())
+                        .altCodes(oid.getAltCodes())
+                        .defaultCritical(oid.getDefaultCritical())
+                        .valueEncoding(oid.getValueEncoding())
+                        .build()));
         return oidToDisplayNameMap;
     }
 }

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -362,11 +362,6 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
         return searchFieldDataByGroupDtos;
     }
 
-    /**
-     * OIDs held by a {@code custom_oid_entry} row that a built-in system OID now shadows, so the row's
-     * configured properties no longer apply. Exposed so the condition can be surfaced to an operator;
-     * the resolution is to delete the row.
-     */
     @Override
     public Set<String> getShadowedCustomOidEntries() {
         return shadowedCustomOidEntries;

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -49,6 +49,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 @Service(Resource.Codes.OID)
@@ -61,7 +62,7 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     private final CustomOidEntryRepository customOidEntryRepository;
     private CertificateInternalService certificateService;
     /** Rows shadowed by a built-in system OID; see {@link #getShadowedCustomOidEntries}. */
-    private volatile Set<String> shadowedCustomOidEntries = Collections.emptySet();
+    private final AtomicReference<Set<String>> shadowedCustomOidEntries = new AtomicReference<>(Set.of());
 
     /** Keeps a lasting shadowed row visible in recent log output without repeating it on every refresh. */
     private final PersistentWarningThrottle shadowedWarnings = new PersistentWarningThrottle(Duration.ofHours(1));
@@ -135,8 +136,8 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
                 })
                 .map(SystemOid::getOid)
                 .collect(Collectors.toCollection(TreeSet::new));
-        boolean changed = !shadowed.equals(shadowedCustomOidEntries);
-        shadowedCustomOidEntries = Collections.unmodifiableSet(shadowed);
+        Set<String> previous = shadowedCustomOidEntries.getAndSet(Collections.unmodifiableSet(shadowed));
+        boolean changed = !shadowed.equals(previous);
         if (!shadowedWarnings.shouldWarn(changed, !shadowed.isEmpty())) {
             return;
         }
@@ -384,7 +385,7 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     @Override
     @ExternalAuthorization(resource = Resource.OID, action = ResourceAction.LIST)
     public Set<String> getShadowedCustomOidEntries() {
-        return shadowedCustomOidEntries;
+        return shadowedCustomOidEntries.get();
     }
 
     private Map<String, OidRecord> getOidToRecordMap(OidCategory oidCategory) {

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -35,6 +35,7 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.function.TriFunction;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -45,6 +46,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service(Resource.Codes.OID)
 @Transactional
 public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService {
@@ -148,6 +150,14 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     @ExternalAuthorization(resource = Resource.OID, action = ResourceAction.UPDATE)
     public CustomOidEntryDetailResponseDto editCustomOidEntry(String oid, CustomOidEntryUpdateRequestDto request) throws NotFoundException {
         CustomOidEntry customOidEntry = customOidEntryRepository.findById(oid).orElseThrow(() -> new NotFoundException(OID_ENTRY, oid));
+        // A row can predate the OID's promotion to a system OID. The registry resolves that OID to the
+        // built-in entry, so an edit would persist and rewrite certificate DNs while never reaching the
+        // cache — a half-applied change reporting success. Refuse instead, and say what to do.
+        SystemOid shadowing = SystemOid.fromOID(oid);
+        if (shadowing != null)
+            throw new ValidationException(
+                    "OID %s is now reserved for system OID %s, so this custom entry no longer takes effect and cannot be edited. Delete it instead."
+                            .formatted(oid, shadowing.name()));
         String code = null;
         List<String> altCodes = null;
         Boolean defaultCritical = null;
@@ -284,6 +294,17 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
                             .valueEncoding(isExt ? ((CertificateExtensionCustomOidEntry) oid).getValueEncoding() : null)
                             .build();
                 })));
+        // A row whose OID has since become a system OID is shadowed by the built-in entry below, so its
+        // configured properties stop taking effect. Report it rather than let it fail silently — the
+        // operator resolves it by deleting the row.
+        Arrays.stream(SystemOid.values())
+                .filter(systemOid -> systemOid.getCategory() == oidCategory)
+                .map(SystemOid::getOid)
+                .filter(oidToDisplayNameMap::containsKey)
+                .forEach(shadowedOid -> log.warn(
+                        "Custom OID entry {} is shadowed by the built-in system OID of the same value; its configured "
+                                + "properties no longer apply. Delete the custom entry to resolve the conflict.", shadowedOid));
+
         // Cache System OIDs. defaultCritical and valueEncoding must be carried through: the projector
         // reads them from this cache, and an unset defaultCritical silently emits a critical extension
         // such as Name Constraints as non-critical.

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -226,8 +226,14 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
             code = additionalProperties.getCode();
             String oldCode = rdnAttributeTypeOidEntry.getCode();
             Set<String> allCodes = getAllCodesInLowerCase();
+            // The uniqueness check must not see this row's own code. The equality guard below is
+            // case-sensitive, so a case-only rename such as FOO -> Foo reaches the check and would be
+            // rejected against the row itself — while the conflict warning tells operators to rename a
+            // contested code, which for a case collision is the only rename that resolves it.
+            Set<String> otherCodes = new HashSet<>(allCodes);
+            otherCodes.remove(oldCode.toLowerCase());
             if (!oldCode.equals(code)) {
-                if (allCodes.contains(code.toLowerCase()))
+                if (otherCodes.contains(code.toLowerCase()))
                     throw new ValidationException("Code %s is already used".formatted(code));
                 rdnAttributeTypeOidEntry.setCode(code);
                 certificateService.updateCertificateDNs(oid, code, oldCode);
@@ -370,6 +376,7 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     }
 
     @Override
+    @ExternalAuthorization(resource = Resource.OID, action = ResourceAction.LIST)
     public Set<String> getShadowedCustomOidEntries() {
         return shadowedCustomOidEntries;
     }

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -284,13 +284,17 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
                             .valueEncoding(isExt ? ((CertificateExtensionCustomOidEntry) oid).getValueEncoding() : null)
                             .build();
                 })));
-        // Cache System OIDs
+        // Cache System OIDs. defaultCritical and valueEncoding must be carried through: the projector
+        // reads them from this cache, and an unset defaultCritical silently emits a critical extension
+        // such as Name Constraints as non-critical.
         oidToDisplayNameMap.putAll(Arrays.stream(SystemOid.values()).filter(oid -> oid.getCategory() == oidCategory)
                 .collect(Collectors.toMap(SystemOid::getOid, oid ->
                         OidRecord.builder()
                                 .displayName(oid.getDisplayName())
                                 .code(oid.getCode())
                                 .altCodes(oid.getAltCodes())
+                                .defaultCritical(oid.getDefaultCritical())
+                                .valueEncoding(oid.getValueEncoding())
                                 .build())));
         return oidToDisplayNameMap;
     }

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -59,14 +59,6 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     /** Rows shadowed by a built-in system OID; see {@link #getShadowedCustomOidEntries}. */
     private volatile Set<String> shadowedCustomOidEntries = Collections.emptySet();
 
-    /**
-     * Serialises whole-registry refreshes against single-entry publications. OidHandler's own monitor
-     * makes each publication atomic but cannot order a refresh's read-then-publish against a concurrent
-     * mutator: the scheduled refresh could read a category, pause, and republish its stale snapshot over
-     * a committed edit. Holding this for the whole read-and-publish closes that window.
-     */
-    private static final Object REGISTRY_PUBLISH_LOCK = new Object();
-
     @Autowired
     public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
@@ -82,15 +74,18 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
 
     @Scheduled(fixedRateString = "${settings.cache.refresh-interval}", timeUnit = TimeUnit.SECONDS, initialDelayString = "${settings.cache.refresh-interval}")
     public void refreshCache() {
-        synchronized (REGISTRY_PUBLISH_LOCK) {
-            refreshCacheUnsynchronised();
-        }
-    }
-
-    /** Caller must hold {@link #REGISTRY_PUBLISH_LOCK}, or route through {@link #publishAfterCommit}. */
-    private void refreshCacheUnsynchronised() {
+        // Read the source data without holding OidHandler's monitor, then publish optimistically: if a
+        // mutator published while these queries ran, the snapshot is stale and is abandoned rather than
+        // allowed to clobber a committed change. The next cycle is one refresh interval away, and every
+        // mutator publishes its own delta, so nothing depends on this cycle succeeding.
+        long expectedGeneration = OidHandler.getGeneration();
+        Map<OidCategory, Map<String, OidRecord>> byCategory = new EnumMap<>(OidCategory.class);
         for (OidCategory oidCategory : OidCategory.values()) {
-            OidHandler.cacheOidCategory(oidCategory, getOidToRecordMap(oidCategory));
+            byCategory.put(oidCategory, getOidToRecordMap(oidCategory));
+        }
+        if (!OidHandler.cacheAllCategories(expectedGeneration, byCategory)) {
+            log.debug("Skipped a registry refresh: a mutation published while its source data was being read.");
+            return;
         }
         publishShadowedCustomOidEntries();
     }
@@ -102,20 +97,15 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
      * Mirrors {@code SettingServiceImpl.cacheAfterCommit}.
      */
     private void publishAfterCommit(Runnable publication) {
-        Runnable serialised = () -> {
-            synchronized (REGISTRY_PUBLISH_LOCK) {
-                publication.run();
-            }
-        };
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    serialised.run();
+                    publication.run();
                 }
             });
         } else {
-            serialised.run();
+            publication.run();
         }
     }
 
@@ -288,31 +278,42 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
         customOidEntryRepository.delete(customOidEntry);
         // Deleting a row that shadowed a built-in must hand the OID back to the built-in rather than drop
         // it from the registry, since the custom record was the effective one while it existed.
-        SystemOid shadowed = SystemOid.fromOID(oid);
         OidCategory deletedCategory = customOidEntry.getCategory();
-        if (shadowed != null && shadowed.getCategory() == deletedCategory) {
-            OidRecord builtIn = OidRecord.builder()
-                    .displayName(shadowed.getDisplayName())
-                    .code(shadowed.getCode())
-                    .altCodes(shadowed.getAltCodes())
-                    .defaultCritical(shadowed.getDefaultCritical())
-                    .valueEncoding(shadowed.getValueEncoding())
-                    .system(true)
-                    .build();
-            publishAfterCommit(() -> {
-                OidHandler.cacheOid(shadowed.getCategory(), oid, builtIn);
-                publishShadowedCustomOidEntries();
-            });
-        } else {
-            publishAfterCommit(() -> OidHandler.removeCachedOid(deletedCategory, oid));
+        publishAfterCommit(() -> publishDeletion(oid, deletedCategory));
+    }
+
+    /**
+     * Drops one deleted OID from the registry, handing it back to the built-in entry when the row was
+     * shadowing one — the custom record was the effective one while it existed, so simply removing it
+     * would take the OID out of the registry entirely.
+     */
+    private void publishDeletion(String oid, OidCategory deletedCategory) {
+        SystemOid shadowed = SystemOid.fromOID(oid);
+        if (shadowed == null || shadowed.getCategory() != deletedCategory) {
+            OidHandler.removeCachedOid(deletedCategory, oid);
+            return;
         }
+        OidHandler.cacheOid(shadowed.getCategory(), oid, OidRecord.builder()
+                .displayName(shadowed.getDisplayName())
+                .code(shadowed.getCode())
+                .altCodes(shadowed.getAltCodes())
+                .defaultCritical(shadowed.getDefaultCritical())
+                .valueEncoding(shadowed.getValueEncoding())
+                .system(true)
+                .build());
+        publishShadowedCustomOidEntries();
     }
 
     @Override
     @ExternalAuthorization(resource = Resource.OID, action = ResourceAction.DELETE)
     public void bulkDeleteCustomOidEntry(List<String> oids) {
+        // Categories must be read before the delete, and the publication must be a set of deltas rather
+        // than a full refresh: a full refresh is abandoned when it loses the generation race, which would
+        // leave these committed deletions unpublished until the next scheduled cycle.
+        Map<String, OidCategory> deletedCategories = customOidEntryRepository.findAllById(oids).stream()
+                .collect(Collectors.toMap(CustomOidEntry::getOid, CustomOidEntry::getCategory));
         customOidEntryRepository.deleteAllById(oids);
-        publishAfterCommit(this::refreshCacheUnsynchronised);
+        publishAfterCommit(() -> deletedCategories.forEach(this::publishDeletion));
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -22,6 +22,7 @@ import com.otilm.core.enums.FilterField;
 import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.oid.OidHandler;
 import com.otilm.core.oid.OidRecord;
+import com.otilm.core.oid.PersistentWarningThrottle;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecurityFilter;
 import com.otilm.core.service.CertificateInternalService;
@@ -45,6 +46,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -60,6 +62,9 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     private CertificateInternalService certificateService;
     /** Rows shadowed by a built-in system OID; see {@link #getShadowedCustomOidEntries}. */
     private volatile Set<String> shadowedCustomOidEntries = Collections.emptySet();
+
+    /** Keeps a lasting shadowed row visible in recent log output without repeating it on every refresh. */
+    private final PersistentWarningThrottle shadowedWarnings = new PersistentWarningThrottle(Duration.ofHours(1));
 
     @Autowired
     public void setCertificateService(CertificateInternalService certificateService) {
@@ -130,10 +135,11 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
                 })
                 .map(SystemOid::getOid)
                 .collect(Collectors.toCollection(TreeSet::new));
-        if (shadowed.equals(shadowedCustomOidEntries)) {
+        boolean changed = !shadowed.equals(shadowedCustomOidEntries);
+        shadowedCustomOidEntries = Collections.unmodifiableSet(shadowed);
+        if (!shadowedWarnings.shouldWarn(changed, !shadowed.isEmpty())) {
             return;
         }
-        shadowedCustomOidEntries = Collections.unmodifiableSet(shadowed);
         shadowed.forEach(oid -> logger.warn(
                 "Custom OID entry {} shares its OID with a built-in system OID. The custom entry wins, so the "
                         + "built-in defaults do not apply; delete the custom entry to fall back to them.", oid));

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -116,12 +116,17 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
      * read-modify-write across categories can drop a category's contribution however volatile the field.
      */
     private void publishShadowedCustomOidEntries() {
-        Set<String> shadowed = customOidEntryRepository.findAll().stream()
-                .filter(entry -> {
-                    SystemOid systemOid = SystemOid.fromOID(entry.getOid());
-                    return systemOid != null && systemOid.getCategory() == entry.getCategory();
+        // Derived from the published registry rather than a table scan: putIfAbsent means a shadowed OID
+        // holds the operator's record, so provenance already distinguishes the two cases. This is also the
+        // more honest answer — the set describes what the registry currently resolves, not what the
+        // database holds, and both callers run straight after the publication they are describing.
+        Set<String> shadowed = Arrays.stream(SystemOid.values())
+                .filter(systemOid -> {
+                    Map<String, OidRecord> categoryCache = OidHandler.getOidCache(systemOid.getCategory());
+                    OidRecord published = categoryCache == null ? null : categoryCache.get(systemOid.getOid());
+                    return published != null && !published.system();
                 })
-                .map(CustomOidEntry::getOid)
+                .map(SystemOid::getOid)
                 .collect(Collectors.toCollection(TreeSet::new));
         if (shadowed.equals(shadowedCustomOidEntries)) {
             return;

--- a/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CustomOidEntryServiceImpl.java
@@ -41,6 +41,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +59,14 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     /** Rows shadowed by a built-in system OID; see {@link #getShadowedCustomOidEntries}. */
     private volatile Set<String> shadowedCustomOidEntries = Collections.emptySet();
 
+    /**
+     * Serialises whole-registry refreshes against single-entry publications. OidHandler's own monitor
+     * makes each publication atomic but cannot order a refresh's read-then-publish against a concurrent
+     * mutator: the scheduled refresh could read a category, pause, and republish its stale snapshot over
+     * a committed edit. Holding this for the whole read-and-publish closes that window.
+     */
+    private static final Object REGISTRY_PUBLISH_LOCK = new Object();
+
     @Autowired
     public void setCertificateService(CertificateInternalService certificateService) {
         this.certificateService = certificateService;
@@ -72,10 +82,41 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
 
     @Scheduled(fixedRateString = "${settings.cache.refresh-interval}", timeUnit = TimeUnit.SECONDS, initialDelayString = "${settings.cache.refresh-interval}")
     public void refreshCache() {
+        synchronized (REGISTRY_PUBLISH_LOCK) {
+            refreshCacheUnsynchronised();
+        }
+    }
+
+    /** Caller must hold {@link #REGISTRY_PUBLISH_LOCK}, or route through {@link #publishAfterCommit}. */
+    private void refreshCacheUnsynchronised() {
         for (OidCategory oidCategory : OidCategory.values()) {
             OidHandler.cacheOidCategory(oidCategory, getOidToRecordMap(oidCategory));
         }
         publishShadowedCustomOidEntries();
+    }
+
+    /**
+     * Runs a registry publication after the surrounding transaction commits, or immediately when there is
+     * none. The registry is process-wide static state with no transaction awareness, so publishing inline
+     * would advertise a create, edit or delete that a rolling-back outer transaction never persisted.
+     * Mirrors {@code SettingServiceImpl.cacheAfterCommit}.
+     */
+    private void publishAfterCommit(Runnable publication) {
+        Runnable serialised = () -> {
+            synchronized (REGISTRY_PUBLISH_LOCK) {
+                publication.run();
+            }
+        };
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    serialised.run();
+                }
+            });
+        } else {
+            serialised.run();
+        }
     }
 
     /**
@@ -155,13 +196,14 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
 
         customOidEntryRepository.save(customOidEntry);
 
-        OidHandler.cacheOid(request.getCategory(), oid, OidRecord.builder()
+        OidRecord created = OidRecord.builder()
                 .displayName(customOidEntry.getDisplayName())
                 .code(code)
                 .altCodes(altCodes)
                 .defaultCritical(defaultCritical)
                 .valueEncoding(valueEncoding)
-                .build());
+                .build();
+        publishAfterCommit(() -> OidHandler.cacheOid(request.getCategory(), oid, created));
         return CustomOidEntryMapper.toDetailDto(customOidEntry);
     }
 
@@ -217,13 +259,15 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
 
         // Cached unconditionally: a custom row wins over a same-OID built-in (see getOidToRecordMap),
         // so skipping this would leave the DB and the registry disagreeing after a successful edit.
-        OidHandler.cacheOid(customOidEntry.getCategory(), oid, OidRecord.builder()
+        OidRecord edited = OidRecord.builder()
                 .displayName(customOidEntry.getDisplayName())
                 .code(code)
                 .altCodes(altCodes)
                 .defaultCritical(defaultCritical)
                 .valueEncoding(valueEncoding)
-                .build());
+                .build();
+        OidCategory editedCategory = customOidEntry.getCategory();
+        publishAfterCommit(() -> OidHandler.cacheOid(editedCategory, oid, edited));
         return CustomOidEntryMapper.toDetailDto(customOidEntry);
     }
 
@@ -245,17 +289,22 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
         // Deleting a row that shadowed a built-in must hand the OID back to the built-in rather than drop
         // it from the registry, since the custom record was the effective one while it existed.
         SystemOid shadowed = SystemOid.fromOID(oid);
-        if (shadowed != null && shadowed.getCategory() == customOidEntry.getCategory()) {
-            OidHandler.cacheOid(shadowed.getCategory(), oid, OidRecord.builder()
+        OidCategory deletedCategory = customOidEntry.getCategory();
+        if (shadowed != null && shadowed.getCategory() == deletedCategory) {
+            OidRecord builtIn = OidRecord.builder()
                     .displayName(shadowed.getDisplayName())
                     .code(shadowed.getCode())
                     .altCodes(shadowed.getAltCodes())
                     .defaultCritical(shadowed.getDefaultCritical())
                     .valueEncoding(shadowed.getValueEncoding())
-                    .build());
-            publishShadowedCustomOidEntries();
+                    .system(true)
+                    .build();
+            publishAfterCommit(() -> {
+                OidHandler.cacheOid(shadowed.getCategory(), oid, builtIn);
+                publishShadowedCustomOidEntries();
+            });
         } else {
-            OidHandler.removeCachedOid(customOidEntry.getCategory(), oid);
+            publishAfterCommit(() -> OidHandler.removeCachedOid(deletedCategory, oid));
         }
     }
 
@@ -263,7 +312,7 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
     @ExternalAuthorization(resource = Resource.OID, action = ResourceAction.DELETE)
     public void bulkDeleteCustomOidEntry(List<String> oids) {
         customOidEntryRepository.deleteAllById(oids);
-        refreshCache();
+        publishAfterCommit(this::refreshCacheUnsynchronised);
     }
 
     @Override
@@ -317,6 +366,7 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
      * configured properties no longer apply. Exposed so the condition can be surfaced to an operator;
      * the resolution is to delete the row.
      */
+    @Override
     public Set<String> getShadowedCustomOidEntries() {
         return shadowedCustomOidEntries;
     }
@@ -352,6 +402,7 @@ public class CustomOidEntryServiceImpl implements CustomOidEntryExternalService 
                         .altCodes(oid.getAltCodes())
                         .defaultCritical(oid.getDefaultCritical())
                         .valueEncoding(oid.getValueEncoding())
+                        .system(true)
                         .build()));
         return oidToDisplayNameMap;
     }

--- a/src/test/java/com/otilm/core/attribute/engine/RequestAttributeDefinitionValidationTest.java
+++ b/src/test/java/com/otilm/core/attribute/engine/RequestAttributeDefinitionValidationTest.java
@@ -8,6 +8,7 @@ import com.otilm.api.model.common.attribute.v3.CustomAttributeV3;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.common.attribute.v3.content.IntegerAttributeContentV3;
 import com.otilm.api.model.common.attribute.v3.content.StringAttributeContentV3;
+import com.otilm.api.model.common.attribute.v3.mapping.ExtensionMappedField;
 import com.otilm.api.model.common.attribute.v3.mapping.FieldMapping;
 import com.otilm.api.model.common.attribute.v3.mapping.FieldType;
 import com.otilm.api.model.common.attribute.v3.mapping.ObjectType;
@@ -163,6 +164,58 @@ class RequestAttributeDefinitionValidationTest {
         DataAttributeV3 definition = validDefinition();
         ((RdnMappedField) definition.getFieldMapping().getFields().get(0)).setRdn("NOPE");
         assertRejected(definition, "not a known RDN code");
+    }
+
+    private static DataAttributeV3 extensionDefinition(String extensionOid) {
+        DataAttributeV3 attribute = validDefinition();
+        attribute.setName("extension");
+        ExtensionMappedField field = new ExtensionMappedField();
+        field.setFieldType(FieldType.EXTENSION);
+        field.setExtensionOid(extensionOid);
+        FieldMapping mapping = new FieldMapping();
+        mapping.setObjectType(ObjectType.X509_CERTIFICATE);
+        mapping.setFields(List.of(field));
+        attribute.setFieldMapping(mapping);
+        return attribute;
+    }
+
+    @Test
+    void extensionMappingOnSubjectAlternativeNameRejected() {
+        // given — the parser diverts 2.5.29.17 into subjectAltNames, so such a mapping never matches
+        // when / then
+        assertRejected(extensionDefinition("2.5.29.17"), "SAN mapping target");
+    }
+
+    @Test
+    void extensionMappingOnCaControlledExtensionRejected() {
+        // given — a requester-supplied value must not drive cA/pathLen, a name-constraints tree, or a
+        // key identifier that no longer matches the key
+        // when / then
+        assertRejected(extensionDefinition("2.5.29.19"), "controlled by the issuing CA");
+        assertRejected(extensionDefinition("2.5.29.30"), "controlled by the issuing CA");
+        assertRejected(extensionDefinition("2.5.29.14"), "controlled by the issuing CA");
+    }
+
+    @Test
+    void extensionMappingOnRequesterOwnedSystemExtensionPasses() {
+        // given — the SystemOid branch of the extension check was unreachable until the enum gained
+        // CERTIFICATE_EXTENSION entries; this is the case core#1883 needs to work
+        List<BaseAttribute> definitions = List.of(extensionDefinition("2.5.29.37"));
+
+        // when / then
+        Assertions.assertDoesNotThrow(() -> AttributeEngine.validateRequestAttributeDefinitions(definitions));
+    }
+
+    @Test
+    void rdnCodeResolvesRegardlessOfCase() {
+        // given — the authoring gate reads getCodeToOidMap while request-time resolution uses the
+        // case-insensitive index; a mixed-case system code such as PostalCode must resolve either way
+        DataAttributeV3 attribute = validDefinition();
+        ((RdnMappedField) attribute.getFieldMapping().getFields().getFirst()).setRdn("postalcode");
+        List<BaseAttribute> definitions = List.of(attribute);
+
+        // when / then
+        Assertions.assertDoesNotThrow(() -> AttributeEngine.validateRequestAttributeDefinitions(definitions));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/attribute/engine/RequestAttributeDefinitionValidationTest.java
+++ b/src/test/java/com/otilm/core/attribute/engine/RequestAttributeDefinitionValidationTest.java
@@ -187,19 +187,9 @@ class RequestAttributeDefinitionValidationTest {
     }
 
     @Test
-    void extensionMappingOnCaControlledExtensionRejected() {
-        // given — a requester-supplied value must not drive cA/pathLen, a name-constraints tree, or a
-        // key identifier that no longer matches the key
-        // when / then
-        assertRejected(extensionDefinition("2.5.29.19"), "controlled by the issuing CA");
-        assertRejected(extensionDefinition("2.5.29.30"), "controlled by the issuing CA");
-        assertRejected(extensionDefinition("2.5.29.14"), "controlled by the issuing CA");
-    }
-
-    @Test
     void extensionMappingOnRequesterOwnedSystemExtensionPasses() {
-        // given — the SystemOid branch of the extension check was unreachable until the enum gained
-        // CERTIFICATE_EXTENSION entries; this is the case core#1883 needs to work
+        // given — a requester-owned system extension is a legitimate mapping target and must pass
+        // the registry check
         List<BaseAttribute> definitions = List.of(extensionDefinition("2.5.29.37"));
 
         // when / then

--- a/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
@@ -299,6 +299,46 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
     }
 
     @Test
+    void testRdnCodeCanBeRenamedToACaseVariantOfItself() throws NotFoundException {
+        // given — the row's own code must be in the registry, or the uniqueness check has nothing to
+        // collide with and the test proves nothing. setUp writes the row straight to the repository.
+        customOidEntryServiceImpl.refreshCache();
+        Assertions.assertEquals(rdnOidEntry.getOid(), OidHandler.getOidForRdnCode("RDN"));
+
+        // The contested-code warning tells an operator to rename the code, and for a collision that
+        // differs only in case a case-only rename is the only one that resolves it.
+        CustomOidEntryUpdateRequestDto request = new CustomOidEntryUpdateRequestDto();
+        request.setDisplayName(rdnOidEntry.getDisplayName());
+        RdnAttributeTypeOidPropertiesDto props = new RdnAttributeTypeOidPropertiesDto();
+        props.setCode("Rdn");
+        props.setAltCodes(rdnOidEntry.getAltCodes());
+        request.setAdditionalProperties(props);
+
+        // when / then — the uniqueness check must not reject the row against its own code
+        customOidEntryService.editCustomOidEntry(rdnOidEntry.getOid(), request);
+
+        Assertions.assertEquals("Rdn",
+                ((RdnAttributeTypeCustomOidEntry) customOidEntryRepository.findById(rdnOidEntry.getOid()).orElseThrow()).getCode());
+        Assertions.assertEquals(rdnOidEntry.getOid(), OidHandler.getOidForRdnCode("Rdn"));
+    }
+
+    @Test
+    void testRdnCodeStillRejectedWhenAnotherRowOwnsIt() {
+        // given — excluding the row's own code must not weaken the check against other rows
+        customOidEntryServiceImpl.refreshCache();
+        CustomOidEntryUpdateRequestDto request = new CustomOidEntryUpdateRequestDto();
+        request.setDisplayName(rdnOidEntry.getDisplayName());
+        RdnAttributeTypeOidPropertiesDto props = new RdnAttributeTypeOidPropertiesDto();
+        props.setCode(SystemOid.COMMON_NAME.getCode());
+        props.setAltCodes(List.of());
+        request.setAdditionalProperties(props);
+
+        // when / then
+        Assertions.assertThrows(ValidationException.class,
+                () -> customOidEntryService.editCustomOidEntry(rdnOidEntry.getOid(), request));
+    }
+
+    @Test
     void testBulkDeletePublishesPerEntryDeltas() {
         // given — a plain custom row and a row shadowing a built-in, deleted together
         seedShadowedRdnRow("LEGACYUID");

--- a/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
@@ -38,6 +38,9 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
     @Autowired
     CustomOidEntryRepository customOidEntryRepository;
 
+    @Autowired
+    com.otilm.core.service.impl.CustomOidEntryServiceImpl customOidEntryServiceImpl;
+
     private CustomOidEntry genericCustomOidEntry;
     private RdnAttributeTypeCustomOidEntry rdnOidEntry;
     private CertificateExtensionCustomOidEntry extensionOidEntry;
@@ -271,34 +274,89 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
                 "Name Constraints must be critical — RFC 5280 4.2.1.10");
     }
 
-    @Test
-    void testEditingARowShadowedByASystemOidIsRefused() {
-        // given — a row that predates its OID's promotion to a system OID. It cannot be created through
-        // the service any more, so seed it through the repository the way an upgrade would leave it.
+    /** Seeds a row the way an upgrade leaves it: valid when created, its OID since promoted to a system OID. */
+    private RdnAttributeTypeCustomOidEntry seedShadowedRdnRow(String code) {
         RdnAttributeTypeCustomOidEntry shadowed = new RdnAttributeTypeCustomOidEntry();
         shadowed.setCategory(OidCategory.RDN_ATTRIBUTE_TYPE);
         shadowed.setDisplayName("legacy user id");
         shadowed.setOid(SystemOid.USER_ID.getOid());
-        shadowed.setCode("LEGACYUID");
+        shadowed.setCode(code);
         shadowed.setAltCodes(List.of());
         customOidEntryRepository.save(shadowed);
+        customOidEntryServiceImpl.refreshCache();
+        return shadowed;
+    }
+
+    @Test
+    void testShadowedRdnRowKeepsItsCodeResolving() {
+        // given — before the promotion this row's code was the only way to resolve that OID, and stored
+        // request-attribute definitions and DN templates reference it
+        seedShadowedRdnRow("LEGACYUID");
+
+        // when / then — the built-in entry must not replace the operator's record wholesale; losing the
+        // code makes every DN carrying it fail to resolve at request time
+        Assertions.assertEquals(SystemOid.USER_ID.getOid(), OidHandler.getOidForRdnCode("LEGACYUID"),
+                "the operator's code must survive the promotion");
+        Assertions.assertTrue(customOidEntryServiceImpl.getShadowedCustomOidEntries().contains(SystemOid.USER_ID.getOid()),
+                "the shadowed row must be reported so an operator can resolve it");
+    }
+
+    @Test
+    void testShadowedExtensionRowKeepsItsConfiguredProperties() {
+        // given — a certificate-extension row registered before the OID was promoted, with an encoding
+        // that differs from the built-in default
+        CertificateExtensionCustomOidEntry shadowed = new CertificateExtensionCustomOidEntry();
+        shadowed.setCategory(OidCategory.CERTIFICATE_EXTENSION);
+        shadowed.setDisplayName("legacy EKU");
+        shadowed.setOid(SystemOid.EXTENDED_KEY_USAGE_EXTENSION.getOid());
+        shadowed.setDefaultCritical(true);
+        shadowed.setValueEncoding(ExtensionValueEncoding.UTF8_STRING);
+        customOidEntryRepository.save(shadowed);
+        customOidEntryServiceImpl.refreshCache();
+
+        // when / then — silently swapping the encoding to the built-in DER makes the renderer
+        // base64-decode a plain string, so issuance fails
+        OidRecord record = OidHandler.getOidCache(OidCategory.CERTIFICATE_EXTENSION)
+                .get(SystemOid.EXTENDED_KEY_USAGE_EXTENSION.getOid());
+        Assertions.assertNotNull(record);
+        Assertions.assertEquals(ExtensionValueEncoding.UTF8_STRING, record.valueEncoding(),
+                "the operator's value encoding must survive the promotion");
+        Assertions.assertEquals(Boolean.TRUE, record.defaultCritical());
+    }
+
+    @Test
+    void testShadowedRowRemainsEditable() throws NotFoundException {
+        // given — the row is authoritative in the cache, so an edit must reach the cache too
+        seedShadowedRdnRow("LEGACYUID");
 
         CustomOidEntryUpdateRequestDto request = new CustomOidEntryUpdateRequestDto();
         request.setDisplayName("renamed");
         RdnAttributeTypeOidPropertiesDto props = new RdnAttributeTypeOidPropertiesDto();
-        props.setCode("STILLLEGACY");
+        props.setCode("RENAMEDUID");
         props.setAltCodes(List.of());
         request.setAdditionalProperties(props);
 
-        // when / then — editing would persist and rewrite certificate DNs while never reaching the
-        // cache, reporting success for a change that has no effect
-        ValidationException e = Assertions.assertThrows(ValidationException.class,
-                () -> customOidEntryService.editCustomOidEntry(SystemOid.USER_ID.getOid(), request));
-        Assertions.assertTrue(e.getMessage().contains("reserved for system OID"),
-                "expected a reserved-OID message but was: " + e.getMessage());
-        Assertions.assertEquals("LEGACYUID",
-                ((RdnAttributeTypeCustomOidEntry) customOidEntryRepository.findById(SystemOid.USER_ID.getOid()).orElseThrow()).getCode(),
-                "the refused edit must not have persisted");
+        // when
+        customOidEntryService.editCustomOidEntry(SystemOid.USER_ID.getOid(), request);
+
+        // then — the edit must not be half-applied: DB and cache agree
+        Assertions.assertEquals(SystemOid.USER_ID.getOid(), OidHandler.getOidForRdnCode("RENAMEDUID"));
+        Assertions.assertNull(OidHandler.getOidForRdnCode("LEGACYUID"), "the old code must stop resolving");
+    }
+
+    @Test
+    void testDeletingAShadowedRowRestoresTheBuiltInEntry() throws NotFoundException {
+        // given — deleting the row is the documented way to resolve the conflict
+        seedShadowedRdnRow("LEGACYUID");
+
+        // when
+        customOidEntryService.deleteCustomOidEntry(SystemOid.USER_ID.getOid());
+
+        // then — the built-in entry takes over rather than the OID disappearing from the registry
+        Assertions.assertEquals(SystemOid.USER_ID.getOid(), OidHandler.getOidForRdnCode(SystemOid.USER_ID.getCode()));
+        Assertions.assertNull(OidHandler.getOidForRdnCode("LEGACYUID"));
+        Assertions.assertFalse(customOidEntryServiceImpl.getShadowedCustomOidEntries().contains(SystemOid.USER_ID.getOid()),
+                "the conflict must clear once the row is gone");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
@@ -299,6 +299,24 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
     }
 
     @Test
+    void testBulkDeletePublishesPerEntryDeltas() {
+        // given — a plain custom row and a row shadowing a built-in, deleted together
+        seedShadowedRdnRow("LEGACYUID");
+        Assertions.assertEquals("1.2.3.4.6", OidHandler.getOidForRdnCode("RDN"));
+
+        // when
+        customOidEntryService.bulkDeleteCustomOidEntry(List.of("1.2.3.4.6", SystemOid.USER_ID.getOid()));
+
+        // then — a delta publication cannot be abandoned as stale, so both deletions take effect: the
+        // plain row leaves the registry and the shadowed one hands its OID back to the built-in
+        Assertions.assertNull(OidHandler.getOidForRdnCode("RDN"), "deleted custom code must stop resolving");
+        Assertions.assertNull(OidHandler.getOidForRdnCode("LEGACYUID"));
+        Assertions.assertEquals(SystemOid.USER_ID.getOid(),
+                OidHandler.getOidForRdnCode(SystemOid.USER_ID.getCode()),
+                "the built-in must take over the OID it was shadowed on");
+    }
+
+    @Test
     void testShadowedRdnRowKeepsItsCodeResolving() {
         // given — before the promotion this row's code was the only way to resolve that OID, and stored
         // request-attribute definitions and DN templates reference it
@@ -413,8 +431,10 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
 
     @Test
     void testRefreshCachePopulatesRecordsFromDb() {
-        // bulkDelete with empty list deletes nothing and calls refreshCache() — exercises getOidToRecordMap for all categories
-        customOidEntryService.bulkDeleteCustomOidEntry(List.of());
+        // Exercises getOidToRecordMap for every category. Previously this piggy-backed on
+        // bulkDeleteCustomOidEntry(List.of()) to trigger a full refresh; bulk delete now publishes
+        // per-entry deltas, so an empty list is a genuine no-op and the refresh is called directly.
+        customOidEntryServiceImpl.refreshCache();
 
         OidRecord rdnRecord = OidHandler.getOidCache(OidCategory.RDN_ATTRIBUTE_TYPE).get(rdnOidEntry.getOid());
         Assertions.assertNotNull(rdnRecord);

--- a/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 class CustomOidEntryServiceITest extends BaseSpringBootTest {
 
@@ -244,8 +245,72 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
     }
 
     @Test
-    void testListSystemOidEntriesCertificateExtensionReturnsEmpty() {
-        Assertions.assertTrue(customOidEntryService.listSystemOidEntries(OidCategory.CERTIFICATE_EXTENSION).isEmpty());
+    void testListSystemOidEntriesCertificateExtensionCarriesTypedProperties() {
+        long expectedExtensionCount = Arrays.stream(SystemOid.values())
+                .filter(o -> o.getCategory() == OidCategory.CERTIFICATE_EXTENSION).count();
+        List<CustomOidEntryDetailResponseDto> extensions =
+                customOidEntryService.listSystemOidEntries(OidCategory.CERTIFICATE_EXTENSION);
+
+        Assertions.assertEquals(expectedExtensionCount, extensions.size());
+        Assertions.assertFalse(extensions.isEmpty(), "the seeded certificate extensions must be listed");
+        // Both fields are required on the response contract, so every entry must carry them.
+        for (CustomOidEntryDetailResponseDto entry : extensions) {
+            CertificateExtensionOidPropertiesDto props =
+                    (CertificateExtensionOidPropertiesDto) entry.getAdditionalProperties();
+            Assertions.assertNotNull(props, "additionalProperties missing for " + entry.getOid());
+            Assertions.assertNotNull(props.getDefaultCritical(), "defaultCritical missing for " + entry.getOid());
+            Assertions.assertNotNull(props.getValueEncoding(), "valueEncoding missing for " + entry.getOid());
+        }
+
+        CustomOidEntryDetailResponseDto nameConstraints = extensions.stream()
+                .filter(e -> e.getOid().equals(SystemOid.NAME_CONSTRAINTS.getOid()))
+                .findFirst().orElseThrow();
+        CertificateExtensionOidPropertiesDto nameConstraintsProps =
+                (CertificateExtensionOidPropertiesDto) nameConstraints.getAdditionalProperties();
+        Assertions.assertTrue(nameConstraintsProps.getDefaultCritical(),
+                "Name Constraints must be critical — RFC 5280 4.2.1.10");
+    }
+
+    @Test
+    void testEditingARowShadowedByASystemOidIsRefused() {
+        // given — a row that predates its OID's promotion to a system OID. It cannot be created through
+        // the service any more, so seed it through the repository the way an upgrade would leave it.
+        RdnAttributeTypeCustomOidEntry shadowed = new RdnAttributeTypeCustomOidEntry();
+        shadowed.setCategory(OidCategory.RDN_ATTRIBUTE_TYPE);
+        shadowed.setDisplayName("legacy user id");
+        shadowed.setOid(SystemOid.USER_ID.getOid());
+        shadowed.setCode("LEGACYUID");
+        shadowed.setAltCodes(List.of());
+        customOidEntryRepository.save(shadowed);
+
+        CustomOidEntryUpdateRequestDto request = new CustomOidEntryUpdateRequestDto();
+        request.setDisplayName("renamed");
+        RdnAttributeTypeOidPropertiesDto props = new RdnAttributeTypeOidPropertiesDto();
+        props.setCode("STILLLEGACY");
+        props.setAltCodes(List.of());
+        request.setAdditionalProperties(props);
+
+        // when / then — editing would persist and rewrite certificate DNs while never reaching the
+        // cache, reporting success for a change that has no effect
+        ValidationException e = Assertions.assertThrows(ValidationException.class,
+                () -> customOidEntryService.editCustomOidEntry(SystemOid.USER_ID.getOid(), request));
+        Assertions.assertTrue(e.getMessage().contains("reserved for system OID"),
+                "expected a reserved-OID message but was: " + e.getMessage());
+        Assertions.assertEquals("LEGACYUID",
+                ((RdnAttributeTypeCustomOidEntry) customOidEntryRepository.findById(SystemOid.USER_ID.getOid()).orElseThrow()).getCode(),
+                "the refused edit must not have persisted");
+    }
+
+    @Test
+    void testSystemCertificateExtensionPropertiesReachTheRuntimeRegistry() {
+        // The projector reads defaultCritical and valueEncoding from this cache, not from the DTO.
+        Map<String, OidRecord> registry = OidHandler.getOidCache(OidCategory.CERTIFICATE_EXTENSION);
+        Assertions.assertNotNull(registry, "certificate-extension category must be cached");
+
+        OidRecord nameConstraints = registry.get(SystemOid.NAME_CONSTRAINTS.getOid());
+        Assertions.assertNotNull(nameConstraints, "Name Constraints missing from the runtime registry");
+        Assertions.assertEquals(Boolean.TRUE, nameConstraints.defaultCritical());
+        Assertions.assertEquals(ExtensionValueEncoding.DER, nameConstraints.valueEncoding());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
@@ -19,7 +19,9 @@ import com.otilm.core.enums.FilterField;
 import com.otilm.core.oid.OidHandler;
 import com.otilm.core.oid.OidRecord;
 import com.otilm.core.service.CustomOidEntryExternalService;
+import com.otilm.core.service.impl.CustomOidEntryServiceImpl;
 import com.otilm.core.util.BaseSpringBootTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +41,7 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
     CustomOidEntryRepository customOidEntryRepository;
 
     @Autowired
-    com.otilm.core.service.impl.CustomOidEntryServiceImpl customOidEntryServiceImpl;
+    CustomOidEntryServiceImpl customOidEntryServiceImpl;
 
     private CustomOidEntry genericCustomOidEntry;
     private RdnAttributeTypeCustomOidEntry rdnOidEntry;
@@ -71,6 +73,15 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
         extensionOidEntry.setDefaultCritical(true);
         extensionOidEntry.setValueEncoding(ExtensionValueEncoding.IA5_STRING);
         customOidEntryRepository.save(extensionOidEntry);
+    }
+
+    @AfterEach
+    void restoreRegistry() {
+        // OidHandler is process-wide static state and the scheduled refresh never fires under test
+        // (settings.cache.refresh-interval is a year in the test profile), so a seeded row would keep
+        // resolving against an already-truncated database for the life of the shared Spring context.
+        customOidEntryRepository.deleteAll();
+        customOidEntryServiceImpl.refreshCache();
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CustomOidEntryServiceITest.java
@@ -333,9 +333,10 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
         props.setAltCodes(List.of());
         request.setAdditionalProperties(props);
 
-        // when / then
+        // when / then — one throwing call in the lambda, so the assertion cannot pass on the wrong one
+        String oid = rdnOidEntry.getOid();
         Assertions.assertThrows(ValidationException.class,
-                () -> customOidEntryService.editCustomOidEntry(rdnOidEntry.getOid(), request));
+                () -> customOidEntryService.editCustomOidEntry(oid, request));
     }
 
     @Test
@@ -385,12 +386,12 @@ class CustomOidEntryServiceITest extends BaseSpringBootTest {
 
         // when / then — silently swapping the encoding to the built-in DER makes the renderer
         // base64-decode a plain string, so issuance fails
-        OidRecord record = OidHandler.getOidCache(OidCategory.CERTIFICATE_EXTENSION)
+        OidRecord cachedRecord = OidHandler.getOidCache(OidCategory.CERTIFICATE_EXTENSION)
                 .get(SystemOid.EXTENDED_KEY_USAGE_EXTENSION.getOid());
-        Assertions.assertNotNull(record);
-        Assertions.assertEquals(ExtensionValueEncoding.UTF8_STRING, record.valueEncoding(),
+        Assertions.assertNotNull(cachedRecord);
+        Assertions.assertEquals(ExtensionValueEncoding.UTF8_STRING, cachedRecord.valueEncoding(),
                 "the operator's value encoding must survive the promotion");
-        Assertions.assertEquals(Boolean.TRUE, record.defaultCritical());
+        Assertions.assertEquals(Boolean.TRUE, cachedRecord.defaultCritical());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/mapper/oid/CustomOidEntryMapperTest.java
+++ b/src/test/java/com/otilm/core/mapper/oid/CustomOidEntryMapperTest.java
@@ -8,6 +8,9 @@ import com.otilm.api.model.core.oid.properties.CertificateExtensionOidProperties
 import com.otilm.api.model.core.oid.properties.RdnAttributeTypeOidPropertiesDto;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -40,10 +43,12 @@ class CustomOidEntryMapperTest {
     @Test
     void everySystemCertificateExtensionSurfacesBothRequiredFields() {
         // given — a single missing branch would ship entries that fail their own schema
-        for (SystemOid entry : SystemOid.values()) {
-            if (entry.getCategory() != OidCategory.CERTIFICATE_EXTENSION) {
-                continue;
-            }
+        List<SystemOid> extensions = Arrays.stream(SystemOid.values())
+                .filter(e -> e.getCategory() == OidCategory.CERTIFICATE_EXTENSION).toList();
+        // Without this the loop below would pass vacuously against an interfaces build that seeds none.
+        assertThat(extensions).isNotEmpty();
+
+        for (SystemOid entry : extensions) {
 
             // when
             CustomOidEntryDetailResponseDto dto = CustomOidEntryMapper.toDetailDto(entry);

--- a/src/test/java/com/otilm/core/mapper/oid/CustomOidEntryMapperTest.java
+++ b/src/test/java/com/otilm/core/mapper/oid/CustomOidEntryMapperTest.java
@@ -1,0 +1,80 @@
+package com.otilm.core.mapper.oid;
+
+import com.otilm.api.model.core.oid.CustomOidEntryDetailResponseDto;
+import com.otilm.api.model.core.oid.ExtensionValueEncoding;
+import com.otilm.api.model.core.oid.OidCategory;
+import com.otilm.api.model.core.oid.SystemOid;
+import com.otilm.api.model.core.oid.properties.CertificateExtensionOidPropertiesDto;
+import com.otilm.api.model.core.oid.properties.RdnAttributeTypeOidPropertiesDto;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Plain unit coverage for the system-OID projection — no Spring context. {@code GET /v1/oids/system}
+ * returns system entries shaped exactly like custom ones, so a category that carries typed properties
+ * must surface them or the response violates its own required-field contract.
+ */
+class CustomOidEntryMapperTest {
+
+    @Test
+    void systemCertificateExtensionCarriesItsTypedProperties() {
+        // given — CertificateExtensionOidPropertiesDto marks both fields required
+        SystemOid keyUsage = SystemOid.KEY_USAGE;
+
+        // when
+        CustomOidEntryDetailResponseDto dto = CustomOidEntryMapper.toDetailDto(keyUsage);
+
+        // then
+        assertThat(dto.getOid()).isEqualTo("2.5.29.15");
+        assertThat(dto.getCategory()).isEqualTo(OidCategory.CERTIFICATE_EXTENSION);
+        assertThat(dto.getAdditionalProperties())
+                .isInstanceOf(CertificateExtensionOidPropertiesDto.class)
+                .satisfies(props -> {
+                    CertificateExtensionOidPropertiesDto ext = (CertificateExtensionOidPropertiesDto) props;
+                    assertThat(ext.getDefaultCritical()).isTrue();
+                    assertThat(ext.getValueEncoding()).isEqualTo(ExtensionValueEncoding.DER);
+                });
+    }
+
+    @Test
+    void everySystemCertificateExtensionSurfacesBothRequiredFields() {
+        // given — a single missing branch would ship entries that fail their own schema
+        for (SystemOid entry : SystemOid.values()) {
+            if (entry.getCategory() != OidCategory.CERTIFICATE_EXTENSION) {
+                continue;
+            }
+
+            // when
+            CustomOidEntryDetailResponseDto dto = CustomOidEntryMapper.toDetailDto(entry);
+
+            // then
+            assertThat(dto.getAdditionalProperties())
+                    .as("additionalProperties for %s", entry.getOid())
+                    .isInstanceOf(CertificateExtensionOidPropertiesDto.class);
+            CertificateExtensionOidPropertiesDto ext =
+                    (CertificateExtensionOidPropertiesDto) dto.getAdditionalProperties();
+            assertThat(ext.getDefaultCritical()).as("defaultCritical for %s", entry.getOid()).isNotNull();
+            assertThat(ext.getValueEncoding()).as("valueEncoding for %s", entry.getOid()).isNotNull();
+        }
+    }
+
+    @Test
+    void systemRdnAttributeTypeStillCarriesCodeAndAltCodes() {
+        // when
+        CustomOidEntryDetailResponseDto dto = CustomOidEntryMapper.toDetailDto(SystemOid.SURNAME);
+
+        // then
+        assertThat(dto.getAdditionalProperties()).isInstanceOf(RdnAttributeTypeOidPropertiesDto.class);
+        RdnAttributeTypeOidPropertiesDto rdn = (RdnAttributeTypeOidPropertiesDto) dto.getAdditionalProperties();
+        assertThat(rdn.getCode()).isEqualTo("SN");
+        assertThat(rdn.getAltCodes()).containsExactly("SURNAME");
+    }
+
+    @Test
+    void systemExtendedKeyUsagePurposeHasNoAdditionalProperties() {
+        // given — EKU purposes and generic identifiers carry nothing beyond the base fields
+        // when / then
+        assertThat(CustomOidEntryMapper.toDetailDto(SystemOid.TIME_STAMPING).getAdditionalProperties()).isNull();
+    }
+}

--- a/src/test/java/com/otilm/core/oid/OidHandlerTest.java
+++ b/src/test/java/com/otilm/core/oid/OidHandlerTest.java
@@ -128,6 +128,47 @@ class OidHandlerTest {
     }
 
     @Test
+    void contestedRdnCode_isPublishedAsQueryableConflictState() {
+        // given — the cache rebuilds every few seconds, so the conflict has to be readable state an
+        // operator can be shown, not just a log line that repeats until it is filtered out
+        Map<String, OidRecord> rdn = new HashMap<>();
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").build());
+        rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("uid").build());
+        OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
+
+        // when / then — matched case-insensitively, and both claimants are named
+        assertThat(OidHandler.getRdnCodeConflicts())
+                .hasSize(1)
+                .satisfies(conflicts -> assertThat(conflicts.values().iterator().next())
+                        .containsExactlyInAnyOrder(SystemOid.USER_ID.getOid(), "1.2.3.4.5.6"));
+    }
+
+    @Test
+    void resolvingAContestedRdnCode_clearsTheConflictState() {
+        // given — a contest that an operator then resolves by renaming their code
+        Map<String, OidRecord> rdn = new HashMap<>();
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").build());
+        rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("UID").build());
+        OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
+        assertThat(OidHandler.getRdnCodeConflicts()).isNotEmpty();
+
+        // when
+        rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("LEGACYUID").build());
+        OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
+
+        // then
+        assertThat(OidHandler.getRdnCodeConflicts()).isEmpty();
+    }
+
+    @Test
+    void unambiguousRegistry_reportsNoConflicts() {
+        OidHandler.cacheOid(OidCategory.RDN_ATTRIBUTE_TYPE, "2.5.4.3",
+                OidRecord.builder().displayName("Common Name").code("CN").build());
+
+        assertThat(OidHandler.getRdnCodeConflicts()).isEmpty();
+    }
+
+    @Test
     void removeCachedOid_deregistersRdnCode() {
         OidHandler.cacheOid(OidCategory.RDN_ATTRIBUTE_TYPE, "2.5.4.3",
                 OidRecord.builder().displayName("Common Name").code("CN").build());

--- a/src/test/java/com/otilm/core/oid/OidHandlerTest.java
+++ b/src/test/java/com/otilm/core/oid/OidHandlerTest.java
@@ -102,7 +102,7 @@ class OidHandlerTest {
         // given — a deployment registered its own OID under code UID before 0.9.2342.19200300.100.1.1
         // became a system OID. Both now claim the token.
         Map<String, OidRecord> rdn = new HashMap<>();
-        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").build());
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").system(true).build());
         rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("UID").build());
         OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
 
@@ -116,7 +116,7 @@ class OidHandlerTest {
     void contestedRdnCode_resolutionSurvivesAnUnrelatedCacheRebuild() {
         // given — the same contest as above
         Map<String, OidRecord> rdn = new HashMap<>();
-        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").build());
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").system(true).build());
         rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("UID").build());
         OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
         String before = OidHandler.getOidForRdnCode("UID");
@@ -134,7 +134,7 @@ class OidHandlerTest {
         // given — the cache rebuilds every few seconds, so the conflict has to be readable state an
         // operator can be shown, not just a log line that repeats until it is filtered out
         Map<String, OidRecord> rdn = new HashMap<>();
-        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").build());
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").system(true).build());
         rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("uid").build());
         OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
 
@@ -150,7 +150,7 @@ class OidHandlerTest {
         // given — the conflict map is process-wide static state reachable through a public accessor, so
         // a caller must not be able to reach through the unmodifiable map into a mutable value set
         Map<String, OidRecord> rdn = new HashMap<>();
-        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").build());
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").system(true).build());
         rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("UID").build());
         OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
 
@@ -167,7 +167,7 @@ class OidHandlerTest {
         // given — every other code lookup in the registry is case-insensitive; this one must agree or a
         // caller reading the conflict for "uid" silently sees nothing
         Map<String, OidRecord> rdn = new HashMap<>();
-        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").build());
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").system(true).build());
         rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("UID").build());
         OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
 
@@ -177,10 +177,38 @@ class OidHandlerTest {
     }
 
     @Test
+    void contestBetweenTwoOperatorRows_keepsTheLexicographicallyFirstOid() {
+        // given — the mirror of the evict arm: no built-in is involved, so provenance cannot break the
+        // tie and only determinism is guaranteed
+        Map<String, OidRecord> rdn = new HashMap<>();
+        rdn.put("0.1.2.3", OidRecord.builder().displayName("First").code("DUP").build());
+        rdn.put("9.8.7.6", OidRecord.builder().displayName("Second").code("DUP").build());
+        OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
+
+        // when / then
+        assertThat(OidHandler.getOidForRdnCode("DUP")).isEqualTo("0.1.2.3");
+        assertThat(OidHandler.getRdnCodeConflicts()).containsKey("DUP");
+    }
+
+    @Test
+    void shadowedOperatorRowKeepsItsTokenAgainstAnotherOperatorRow() {
+        // given — a custom row occupying a system OID, contested by a second custom row that sorts AFTER
+        // it. The shadowed row therefore claims the token first, and keeps it only if provenance decides
+        // the contest: classifying by OID identity would read it as built-in and evict it.
+        Map<String, OidRecord> rdn = new HashMap<>();
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("Shadowed row").code("DUP").build());
+        rdn.put("1.2.3.4", OidRecord.builder().displayName("Other operator row").code("DUP").build());
+        OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
+
+        // when / then — neither record is built-in, so the first claimant keeps the token
+        assertThat(OidHandler.getOidForRdnCode("DUP")).isEqualTo(SystemOid.USER_ID.getOid());
+    }
+
+    @Test
     void resolvingAContestedRdnCode_clearsTheConflictState() {
         // given — a contest that an operator then resolves by renaming their code
         Map<String, OidRecord> rdn = new HashMap<>();
-        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").build());
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").system(true).build());
         rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("UID").build());
         OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
         assertThat(OidHandler.getRdnCodeConflicts()).isNotEmpty();

--- a/src/test/java/com/otilm/core/oid/OidHandlerTest.java
+++ b/src/test/java/com/otilm/core/oid/OidHandlerTest.java
@@ -1,6 +1,7 @@
 package com.otilm.core.oid;
 
 import com.otilm.api.model.core.oid.OidCategory;
+import com.otilm.api.model.core.oid.SystemOid;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,6 +81,50 @@ class OidHandlerTest {
         assertThat(OidHandler.getOidForRdnCode("email")).isEqualTo("1.2.840.113549.1.9.1");
         assertThat(OidHandler.getOidForRdnCode("e")).isEqualTo("1.2.840.113549.1.9.1");
         assertThat(OidHandler.getOidForRdnCode("EmailAddress")).isEqualTo("1.2.840.113549.1.9.1");
+    }
+
+    @Test
+    void getCodeToOidMap_isCaseInsensitiveAtTheSource() {
+        // The authoring-time gate reads this map directly rather than the derived index, so it must
+        // match the same way request-time resolution does — otherwise a mixed-case system code such
+        // as PostalCode is rejected when authored in another casing but resolves fine at runtime.
+        OidHandler.cacheOid(OidCategory.RDN_ATTRIBUTE_TYPE, "2.5.4.17",
+                OidRecord.builder().displayName("Postal Code").code("PostalCode").build());
+
+        assertThat(OidHandler.getCodeToOidMap()).containsEntry("POSTALCODE", "2.5.4.17");
+        assertThat(OidHandler.getCodeToOidMap()).containsEntry("postalcode", "2.5.4.17");
+    }
+
+    @Test
+    void contestedRdnCode_resolvesToTheOperatorRegisteredEntry() {
+        // given — a deployment registered its own OID under code UID before 0.9.2342.19200300.100.1.1
+        // became a system OID. Both now claim the token.
+        Map<String, OidRecord> rdn = new HashMap<>();
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").build());
+        rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("UID").build());
+        OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
+
+        // when / then — the custom entry keeps the token; promoting an OID must not silently repoint
+        // a DN that was already parsing to the operator's attribute type
+        assertThat(OidHandler.getOidForRdnCode("UID")).isEqualTo("1.2.3.4.5.6");
+        assertThat(OidHandler.getOidForRdnCode("uid")).isEqualTo("1.2.3.4.5.6");
+    }
+
+    @Test
+    void contestedRdnCode_resolutionSurvivesAnUnrelatedCacheRebuild() {
+        // given — the same contest as above
+        Map<String, OidRecord> rdn = new HashMap<>();
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").build());
+        rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("UID").build());
+        OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
+        String before = OidHandler.getOidForRdnCode("UID");
+
+        // when — any unrelated custom-OID write rebuilds the derived index
+        OidHandler.cacheOid(OidCategory.RDN_ATTRIBUTE_TYPE, "9.8.7.6",
+                OidRecord.builder().displayName("Unrelated").code("UNRELATED").build());
+
+        // then — the winner must not flip; previously this depended on HashMap iteration order
+        assertThat(OidHandler.getOidForRdnCode("UID")).isEqualTo(before).isEqualTo("1.2.3.4.5.6");
     }
 
     @Test

--- a/src/test/java/com/otilm/core/oid/OidHandlerTest.java
+++ b/src/test/java/com/otilm/core/oid/OidHandlerTest.java
@@ -12,9 +12,11 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Pure unit coverage for the {@link OidHandler} RDN-code lookup and copy-on-write mutators —
@@ -141,6 +143,37 @@ class OidHandlerTest {
                 .hasSize(1)
                 .satisfies(conflicts -> assertThat(conflicts.values().iterator().next())
                         .containsExactlyInAnyOrder(SystemOid.USER_ID.getOid(), "1.2.3.4.5.6"));
+    }
+
+    @Test
+    void publishedConflictState_isDeeplyImmutable() {
+        // given — the conflict map is process-wide static state reachable through a public accessor, so
+        // a caller must not be able to reach through the unmodifiable map into a mutable value set
+        Map<String, OidRecord> rdn = new HashMap<>();
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").build());
+        rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("UID").build());
+        OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
+
+        Set<String> claimants = OidHandler.getRdnCodeConflicts().get("UID");
+
+        // when / then — mutating a claimant set would corrupt the shared state and break the
+        // change-detection that keeps the warning from repeating on every rebuild
+        assertThat(claimants).isNotNull();
+        assertThatThrownBy(() -> claimants.add("9.9.9.9")).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void publishedConflictState_looksUpTokensCaseInsensitively() {
+        // given — every other code lookup in the registry is case-insensitive; this one must agree or a
+        // caller reading the conflict for "uid" silently sees nothing
+        Map<String, OidRecord> rdn = new HashMap<>();
+        rdn.put(SystemOid.USER_ID.getOid(), OidRecord.builder().displayName("User ID").code("UID").build());
+        rdn.put("1.2.3.4.5.6", OidRecord.builder().displayName("Legacy UID").code("UID").build());
+        OidHandler.cacheOidCategory(OidCategory.RDN_ATTRIBUTE_TYPE, rdn);
+
+        // when / then
+        assertThat(OidHandler.getRdnCodeConflicts().get("uid")).isNotNull();
+        assertThat(OidHandler.getRdnCodeConflicts().get("UID")).isNotNull();
     }
 
     @Test

--- a/src/test/java/com/otilm/core/oid/OidHandlerTest.java
+++ b/src/test/java/com/otilm/core/oid/OidHandlerTest.java
@@ -230,6 +230,53 @@ class OidHandlerTest {
     }
 
     @Test
+    void cacheAllCategories_abandonsAStaleSnapshot() {
+        // given — a refresh read its source data, then a mutator published before the refresh could
+        long staleGeneration = OidHandler.getGeneration();
+        OidHandler.cacheOid(OidCategory.RDN_ATTRIBUTE_TYPE, "2.5.4.3",
+                OidRecord.builder().displayName("Common Name").code("CN").build());
+
+        // when — the refresh tries to publish a snapshot that predates that mutation
+        boolean published = OidHandler.cacheAllCategories(staleGeneration,
+                Map.of(OidCategory.RDN_ATTRIBUTE_TYPE, Map.of()));
+
+        // then — abandoned, so the committed mutation is not clobbered
+        assertThat(published).isFalse();
+        assertThat(OidHandler.getOidForRdnCode("CN")).isEqualTo("2.5.4.3");
+    }
+
+    @Test
+    void cacheAllCategories_publishesWhenTheGenerationStillMatches() {
+        // given
+        OidHandler.cacheOid(OidCategory.RDN_ATTRIBUTE_TYPE, "2.5.4.3",
+                OidRecord.builder().displayName("Common Name").code("CN").build());
+        long current = OidHandler.getGeneration();
+
+        // when — a full swap of the category, replacing its contents
+        boolean published = OidHandler.cacheAllCategories(current, Map.of(OidCategory.RDN_ATTRIBUTE_TYPE,
+                Map.of("2.5.4.6", OidRecord.builder().displayName("Country").code("C").build())));
+
+        // then — published, dropping what the snapshot did not contain, and the derived index is rebuilt
+        assertThat(published).isTrue();
+        assertThat(OidHandler.getOidForRdnCode("C")).isEqualTo("2.5.4.6");
+        assertThat(OidHandler.getOidForRdnCode("CN")).isNull();
+    }
+
+    @Test
+    void cacheAllCategories_leavesUnsuppliedCategoriesUntouched() {
+        // given — a category absent from the snapshot must not be cleared: null means "not loaded" to
+        // every reader, and PlatformX500NameStyle dereferences the RDN category without a null check
+        OidHandler.cacheOid(OidCategory.GENERIC, "1.2.3.4", OidRecord.builder().displayName("kept").build());
+
+        // when
+        OidHandler.cacheAllCategories(OidHandler.getGeneration(),
+                Map.of(OidCategory.RDN_ATTRIBUTE_TYPE, Map.of()));
+
+        // then
+        assertThat(OidHandler.getOidCache(OidCategory.GENERIC)).containsKey("1.2.3.4");
+    }
+
+    @Test
     void removeCachedOid_deregistersRdnCode() {
         OidHandler.cacheOid(OidCategory.RDN_ATTRIBUTE_TYPE, "2.5.4.3",
                 OidRecord.builder().displayName("Common Name").code("CN").build());

--- a/src/test/java/com/otilm/core/oid/PersistentWarningThrottleTest.java
+++ b/src/test/java/com/otilm/core/oid/PersistentWarningThrottleTest.java
@@ -1,0 +1,72 @@
+package com.otilm.core.oid;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pure unit coverage for the warning-repeat policy — no Spring context, no clock manipulation: an
+ * interval of zero stands in for "the repeat window has elapsed", and a long interval for "it has not".
+ */
+class PersistentWarningThrottleTest {
+
+    private static final Duration NEVER_ELAPSES = Duration.ofDays(1);
+    private static final Duration ALWAYS_ELAPSED = Duration.ZERO;
+
+    @Test
+    void warnsWhenTheConditionFirstAppears() {
+        PersistentWarningThrottle throttle = new PersistentWarningThrottle(NEVER_ELAPSES);
+
+        assertThat(throttle.shouldWarn(true, true)).isTrue();
+    }
+
+    @Test
+    void staysQuietWhileNothingChangedAndTheWindowHasNotElapsed() {
+        PersistentWarningThrottle throttle = new PersistentWarningThrottle(NEVER_ELAPSES);
+        throttle.shouldWarn(true, true);
+
+        // The registry rebuilds every 30s by default; this is the case that would otherwise flood.
+        assertThat(throttle.shouldWarn(false, true)).isFalse();
+        assertThat(throttle.shouldWarn(false, true)).isFalse();
+    }
+
+    @Test
+    void warnsAgainOnceTheWindowElapsesEvenWithoutAChange() {
+        // The point of the policy: a lasting condition stays visible in recent log output, so its
+        // absence means resolved rather than already-reported.
+        PersistentWarningThrottle throttle = new PersistentWarningThrottle(ALWAYS_ELAPSED);
+        throttle.shouldWarn(true, true);
+
+        assertThat(throttle.shouldWarn(false, true)).isTrue();
+    }
+
+    @Test
+    void warnsOnAChangeEvenInsideTheWindow() {
+        // A different set of conflicting tokens is new information, not a repeat.
+        PersistentWarningThrottle throttle = new PersistentWarningThrottle(NEVER_ELAPSES);
+        throttle.shouldWarn(true, true);
+
+        assertThat(throttle.shouldWarn(true, true)).isTrue();
+    }
+
+    @Test
+    void staysQuietWhenThereIsNothingToReport() {
+        PersistentWarningThrottle throttle = new PersistentWarningThrottle(ALWAYS_ELAPSED);
+
+        assertThat(throttle.shouldWarn(true, false)).isFalse();
+        assertThat(throttle.shouldWarn(false, false)).isFalse();
+    }
+
+    @Test
+    void reportsARecurrenceImmediatelyRatherThanWaitingOutTheOldWindow() {
+        // given — a condition that appeared, then resolved
+        PersistentWarningThrottle throttle = new PersistentWarningThrottle(NEVER_ELAPSES);
+        throttle.shouldWarn(true, true);
+        throttle.shouldWarn(true, false);
+
+        // when / then — the same condition returning must not be muted by the earlier occurrence
+        assertThat(throttle.shouldWarn(false, true)).isTrue();
+    }
+}


### PR DESCRIPTION
Closes #1894

## Blocked by interfaces#792 — expect a red build until it merges

This compiles against `com.otilm:interfaces:2.18.1-SNAPSHOT` containing `getDefaultCritical()` and `getValueEncoding()` on `SystemOid`. Those ship in **interfaces#792**, still open, so CI here resolves the last published SNAPSHOT and fails to compile. Verified locally against a `mvn install` of that branch.

Merge order: interfaces#792 → its SNAPSHOT publishes → this.

## What changed

**Registry propagation.** `getOidToRecordMap` carries `defaultCritical` and `valueEncoding` into system-derived `OidRecord`s. Without it the projector reads them unset and emits Name Constraints as **non-critical**, contrary to RFC 5280 §4.2.1.10 — Key Usage and Basic Constraints only looked correct because `X509RequestContentRenderer.CRITICALITY_FORCED_OIDS` force-criticals them, masking the gap.

**API contract.** `toDetailDto(SystemOid)` gains a `CERTIFICATE_EXTENSION` branch, so `GET /v1/oids/system` stops returning entries whose required `defaultCritical` and `valueEncoding` are absent.

**SAN mapping guard.** `ExtensionMappedField` on `2.5.29.17` is rejected pointing at the SAN mapping target — the parser diverts SAN out of the extension list, so such a mapping could never match. Scoped to that one OID: it is the only OID special-cased in the request pipeline, and EKU, keyUsage and basicConstraints must stay mappable.

**Deterministic RDN code resolution.** `getCodeToOidMap` resolved a contested token by `HashMap` iteration order, so the winner was arbitrary and could flip on any unrelated cache rebuild, silently repointing a DN to another attribute type. It now resolves in favour of the operator-registered entry and is case-insensitive at the source, which also aligns the authoring gate with request-time resolution (authoring previously rejected `postalcode` while runtime accepted it).

**Shadowed rows are preserved, reported and manageable.** A `custom_oid_entry` row can predate its OID's promotion. System entries are merged with `putIfAbsent`, so the operator's record wins; the row is reported; it stays editable, with edits reaching the cache; and deleting it hands the OID back to the built-in.

**Conflicts are queryable state, not log noise.** `refreshCache` runs every 30 s by default, so a per-rebuild log line would emit ~2,880 identical lines a day per conflict. Both sets are published, logged only on change, and readable via `OidHandler.getRdnCodeConflicts()` and `CustomOidEntryServiceImpl.getShadowedCustomOidEntries()`.

## Decisions worth reviewing

**One consistent rule: the operator's record wins, and nothing is mutated.** This now applies to both hazards — a contested *code* across two OIDs, and a *same-OID* row shadowed by a promotion. Before the promotion only the operator's entry was in play, so letting it keep winning means the upgrade changes nothing. Failing startup was rejected as disproportionate (core down means no issuance or revocation, and SaaS tenants cannot self-remediate); deleting the row was rejected because it discards operator-chosen criticality and encoding irreversibly. Cost is bounded: DN *rendering* is OID→code, so no collision is possible in that direction. (An earlier version of this description claimed the mapping UI stores only dotted OIDs — it does not; `RdnMappedField.rdn` accepts a short code or a dotted OID.)

**The delete migration in the DoD is deliberately not implemented.** With shadowed rows now preserved and recoverable in place — editable, deletable, reported — the destructive migration has no remaining job. Recommend listing the newly reserved OIDs in the release note instead.

## Review round — what a multi-reviewer pass changed

Four independent reviewers (Copilot CLI, guided review, superpowers, hygiene) produced 41 findings, deduped to 24. Two clusters were substantive and both are fixed in `e9e5d47`:

**`caControlled` is reverted, here and in interfaces#792.** An earlier revision marked basicConstraints, nameConstraints and subjectKeyIdentifier as CA-owned and refused them as mapping targets. That was wrong: the STRICT whitelist admits an extension only when some request attribute maps its OID — `mappedExtensionOids` is populated solely from `ExtensionMappedField`, and the check is plain set membership with no exemption path. So refusing them as mapping targets also refused them **in incoming CSRs**, breaking the case core#1883 exists to fix, for an extension seeded precisely because `openssl req -addext` emits it. An earlier version of this PR body claimed they "remain admissible under the STRICT whitelist" — that claim was false. Blocking requester-driven CA-owned extensions properly needs a whitelist exemption plus a projection-time guard, designed together, which is separate work.

**Same-OID shadowing was destructive and silent.** `getOidToRecordMap` replaced the entire `OidRecord` for an OID a custom row already held, dropping the operator's code, alt codes, criticality and encoding before the contested-code logic ever ran — no contest, no conflict entry. A lost code leaves the registry entirely, so `resolveOid` fails and every DN carrying it breaks at request time; interfaces#792 promotes exactly the five RDN OIDs an operator previously had to hand-register. The reviewers were right that this made skipping the delete migration incoherent — one hazard was handled non-destructively while its twin was destructive.

Also from that pass: `getCodeToOidMap` no longer publishes state from unsynchronized read paths (it was called per CSR validation, per EST `csrattrs` call, and inside the Intune revocation loop, so a reader could overwrite the writer's fresh snapshot); the shadowed-row set is derived from one query and published in a single assignment, replacing a per-category read-modify-write on a `volatile` field; a mapper test that would pass vacuously against an interfaces build with no seeded extensions now asserts non-empty first.

## Two review predictions that did not hold

`PlatformX500NameStyleITest` was expected to break because its fixture registers code `UID` on custom OID `1.2.3.4.5.6`. It passes **8/8 unchanged** — that fixture is a *custom* entry, so operator-wins keeps it resolving exactly as the test already asserts. Core's own pre-existing test independently validates the precedence direction.

Only `CustomOidEntryServiceITest` needed updating, for its assertion that the system `CERTIFICATE_EXTENSION` list is empty.

## Tests

66 green locally across the six affected classes.

Both non-obvious behaviours were proved rather than assumed — the logic was written before its test in each case, so the test was checked against the old behaviour first:

- Reverting `claimToken` to last-writer-wins **and** the `TreeSet` iteration to raw `HashMap` order makes both precedence tests fail, resolving to the system OID instead of the operator's. Both reverts are needed: with the sorted iteration retained, the system OID happens to sort first, so last-writer-wins alone would still leave the custom entry winning.
- Restoring the destructive `put` makes the two shadowing tests fail with `expected: <0.9.2342.19200300.100.1.1> but was: <null>` (the code left the registry) and `expected: <UTF8_STRING> but was: <DER>`.

Conflict reporting is asserted through the published state rather than by capturing log output. `CustomOidEntryMapperTest` asserts every seeded extension surfaces both required fields, so a missing branch cannot ship entries that fail their own schema.

## Still outstanding

- **documentation PR #332** states "There are no built-in `Certificate Extension` entries. All extension OIDs are registered by you as **Custom OIDs**" and walks the operator through creating them — both become false on merge, since `createCustomOidEntry` now rejects the reserved OIDs. That page is the natural home for the release note listing them.
- No admin API serves the two conflict accessors, so the DoD's "admin-visible warning" is half met: the state exists, nothing exposes it.
- `CertificateRequestAttributeProjector.toRequestedExtension` falls back to non-critical with no encoding when the registry lacks an OID, rather than to `SystemOid`, leaving two sources of truth for built-in criticality.

