### PR TITLE
Adopt the surviving cryptographic key when a concurrent upload wins

### DIFF
--- a/src/main/java/com/otilm/core/dao/repository/CryptographicKeyItemRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CryptographicKeyItemRepository.java
@@ -36,6 +36,10 @@ public interface CryptographicKeyItemRepository extends SecurityFilterRepository
 
     List<CryptographicKeyItem> findByKeyTokenProfileUuid(UUID tokenProfileUuid);
 
+    /**
+     * @return the number of rows inserted — 1 when this caller inserted the item, 0 when an item with the same
+     * fingerprint already existed and the caller must resolve the surviving key by fingerprint
+     */
     @Modifying
     @Query(value = """
             INSERT INTO {h-schema}cryptographic_key_item (

--- a/src/main/java/com/otilm/core/dao/repository/CryptographicKeyItemRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CryptographicKeyItemRepository.java
@@ -48,7 +48,7 @@ public interface CryptographicKeyItemRepository extends SecurityFilterRepository
                 :#{#cki.updatedAt}, :#{#cki.usageBitmask}
             ) ON CONFLICT (fingerprint) DO NOTHING
             """, nativeQuery = true)
-    void insertWithFingerprintConflictResolve(@Param("cki") CryptographicKeyItem keyItem);
+    Integer insertWithFingerprintConflictResolve(@Param("cki") CryptographicKeyItem keyItem);
 
     @Query(value = """
             SELECT COUNT(c.uuid)

--- a/src/main/java/com/otilm/core/service/CryptographicKeyInternalService.java
+++ b/src/main/java/com/otilm/core/service/CryptographicKeyInternalService.java
@@ -41,7 +41,10 @@ public interface CryptographicKeyInternalService extends ResourceExtensionServic
      * @param publicKey    Public Key to be uploaded
      * @param keyLength    Length of the Public Key
      * @param fingerprint  Unique fingerprint of the Public Key
-     * @return UUID of the uploaded Cryptographic Key
+     * @return UUID of the Cryptographic Key holding this public key — the one created by this call, or, when a
+     * concurrent caller committed the same fingerprint first, that pre-existing key. In the latter case the key
+     * created by this call is discarded, so no key is left without a key item. Callers must therefore not
+     * assume exclusive ownership of the returned key.
      */
     UUID uploadCertificatePublicKey(String name, PublicKey publicKey, int keyLength, String fingerprint);
 }

--- a/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
@@ -995,7 +995,7 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
         cryptographicKeyItem.setCreatedAt(now);
         cryptographicKeyItem.setUpdatedAt(now);
         Integer inserted = cryptographicKeyItemRepository.insertWithFingerprintConflictResolve(cryptographicKeyItem);
-        if (inserted != null && inserted == 1) {
+        if (inserted == 1) {
             return cryptographicKey.getUuid();
         }
 
@@ -1007,6 +1007,8 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
             throw new IllegalStateException("Public key with the same fingerprint was committed concurrently but could no longer be read");
         }
         cryptographicKeyRepository.delete(cryptographicKey);
+        logger.debug("Adopted existing cryptographic key {} for fingerprint {}; discarded locally created key {}",
+                survivingKeyUuid, fingerprint, cryptographicKey.getUuid());
         return survivingKeyUuid;
     }
 

--- a/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
@@ -994,8 +994,20 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
         cryptographicKeyItem.setEnabled(true);
         cryptographicKeyItem.setCreatedAt(now);
         cryptographicKeyItem.setUpdatedAt(now);
-        cryptographicKeyItemRepository.insertWithFingerprintConflictResolve(cryptographicKeyItem);
-        return cryptographicKey.getUuid();
+        Integer inserted = cryptographicKeyItemRepository.insertWithFingerprintConflictResolve(cryptographicKeyItem);
+        if (inserted != null && inserted == 1) {
+            return cryptographicKey.getUuid();
+        }
+
+        // Another caller already holds this key. Its parent is the surviving one, so adopt it and drop the
+        // parent created here, which has no items and nothing references yet — otherwise it is orphaned
+        // permanently and the returned UUID points at a key with no material.
+        UUID survivingKeyUuid = findKeyByFingerprint(fingerprint);
+        if (survivingKeyUuid == null) {
+            throw new IllegalStateException("Public key with the same fingerprint was committed concurrently but could no longer be read");
+        }
+        cryptographicKeyRepository.delete(cryptographicKey);
+        return survivingKeyUuid;
     }
 
     @Override

--- a/src/test/java/com/otilm/core/integration/service/CryptographicKeyServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicKeyServiceITest.java
@@ -37,6 +37,7 @@ import com.otilm.core.security.authz.opa.dto.OpaRequestedResource;
 import com.otilm.core.service.CryptographicKeyExternalService;
 import com.otilm.core.service.CryptographicKeyInternalService;
 import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.CertificateUtil;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.AfterEach;
@@ -46,7 +47,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
 import java.util.*;
 
 class CryptographicKeyServiceITest extends BaseSpringBootTest {
@@ -71,6 +77,8 @@ class CryptographicKeyServiceITest extends BaseSpringBootTest {
     private CryptographicKeyItemRepository cryptographicKeyItemRepository;
     @Autowired
     private OwnerAssociationRepository ownerAssociationRepository;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
     @MockitoBean
     private NotificationProducer notificationProducer;
 
@@ -954,6 +962,32 @@ class CryptographicKeyServiceITest extends BaseSpringBootTest {
         return resource != null && resource.getProperties() != null &&
                 (resource.getProperties().containsKey("name") && resource.getProperties().get("name").equals(name)) &&
                 (resource.getProperties().containsKey("action") && resource.getProperties().get("action").equals(action));
+    }
+
+    @Test
+    void uploadingTheSameKeyTwiceConvergesOnOneKeyAndLeavesNoOrphan() throws Exception {
+        PublicKey publicKey = KeyPairGenerator.getInstance("RSA").generateKeyPair().getPublic();
+        String fingerprint = CertificateUtil.getThumbprint(
+                Base64.getEncoder().encodeToString(publicKey.getEncoded()).getBytes(StandardCharsets.UTF_8));
+        long itemlessKeysBefore = countItemlessKeys();
+
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        UUID firstKeyUuid = template.execute(status -> cryptographicKeyInternalService
+                .uploadCertificatePublicKey("certKey_first", publicKey, 2048, fingerprint));
+        UUID secondKeyUuid = template.execute(status -> cryptographicKeyInternalService
+                .uploadCertificatePublicKey("certKey_second", publicKey, 2048, fingerprint));
+
+        Assertions.assertEquals(firstKeyUuid, secondKeyUuid,
+                "the second caller must adopt the surviving key, not the parent it created itself");
+        Assertions.assertTrue(cryptographicKeyItemRepository.findByFingerprint(fingerprint).isPresent());
+        Assertions.assertEquals(itemlessKeysBefore, countItemlessKeys(),
+                "no cryptographic key may be left behind without an item");
+    }
+
+    private long countItemlessKeys() {
+        return cryptographicKeyRepository.findAll().stream()
+                .filter(key -> cryptographicKeyItemRepository.findByKeyUuidIn(List.of(key.getUuid())).isEmpty())
+                .count();
     }
 
 }

--- a/src/test/java/com/otilm/core/integration/service/CryptographicKeyServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicKeyServiceITest.java
@@ -51,6 +51,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.util.*;
 
@@ -968,7 +969,7 @@ class CryptographicKeyServiceITest extends BaseSpringBootTest {
      * holder of the open transaction waiting on a thread blocked inside its own insert.
      */
     @Test
-    void uploadingTheSameKeyTwiceConvergesOnOneKeyAndLeavesNoOrphan() throws Exception {
+    void uploadingTheSameKeyTwiceConvergesOnOneKeyAndLeavesNoOrphan() throws NoSuchAlgorithmException {
         KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
         generator.initialize(2048);
         PublicKey publicKey = generator.generateKeyPair().getPublic();

--- a/src/test/java/com/otilm/core/integration/service/CryptographicKeyServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicKeyServiceITest.java
@@ -38,6 +38,7 @@ import com.otilm.core.service.CryptographicKeyExternalService;
 import com.otilm.core.service.CryptographicKeyInternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.CertificateUtil;
+import com.otilm.core.util.KeySizeUtil;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.AfterEach;
@@ -47,8 +48,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPairGenerator;
@@ -77,8 +76,6 @@ class CryptographicKeyServiceITest extends BaseSpringBootTest {
     private CryptographicKeyItemRepository cryptographicKeyItemRepository;
     @Autowired
     private OwnerAssociationRepository ownerAssociationRepository;
-    @Autowired
-    private PlatformTransactionManager transactionManager;
     @MockitoBean
     private NotificationProducer notificationProducer;
 
@@ -964,30 +961,35 @@ class CryptographicKeyServiceITest extends BaseSpringBootTest {
                 (resource.getProperties().containsKey("action") && resource.getProperties().get("action").equals(action));
     }
 
+    /**
+     * The second upload stands in for the losing side of a concurrent race: {@code uploadCertificatePublicKey}
+     * carries no fingerprint pre-check of its own — that guard lives in its callers — so the second call always
+     * reaches the conflict-resolving insert and takes the adopt path. A two-thread version would deadlock, the
+     * holder of the open transaction waiting on a thread blocked inside its own insert.
+     */
     @Test
     void uploadingTheSameKeyTwiceConvergesOnOneKeyAndLeavesNoOrphan() throws Exception {
-        PublicKey publicKey = KeyPairGenerator.getInstance("RSA").generateKeyPair().getPublic();
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        PublicKey publicKey = generator.generateKeyPair().getPublic();
+        int keyLength = KeySizeUtil.getKeyLength(publicKey);
         String fingerprint = CertificateUtil.getThumbprint(
                 Base64.getEncoder().encodeToString(publicKey.getEncoded()).getBytes(StandardCharsets.UTF_8));
-        long itemlessKeysBefore = countItemlessKeys();
 
-        TransactionTemplate template = new TransactionTemplate(transactionManager);
-        UUID firstKeyUuid = template.execute(status -> cryptographicKeyInternalService
-                .uploadCertificatePublicKey("certKey_first", publicKey, 2048, fingerprint));
-        UUID secondKeyUuid = template.execute(status -> cryptographicKeyInternalService
-                .uploadCertificatePublicKey("certKey_second", publicKey, 2048, fingerprint));
+        UUID firstKeyUuid = cryptographicKeyInternalService
+                .uploadCertificatePublicKey("certKey_first", publicKey, keyLength, fingerprint);
+        long keysAfterFirstUpload = cryptographicKeyRepository.count();
+        UUID secondKeyUuid = cryptographicKeyInternalService
+                .uploadCertificatePublicKey("certKey_second", publicKey, keyLength, fingerprint);
 
+        Assertions.assertNotNull(firstKeyUuid);
         Assertions.assertEquals(firstKeyUuid, secondKeyUuid,
                 "the second caller must adopt the surviving key, not the parent it created itself");
-        Assertions.assertTrue(cryptographicKeyItemRepository.findByFingerprint(fingerprint).isPresent());
-        Assertions.assertEquals(itemlessKeysBefore, countItemlessKeys(),
-                "no cryptographic key may be left behind without an item");
-    }
-
-    private long countItemlessKeys() {
-        return cryptographicKeyRepository.findAll().stream()
-                .filter(key -> cryptographicKeyItemRepository.findByKeyUuidIn(List.of(key.getUuid())).isEmpty())
-                .count();
+        Assertions.assertEquals(firstKeyUuid,
+                cryptographicKeyItemRepository.findByFingerprint(fingerprint).orElseThrow().getKey().getUuid(),
+                "the surviving key item must belong to the adopted key");
+        Assertions.assertEquals(keysAfterFirstUpload, cryptographicKeyRepository.count(),
+                "the discarded key must not be left behind");
     }
 
 }


### PR DESCRIPTION
Fixes #1896.

## Problem

`uploadCertificatePublicKey` writes a `CryptographicKey` parent and a `CryptographicKeyItem` child. Only the child is protected against concurrent insertion of the same key — `ON CONFLICT (fingerprint) DO NOTHING` — and `cryptographic_key` has no natural key, so the parent cannot be given an arbiter of its own.

Because that insert returned `void`, a caller whose insert conflicted could not tell it had lost, and returned the parent it had just created. The result was permanent: an orphaned key with no items, and a certificate whose `keyUuid` pointed at a key holding no material, so key detail renders empty and item joins return nothing. Two certificates sharing a public key ended up on different parents while `findKeyByFingerprint` resolved to the winner, so the orphan was never adopted. No cleanup job collects itemless parents, and the `V202508281320` dedup migration groups by *item* fingerprint, so they escaped it.

## Fix

The child insert returns the inserted row count, matching the shape `CertificateRepository.insertWithFingerprintConflictResolve` already uses. On `1` the caller keeps its own parent. On `0` it resolves the surviving key by fingerprint, deletes the parent it created, and returns the survivor.

Deleting that parent is safe: on the conflict path no child row exists, `CryptographicKeyItem.setKey` assigns only `keyUuid` and never populates the inverse `items` collection, so the `CascadeType.ALL` association stays empty; nothing references the fresh UUID before the method returns, and this path creates no owner, group or attribute rows.

If the survivor lookup comes back empty — the winner's item deleted between our conflict and our read — the method throws `IllegalStateException`. That is deliberate over a domain type: both the class and the method declare `noRollbackFor = ValidationException.class`, so a `ValidationException` would leave the partial parent insert committed. `NotFoundException` is checked and would change the signature at all five call sites.

## Notes for review

- **Contract change.** The method may now return a key it did not create. The interface Javadoc says so, since all five call sites depend on it.
- **The test is deliberately sequential.** `uploadCertificatePublicKey` carries no fingerprint pre-check of its own — that guard lives in its callers — so the second call always reaches the conflict and takes the adopt path. It fails on exactly that assertion against the pre-fix code. A two-thread version deadlocks: the holder of the open transaction waits on a thread blocked inside its own insert.
- **Uncovered on new code:** the `survivingKeyUuid == null` branch and its throw. Covering it needs a stubbed repository, which on this test class would fork a new Spring context signature and require bumping `ContextSignatureGuardTest.BASELINE` — a deliberate purchase I did not make here. Flagging it for the coverage gate rather than hiding it.

## Verification

- `CryptographicKeyServiceITest` (30), `CryptographicKeyItemCacheITest` (11), `CertificateValidationITest` (21) — the last exercises `createCertificateAtomic` → `uploadCertificateKey`, which consumes the changed return value.
- `TransactionalBoundaryArchTest`, `NativeQuerySchemaArchTest`, `ExternalServiceAuthorizationArchTest`, `PlatformExceptionTest`, `ContextSignatureGuardTest` all pass with the ArchUnit frozen store unchanged — the frozen violation text carries caller, declaring type and method name, not the return type.

Blocks #1897, which assumes public key upload is race-safe.
