### PR TITLE
Accept and authenticate SCEP renewal without a challenge password

### DIFF
--- a/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
@@ -58,7 +58,6 @@ import org.bouncycastle.cms.CMSProcessableByteArray;
 import org.bouncycastle.cms.CMSSignedDataGenerator;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.pkcs.PKCSException;
-import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -324,11 +323,25 @@ public class ScepServiceImpl implements ScepExternalService {
     }
 
     private ResponseEntity<Object> pkiOperation(byte[] body) throws ScepException {
-        ScepRequest scepRequest;
+        ScepRequest scepRequest = new ScepRequest(body);
+        try {
+            return processPkiOperation(scepRequest);
+        } catch (RuntimeException e) {
+            // An unexpected runtime failure would otherwise escape to the generic error handler and leave
+            // the client with an HTTP 500 JSON body it cannot parse. Answer with a SCEP FAILURE instead, so
+            // the endpoint always responds in application/x-pki-message. The failInfoText is generic on
+            // purpose: internal exception messages are not shaped for the wire.
+            logger.error("Unexpected failure while processing SCEP PKIOperation: transactionId={}",
+                    scepRequest.getTransactionId(), e);
+            return buildResponse(scepRequest, buildFailedResponse(
+                    new ScepException("SCEP request processing failed", FailInfo.BAD_REQUEST),
+                    scepRequest.getTransactionId()));
+        }
+    }
+
+    private ResponseEntity<Object> processPkiOperation(ScepRequest scepRequest) throws ScepException {
         ScepResponse scepResponse;
         IntuneScepServiceClient intuneClient = null;
-
-        scepRequest = new ScepRequest(body);
 
         logger.debug("Processing SCEP request: transactionId={}", scepRequest.getTransactionId());
 
@@ -363,13 +376,14 @@ public class ScepServiceImpl implements ScepExternalService {
             intuneClient = buildIntuneClient(properties);
         }
 
-        // validate challenge password, if configured
         if (scepRequest.getMessageType().equals(MessageType.PKCS_REQ) || scepRequest.getMessageType().equals(MessageType.RENEWAL_REQ)) {
-            if (!validateScepChallengePassword(scepRequest.getChallengePassword())) {
-                return buildResponse(scepRequest, buildFailedResponse(new ScepException("Challenge password validation failed.", FailInfo.BAD_MESSAGE_CHECK), scepRequest.getTransactionId()));
-            }
-            // validate the request POP
             try {
+                // Classify the request before enforcing the shared secret: a renewal authenticates with the
+                // key of the certificate it replaces and legitimately carries no challenge password.
+                boolean authenticatedRenewal = authenticateRenewal(scepRequest);
+                // validate challenge password, if configured
+                validateChallengePassword(scepRequest.getChallengePassword(), authenticatedRenewal);
+                // validate the request POP
                 verifyRequest(scepRequest);
             } catch (ScepException e) {
                 return buildResponse(scepRequest, buildFailedResponse(e, scepRequest.getTransactionId()));
@@ -763,11 +777,32 @@ public class ScepServiceImpl implements ScepExternalService {
         return scepTransactionRepository.findByTransactionId(transactionId).orElse(null);
     }
 
-    private boolean validateScepChallengePassword(String challengePassword) {
-        if (scepProfile.getChallengePassword() == null || scepProfile.getChallengePassword().isEmpty()) {
-            return true;
+    /**
+     * Enforces the challenge password configured on the SCEP profile. A renewal request is signed with
+     * the key of the certificate being replaced and carries no challengePassword attribute
+     * (RFC 8894 §3.3.1.2), so an absent password is accepted once {@link #authenticateRenewal} has
+     * proven possession of that certificate's key. The waiver covers only an absent password: one that
+     * is present must still match, so a wrong shared secret is never silently accepted.
+     *
+     * @throws ScepException with {@link FailInfo#BAD_MESSAGE_CHECK} when the password is missing where
+     *                       required, or does not match the one configured on the profile
+     */
+    void validateChallengePassword(String requestChallengePassword, boolean authenticatedRenewal) throws ScepException {
+        String profileChallengePassword = scepProfile.getChallengePassword();
+        if (profileChallengePassword == null || profileChallengePassword.isEmpty()) {
+            return;
         }
-        return challengePassword.equals(scepProfile.getChallengePassword());
+        if (requestChallengePassword == null) {
+            if (authenticatedRenewal) {
+                logger.debug("Challenge password waived for an authenticated renewal request");
+                return;
+            }
+            throw new ScepException("The SCEP profile requires a challenge password but the request does not contain one.",
+                    FailInfo.BAD_MESSAGE_CHECK);
+        }
+        if (!profileChallengePassword.equals(requestChallengePassword)) {
+            throw new ScepException("Challenge password validation failed.", FailInfo.BAD_MESSAGE_CHECK);
+        }
     }
 
     public void verifyRequest(ScepRequest scepRequest) throws ScepException {
@@ -777,12 +812,9 @@ public class ScepServiceImpl implements ScepExternalService {
             throw new ScepException("Unsupported Operation", FailInfo.BAD_REQUEST);
         }
 
+        // The renewal classification and its validation run in authenticateRenewal, before the challenge
+        // password gate, because a renewal is authenticated by the signer certificate instead of the password.
         if (scepRequest.getMessageType().equals(MessageType.PKCS_REQ)) {
-            // Renewal check must be done for PKCS Request also. According to the RFC Version 3.1.1.2
-            // (https://datatracker.ietf.org/doc/id/draft-nourse-scep-23.txt), RENEWAL_REQ is not part of the message type
-            // Commonly used SCEP clients like JSCEP and SSCEP uses this version of RFC and
-            // may use PKCS_REQ for renewal
-            renewalValidation(scepRequest);
             try {
                 if (!scepRequest.verifyRequest()) {
                     throw new ScepException("Failed to verify PKCS#10 request POP, invalid signature", FailInfo.BAD_REQUEST);
@@ -790,42 +822,75 @@ public class ScepServiceImpl implements ScepExternalService {
             } catch (PKCSException | NoSuchAlgorithmException | InvalidKeyException | OperatorCreationException e) {
                 throw new ScepException("Failed to verify PKCS#10 request POP", FailInfo.BAD_REQUEST);
             }
-        } else if (scepRequest.getMessageType().equals(MessageType.RENEWAL_REQ)) {
-            renewalValidation(scepRequest);
         }
     }
 
-    private void renewalValidation(ScepRequest scepRequest) throws ScepException {
-        JcaPKCS10CertificationRequest pkcs10Request = scepRequest.getPkcs10Request();
-        Certificate extCertificate;
+    /**
+     * Classifies the request as a renewal and validates it when it is one. The classification follows the
+     * signer certificate rather than the message type: per draft-nourse-scep-23 §3.1.1.2 — the version
+     * implemented by common clients such as sscep and jscep — a renewal is a PKCS_REQ signed with the key
+     * of the certificate being replaced.
+     *
+     * @return {@code true} when the request proved possession of a certificate issued under this RA profile
+     *         and may therefore enroll without the profile's challenge password
+     * @throws ScepException when the request is a renewal that must be rejected (unverifiable signature,
+     *                       archived or pending certificate, subject DN mismatch, outside the renewal timeframe)
+     */
+    boolean authenticateRenewal(ScepRequest scepRequest) throws ScepException {
+        Certificate renewedCertificate = resolveRenewedCertificate(scepRequest);
+        if (renewedCertificate == null) {
+            // No known certificate behind the signer: an initial enrollment, not a renewal.
+            return false;
+        }
+        validateRenewal(scepRequest, renewedCertificate);
+        // Waive the challenge password only for a certificate issued under this profile's RA profile:
+        // holding some other RA profile's certificate does not entitle a client to enroll here.
+        return renewedCertificate.getRaProfileUuid() != null
+                && renewedCertificate.getRaProfileUuid().equals(raProfile.getUuid());
+    }
+
+    /**
+     * Resolves the inventory certificate the request is signed with, or {@code null} when the request has
+     * no signer certificate or the platform does not know it — both meaning this is not a renewal.
+     */
+    private Certificate resolveRenewedCertificate(ScepRequest scepRequest) throws ScepException {
+        X509Certificate signerCertificate = scepRequest.getSignerCertificate();
+        if (signerCertificate == null) {
+            return null;
+        }
         try {
-            extCertificate = certificateService.getCertificateEntityByFingerprint(CertificateUtil.getThumbprint(scepRequest.getSignerCertificate()));
+            return certificateService.getCertificateEntityByFingerprint(CertificateUtil.getThumbprint(signerCertificate));
         } catch (NotFoundException e) {
-            // Certificate is not found with the fingerprint. Meaning its not a renewal request. So do nothing
-            return;
+            return null;
         } catch (CertificateEncodingException | NoSuchAlgorithmException e) {
             throw new ScepException("Unable to parse the signer certificate");
         }
-        if (extCertificate.isArchived())
-            throw new ScepException("Certificate with UUID %s is archived. Cannot be renewed by SCEP.".formatted(extCertificate.getUuid()));
-        if (extCertificate.getState() == CertificateState.PENDING_ISSUE
-                || extCertificate.getState() == CertificateState.PENDING_REVOKE) {
-            throw new ScepException("Cannot renew certificate with a pending operation. Finalize or cancel "
-                    + "the pending operation first. Certificate UUID: " + extCertificate.getUuid(),
-                    FailInfo.BAD_REQUEST);
-        }
-        if (!(new X500Name(extCertificate.getSubjectDn())).equals(pkcs10Request.getSubject())) {
-            throw new ScepException("Subject DN for the renewal request does not match the original certificate");
-        }
+    }
+
+    private void validateRenewal(ScepRequest scepRequest, Certificate renewedCertificate) throws ScepException {
+        // Verify possession of the existing certificate's key first: the checks below report the state of
+        // that certificate, which an unauthenticated client must not be able to probe by replaying a
+        // certificate it does not own.
         try {
             if (!scepRequest.verifySignature(scepRequest.getSignerCertificate().getPublicKey())) {
-                throw new ScepException("SCEP Request signature verification failed");
+                throw new ScepException("SCEP Request signature verification failed", FailInfo.BAD_MESSAGE_CHECK);
             }
         } catch (OperatorCreationException | CMSException e) {
-            throw new ScepException("Exception when verifying signature." + e.getMessage());
+            throw new ScepException("Exception when verifying signature." + e.getMessage(), FailInfo.BAD_MESSAGE_CHECK);
+        }
+        if (renewedCertificate.isArchived())
+            throw new ScepException("Certificate with UUID %s is archived. Cannot be renewed by SCEP.".formatted(renewedCertificate.getUuid()));
+        if (renewedCertificate.getState() == CertificateState.PENDING_ISSUE
+                || renewedCertificate.getState() == CertificateState.PENDING_REVOKE) {
+            throw new ScepException("Cannot renew certificate with a pending operation. Finalize or cancel "
+                    + "the pending operation first. Certificate UUID: " + renewedCertificate.getUuid(),
+                    FailInfo.BAD_REQUEST);
+        }
+        if (!(new X500Name(renewedCertificate.getSubjectDn())).equals(scepRequest.getPkcs10Request().getSubject())) {
+            throw new ScepException("Subject DN for the renewal request does not match the original certificate");
         }
         // No need to verify the same key pair used in request since it is already handled by the rekey method in client operations
-        checkRenewalTimeframe(extCertificate);
+        checkRenewalTimeframe(renewedCertificate);
     }
 
     private void checkRenewalTimeframe(Certificate certificate) throws ScepException {

--- a/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
@@ -412,9 +412,15 @@ public class ScepServiceImpl implements ScepExternalService {
             // ScepException covers the undecryptable cases decryptData rejects itself (e.g. a password
             // recipient with no challenge password configured); answering here keeps the response in the
             // SCEP format instead of letting it reach the generic JSON error handler.
-            ScepException failure = e instanceof ScepException scepException
-                    ? scepException
-                    : new ScepException("Unable to decrypt the data. " + e.getMessage(), FailInfo.BAD_REQUEST);
+            ScepException failure;
+            if (e instanceof ScepException scepException) {
+                failure = scepException;
+            } else {
+                // The CMS detail stays in the log: failInfoText is read by an unauthenticated client and
+                // parsing internals are not shaped for the wire.
+                logger.error("Failed to decrypt the SCEP request: transactionId={}", scepRequest.getTransactionId(), e);
+                failure = new ScepException("Unable to decrypt the request data", FailInfo.BAD_REQUEST);
+            }
             return buildResponse(scepRequest, buildFailedResponse(failure, scepRequest.getTransactionId()));
         }
 
@@ -996,6 +1002,13 @@ public class ScepServiceImpl implements ScepExternalService {
         checkRenewalTimeframe(renewedCertificate);
     }
 
+    /**
+     * Applies the profile's renewal window. Callers must have established that the certificate is in a
+     * renewable state — {@link #validateRenewal} rejects revoked, expired and otherwise unusable
+     * certificates for every threshold configuration, which is also why this method no longer repeats that
+     * test on the configured-threshold branch: it was unreachable there, and dereferenced a nullable
+     * validation status to do it.
+     */
     private void checkRenewalTimeframe(Certificate certificate) throws ScepException {
         // Empty renewal threshold or the value 0 will be considered as null value and the half life of the certificate will be assumed
         if (scepProfile.getRenewalThreshold() == null || scepProfile.getRenewalThreshold() == 0) {
@@ -1004,12 +1017,8 @@ public class ScepServiceImpl implements ScepExternalService {
             if (certificate.getValidity() / 2 < certificate.getExpiryInDays()) {
                 throw new ScepException("Cannot renew certificate. Validity exceeds the half life time of certificate", FailInfo.BAD_REQUEST);
             }
-        } else if (certificate.getValidationStatus().equals(CertificateValidationStatus.EXPIRED) || certificate.getState().equals(CertificateState.REVOKED)) {
-            throw new ScepException("Cannot renew certificate. Certificate is already in expired or revoked state", FailInfo.BAD_REQUEST);
-        } else {
-            if (certificate.getExpiryInDays() > scepProfile.getRenewalThreshold()) {
-                throw new ScepException("Cannot renew certificate. Validity exceeds the configured value in SCEP profile", FailInfo.BAD_REQUEST);
-            }
+        } else if (certificate.getExpiryInDays() > scepProfile.getRenewalThreshold()) {
+            throw new ScepException("Cannot renew certificate. Validity exceeds the configured value in SCEP profile", FailInfo.BAD_REQUEST);
         }
     }
 

--- a/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
@@ -22,6 +22,7 @@ import com.otilm.core.attribute.engine.AttributeOperation;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.certificate.request.RequestAttributePolicyViolationException;
 import com.otilm.core.client.ConnectorApiFactory;
+import com.otilm.core.model.request.Pkcs10CertificateRequest;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CryptographicKey;
 import com.otilm.core.dao.entity.CryptographicKeyItem;
@@ -65,11 +66,15 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.NoTransactionException;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.interceptor.TransactionAspectSupport;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
@@ -98,6 +103,14 @@ public class ScepServiceImpl implements ScepExternalService {
             "AES",
             "Renewal",
             "SCEPStandard"
+    );
+    // Validation statuses that make a certificate unusable, and therefore not renewable. EnumSet is used
+    // deliberately: unlike Set.of it tolerates a null argument to contains().
+    private static final Set<CertificateValidationStatus> NON_RENEWABLE_VALIDATION_STATUSES = EnumSet.of(
+            CertificateValidationStatus.REVOKED,
+            CertificateValidationStatus.EXPIRED,
+            CertificateValidationStatus.INVALID,
+            CertificateValidationStatus.FAILED
     );
 
     private IntuneConfigProperties intuneConfigProperties;
@@ -323,19 +336,47 @@ public class ScepServiceImpl implements ScepExternalService {
     }
 
     private ResponseEntity<Object> pkiOperation(byte[] body) throws ScepException {
-        ScepRequest scepRequest = new ScepRequest(body);
+        ScepRequest scepRequest = null;
         try {
+            // Parsing the request belongs inside the guard: the body is attacker-supplied DER and
+            // BouncyCastle reports malformed structures with unchecked exceptions.
+            scepRequest = new ScepRequest(body);
             return processPkiOperation(scepRequest);
         } catch (RuntimeException e) {
             // An unexpected runtime failure would otherwise escape to the generic error handler and leave
             // the client with an HTTP 500 JSON body it cannot parse. Answer with a SCEP FAILURE instead, so
-            // the endpoint always responds in application/x-pki-message. The failInfoText is generic on
-            // purpose: internal exception messages are not shaped for the wire.
-            logger.error("Unexpected failure while processing SCEP PKIOperation: transactionId={}",
-                    scepRequest.getTransactionId(), e);
-            return buildResponse(scepRequest, buildFailedResponse(
-                    new ScepException("SCEP request processing failed", FailInfo.BAD_REQUEST),
-                    scepRequest.getTransactionId()));
+            // the endpoint responds in application/x-pki-message. The failInfoText is generic on purpose:
+            // internal exception messages are not shaped for the wire.
+            String transactionId = scepRequest != null ? scepRequest.getTransactionId() : null;
+            logger.error("Unexpected failure while processing SCEP PKIOperation: transactionId={}", transactionId, e);
+            // Discard whatever the failed attempt wrote before answering.
+            markCurrentTransactionRollbackOnly();
+            try {
+                return buildResponse(scepRequest, buildFailedResponse(
+                        new ScepException("SCEP request processing failed", FailInfo.BAD_REQUEST), transactionId));
+            } catch (Exception failureResponseError) {
+                // Building the failure needs the profile's CA key through the token connector; when that is
+                // what broke, no SCEP message can be produced at all. Answer with a bare status rather than
+                // a JSON body the client cannot parse.
+                logger.error("Failed to build the SCEP failure response", failureResponseError);
+                return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+        }
+    }
+
+    /**
+     * Rolls back the work of a failed PKIOperation without discarding the failure response: a locally set
+     * rollback-only flag makes Spring roll the transaction back at the boundary and still return this
+     * method's value. A flag already set by a nested transactional collaborator is global, and that commit
+     * fails with {@code UnexpectedRollbackException} regardless — guaranteeing the protocol format for a
+     * failure raised inside a nested transaction needs the boundary to sit outside the transaction.
+     */
+    private void markCurrentTransactionRollbackOnly() {
+        try {
+            TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
+        } catch (NoTransactionException e) {
+            // No active transaction (e.g. a unit test driving the service directly) — nothing to roll back.
+            logger.debug("No active transaction to roll back for the failed SCEP request");
         }
     }
 
@@ -367,8 +408,14 @@ public class ScepServiceImpl implements ScepExternalService {
                     cryptographicKeyService.getKeyItemFromKey(scepProfile.getCaCertificate().getKey(), KeyType.PRIVATE_KEY).getKeyAlgorithm(),
                     scepProfile.getChallengePassword()
             );
-        } catch (CMSException e) {
-            return buildResponse(scepRequest, buildFailedResponse(new ScepException("Unable to decrypt the data. " + e.getMessage(), FailInfo.BAD_REQUEST), scepRequest.getTransactionId()));
+        } catch (ScepException | CMSException e) {
+            // ScepException covers the undecryptable cases decryptData rejects itself (e.g. a password
+            // recipient with no challenge password configured); answering here keeps the response in the
+            // SCEP format instead of letting it reach the generic JSON error handler.
+            ScepException failure = e instanceof ScepException scepException
+                    ? scepException
+                    : new ScepException("Unable to decrypt the data. " + e.getMessage(), FailInfo.BAD_REQUEST);
+            return buildResponse(scepRequest, buildFailedResponse(failure, scepRequest.getTransactionId()));
         }
 
         if (scepProfile.isIntuneEnabled()) {
@@ -378,13 +425,10 @@ public class ScepServiceImpl implements ScepExternalService {
 
         if (scepRequest.getMessageType().equals(MessageType.PKCS_REQ) || scepRequest.getMessageType().equals(MessageType.RENEWAL_REQ)) {
             try {
-                // Classify the request before enforcing the shared secret: a renewal authenticates with the
-                // key of the certificate it replaces and legitimately carries no challenge password.
+                // Classify first: the challenge password gate needs the renewal verdict.
                 boolean authenticatedRenewal = authenticateRenewal(scepRequest);
-                // validate challenge password, if configured
                 validateChallengePassword(scepRequest.getChallengePassword(), authenticatedRenewal);
-                // validate the request POP
-                verifyRequest(scepRequest);
+                verifyProofOfPossession(scepRequest);
             } catch (ScepException e) {
                 return buildResponse(scepRequest, buildFailedResponse(e, scepRequest.getTransactionId()));
             }
@@ -439,7 +483,8 @@ public class ScepServiceImpl implements ScepExternalService {
     private ScepResponse buildFailedResponse(ScepException scepException, String transactionId) {
         ScepResponse scepResponse = new ScepResponse();
         scepResponse.setPkiStatus(PkiStatus.FAILURE);
-        scepResponse.setFailInfo(scepException.getFailInfo());
+        // Not every ScepException constructor sets a failInfo, and the response attributes require one.
+        scepResponse.setFailInfo(scepException.getFailInfo() != null ? scepException.getFailInfo() : FailInfo.BAD_REQUEST);
         scepResponse.setFailInfoText(scepException.getMessage());
         if (transactionId != null) {
             scepResponse.setTransactionId(transactionId);
@@ -781,18 +826,20 @@ public class ScepServiceImpl implements ScepExternalService {
      * Enforces the challenge password configured on the SCEP profile. A renewal request is signed with
      * the key of the certificate being replaced and carries no challengePassword attribute
      * (RFC 8894 §3.3.1.2), so an absent password is accepted once {@link #authenticateRenewal} has
-     * proven possession of that certificate's key. The waiver covers only an absent password: one that
-     * is present must still match, so a wrong shared secret is never silently accepted.
+     * proven possession of that certificate's key. Absent covers a blank attribute too — clients are
+     * commonly configured to send an empty challengePassword on renewal. A password that carries a value
+     * must still match, so a wrong shared secret is never silently accepted.
      *
      * @throws ScepException with {@link FailInfo#BAD_MESSAGE_CHECK} when the password is missing where
      *                       required, or does not match the one configured on the profile
      */
+    // package-private for unit tests
     void validateChallengePassword(String requestChallengePassword, boolean authenticatedRenewal) throws ScepException {
         String profileChallengePassword = scepProfile.getChallengePassword();
         if (profileChallengePassword == null || profileChallengePassword.isEmpty()) {
             return;
         }
-        if (requestChallengePassword == null) {
+        if (requestChallengePassword == null || requestChallengePassword.isEmpty()) {
             if (authenticatedRenewal) {
                 logger.debug("Challenge password waived for an authenticated renewal request");
                 return;
@@ -800,20 +847,20 @@ public class ScepServiceImpl implements ScepExternalService {
             throw new ScepException("The SCEP profile requires a challenge password but the request does not contain one.",
                     FailInfo.BAD_MESSAGE_CHECK);
         }
-        if (!profileChallengePassword.equals(requestChallengePassword)) {
+        // Constant-time comparison: the endpoint is unauthenticated and the shared secret is long-lived.
+        if (!MessageDigest.isEqual(profileChallengePassword.getBytes(StandardCharsets.UTF_8),
+                requestChallengePassword.getBytes(StandardCharsets.UTF_8))) {
             throw new ScepException("Challenge password validation failed.", FailInfo.BAD_MESSAGE_CHECK);
         }
     }
 
-    public void verifyRequest(ScepRequest scepRequest) throws ScepException {
+    private void verifyProofOfPossession(ScepRequest scepRequest) throws ScepException {
 
         // Throw exception if the request type is not renewal or issuing a new certificate
         if (!scepRequest.getMessageType().equals(MessageType.RENEWAL_REQ) && !scepRequest.getMessageType().equals(MessageType.PKCS_REQ)) {
             throw new ScepException("Unsupported Operation", FailInfo.BAD_REQUEST);
         }
 
-        // The renewal classification and its validation run in authenticateRenewal, before the challenge
-        // password gate, because a renewal is authenticated by the signer certificate instead of the password.
         if (scepRequest.getMessageType().equals(MessageType.PKCS_REQ)) {
             try {
                 if (!scepRequest.verifyRequest()) {
@@ -831,11 +878,19 @@ public class ScepServiceImpl implements ScepExternalService {
      * implemented by common clients such as sscep and jscep — a renewal is a PKCS_REQ signed with the key
      * of the certificate being replaced.
      *
-     * @return {@code true} when the request proved possession of a certificate issued under this RA profile
-     *         and may therefore enroll without the profile's challenge password
+     * <p>The waiver is deliberately narrower than the renewal itself: it additionally requires the renewed
+     * certificate to be associated with this profile's RA profile and the request to ask for no name the
+     * renewed certificate does not already carry. An RA-profile association can also be set by an operator
+     * on a certificate the platform never issued, so the waiver trusts that association — narrowing it to
+     * proven issuance provenance is tracked separately.</p>
+     *
+     * @return {@code true} when the request proved possession of a certificate of this RA profile and may
+     *         therefore enroll without the profile's challenge password
      * @throws ScepException when the request is a renewal that must be rejected (unverifiable signature,
-     *                       archived or pending certificate, subject DN mismatch, outside the renewal timeframe)
+     *                       archived, pending, revoked or otherwise unusable certificate, subject DN
+     *                       mismatch, outside the renewal timeframe)
      */
+    // package-private for unit tests
     boolean authenticateRenewal(ScepRequest scepRequest) throws ScepException {
         Certificate renewedCertificate = resolveRenewedCertificate(scepRequest);
         if (renewedCertificate == null) {
@@ -843,15 +898,50 @@ public class ScepServiceImpl implements ScepExternalService {
             return false;
         }
         validateRenewal(scepRequest, renewedCertificate);
-        // Waive the challenge password only for a certificate issued under this profile's RA profile:
-        // holding some other RA profile's certificate does not entitle a client to enroll here.
-        return renewedCertificate.getRaProfileUuid() != null
-                && renewedCertificate.getRaProfileUuid().equals(raProfile.getUuid());
+        // Waive the challenge password only for a certificate of this profile's RA profile: holding some
+        // other RA profile's certificate does not entitle a client to enroll here.
+        if (renewedCertificate.getRaProfileUuid() == null
+                || !renewedCertificate.getRaProfileUuid().equals(raProfile.getUuid())) {
+            logger.debug("Challenge password not waived: the signer certificate belongs to another RA profile");
+            return false;
+        }
+        // ... and only when the request asks for no identity the renewed certificate does not already hold,
+        // so a waived renewal cannot obtain a certificate for a name it was never issued.
+        if (!requestedNamesAreAlreadyHeld(scepRequest)) {
+            logger.debug("Challenge password not waived: the request asks for subject alternative names the "
+                    + "renewed certificate does not carry");
+            return false;
+        }
+        return true;
     }
 
     /**
-     * Resolves the inventory certificate the request is signed with, or {@code null} when the request has
-     * no signer certificate or the platform does not know it — both meaning this is not a renewal.
+     * Whether every subject alternative name the request asks for is already present in the certificate
+     * being renewed — which is the request's signer certificate, so no second parse of the inventory
+     * content is needed. Names that cannot be read withhold the waiver rather than guess.
+     */
+    private boolean requestedNamesAreAlreadyHeld(ScepRequest scepRequest) {
+        try {
+            Map<String, List<String>> heldNames = CertificateUtil.getSAN(scepRequest.getSignerCertificate());
+            Map<String, List<String>> requestedNames = new Pkcs10CertificateRequest(
+                    scepRequest.getPkcs10Request().getEncoded()).getSubjectAlternativeNames();
+            for (Map.Entry<String, List<String>> requested : requestedNames.entrySet()) {
+                List<String> held = heldNames.getOrDefault(requested.getKey(), List.of());
+                if (!held.containsAll(requested.getValue())) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (CertificateRequestException | IOException | RuntimeException e) {
+            logger.debug("Unable to compare the subject alternative names of the renewal request", e);
+            return false;
+        }
+    }
+
+    /**
+     * Resolves the inventory certificate the request is signed with, or {@code null} when the platform does
+     * not know it — meaning this is not a renewal. {@code ScepRequest} rejects a message with no resolvable
+     * signer certificate at construction, so the null check below is defense in depth.
      */
     private Certificate resolveRenewedCertificate(ScepRequest scepRequest) throws ScepException {
         X509Certificate signerCertificate = scepRequest.getSignerCertificate();
@@ -876,18 +966,31 @@ public class ScepServiceImpl implements ScepExternalService {
                 throw new ScepException("SCEP Request signature verification failed", FailInfo.BAD_MESSAGE_CHECK);
             }
         } catch (OperatorCreationException | CMSException e) {
-            throw new ScepException("Exception when verifying signature." + e.getMessage(), FailInfo.BAD_MESSAGE_CHECK);
+            logger.debug("Failed to verify the signature of the SCEP request", e);
+            throw new ScepException("Failed to verify the SCEP request signature", FailInfo.BAD_MESSAGE_CHECK);
         }
         if (renewedCertificate.isArchived())
-            throw new ScepException("Certificate with UUID %s is archived. Cannot be renewed by SCEP.".formatted(renewedCertificate.getUuid()));
+            throw new ScepException("Certificate with UUID %s is archived. Cannot be renewed by SCEP.".formatted(renewedCertificate.getUuid()),
+                    FailInfo.BAD_REQUEST);
         if (renewedCertificate.getState() == CertificateState.PENDING_ISSUE
                 || renewedCertificate.getState() == CertificateState.PENDING_REVOKE) {
             throw new ScepException("Cannot renew certificate with a pending operation. Finalize or cancel "
                     + "the pending operation first. Certificate UUID: " + renewedCertificate.getUuid(),
                     FailInfo.BAD_REQUEST);
         }
+        // A certificate that is no longer usable must not be renewable — and must certainly not authenticate
+        // the request in place of the challenge password. checkRenewalTimeframe applies the revoked/expired
+        // test only on the branch where a renewal threshold is configured, so enforce it for every
+        // configuration here, before the timeframe policy runs.
+        if (renewedCertificate.getState() != CertificateState.ISSUED
+                || NON_RENEWABLE_VALIDATION_STATUSES.contains(renewedCertificate.getValidationStatus())) {
+            throw new ScepException("Cannot renew certificate with UUID %s: it is not in a renewable state (state=%s, validation status=%s)"
+                    .formatted(renewedCertificate.getUuid(), renewedCertificate.getState(), renewedCertificate.getValidationStatus()),
+                    FailInfo.BAD_REQUEST);
+        }
         if (!(new X500Name(renewedCertificate.getSubjectDn())).equals(scepRequest.getPkcs10Request().getSubject())) {
-            throw new ScepException("Subject DN for the renewal request does not match the original certificate");
+            throw new ScepException("Subject DN for the renewal request does not match the original certificate",
+                    FailInfo.BAD_REQUEST);
         }
         // No need to verify the same key pair used in request since it is already handled by the rekey method in client operations
         checkRenewalTimeframe(renewedCertificate);

--- a/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
@@ -22,7 +22,6 @@ import com.otilm.core.attribute.engine.AttributeOperation;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.certificate.request.RequestAttributePolicyViolationException;
 import com.otilm.core.client.ConnectorApiFactory;
-import com.otilm.core.model.request.Pkcs10CertificateRequest;
 import com.otilm.core.dao.entity.Certificate;
 import com.otilm.core.dao.entity.CryptographicKey;
 import com.otilm.core.dao.entity.CryptographicKeyItem;
@@ -52,13 +51,21 @@ import com.otilm.core.util.CertificateUtil;
 import com.otilm.core.util.CertificateEligibilityUtil;
 import com.otilm.core.util.CertificateRequestUtils;
 import com.otilm.core.util.RandomUtil;
+import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.pkcs.Attribute;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.cert.jcajce.JcaCertStore;
 import org.bouncycastle.cms.CMSException;
 import org.bouncycastle.cms.CMSProcessableByteArray;
 import org.bouncycastle.cms.CMSSignedDataGenerator;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.pkcs.PKCSException;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -104,12 +111,17 @@ public class ScepServiceImpl implements ScepExternalService {
             "Renewal",
             "SCEPStandard"
     );
-    // Validation statuses that make a certificate unusable, and therefore not renewable. EnumSet is used
-    // deliberately: unlike Set.of it tolerates a null argument to contains().
+    // The principle: reject only on evidence that the certificate itself is unusable. EnumSet is used
+    // deliberately here and below: unlike Set.of it tolerates a null argument to contains().
     private static final Set<CertificateValidationStatus> NON_RENEWABLE_VALIDATION_STATUSES = EnumSet.of(
             CertificateValidationStatus.REVOKED,
             CertificateValidationStatus.EXPIRED,
-            CertificateValidationStatus.INVALID,
+            CertificateValidationStatus.INVALID
+    );
+    // FAILED means the platform could not complete validation (an unreachable CRL or OCSP responder), which
+    // is not evidence against the certificate — so it does not reject the renewal. It is not evidence for the
+    // certificate either, so it withholds the challenge password waiver and the shared secret is required.
+    private static final Set<CertificateValidationStatus> INCONCLUSIVE_VALIDATION_STATUSES = EnumSet.of(
             CertificateValidationStatus.FAILED
     );
 
@@ -342,19 +354,27 @@ public class ScepServiceImpl implements ScepExternalService {
             // BouncyCastle reports malformed structures with unchecked exceptions.
             scepRequest = new ScepRequest(body);
             return processPkiOperation(scepRequest);
-        } catch (RuntimeException e) {
-            // An unexpected runtime failure would otherwise escape to the generic error handler and leave
-            // the client with an HTTP 500 JSON body it cannot parse. Answer with a SCEP FAILURE instead, so
-            // the endpoint responds in application/x-pki-message. The failInfoText is generic on purpose:
-            // internal exception messages are not shaped for the wire.
-            String transactionId = scepRequest != null ? scepRequest.getTransactionId() : null;
+        } catch (Exception e) {
+            // Any failure here would otherwise escape to the generic error handler and leave the client with a
+            // JSON body it cannot parse — including the checked ScepException that response building raises
+            // when signing fails. Answer with a SCEP FAILURE instead, so the endpoint responds in
+            // application/x-pki-message. The failInfoText is generic on purpose: internal exception messages
+            // are not shaped for the wire.
+            if (scepRequest == null) {
+                // The message did not parse, so there is no transaction id or nonce to echo and no SCEP
+                // response can be formed. Surface it as a protocol-level error instead.
+                logger.error("Failed to parse the SCEP PKIOperation request", e);
+                throw e instanceof ScepException scepException ? scepException
+                        : new ScepException("Failed to parse the SCEP request", FailInfo.BAD_REQUEST);
+            }
+            String transactionId = scepRequest.getTransactionId();
             logger.error("Unexpected failure while processing SCEP PKIOperation: transactionId={}", transactionId, e);
             // Discard whatever the failed attempt wrote before answering.
             markCurrentTransactionRollbackOnly();
             try {
                 return buildResponse(scepRequest, buildFailedResponse(
                         new ScepException("SCEP request processing failed", FailInfo.BAD_REQUEST), transactionId));
-            } catch (Exception failureResponseError) {
+            } catch (Exception failureResponseError) { // NOSONAR - the fallback must not itself escape
                 // Building the failure needs the profile's CA key through the token connector; when that is
                 // what broke, no SCEP message can be produced at all. Answer with a bare status rather than
                 // a JSON body the client cannot parse.
@@ -920,6 +940,12 @@ public class ScepServiceImpl implements ScepExternalService {
             logger.debug("Challenge password not waived: the signer certificate belongs to another RA profile");
             return false;
         }
+        // ... nor when the platform could not establish that the certificate is still valid.
+        if (INCONCLUSIVE_VALIDATION_STATUSES.contains(renewedCertificate.getValidationStatus())) {
+            logger.debug("Challenge password not waived: validation of certificate {} is inconclusive (status={})",
+                    renewedCertificate.getUuid(), renewedCertificate.getValidationStatus());
+            return false;
+        }
         // ... and only when the request asks for no identity the renewed certificate does not already hold,
         // so a waived renewal cannot obtain a certificate for a name it was never issued.
         if (!requestedNamesAreAlreadyHeld(scepRequest)) {
@@ -937,20 +963,45 @@ public class ScepServiceImpl implements ScepExternalService {
      */
     private boolean requestedNamesAreAlreadyHeld(ScepRequest scepRequest) {
         try {
-            Map<String, List<String>> heldNames = CertificateUtil.getSAN(scepRequest.getSignerCertificate());
-            Map<String, List<String>> requestedNames = new Pkcs10CertificateRequest(
-                    scepRequest.getPkcs10Request().getEncoded()).getSubjectAlternativeNames();
-            for (Map.Entry<String, List<String>> requested : requestedNames.entrySet()) {
-                List<String> held = heldNames.getOrDefault(requested.getKey(), List.of());
-                if (!held.containsAll(requested.getValue())) {
-                    return false;
-                }
-            }
-            return true;
-        } catch (CertificateRequestException | IOException | RuntimeException e) {
+            return subjectAlternativeNames(scepRequest.getSignerCertificate())
+                    .containsAll(subjectAlternativeNames(scepRequest.getPkcs10Request()));
+        } catch (RuntimeException e) {
             logger.debug("Unable to compare the subject alternative names of the renewal request", e);
             return false;
         }
+    }
+
+    /**
+     * The names carried by the certificate being renewed, as DER structures. The comparison is deliberately
+     * made on the encoded form rather than on the platform's string rendering of it: the renderings disagree
+     * for an iPAddress — decoded text on the certificate side, a hex octet string on the request side — which
+     * would withhold the waiver from a device renewing on an address it already holds.
+     */
+    private static Set<GeneralName> subjectAlternativeNames(X509Certificate certificate) {
+        byte[] extension = certificate.getExtensionValue(Extension.subjectAlternativeName.getId());
+        if (extension == null) {
+            return Set.of();
+        }
+        return namesOf(GeneralNames.getInstance(ASN1OctetString.getInstance(extension).getOctets()));
+    }
+
+    /** The names the request asks for, read from its extensionRequest attribute as DER structures. */
+    private static Set<GeneralName> subjectAlternativeNames(JcaPKCS10CertificationRequest pkcs10Request) {
+        for (Attribute attribute : pkcs10Request.getAttributes(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest)) {
+            if (attribute.getAttrValues().size() == 0) {
+                continue;
+            }
+            GeneralNames names = GeneralNames.fromExtensions(
+                    Extensions.getInstance(attribute.getAttrValues().getObjectAt(0)), Extension.subjectAlternativeName);
+            if (names != null) {
+                return namesOf(names);
+            }
+        }
+        return Set.of();
+    }
+
+    private static Set<GeneralName> namesOf(GeneralNames names) {
+        return new HashSet<>(Arrays.asList(names.getNames()));
     }
 
     /**
@@ -1003,6 +1054,9 @@ public class ScepServiceImpl implements ScepExternalService {
                     .formatted(renewedCertificate.getUuid(), renewedCertificate.getState(), renewedCertificate.getValidationStatus()),
                     FailInfo.BAD_REQUEST);
         }
+        // A subject DN mismatch rejects the request rather than merely withholding the waiver, which is the
+        // behaviour that predates the waiver: signing with a certificate and then asking for a different
+        // subject is treated as a malformed renewal, not as an enrollment the shared secret could authorize.
         if (!(new X500Name(renewedCertificate.getSubjectDn())).equals(scepRequest.getPkcs10Request().getSubject())) {
             throw new ScepException("Subject DN for the renewal request does not match the original certificate",
                     FailInfo.BAD_REQUEST);

--- a/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
@@ -381,33 +381,10 @@ public class ScepServiceImpl implements ScepExternalService {
     }
 
     private ResponseEntity<Object> processPkiOperation(ScepRequest scepRequest) throws ScepException {
-        ScepResponse scepResponse;
-        IntuneScepServiceClient intuneClient = null;
-
         logger.debug("Processing SCEP request: transactionId={}", scepRequest.getTransactionId());
 
-        CryptographicKey key = scepProfile.getCaCertificate().getKey();
-        CryptographicKeyItem item = cryptographicKeyService.getKeyItemFromKey(key, KeyType.PRIVATE_KEY);
-        var connectorDto = key.getTokenInstanceReference().getConnector().mapToDto();
-        // Get the private key from the configuration of SCEP Profile
-        PlatformPrivateKey privateKey = new PlatformPrivateKey(
-                key.getTokenInstanceReference().getTokenInstanceUuid(),
-                item.getKeyReferenceUuid().toString(),
-                connectorDto,
-                item.getKeyAlgorithm().getLabel()
-        );
-
-        CryptographicOperationsSyncApiClient cryptoApiClient = connectorApiFactory.getCryptographicOperationsApiClient(connectorDto);
-        PlatformProvider provider = PlatformProvider.getInstance(scepProfile.getName(), true, cryptoApiClient);
-
-        // decrypt the PKCS#10 request
         try {
-            scepRequest.decryptData(
-                    privateKey,
-                    provider,
-                    cryptographicKeyService.getKeyItemFromKey(scepProfile.getCaCertificate().getKey(), KeyType.PRIVATE_KEY).getKeyAlgorithm(),
-                    scepProfile.getChallengePassword()
-            );
+            decryptRequestData(scepRequest);
         } catch (ScepException | CMSException e) {
             // ScepException covers the undecryptable cases decryptData rejects itself (e.g. a password
             // recipient with no challenge password configured); answering here keeps the response in the
@@ -424,10 +401,9 @@ public class ScepServiceImpl implements ScepExternalService {
             return buildResponse(scepRequest, buildFailedResponse(failure, scepRequest.getTransactionId()));
         }
 
-        if (scepProfile.isIntuneEnabled()) {
-            Properties properties = getIntuneConfiguration();
-            intuneClient = buildIntuneClient(properties);
-        }
+        IntuneScepServiceClient intuneClient = scepProfile.isIntuneEnabled()
+                ? buildIntuneClient(getIntuneConfiguration())
+                : null;
 
         if (scepRequest.getMessageType().equals(MessageType.PKCS_REQ) || scepRequest.getMessageType().equals(MessageType.RENEWAL_REQ)) {
             try {
@@ -440,50 +416,83 @@ public class ScepServiceImpl implements ScepExternalService {
             }
         }
 
+        return buildResponse(scepRequest, resolveResponse(scepRequest, intuneClient));
+    }
+
+    /** Decrypts the enveloped PKCS#10 request with the private key of the SCEP profile's CA certificate. */
+    private void decryptRequestData(ScepRequest scepRequest) throws ScepException, CMSException {
+        CryptographicKey key = scepProfile.getCaCertificate().getKey();
+        CryptographicKeyItem item = cryptographicKeyService.getKeyItemFromKey(key, KeyType.PRIVATE_KEY);
+        var connectorDto = key.getTokenInstanceReference().getConnector().mapToDto();
+        // Get the private key from the configuration of SCEP Profile
+        PlatformPrivateKey privateKey = new PlatformPrivateKey(
+                key.getTokenInstanceReference().getTokenInstanceUuid(),
+                item.getKeyReferenceUuid().toString(),
+                connectorDto,
+                item.getKeyAlgorithm().getLabel()
+        );
+
+        CryptographicOperationsSyncApiClient cryptoApiClient = connectorApiFactory.getCryptographicOperationsApiClient(connectorDto);
+        PlatformProvider provider = PlatformProvider.getInstance(scepProfile.getName(), true, cryptoApiClient);
+
+        scepRequest.decryptData(privateKey, provider, item.getKeyAlgorithm(), scepProfile.getChallengePassword());
+    }
+
+    /** Produces the response body for a request that has been decrypted and, where applicable, authenticated. */
+    private ScepResponse resolveResponse(ScepRequest scepRequest, IntuneScepServiceClient intuneClient) throws ScepException {
         if (scepTransactionRepository.existsByTransactionIdAndScepProfile(scepRequest.getTransactionId(), scepProfile)) {
             LoggingHelper.putAuditLogOperation(Operation.SCEP_TRANSACTION_CHECK);
-            try {
-                scepResponse = getExistingTransaction(scepRequest.getTransactionId());
-            } catch (ScepException e) {
-                scepResponse = buildFailedResponse(new ScepException("Error while formatting certificate", FailInfo.BAD_REQUEST), scepRequest.getTransactionId());
-            } catch (NotFoundException e) {
-                scepResponse = buildFailedResponse(new ScepException("Transaction certificate not found", FailInfo.BAD_REQUEST), scepRequest.getTransactionId());
+            return existingTransactionResponse(scepRequest);
+        }
+        if (scepRequest.getMessageType().equals(MessageType.PKCS_REQ)) {
+            return enrollmentResponse(scepRequest, intuneClient);
+        }
+        if (scepRequest.getMessageType().equals(MessageType.CERT_POLL)) {
+            LoggingHelper.putAuditLogOperation(Operation.SCEP_CERTIFICATE_POLL);
+            return pollCertificate(scepRequest, intuneClient);
+        }
+        return buildFailedResponse(new ScepException("Unsupported Operation. The requested operation is not supported", FailInfo.BAD_REQUEST), scepRequest.getTransactionId());
+    }
+
+    private ScepResponse existingTransactionResponse(ScepRequest scepRequest) {
+        try {
+            return getExistingTransaction(scepRequest.getTransactionId());
+        } catch (ScepException e) {
+            return buildFailedResponse(new ScepException("Error while formatting certificate", FailInfo.BAD_REQUEST), scepRequest.getTransactionId());
+        } catch (NotFoundException e) {
+            return buildFailedResponse(new ScepException("Transaction certificate not found", FailInfo.BAD_REQUEST), scepRequest.getTransactionId());
+        }
+    }
+
+    private ScepResponse enrollmentResponse(ScepRequest scepRequest, IntuneScepServiceClient intuneClient) {
+        try {
+            // Reject before issuing when the response could never be delivered, so the platform
+            // does not commit a certificate the client can never retrieve (RFC 8894 §3.2.2).
+            verifyResponseEnvelopable(scepRequest);
+            // Manual approval for the SCEP clients are configured in the SCEP Profile.
+            // If the SCEP Profile has the manual approval set to true, only the CSR will be generated
+            if (scepProfile.getRequireManualApproval() != null && !scepProfile.getRequireManualApproval()) {
+                LoggingHelper.putAuditLogOperation(Operation.ISSUE);
+                return issueCertificate(scepRequest, intuneClient);
             }
-        } else if (scepRequest.getMessageType().equals(MessageType.PKCS_REQ)) {
-            try {
-                // Reject before issuing when the response could never be delivered, so the platform
-                // does not commit a certificate the client can never retrieve (RFC 8894 §3.2.2).
-                verifyResponseEnvelopable(scepRequest);
-                // Manual approval for the SCEP clients are configured in the SCEP Profile.
-                // If the SCEP Profile has the manual approval set to true, only the CSR will be generated
-                if (scepProfile.getRequireManualApproval() != null && !scepProfile.getRequireManualApproval()) {
-                    LoggingHelper.putAuditLogOperation(Operation.ISSUE);
-                    scepResponse = issueCertificate(scepRequest, intuneClient);
-                } else {
-                    LoggingHelper.putAuditLogOperation(Operation.REQUEST);
-                    scepResponse = generateCsr(scepRequest, intuneClient);
-                }
-            } catch (ScepException e) {
-                scepResponse = buildFailedResponse(e, scepRequest.getTransactionId());
+            LoggingHelper.putAuditLogOperation(Operation.REQUEST);
+            return generateCsr(scepRequest, intuneClient);
+        } catch (ScepException e) {
+            ScepResponse failureResponse = buildFailedResponse(e, scepRequest.getTransactionId());
+            if (scepProfile.isIntuneEnabled()) {
                 // 32-bit error code formulated using the instructions specified in https://msdn.microsoft.com/en-us/library/cc231198.aspx
                 // this is a vendor specific error code
-                final long errorCode = 0x20000000L + e.getFailInfo().getValue();
-                if (scepProfile.isIntuneEnabled()) {
-                    sendIntuneFailureMessage(
-                            intuneClient,
-                            scepRequest,
-                            errorCode,
-                            e.getMessage().substring(0, Math.min(e.getMessage().length(), 255))
-                    );
-                }
+                FailInfo failInfo = e.getFailInfo() != null ? e.getFailInfo() : FailInfo.BAD_REQUEST;
+                String detail = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+                sendIntuneFailureMessage(
+                        intuneClient,
+                        scepRequest,
+                        0x20000000L + failInfo.getValue(),
+                        detail.substring(0, Math.min(detail.length(), 255))
+                );
             }
-        } else if (scepRequest.getMessageType().equals(MessageType.CERT_POLL)) {
-            LoggingHelper.putAuditLogOperation(Operation.SCEP_CERTIFICATE_POLL);
-            scepResponse = pollCertificate(scepRequest, intuneClient);
-        } else {
-            scepResponse = buildFailedResponse(new ScepException("Unsupported Operation. The requested operation is not supported", FailInfo.BAD_REQUEST), scepRequest.getTransactionId());
+            return failureResponse;
         }
-        return buildResponse(scepRequest, scepResponse);
     }
 
     private ScepResponse buildFailedResponse(ScepException scepException, String transactionId) {

--- a/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/scep/impl/ScepServiceImpl.java
@@ -439,7 +439,7 @@ public class ScepServiceImpl implements ScepExternalService {
     }
 
     /** Produces the response body for a request that has been decrypted and, where applicable, authenticated. */
-    private ScepResponse resolveResponse(ScepRequest scepRequest, IntuneScepServiceClient intuneClient) throws ScepException {
+    private ScepResponse resolveResponse(ScepRequest scepRequest, IntuneScepServiceClient intuneClient) {
         if (scepTransactionRepository.existsByTransactionIdAndScepProfile(scepRequest.getTransactionId(), scepProfile)) {
             LoggingHelper.putAuditLogOperation(Operation.SCEP_TRANSACTION_CHECK);
             return existingTransactionResponse(scepRequest);

--- a/src/main/java/com/otilm/core/service/scep/message/ScepRequest.java
+++ b/src/main/java/com/otilm/core/service/scep/message/ScepRequest.java
@@ -324,7 +324,11 @@ public class ScepRequest {
                 decryptedData = recipient.getContent(jcePasswordEnvelopedRecipient);
             }
         }
-        assert decryptedData != null;
+        // A bare assert is a no-op in production: an EnvelopedData carrying no recipientInfo would skip the
+        // block above and reach the PKCS#10 parse with no content.
+        if (decryptedData == null) {
+            throw new ScepException("The SCEP request contains no recipient information to decrypt", FailInfo.BAD_REQUEST);
+        }
         try {
             if (messageType.equals(MessageType.PKCS_REQ) || messageType.equals(MessageType.RENEWAL_REQ)) {
                 pkcs10Request = new JcaPKCS10CertificationRequest(decryptedData);

--- a/src/main/java/com/otilm/core/service/scep/message/ScepRequest.java
+++ b/src/main/java/com/otilm/core/service/scep/message/ScepRequest.java
@@ -313,6 +313,12 @@ public class ScepRequest {
                     throw new ScepException(errorMessage, e, FailInfo.BAD_REQUEST);
                 }
             } else {
+                // A non-key-transport CA key can only unwrap the RFC 8894 password recipient, which needs
+                // the shared challenge password: without one the request is undecryptable, not malformed.
+                if (challengePassword == null || challengePassword.isEmpty()) {
+                    throw new ScepException("A challenge password must be configured on the SCEP profile to decrypt "
+                            + "requests enveloped to a non-RSA CA key", FailInfo.BAD_ALG);
+                }
                 JcePasswordEnvelopedRecipient jcePasswordEnvelopedRecipient = new JcePasswordEnvelopedRecipient(challengePassword.toCharArray());
                 jcePasswordEnvelopedRecipient.setProvider(BouncyCastleProvider.PROVIDER_NAME);
                 decryptedData = recipient.getContent(jcePasswordEnvelopedRecipient);

--- a/src/test/java/com/otilm/core/integration/service/scep/ScepPkiOperationITest.java
+++ b/src/test/java/com/otilm/core/integration/service/scep/ScepPkiOperationITest.java
@@ -9,6 +9,7 @@ import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.certificate.CertificateValidationStatus;
 import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.core.scep.FailInfo;
+import com.otilm.api.model.core.scep.MessageType;
 import com.otilm.api.model.core.scep.PkiStatus;
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.Certificate;
@@ -18,6 +19,7 @@ import com.otilm.core.dao.entity.CryptographicKey;
 import com.otilm.core.dao.entity.RaProfile;
 import com.otilm.core.dao.entity.TokenInstanceReference;
 import com.otilm.core.dao.entity.scep.ScepProfile;
+import com.otilm.core.dao.entity.scep.ScepTransaction;
 import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
 import com.otilm.core.dao.repository.CertificateContentRepository;
 import com.otilm.core.dao.repository.CertificateRepository;
@@ -25,6 +27,7 @@ import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.RaProfileRepository;
 import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
 import com.otilm.core.dao.repository.scep.ScepProfileRepository;
+import com.otilm.core.dao.repository.scep.ScepTransactionRepository;
 import com.otilm.core.service.scep.ScepExternalService;
 import com.otilm.core.service.scep.ScepMessageTestData;
 import com.otilm.core.service.scep.impl.ScepServiceImpl;
@@ -56,6 +59,7 @@ import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Date;
+import java.util.UUID;
 
 import static com.otilm.core.util.seeders.CryptographicKeySeeder.KeyItemSpec.signingPrivateKey;
 import static com.otilm.core.util.seeders.CryptographicKeySeeder.KeyItemSpec.verifyingPublicKey;
@@ -101,10 +105,13 @@ class ScepPkiOperationITest extends BaseSpringBootTest {
     @Autowired
     private TokenInstanceReferenceRepository tokenInstanceReferenceRepository;
     @Autowired
+    private ScepTransactionRepository scepTransactionRepository;
+    @Autowired
     private CryptographicKeySeeder cryptographicKeySeeder;
 
     private WireMockServer mockServer;
     private RaProfile raProfile;
+    private ScepProfile scepProfile;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -149,7 +156,7 @@ class ScepPkiOperationITest extends BaseSpringBootTest {
 
         Certificate caCertificate = storeCertificate(selfSignedEcCertificate(caKeyPair), caKey, null);
 
-        ScepProfile scepProfile = new ScepProfile();
+        scepProfile = new ScepProfile();
         scepProfile.setName(SCEP_PROFILE_NAME);
         scepProfile.setDescription("PKIOperation end-to-end profile");
         scepProfile.setEnabled(true);
@@ -158,7 +165,7 @@ class ScepPkiOperationITest extends BaseSpringBootTest {
         scepProfile.setChallengePassword(ScepMessageTestData.CHALLENGE_PASSWORD);
         scepProfile.setCaCertificate(caCertificate);
         scepProfile.setRaProfile(raProfile);
-        scepProfileRepository.save(scepProfile);
+        scepProfile = scepProfileRepository.save(scepProfile);
 
         stubTokenSigning();
     }
@@ -209,6 +216,75 @@ class ScepPkiOperationITest extends BaseSpringBootTest {
         assertScepFormatted(response);
         assertNotEquals(FailInfo.BAD_MESSAGE_CHECK.getValue(), Integer.parseInt(attribute(response, ScepConstants.id_failInfo)),
                 "a matching challenge password must not be reported as an integrity failure");
+    }
+
+    /**
+     * A request whose transaction is already known is answered from that transaction rather than enrolled
+     * again. PENDING is the discriminator: only the transaction branch can produce it for this profile,
+     * which has manual approval disabled.
+     */
+    @Test
+    void knownTransaction_isAnsweredFromTheTransaction() throws Exception {
+        // A certificate unrelated to the request's signer, so the request is not classified as its renewal.
+        Certificate pending = storeCertificate(
+                selfSignedEcCertificate(KeyPairGenerator.getInstance("EC").generateKeyPair()), null, raProfile);
+        pending.setState(CertificateState.PENDING_ISSUE);
+        certificateRepository.save(pending);
+        storeTransaction(pending.getUuid());
+
+        ResponseEntity<Object> response = scepService.handlePost(
+                SCEP_PROFILE_NAME, ScepServiceImpl.SCEP_OPERATION_PKI_OPERATION,
+                ScepMessageTestData.passwordEnvelopedPkcsReq(ScepMessageTestData.CHALLENGE_PASSWORD));
+
+        assertScepFormatted(response);
+        assertEquals(String.valueOf(PkiStatus.PENDING.getValue()), attribute(response, ScepConstants.id_pkiStatus));
+    }
+
+    /**
+     * A request the platform cannot decrypt — enveloped to a password the profile does not hold — is
+     * answered as a SCEP failure rather than escaping as a checked exception to the JSON error handler.
+     */
+    @Test
+    void undecryptableRequest_isAnsweredAsAScepFailure() throws Exception {
+        ResponseEntity<Object> response = scepService.handlePost(
+                SCEP_PROFILE_NAME, ScepServiceImpl.SCEP_OPERATION_PKI_OPERATION,
+                ScepMessageTestData.pkcsReqEnvelopedWith("someOtherPassword"));
+
+        assertScepFormatted(response);
+        assertEquals(String.valueOf(PkiStatus.FAILURE.getValue()), attribute(response, ScepConstants.id_pkiStatus));
+        assertEquals(String.valueOf(FailInfo.BAD_REQUEST.getValue()), attribute(response, ScepConstants.id_failInfo));
+    }
+
+    /** A CertPoll message is dispatched to polling rather than treated as an enrollment. */
+    @Test
+    void certPoll_isAnsweredInScepFormat() throws Exception {
+        ResponseEntity<Object> response = scepService.handlePost(
+                SCEP_PROFILE_NAME, ScepServiceImpl.SCEP_OPERATION_PKI_OPERATION,
+                ScepMessageTestData.passwordEnvelopedMessage(MessageType.CERT_POLL, null));
+
+        assertScepFormatted(response);
+    }
+
+    /**
+     * RENEWAL_REQ (message type 17) is validated but has no issuance branch, so it is reported as an
+     * unsupported operation — tracked for implementation in #1901.
+     */
+    @Test
+    void renewalReqMessageType_isReportedUnsupported() throws Exception {
+        ResponseEntity<Object> response = scepService.handlePost(
+                SCEP_PROFILE_NAME, ScepServiceImpl.SCEP_OPERATION_PKI_OPERATION,
+                ScepMessageTestData.passwordEnvelopedMessage(MessageType.RENEWAL_REQ, ScepMessageTestData.CHALLENGE_PASSWORD));
+
+        assertScepFormatted(response);
+        assertEquals(String.valueOf(FailInfo.BAD_REQUEST.getValue()), attribute(response, ScepConstants.id_failInfo));
+    }
+
+    private void storeTransaction(UUID certificateUuid) {
+        ScepTransaction transaction = new ScepTransaction();
+        transaction.setTransactionId(ScepMessageTestData.TRANSACTION_ID);
+        transaction.setCertificateUuid(certificateUuid);
+        transaction.setScepProfile(scepProfile);
+        scepTransactionRepository.save(transaction);
     }
 
     private void assertScepFormatted(ResponseEntity<Object> response) throws Exception {

--- a/src/test/java/com/otilm/core/integration/service/scep/ScepPkiOperationITest.java
+++ b/src/test/java/com/otilm/core/integration/service/scep/ScepPkiOperationITest.java
@@ -1,0 +1,306 @@
+package com.otilm.core.integration.service.scep;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.otilm.api.model.client.connector.v2.ConnectorVersion;
+import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.otilm.api.model.common.enums.cryptography.KeyFormat;
+import com.otilm.api.model.core.certificate.CertificateState;
+import com.otilm.api.model.core.certificate.CertificateValidationStatus;
+import com.otilm.api.model.core.connector.ConnectorStatus;
+import com.otilm.api.model.core.scep.FailInfo;
+import com.otilm.api.model.core.scep.PkiStatus;
+import com.otilm.core.dao.entity.AuthorityInstanceReference;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.CertificateContent;
+import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.entity.CryptographicKey;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.dao.entity.TokenInstanceReference;
+import com.otilm.core.dao.entity.scep.ScepProfile;
+import com.otilm.core.dao.repository.AuthorityInstanceReferenceRepository;
+import com.otilm.core.dao.repository.CertificateContentRepository;
+import com.otilm.core.dao.repository.CertificateRepository;
+import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.dao.repository.RaProfileRepository;
+import com.otilm.core.dao.repository.TokenInstanceReferenceRepository;
+import com.otilm.core.dao.repository.scep.ScepProfileRepository;
+import com.otilm.core.service.scep.ScepExternalService;
+import com.otilm.core.service.scep.ScepMessageTestData;
+import com.otilm.core.service.scep.impl.ScepServiceImpl;
+import com.otilm.core.service.scep.message.ScepConstants;
+import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.CertificateUtil;
+import com.otilm.core.util.seeders.CryptographicKeySeeder;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.ASN1String;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.cms.CMSSignedData;
+import org.bouncycastle.cms.SignerInformation;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Date;
+
+import static com.otilm.core.util.seeders.CryptographicKeySeeder.KeyItemSpec.signingPrivateKey;
+import static com.otilm.core.util.seeders.CryptographicKeySeeder.KeyItemSpec.verifyingPublicKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * End-to-end PKIOperation tests: a real signed CMS PKCSReq goes in, and the assertion is on what a SCEP
+ * client actually receives. Issue #1887 was a renewal request answered with an {@code application/json}
+ * HTTP 500 the client cannot parse, so the contract under test is that the endpoint always replies in
+ * {@code application/x-pki-message}.
+ *
+ * <p>The profile's CA key is EC, so the request's password recipient is opened with the challenge password
+ * and no connector decrypt call is needed. Signing the response does go through the token connector, which
+ * WireMock stubs — the returned signature is not independently verified, so a well-formed value suffices to
+ * exercise the real response-building path. Issuance is deliberately left unstubbed: these tests are about
+ * the protocol envelope, not about the authority.</p>
+ */
+class ScepPkiOperationITest extends BaseSpringBootTest {
+
+    private static final String SCEP_PROFILE_NAME = "pkiOperationProfile";
+    private static final String CA_DN = "CN=Test SCEP CA";
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    @Autowired
+    private ScepExternalService scepService;
+    @Autowired
+    private ScepProfileRepository scepProfileRepository;
+    @Autowired
+    private RaProfileRepository raProfileRepository;
+    @Autowired
+    private CertificateRepository certificateRepository;
+    @Autowired
+    private CertificateContentRepository certificateContentRepository;
+    @Autowired
+    private ConnectorRepository connectorRepository;
+    @Autowired
+    private AuthorityInstanceReferenceRepository authorityInstanceReferenceRepository;
+    @Autowired
+    private TokenInstanceReferenceRepository tokenInstanceReferenceRepository;
+    @Autowired
+    private CryptographicKeySeeder cryptographicKeySeeder;
+
+    private WireMockServer mockServer;
+    private RaProfile raProfile;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockServer = new WireMockServer(0);
+        mockServer.start();
+        WireMock.configureFor("localhost", mockServer.port());
+
+        Connector connector = new Connector();
+        connector.setName("scepTestConnector");
+        connector.setUrl("http://localhost:" + mockServer.port());
+        connector.setVersion(ConnectorVersion.V1);
+        connector.setStatus(ConnectorStatus.CONNECTED);
+        connector = connectorRepository.save(connector);
+
+        AuthorityInstanceReference authorityInstance = new AuthorityInstanceReference();
+        authorityInstance.setName("scepTestAuthority");
+        authorityInstance.setConnector(connector);
+        authorityInstance.setConnectorUuid(connector.getUuid());
+        authorityInstance.setKind("sample");
+        authorityInstance.setAuthorityInstanceUuid("1l");
+        authorityInstance = authorityInstanceReferenceRepository.save(authorityInstance);
+
+        raProfile = new RaProfile();
+        raProfile.setName("scepTestRaProfile");
+        raProfile.setEnabled(true);
+        raProfile.setAuthorityInstanceReference(authorityInstance);
+        raProfile = raProfileRepository.save(raProfile);
+
+        TokenInstanceReference tokenInstance = new TokenInstanceReference();
+        tokenInstance.setName("scepTestTokenInstance");
+        tokenInstance.setConnector(connector);
+        tokenInstance.setConnectorUuid(connector.getUuid());
+        tokenInstance.setKind("sample");
+        tokenInstance.setTokenInstanceUuid("22222222-2222-2222-2222-222222222222");
+        tokenInstance = tokenInstanceReferenceRepository.save(tokenInstance);
+
+        KeyPair caKeyPair = KeyPairGenerator.getInstance("EC").generateKeyPair();
+        CryptographicKey caKey = cryptographicKeySeeder.seedKey("scepCaKey", null, tokenInstance,
+                signingPrivateKey(KeyAlgorithm.ECDSA).withMaterial(KeyFormat.PRKI, "placeholder"),
+                verifyingPublicKey(KeyAlgorithm.ECDSA)
+                        .withMaterial(KeyFormat.SPKI, Base64.getEncoder().encodeToString(caKeyPair.getPublic().getEncoded())));
+
+        Certificate caCertificate = storeCertificate(selfSignedEcCertificate(caKeyPair), caKey, null);
+
+        ScepProfile scepProfile = new ScepProfile();
+        scepProfile.setName(SCEP_PROFILE_NAME);
+        scepProfile.setDescription("PKIOperation end-to-end profile");
+        scepProfile.setEnabled(true);
+        scepProfile.setRequireManualApproval(false);
+        scepProfile.setIncludeCaCertificate(true);
+        scepProfile.setChallengePassword(ScepMessageTestData.CHALLENGE_PASSWORD);
+        scepProfile.setCaCertificate(caCertificate);
+        scepProfile.setRaProfile(raProfile);
+        scepProfileRepository.save(scepProfile);
+
+        stubTokenSigning();
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockServer.stop();
+    }
+
+    /**
+     * The reported defect (#1887) at the entry point: a renewal PKCSReq signed with an existing certificate
+     * and carrying no challengePassword must not be rejected for a missing shared secret, and must be
+     * answered in the SCEP format rather than as a JSON error.
+     */
+    @Test
+    void renewalWithoutChallengePassword_isNotRejectedForAMissingSecret() throws Exception {
+        registerSignerCertificate();
+
+        ResponseEntity<Object> response = scepService.handlePost(
+                SCEP_PROFILE_NAME, ScepServiceImpl.SCEP_OPERATION_PKI_OPERATION,
+                ScepMessageTestData.passwordEnvelopedPkcsReq(null));
+
+        assertScepFormatted(response);
+        // Issuance is unstubbed, so the outcome is a failure — but it must not be the challenge password one.
+        assertNotEquals(FailInfo.BAD_MESSAGE_CHECK.getValue(), Integer.parseInt(attribute(response, ScepConstants.id_failInfo)),
+                "the renewal must get past the challenge password gate");
+    }
+
+    /** An initial enrollment with no challenge password is still rejected — with a SCEP failure, not a crash. */
+    @Test
+    void initialEnrollmentWithoutChallengePassword_isRejectedWithBadMessageCheck() throws Exception {
+        ResponseEntity<Object> response = scepService.handlePost(
+                SCEP_PROFILE_NAME, ScepServiceImpl.SCEP_OPERATION_PKI_OPERATION,
+                ScepMessageTestData.passwordEnvelopedPkcsReq(null));
+
+        assertScepFormatted(response);
+        assertEquals(String.valueOf(PkiStatus.FAILURE.getValue()), attribute(response, ScepConstants.id_pkiStatus));
+        assertEquals(String.valueOf(FailInfo.BAD_MESSAGE_CHECK.getValue()), attribute(response, ScepConstants.id_failInfo));
+    }
+
+    /** A matching challenge password gets past the gate and is answered in the SCEP format. */
+    @Test
+    void initialEnrollmentWithChallengePassword_isNotRejectedForAMissingSecret() throws Exception {
+        ResponseEntity<Object> response = scepService.handlePost(
+                SCEP_PROFILE_NAME, ScepServiceImpl.SCEP_OPERATION_PKI_OPERATION,
+                ScepMessageTestData.passwordEnvelopedPkcsReq(ScepMessageTestData.CHALLENGE_PASSWORD));
+
+        assertScepFormatted(response);
+        assertNotEquals(FailInfo.BAD_MESSAGE_CHECK.getValue(), Integer.parseInt(attribute(response, ScepConstants.id_failInfo)),
+                "a matching challenge password must not be reported as an integrity failure");
+    }
+
+    private void assertScepFormatted(ResponseEntity<Object> response) throws Exception {
+        assertEquals("application/x-pki-message", response.getHeaders().getFirst("Content-Type"),
+                "a SCEP client can only parse application/x-pki-message");
+        assertNotNull(response.getBody());
+        assertNotNull(new CMSSignedData((byte[]) response.getBody()).getSignerInfos().getSigners());
+    }
+
+    /** Reads a SCEP attribute out of the signed response. */
+    private String attribute(ResponseEntity<Object> response, String oid) throws Exception {
+        CMSSignedData signedData = new CMSSignedData((byte[]) response.getBody());
+        SignerInformation signer = signedData.getSignerInfos().getSigners().iterator().next();
+        ASN1Primitive value = signer.getSignedAttributes()
+                .get(new ASN1ObjectIdentifier(oid)).getAttrValues().getObjectAt(0).toASN1Primitive();
+        return ((ASN1String) value).getString();
+    }
+
+    /**
+     * Registers the request's signer certificate as an issued certificate of this RA profile, with the
+     * subject the request asks for and a validity inside the default half-life renewal window.
+     */
+    private void registerSignerCertificate() throws Exception {
+        X509Certificate signerCertificate = ScepMessageTestData.signerCertificate();
+        Certificate certificate = storeCertificate(signerCertificate, null, raProfile);
+        certificate.setSubjectDn(new X500Name(ScepMessageTestData.SUBJECT_DN).toString());
+        certificate.setNotBefore(new Date(System.currentTimeMillis() - 30L * 24 * 3600 * 1000));
+        certificate.setNotAfter(new Date(System.currentTimeMillis() + 10L * 24 * 3600 * 1000));
+        certificateRepository.save(certificate);
+    }
+
+    private Certificate storeCertificate(X509Certificate x509Certificate, CryptographicKey key, RaProfile owner) throws Exception {
+        String encoded = Base64.getEncoder().encodeToString(x509Certificate.getEncoded());
+        String fingerprint = CertificateUtil.getThumbprint(x509Certificate);
+
+        CertificateContent content = new CertificateContent();
+        content.setContent(encoded);
+        content.setFingerprint(fingerprint);
+        content = certificateContentRepository.save(content);
+
+        Certificate certificate = new Certificate();
+        certificate.setCertificateContent(content);
+        certificate.setCertificateContentId(content.getId());
+        certificate.setFingerprint(fingerprint);
+        certificate.setSubjectDn(x509Certificate.getSubjectX500Principal().getName());
+        certificate.setIssuerDn(x509Certificate.getIssuerX500Principal().getName());
+        certificate.setSerialNumber(x509Certificate.getSerialNumber().toString(16));
+        certificate.setState(CertificateState.ISSUED);
+        certificate.setValidationStatus(CertificateValidationStatus.VALID);
+        certificate.setNotBefore(x509Certificate.getNotBefore());
+        certificate.setNotAfter(x509Certificate.getNotAfter());
+        if (key != null) {
+            certificate.setKey(key);
+        }
+        if (owner != null) {
+            certificate.setRaProfile(owner);
+        }
+        return certificateRepository.save(certificate);
+    }
+
+    private static X509Certificate selfSignedEcCertificate(KeyPair keyPair) throws Exception {
+        X500Name dn = new X500Name(CA_DN);
+        Date notBefore = new Date(System.currentTimeMillis() - 3_600_000L);
+        Date notAfter = new Date(System.currentTimeMillis() + 365L * 24 * 3600 * 1000);
+        JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                dn, BigInteger.valueOf(System.currentTimeMillis()), notBefore, notAfter, dn, keyPair.getPublic());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withECDSA")
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME).build(keyPair.getPrivate());
+        return new JcaX509CertificateConverter()
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME).getCertificate(builder.build(signer));
+    }
+
+    /**
+     * The token connector signs the response. The value is passed through without verification here, so a
+     * fixed well-formed signature is enough to exercise the real response-building path.
+     */
+    private void stubTokenSigning() throws Exception {
+        KeyPair throwaway = KeyPairGenerator.getInstance("EC").generateKeyPair();
+        java.security.Signature signature = java.security.Signature.getInstance("SHA256withECDSA");
+        signature.initSign(throwaway.getPrivate());
+        signature.update("scep".getBytes());
+        String signed = Base64.getEncoder().encodeToString(signature.sign());
+
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/keys/[^/]+/sign"))
+                .willReturn(WireMock.okJson("""
+                        {"signatures": [{"data": "%s"}]}
+                        """.formatted(signed))));
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/keys/[^/]+/verify"))
+                .willReturn(WireMock.okJson("""
+                        {"verifications": [{"result": true}]}
+                        """)));
+    }
+}

--- a/src/test/java/com/otilm/core/service/scep/EcdsaCmsMessageTest.java
+++ b/src/test/java/com/otilm/core/service/scep/EcdsaCmsMessageTest.java
@@ -39,4 +39,18 @@ public class EcdsaCmsMessageTest {
                 () -> scepRequest.decryptData(null, null, KeyAlgorithm.ECDSA, null));
         Assertions.assertEquals(FailInfo.BAD_ALG, thrown.getFailInfo());
     }
+
+    /**
+     * An EnvelopedData with no recipientInfo leaves nothing to decrypt. That must be rejected explicitly
+     * rather than reaching the PKCS#10 parse with no content — the bare {@code assert} that used to guard
+     * this is disabled in production.
+     */
+    @Test
+    public void testGenerateEcdsaSignedMessage_noRecipientInformation() throws Exception {
+        ScepRequest scepRequest = new ScepRequest(ScepMessageTestData.recipientlessPkcsReq());
+
+        ScepException thrown = Assertions.assertThrows(ScepException.class,
+                () -> scepRequest.decryptData(null, null, KeyAlgorithm.ECDSA, ScepMessageTestData.CHALLENGE_PASSWORD));
+        Assertions.assertEquals(FailInfo.BAD_REQUEST, thrown.getFailInfo());
+    }
 }

--- a/src/test/java/com/otilm/core/service/scep/EcdsaCmsMessageTest.java
+++ b/src/test/java/com/otilm/core/service/scep/EcdsaCmsMessageTest.java
@@ -4,60 +4,27 @@ import com.otilm.api.exception.ScepException;
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
 import com.otilm.api.model.core.scep.FailInfo;
 import com.otilm.api.model.core.scep.MessageType;
-import com.otilm.core.service.scep.message.ScepConstants;
 import com.otilm.core.service.scep.message.ScepRequest;
-import com.otilm.core.util.CertificateUtil;
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.DERPrintableString;
-import org.bouncycastle.asn1.DERSet;
-import org.bouncycastle.asn1.cms.Attribute;
-import org.bouncycastle.asn1.cms.AttributeTable;
-import org.bouncycastle.cert.jcajce.JcaCertStore;
-import org.bouncycastle.cms.*;
-import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder;
-import org.bouncycastle.cms.jcajce.JceCMSContentEncryptorBuilder;
-import org.bouncycastle.cms.jcajce.JcePasswordRecipientInfoGenerator;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.operator.ContentSigner;
-import org.bouncycastle.operator.OperatorCreationException;
-import org.bouncycastle.operator.OutputEncryptor;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
-import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+import org.bouncycastle.cms.CMSException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.Security;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.Hashtable;
 
 public class EcdsaCmsMessageTest {
 
     @Test
-    public void testGenerateEcdsaSignedMessage() throws CertificateException, NoSuchAlgorithmException, IOException, InvalidKeySpecException, OperatorCreationException, CMSException, ScepException {
-        CMSProcessableByteArray cmsProcessableByteArray = generateEnvelopedData();
-        CMSSignedData signedData = createSignedData(cmsProcessableByteArray);
-        ScepRequest scepRequest = new ScepRequest(signedData.getEncoded());
-        scepRequest.decryptData(null, null, KeyAlgorithm.ECDSA, "mysecretpassword");
+    public void testGenerateEcdsaSignedMessage() throws Exception {
+        ScepRequest scepRequest = new ScepRequest(ScepMessageTestData.passwordEnvelopedPkcsReq());
+        scepRequest.decryptData(null, null, KeyAlgorithm.ECDSA, ScepMessageTestData.CHALLENGE_PASSWORD);
         Assertions.assertEquals(scepRequest.getMessageType(), MessageType.PKCS_REQ);
-        Assertions.assertEquals("CN=x11", scepRequest.getPkcs10Request().getSubject().toString());
+        Assertions.assertEquals(ScepMessageTestData.SUBJECT_DN, scepRequest.getPkcs10Request().getSubject().toString());
     }
 
     @Test
-    public void testGenerateEcdsaSignedMessage_wrongChallenge() throws CertificateException, NoSuchAlgorithmException, IOException, InvalidKeySpecException, OperatorCreationException, CMSException, ScepException {
-        CMSProcessableByteArray cmsProcessableByteArray = generateEnvelopedData();
-        CMSSignedData signedData = createSignedData(cmsProcessableByteArray);
-        ScepRequest scepRequest = new ScepRequest(signedData.getEncoded());
-        Assertions.assertThrows(CMSException.class, () -> scepRequest.decryptData(null, null, KeyAlgorithm.ECDSA, "wrongpassword"));
+    public void testGenerateEcdsaSignedMessage_wrongChallenge() throws Exception {
+        ScepRequest scepRequest = new ScepRequest(ScepMessageTestData.passwordEnvelopedPkcsReq());
+
+        Assertions.assertThrows(CMSException.class,
+                () -> scepRequest.decryptData(null, null, KeyAlgorithm.ECDSA, "wrongpassword"));
     }
 
     /**
@@ -65,84 +32,11 @@ public class EcdsaCmsMessageTest {
      * configured: that must surface as a SCEP rejection rather than a {@code NullPointerException}.
      */
     @Test
-    public void testGenerateEcdsaSignedMessage_noChallengePasswordConfigured() throws CertificateException, NoSuchAlgorithmException, IOException, InvalidKeySpecException, OperatorCreationException, CMSException, ScepException {
-        CMSProcessableByteArray cmsProcessableByteArray = generateEnvelopedData();
-        CMSSignedData signedData = createSignedData(cmsProcessableByteArray);
-        ScepRequest scepRequest = new ScepRequest(signedData.getEncoded());
+    public void testGenerateEcdsaSignedMessage_noChallengePasswordConfigured() throws Exception {
+        ScepRequest scepRequest = new ScepRequest(ScepMessageTestData.passwordEnvelopedPkcsReq());
 
         ScepException thrown = Assertions.assertThrows(ScepException.class,
                 () -> scepRequest.decryptData(null, null, KeyAlgorithm.ECDSA, null));
         Assertions.assertEquals(FailInfo.BAD_ALG, thrown.getFailInfo());
     }
-
-    private static CMSProcessableByteArray generateEnvelopedData() throws IOException, CMSException {
-
-        Security.addProvider(new BouncyCastleProvider());
-
-        String password = "mysecretpassword";
-        byte[] csrBytes = Base64.getDecoder().decode("MIICUzCCATsCAQAwDjEMMAoGA1UEAwwDeDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx3yEn1ivUp4etk3kdNrRXNP5PeIpTYobGj4lQrW57rsj9hhOhY/SwaeCu6sYPVvYIXPWnlc4tTafjcen/8Ikc7pY2NuzD0HaIAOujblcMKT2KAKA/OU+RrI2o/swU9UmEQ2wYveNYCGobimt/foURrB9opeDCx3pFXkddYsXAziaWu3AQIF5gIf/b+r7hYRIXh8V/u01t6FCnpBWCtdmYVrJ5e8KZw0yqptNpgDK1plu+8AR5tviP/vgrpBquwzNsVREsnRZJxOM6rXq9rG5scoqO+gxdsm6+EqfRiGiBvcaIr+Zpv81ryfiABLdixvyhoZ//3o8rAU0O7Pjm7HTxwIDAQABoAAwDQYJKoZIhvcNAQELBQADggEBAKM6lsrzME64G90fm98Zdgxe6IMBmIWTzA03V0OWGTYjYjYZbfsddAQAO1h3EMKjPl5nFaXkTVGoq8G4ZHvdu2fX72dyNJaGG+mG89uoW9iFd2US+nU5aN8xSpPx1k89DhPat/q5kdOwIIGAXvIbLWSXGx9A25DxdqvouuhDT7NJZqGTsPivHuFXgP3Mb1HTr/qnshx+shTnJ+FnYncARl3KmflCyCPC4NBKcorWl8kVFRDw2Y7aeg3a1hV3EJJfElFSwlmmT2Y/VDuZcMalFnnAKq2NqXByBlK9s7s67sMKzsqaAGwlg3TT37v6QN6L2q0zUU6egAuA4Av2LR6nJkw=".getBytes());
-        PasswordRecipientInfoGenerator priGen = new JcePasswordRecipientInfoGenerator(
-                CMSAlgorithm.AES128_CBC, password.toCharArray());
-
-        CMSProcessableByteArray cmsData = new CMSProcessableByteArray(csrBytes);
-        CMSEnvelopedDataGenerator edGen = new CMSEnvelopedDataGenerator();
-        edGen.addRecipientInfoGenerator(priGen);
-
-        OutputEncryptor encryptor = new JceCMSContentEncryptorBuilder(CMSAlgorithm.AES256_CBC).setProvider("BC").build();
-        CMSEnvelopedData cmsEnvelope = edGen.generate(cmsData, encryptor);
-        return new CMSProcessableByteArray(cmsEnvelope.getEncoded());
-    }
-
-    private CMSSignedData createSignedData(CMSProcessableByteArray responseData) throws NoSuchAlgorithmException, CertificateException, OperatorCreationException, CMSException, InvalidKeySpecException {
-        CMSSignedDataGenerator cmsSignedDataGenerator = new CMSSignedDataGenerator();
-        // Create attributes that will be signed
-        Hashtable<ASN1ObjectIdentifier, Attribute> attributes = createAttributes();
-
-        X509Certificate signerCertificate = CertificateUtil.parseCertificate("MIIB5TCCAYqgAwIBAgIUQWJcNhcZ8rdJ8d+Y0/zjDauIDvAwCgYIKoZIzj0EAwIwNzELMAkGA1UEBhMCSU4xEzARBgNVBAgMClRhbWlsIE5hZHUxEzARBgNVBAcMCkNvaW1iYXRvcmUwHhcNMjMwNDE5MTAxNjI0WhcNMjQwNDE4MTAxNjI0WjA3MQswCQYDVQQGEwJJTjETMBEGA1UECAwKVGFtaWwgTmFkdTETMBEGA1UEBwwKQ29pbWJhdG9yZTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI1ILz/GLiGtx9JIoFesLv6ssTrBr5W1c+FUuCKUGjvZpM8l5wAbC9TJaYwcA3B45iuTAzmTTOoPCwrr/ALGhoyjdDByMB0GA1UdDgQWBBT4VuTPGMKzKGqAYgAtq7eFR+nPpzAfBgNVHSMEGDAWgBT4VuTPGMKzKGqAYgAtq7eFR+nPpzAOBgNVHQ8BAf8EBAMCBaAwIAYDVR0lAQH/BBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAoGCCqGSM49BAMCA0kAMEYCIQCUxvkZzxraytwbhhoCafIzHaj62EGVbxW5bUlvLTZPIwIhAJ6eFFyO8f9udwCHUt+4aMQGyBHCISbgvgvejMU6NSZU");
-        String signatureAlgorithmName = "SHA256WithECDSA";
-
-        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode("MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgR7jrC6SUkUlWEouD/5yVwazngKD0mHjA4YsOhesg+fShRANCAASNSC8/xi4hrcfSSKBXrC7+rLE6wa+VtXPhVLgilBo72aTPJecAGwvUyWmMHANweOYrkwM5k0zqDwsK6/wCxoaM"));
-        KeyFactory kf = KeyFactory.getInstance("EC");
-        PrivateKey signerPrivateKey = kf.generatePrivate(keySpec);
-
-        Security.addProvider(new BouncyCastleProvider());
-
-
-        ContentSigner contentSigner = new JcaContentSignerBuilder(signatureAlgorithmName).setProvider(BouncyCastleProvider.PROVIDER_NAME).build(signerPrivateKey);
-        JcaDigestCalculatorProviderBuilder calculatorProviderBuilder = new JcaDigestCalculatorProviderBuilder().setProvider(BouncyCastleProvider.PROVIDER_NAME);
-        JcaSignerInfoGeneratorBuilder builder = new JcaSignerInfoGeneratorBuilder(calculatorProviderBuilder.build());
-        builder.setSignedAttributeGenerator(new DefaultSignedAttributeTableGenerator(new AttributeTable(attributes)));
-        cmsSignedDataGenerator.addSignerInfoGenerator(builder.build(contentSigner, signerCertificate));
-
-        JcaCertStore certStore = new JcaCertStore(Collections.singletonList(signerCertificate));
-        cmsSignedDataGenerator.addCertificates(certStore);
-
-        return cmsSignedDataGenerator.generate(responseData, true);
-    }
-
-    private Hashtable<ASN1ObjectIdentifier, Attribute> createAttributes() {
-        Hashtable<ASN1ObjectIdentifier, Attribute> attributes = new Hashtable<>();
-        ASN1ObjectIdentifier oid;
-        Attribute attribute;
-        DERSet value;
-
-        oid = new ASN1ObjectIdentifier(ScepConstants.id_messageType);
-        value = new DERSet(new DERPrintableString(Integer.toString(MessageType.PKCS_REQ.getValue())));
-        attribute = new Attribute(oid, value);
-        attributes.put(attribute.getAttrType(), attribute);
-
-        oid = new ASN1ObjectIdentifier(ScepConstants.id_transactionId);
-        value = new DERSet(new DERPrintableString("361ba25258bfc72fe6cf8aa70f75e21facd8fc3d"));
-        attribute = new Attribute(oid, value);
-        attributes.put(attribute.getAttrType(), attribute);
-
-        oid = new ASN1ObjectIdentifier(ScepConstants.id_senderNonce);
-        value = new DERSet(new DEROctetString(Base64.getDecoder().decode("cVpmdzRXdDBPV25JNVA0Y1pMcHZvSzJuUG9fUlR2cXhZT0RBOUdGdlE2cw==")));
-        attribute = new Attribute(oid, value);
-        attributes.put(attribute.getAttrType(), attribute);
-
-        return attributes;
-    }
-
-
 }

--- a/src/test/java/com/otilm/core/service/scep/EcdsaCmsMessageTest.java
+++ b/src/test/java/com/otilm/core/service/scep/EcdsaCmsMessageTest.java
@@ -2,6 +2,7 @@ package com.otilm.core.service.scep;
 
 import com.otilm.api.exception.ScepException;
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.otilm.api.model.core.scep.FailInfo;
 import com.otilm.api.model.core.scep.MessageType;
 import com.otilm.core.service.scep.message.ScepConstants;
 import com.otilm.core.service.scep.message.ScepRequest;
@@ -57,6 +58,21 @@ public class EcdsaCmsMessageTest {
         CMSSignedData signedData = createSignedData(cmsProcessableByteArray);
         ScepRequest scepRequest = new ScepRequest(signedData.getEncoded());
         Assertions.assertThrows(CMSException.class, () -> scepRequest.decryptData(null, null, KeyAlgorithm.ECDSA, "wrongpassword"));
+    }
+
+    /**
+     * A password-enveloped request cannot be decrypted at all when the profile has no challenge password
+     * configured: that must surface as a SCEP rejection rather than a {@code NullPointerException}.
+     */
+    @Test
+    public void testGenerateEcdsaSignedMessage_noChallengePasswordConfigured() throws CertificateException, NoSuchAlgorithmException, IOException, InvalidKeySpecException, OperatorCreationException, CMSException, ScepException {
+        CMSProcessableByteArray cmsProcessableByteArray = generateEnvelopedData();
+        CMSSignedData signedData = createSignedData(cmsProcessableByteArray);
+        ScepRequest scepRequest = new ScepRequest(signedData.getEncoded());
+
+        ScepException thrown = Assertions.assertThrows(ScepException.class,
+                () -> scepRequest.decryptData(null, null, KeyAlgorithm.ECDSA, null));
+        Assertions.assertEquals(FailInfo.BAD_ALG, thrown.getFailInfo());
     }
 
     private static CMSProcessableByteArray generateEnvelopedData() throws IOException, CMSException {

--- a/src/test/java/com/otilm/core/service/scep/ScepMessageTestData.java
+++ b/src/test/java/com/otilm/core/service/scep/ScepMessageTestData.java
@@ -24,9 +24,14 @@ import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OutputEncryptor;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import com.otilm.api.model.core.scep.MessageType;
 
 import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.Security;
 import java.security.cert.X509Certificate;
@@ -56,7 +61,29 @@ public final class ScepMessageTestData {
 
     /** A signed PKCSReq whose PKCS#10 request is enveloped to a password recipient. */
     public static byte[] passwordEnvelopedPkcsReq() throws Exception {
-        return signedMessage(envelopedPkcs10Request()).getEncoded();
+        return signedMessage(envelopedPkcs10Request(Base64.getDecoder().decode(CSR_B64))).getEncoded();
+    }
+
+    /**
+     * The same message with a freshly generated PKCS#10 request for {@link #SUBJECT_DN}, optionally carrying
+     * a challengePassword attribute — {@code null} reproduces a renewal request, which omits it
+     * (RFC 8894 §3.3.1.2).
+     */
+    public static byte[] passwordEnvelopedPkcsReq(String csrChallengePassword) throws Exception {
+        return signedMessage(envelopedPkcs10Request(generatedCsr(csrChallengePassword))).getEncoded();
+    }
+
+    private static byte[] generatedCsr(String challengePassword) throws Exception {
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        JcaPKCS10CertificationRequestBuilder builder =
+                new JcaPKCS10CertificationRequestBuilder(new X500Name(SUBJECT_DN), keyPair.getPublic());
+        if (challengePassword != null) {
+            builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_challengePassword,
+                    new DERPrintableString(challengePassword));
+        }
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME).build(keyPair.getPrivate());
+        return builder.build(signer).getEncoded();
     }
 
     /** The signer certificate the message above is signed with. */
@@ -64,10 +91,9 @@ public final class ScepMessageTestData {
         return CertificateUtil.parseCertificate(SIGNER_CERT_B64);
     }
 
-    private static CMSProcessableByteArray envelopedPkcs10Request() throws Exception {
+    private static CMSProcessableByteArray envelopedPkcs10Request(byte[] csrBytes) throws Exception {
         Security.addProvider(new BouncyCastleProvider());
 
-        byte[] csrBytes = Base64.getDecoder().decode(CSR_B64.getBytes());
         PasswordRecipientInfoGenerator recipientGenerator = new JcePasswordRecipientInfoGenerator(
                 CMSAlgorithm.AES128_CBC, CHALLENGE_PASSWORD.toCharArray());
 

--- a/src/test/java/com/otilm/core/service/scep/ScepMessageTestData.java
+++ b/src/test/java/com/otilm/core/service/scep/ScepMessageTestData.java
@@ -53,7 +53,7 @@ public final class ScepMessageTestData {
     private static final String CSR_B64 = "MIICUzCCATsCAQAwDjEMMAoGA1UEAwwDeDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx3yEn1ivUp4etk3kdNrRXNP5PeIpTYobGj4lQrW57rsj9hhOhY/SwaeCu6sYPVvYIXPWnlc4tTafjcen/8Ikc7pY2NuzD0HaIAOujblcMKT2KAKA/OU+RrI2o/swU9UmEQ2wYveNYCGobimt/foURrB9opeDCx3pFXkddYsXAziaWu3AQIF5gIf/b+r7hYRIXh8V/u01t6FCnpBWCtdmYVrJ5e8KZw0yqptNpgDK1plu+8AR5tviP/vgrpBquwzNsVREsnRZJxOM6rXq9rG5scoqO+gxdsm6+EqfRiGiBvcaIr+Zpv81ryfiABLdixvyhoZ//3o8rAU0O7Pjm7HTxwIDAQABoAAwDQYJKoZIhvcNAQELBQADggEBAKM6lsrzME64G90fm98Zdgxe6IMBmIWTzA03V0OWGTYjYjYZbfsddAQAO1h3EMKjPl5nFaXkTVGoq8G4ZHvdu2fX72dyNJaGG+mG89uoW9iFd2US+nU5aN8xSpPx1k89DhPat/q5kdOwIIGAXvIbLWSXGx9A25DxdqvouuhDT7NJZqGTsPivHuFXgP3Mb1HTr/qnshx+shTnJ+FnYncARl3KmflCyCPC4NBKcorWl8kVFRDw2Y7aeg3a1hV3EJJfElFSwlmmT2Y/VDuZcMalFnnAKq2NqXByBlK9s7s67sMKzsqaAGwlg3TT37v6QN6L2q0zUU6egAuA4Av2LR6nJkw=";
     private static final String SIGNER_CERT_B64 = "MIIB5TCCAYqgAwIBAgIUQWJcNhcZ8rdJ8d+Y0/zjDauIDvAwCgYIKoZIzj0EAwIwNzELMAkGA1UEBhMCSU4xEzARBgNVBAgMClRhbWlsIE5hZHUxEzARBgNVBAcMCkNvaW1iYXRvcmUwHhcNMjMwNDE5MTAxNjI0WhcNMjQwNDE4MTAxNjI0WjA3MQswCQYDVQQGEwJJTjETMBEGA1UECAwKVGFtaWwgTmFkdTETMBEGA1UEBwwKQ29pbWJhdG9yZTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI1ILz/GLiGtx9JIoFesLv6ssTrBr5W1c+FUuCKUGjvZpM8l5wAbC9TJaYwcA3B45iuTAzmTTOoPCwrr/ALGhoyjdDByMB0GA1UdDgQWBBT4VuTPGMKzKGqAYgAtq7eFR+nPpzAfBgNVHSMEGDAWgBT4VuTPGMKzKGqAYgAtq7eFR+nPpzAOBgNVHQ8BAf8EBAMCBaAwIAYDVR0lAQH/BBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAoGCCqGSM49BAMCA0kAMEYCIQCUxvkZzxraytwbhhoCafIzHaj62EGVbxW5bUlvLTZPIwIhAJ6eFFyO8f9udwCHUt+4aMQGyBHCISbgvgvejMU6NSZU";
     private static final String SIGNER_KEY_B64 = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgR7jrC6SUkUlWEouD/5yVwazngKD0mHjA4YsOhesg+fShRANCAASNSC8/xi4hrcfSSKBXrC7+rLE6wa+VtXPhVLgilBo72aTPJecAGwvUyWmMHANweOYrkwM5k0zqDwsK6/wCxoaM";
-    private static final String TRANSACTION_ID = "361ba25258bfc72fe6cf8aa70f75e21facd8fc3d";
+    public static final String TRANSACTION_ID = "361ba25258bfc72fe6cf8aa70f75e21facd8fc3d";
     private static final String SENDER_NONCE_B64 = "cVpmdzRXdDBPV25JNVA0Y1pMcHZvSzJuUG9fUlR2cXhZT0RBOUdGdlE2cw==";
 
     private ScepMessageTestData() {
@@ -61,7 +61,7 @@ public final class ScepMessageTestData {
 
     /** A signed PKCSReq whose PKCS#10 request is enveloped to a password recipient. */
     public static byte[] passwordEnvelopedPkcsReq() throws Exception {
-        return signedMessage(envelopedPkcs10Request(Base64.getDecoder().decode(CSR_B64))).getEncoded();
+        return signedMessage(envelopedPkcs10Request(Base64.getDecoder().decode(CSR_B64)), MessageType.PKCS_REQ).getEncoded();
     }
 
     /**
@@ -70,7 +70,30 @@ public final class ScepMessageTestData {
      * (RFC 8894 §3.3.1.2).
      */
     public static byte[] passwordEnvelopedPkcsReq(String csrChallengePassword) throws Exception {
-        return signedMessage(envelopedPkcs10Request(generatedCsr(csrChallengePassword))).getEncoded();
+        return passwordEnvelopedMessage(MessageType.PKCS_REQ, csrChallengePassword);
+    }
+
+    /**
+     * A PKCSReq enveloped to a different password than the profile holds, so the platform cannot open it.
+     */
+    public static byte[] pkcsReqEnvelopedWith(String envelopePassword) throws Exception {
+        return signedMessage(envelopedPkcs10Request(generatedCsr(null), envelopePassword), MessageType.PKCS_REQ).getEncoded();
+    }
+
+    /** The same message declared as an arbitrary SCEP message type. */
+    public static byte[] passwordEnvelopedMessage(MessageType messageType, String csrChallengePassword) throws Exception {
+        return signedMessage(envelopedPkcs10Request(generatedCsr(csrChallengePassword)), messageType).getEncoded();
+    }
+
+    /**
+     * A PKCSReq whose EnvelopedData carries no recipientInfo at all, so nothing can be decrypted from it.
+     */
+    public static byte[] recipientlessPkcsReq() throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+        OutputEncryptor encryptor = new JceCMSContentEncryptorBuilder(CMSAlgorithm.AES256_CBC).setProvider("BC").build();
+        CMSEnvelopedData envelope = new CMSEnvelopedDataGenerator()
+                .generate(new CMSProcessableByteArray(generatedCsr(null)), encryptor);
+        return signedMessage(new CMSProcessableByteArray(envelope.getEncoded()), MessageType.PKCS_REQ).getEncoded();
     }
 
     private static byte[] generatedCsr(String challengePassword) throws Exception {
@@ -92,10 +115,14 @@ public final class ScepMessageTestData {
     }
 
     private static CMSProcessableByteArray envelopedPkcs10Request(byte[] csrBytes) throws Exception {
+        return envelopedPkcs10Request(csrBytes, CHALLENGE_PASSWORD);
+    }
+
+    private static CMSProcessableByteArray envelopedPkcs10Request(byte[] csrBytes, String envelopePassword) throws Exception {
         Security.addProvider(new BouncyCastleProvider());
 
         PasswordRecipientInfoGenerator recipientGenerator = new JcePasswordRecipientInfoGenerator(
-                CMSAlgorithm.AES128_CBC, CHALLENGE_PASSWORD.toCharArray());
+                CMSAlgorithm.AES128_CBC, envelopePassword.toCharArray());
 
         CMSEnvelopedDataGenerator envelopedDataGenerator = new CMSEnvelopedDataGenerator();
         envelopedDataGenerator.addRecipientInfoGenerator(recipientGenerator);
@@ -105,7 +132,7 @@ public final class ScepMessageTestData {
         return new CMSProcessableByteArray(envelope.getEncoded());
     }
 
-    private static org.bouncycastle.cms.CMSSignedData signedMessage(CMSProcessableByteArray content) throws Exception {
+    private static org.bouncycastle.cms.CMSSignedData signedMessage(CMSProcessableByteArray content, MessageType messageType) throws Exception {
         Security.addProvider(new BouncyCastleProvider());
 
         X509Certificate signerCertificate = signerCertificate();
@@ -117,7 +144,7 @@ public final class ScepMessageTestData {
         JcaDigestCalculatorProviderBuilder digestProviderBuilder = new JcaDigestCalculatorProviderBuilder()
                 .setProvider(BouncyCastleProvider.PROVIDER_NAME);
         JcaSignerInfoGeneratorBuilder signerInfoBuilder = new JcaSignerInfoGeneratorBuilder(digestProviderBuilder.build());
-        signerInfoBuilder.setSignedAttributeGenerator(new DefaultSignedAttributeTableGenerator(new AttributeTable(scepAttributes())));
+        signerInfoBuilder.setSignedAttributeGenerator(new DefaultSignedAttributeTableGenerator(new AttributeTable(scepAttributes(messageType))));
 
         CMSSignedDataGenerator signedDataGenerator = new CMSSignedDataGenerator();
         signedDataGenerator.addSignerInfoGenerator(signerInfoBuilder.build(contentSigner, signerCertificate));
@@ -126,10 +153,10 @@ public final class ScepMessageTestData {
         return signedDataGenerator.generate(content, true);
     }
 
-    private static Hashtable<ASN1ObjectIdentifier, Attribute> scepAttributes() {
+    private static Hashtable<ASN1ObjectIdentifier, Attribute> scepAttributes(MessageType messageType) {
         Hashtable<ASN1ObjectIdentifier, Attribute> attributes = new Hashtable<>();
         addAttribute(attributes, ScepConstants.id_messageType,
-                new DERSet(new DERPrintableString(Integer.toString(MessageType.PKCS_REQ.getValue()))));
+                new DERSet(new DERPrintableString(Integer.toString(messageType.getValue()))));
         addAttribute(attributes, ScepConstants.id_transactionId, new DERSet(new DERPrintableString(TRANSACTION_ID)));
         addAttribute(attributes, ScepConstants.id_senderNonce,
                 new DERSet(new DEROctetString(Base64.getDecoder().decode(SENDER_NONCE_B64))));

--- a/src/test/java/com/otilm/core/service/scep/ScepMessageTestData.java
+++ b/src/test/java/com/otilm/core/service/scep/ScepMessageTestData.java
@@ -1,0 +1,117 @@
+package com.otilm.core.service.scep;
+
+import com.otilm.core.service.scep.message.ScepConstants;
+import com.otilm.core.util.CertificateUtil;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERPrintableString;
+import org.bouncycastle.asn1.DERSet;
+import org.bouncycastle.asn1.cms.Attribute;
+import org.bouncycastle.asn1.cms.AttributeTable;
+import org.bouncycastle.cert.jcajce.JcaCertStore;
+import org.bouncycastle.cms.CMSAlgorithm;
+import org.bouncycastle.cms.CMSEnvelopedData;
+import org.bouncycastle.cms.CMSEnvelopedDataGenerator;
+import org.bouncycastle.cms.CMSProcessableByteArray;
+import org.bouncycastle.cms.CMSSignedDataGenerator;
+import org.bouncycastle.cms.DefaultSignedAttributeTableGenerator;
+import org.bouncycastle.cms.PasswordRecipientInfoGenerator;
+import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder;
+import org.bouncycastle.cms.jcajce.JceCMSContentEncryptorBuilder;
+import org.bouncycastle.cms.jcajce.JcePasswordRecipientInfoGenerator;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OutputEncryptor;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+import com.otilm.api.model.core.scep.MessageType;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Hashtable;
+
+/**
+ * SCEP wire messages for tests. The material is a P-256 signer certificate with its private key and a
+ * PKCS#10 request for {@code CN=x11}, so a message can be produced whose enveloped content is decryptable
+ * with {@link #CHALLENGE_PASSWORD} through the RFC 8894 password recipient — no token connector needed.
+ */
+public final class ScepMessageTestData {
+
+    public static final String CHALLENGE_PASSWORD = "mysecretpassword";
+    public static final String SUBJECT_DN = "CN=x11";
+
+    private static final String CSR_B64 = "MIICUzCCATsCAQAwDjEMMAoGA1UEAwwDeDExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx3yEn1ivUp4etk3kdNrRXNP5PeIpTYobGj4lQrW57rsj9hhOhY/SwaeCu6sYPVvYIXPWnlc4tTafjcen/8Ikc7pY2NuzD0HaIAOujblcMKT2KAKA/OU+RrI2o/swU9UmEQ2wYveNYCGobimt/foURrB9opeDCx3pFXkddYsXAziaWu3AQIF5gIf/b+r7hYRIXh8V/u01t6FCnpBWCtdmYVrJ5e8KZw0yqptNpgDK1plu+8AR5tviP/vgrpBquwzNsVREsnRZJxOM6rXq9rG5scoqO+gxdsm6+EqfRiGiBvcaIr+Zpv81ryfiABLdixvyhoZ//3o8rAU0O7Pjm7HTxwIDAQABoAAwDQYJKoZIhvcNAQELBQADggEBAKM6lsrzME64G90fm98Zdgxe6IMBmIWTzA03V0OWGTYjYjYZbfsddAQAO1h3EMKjPl5nFaXkTVGoq8G4ZHvdu2fX72dyNJaGG+mG89uoW9iFd2US+nU5aN8xSpPx1k89DhPat/q5kdOwIIGAXvIbLWSXGx9A25DxdqvouuhDT7NJZqGTsPivHuFXgP3Mb1HTr/qnshx+shTnJ+FnYncARl3KmflCyCPC4NBKcorWl8kVFRDw2Y7aeg3a1hV3EJJfElFSwlmmT2Y/VDuZcMalFnnAKq2NqXByBlK9s7s67sMKzsqaAGwlg3TT37v6QN6L2q0zUU6egAuA4Av2LR6nJkw=";
+    private static final String SIGNER_CERT_B64 = "MIIB5TCCAYqgAwIBAgIUQWJcNhcZ8rdJ8d+Y0/zjDauIDvAwCgYIKoZIzj0EAwIwNzELMAkGA1UEBhMCSU4xEzARBgNVBAgMClRhbWlsIE5hZHUxEzARBgNVBAcMCkNvaW1iYXRvcmUwHhcNMjMwNDE5MTAxNjI0WhcNMjQwNDE4MTAxNjI0WjA3MQswCQYDVQQGEwJJTjETMBEGA1UECAwKVGFtaWwgTmFkdTETMBEGA1UEBwwKQ29pbWJhdG9yZTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI1ILz/GLiGtx9JIoFesLv6ssTrBr5W1c+FUuCKUGjvZpM8l5wAbC9TJaYwcA3B45iuTAzmTTOoPCwrr/ALGhoyjdDByMB0GA1UdDgQWBBT4VuTPGMKzKGqAYgAtq7eFR+nPpzAfBgNVHSMEGDAWgBT4VuTPGMKzKGqAYgAtq7eFR+nPpzAOBgNVHQ8BAf8EBAMCBaAwIAYDVR0lAQH/BBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAoGCCqGSM49BAMCA0kAMEYCIQCUxvkZzxraytwbhhoCafIzHaj62EGVbxW5bUlvLTZPIwIhAJ6eFFyO8f9udwCHUt+4aMQGyBHCISbgvgvejMU6NSZU";
+    private static final String SIGNER_KEY_B64 = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgR7jrC6SUkUlWEouD/5yVwazngKD0mHjA4YsOhesg+fShRANCAASNSC8/xi4hrcfSSKBXrC7+rLE6wa+VtXPhVLgilBo72aTPJecAGwvUyWmMHANweOYrkwM5k0zqDwsK6/wCxoaM";
+    private static final String TRANSACTION_ID = "361ba25258bfc72fe6cf8aa70f75e21facd8fc3d";
+    private static final String SENDER_NONCE_B64 = "cVpmdzRXdDBPV25JNVA0Y1pMcHZvSzJuUG9fUlR2cXhZT0RBOUdGdlE2cw==";
+
+    private ScepMessageTestData() {
+    }
+
+    /** A signed PKCSReq whose PKCS#10 request is enveloped to a password recipient. */
+    public static byte[] passwordEnvelopedPkcsReq() throws Exception {
+        return signedMessage(envelopedPkcs10Request()).getEncoded();
+    }
+
+    /** The signer certificate the message above is signed with. */
+    public static X509Certificate signerCertificate() throws Exception {
+        return CertificateUtil.parseCertificate(SIGNER_CERT_B64);
+    }
+
+    private static CMSProcessableByteArray envelopedPkcs10Request() throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+
+        byte[] csrBytes = Base64.getDecoder().decode(CSR_B64.getBytes());
+        PasswordRecipientInfoGenerator recipientGenerator = new JcePasswordRecipientInfoGenerator(
+                CMSAlgorithm.AES128_CBC, CHALLENGE_PASSWORD.toCharArray());
+
+        CMSEnvelopedDataGenerator envelopedDataGenerator = new CMSEnvelopedDataGenerator();
+        envelopedDataGenerator.addRecipientInfoGenerator(recipientGenerator);
+
+        OutputEncryptor encryptor = new JceCMSContentEncryptorBuilder(CMSAlgorithm.AES256_CBC).setProvider("BC").build();
+        CMSEnvelopedData envelope = envelopedDataGenerator.generate(new CMSProcessableByteArray(csrBytes), encryptor);
+        return new CMSProcessableByteArray(envelope.getEncoded());
+    }
+
+    private static org.bouncycastle.cms.CMSSignedData signedMessage(CMSProcessableByteArray content) throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+
+        X509Certificate signerCertificate = signerCertificate();
+        PrivateKey signerPrivateKey = KeyFactory.getInstance("EC")
+                .generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder().decode(SIGNER_KEY_B64)));
+
+        ContentSigner contentSigner = new JcaContentSignerBuilder("SHA256WithECDSA")
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME).build(signerPrivateKey);
+        JcaDigestCalculatorProviderBuilder digestProviderBuilder = new JcaDigestCalculatorProviderBuilder()
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME);
+        JcaSignerInfoGeneratorBuilder signerInfoBuilder = new JcaSignerInfoGeneratorBuilder(digestProviderBuilder.build());
+        signerInfoBuilder.setSignedAttributeGenerator(new DefaultSignedAttributeTableGenerator(new AttributeTable(scepAttributes())));
+
+        CMSSignedDataGenerator signedDataGenerator = new CMSSignedDataGenerator();
+        signedDataGenerator.addSignerInfoGenerator(signerInfoBuilder.build(contentSigner, signerCertificate));
+        signedDataGenerator.addCertificates(new JcaCertStore(Collections.singletonList(signerCertificate)));
+
+        return signedDataGenerator.generate(content, true);
+    }
+
+    private static Hashtable<ASN1ObjectIdentifier, Attribute> scepAttributes() {
+        Hashtable<ASN1ObjectIdentifier, Attribute> attributes = new Hashtable<>();
+        addAttribute(attributes, ScepConstants.id_messageType,
+                new DERSet(new DERPrintableString(Integer.toString(MessageType.PKCS_REQ.getValue()))));
+        addAttribute(attributes, ScepConstants.id_transactionId, new DERSet(new DERPrintableString(TRANSACTION_ID)));
+        addAttribute(attributes, ScepConstants.id_senderNonce,
+                new DERSet(new DEROctetString(Base64.getDecoder().decode(SENDER_NONCE_B64))));
+        return attributes;
+    }
+
+    private static void addAttribute(Hashtable<ASN1ObjectIdentifier, Attribute> attributes, String oid, DERSet value) {
+        Attribute attribute = new Attribute(new ASN1ObjectIdentifier(oid), value);
+        attributes.put(attribute.getAttrType(), attribute);
+    }
+}

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplChallengePasswordTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplChallengePasswordTest.java
@@ -84,6 +84,26 @@ class ScepServiceImplChallengePasswordTest {
     }
 
     /**
+     * A present-but-empty challengePassword attribute counts as absent: clients (and our own jscep guide)
+     * are commonly configured to send an empty password on renewal.
+     */
+    @Test
+    void blankRequestPassword_authenticatedRenewal_passes() {
+        when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
+
+        assertDoesNotThrow(() -> service.validateChallengePassword("", true));
+    }
+
+    @Test
+    void blankRequestPassword_notARenewal_rejectedWithBadMessageCheck() {
+        when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
+
+        ScepException thrown = assertThrows(ScepException.class,
+                () -> service.validateChallengePassword("", false));
+        assertEquals(FailInfo.BAD_MESSAGE_CHECK, thrown.getFailInfo());
+    }
+
+    /**
      * The waiver only covers an <em>absent</em> password. A renewal that does supply one must still
      * match, so a wrong shared secret is never silently ignored.
      */

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplChallengePasswordTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplChallengePasswordTest.java
@@ -5,6 +5,9 @@ import com.otilm.api.model.core.scep.FailInfo;
 import com.otilm.core.dao.entity.scep.ScepProfile;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -33,33 +36,48 @@ class ScepServiceImplChallengePasswordTest {
         ReflectionTestUtils.setField(service, "scepProfile", profile);
     }
 
-    @Test
-    void profileWithoutChallengePassword_absentRequestPassword_passes() {
-        when(profile.getChallengePassword()).thenReturn(null);
+    /** A profile that configures no challenge password never requires one. */
+    @ParameterizedTest(name = "profile password [{0}]")
+    @NullAndEmptySource
+    void profileWithoutChallengePassword_passes(String profileChallengePassword) {
+        when(profile.getChallengePassword()).thenReturn(profileChallengePassword);
 
         assertDoesNotThrow(() -> service.validateChallengePassword(null, false));
     }
 
-    @Test
-    void profileWithEmptyChallengePassword_absentRequestPassword_passes() {
-        when(profile.getChallengePassword()).thenReturn("");
-
-        assertDoesNotThrow(() -> service.validateChallengePassword(null, false));
-    }
-
-    @Test
-    void matchingRequestPassword_passes() {
+    /**
+     * The waiver covers an absent password — including a present-but-empty attribute, which clients (and
+     * our own jscep guide) are commonly configured to send on renewal. A password carrying a value is
+     * accepted only when it matches.
+     */
+    @ParameterizedTest(name = "request password [{0}], authenticated renewal {1}")
+    @CsvSource(nullValues = "NULL", value = {
+            "mysecretpassword, false",  // matches PROFILE_PASSWORD on an initial enrollment
+            "NULL,             true",   // renewal omits the attribute
+            "'',               true"    // renewal sends the attribute empty
+    })
+    void acceptedChallengePassword(String requestChallengePassword, boolean authenticatedRenewal) {
         when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
 
-        assertDoesNotThrow(() -> service.validateChallengePassword(PROFILE_PASSWORD, false));
+        assertDoesNotThrow(() -> service.validateChallengePassword(requestChallengePassword, authenticatedRenewal));
     }
 
-    @Test
-    void mismatchedRequestPassword_rejectedWithBadMessageCheck() {
+    /**
+     * A wrong password is rejected whether or not the request is a renewal: the waiver never silently
+     * accepts a supplied credential that does not match. An empty attribute is rejected wherever the
+     * shared secret is actually required.
+     */
+    @ParameterizedTest(name = "request password [{0}], authenticated renewal {1}")
+    @CsvSource(nullValues = "NULL", value = {
+            "wrong, false",  // wrong password on an initial enrollment
+            "wrong, true",   // wrong password on an otherwise authenticated renewal
+            "'',    false"   // empty attribute where the shared secret is required
+    })
+    void rejectedChallengePassword(String requestChallengePassword, boolean authenticatedRenewal) {
         when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
 
         ScepException thrown = assertThrows(ScepException.class,
-                () -> service.validateChallengePassword("wrong", false));
+                () -> service.validateChallengePassword(requestChallengePassword, authenticatedRenewal));
         assertEquals(FailInfo.BAD_MESSAGE_CHECK, thrown.getFailInfo());
     }
 
@@ -73,46 +91,6 @@ class ScepServiceImplChallengePasswordTest {
 
         ScepException thrown = assertThrows(ScepException.class,
                 () -> service.validateChallengePassword(null, false));
-        assertEquals(FailInfo.BAD_MESSAGE_CHECK, thrown.getFailInfo());
-    }
-
-    @Test
-    void absentRequestPassword_authenticatedRenewal_passes() {
-        when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
-
-        assertDoesNotThrow(() -> service.validateChallengePassword(null, true));
-    }
-
-    /**
-     * A present-but-empty challengePassword attribute counts as absent: clients (and our own jscep guide)
-     * are commonly configured to send an empty password on renewal.
-     */
-    @Test
-    void blankRequestPassword_authenticatedRenewal_passes() {
-        when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
-
-        assertDoesNotThrow(() -> service.validateChallengePassword("", true));
-    }
-
-    @Test
-    void blankRequestPassword_notARenewal_rejectedWithBadMessageCheck() {
-        when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
-
-        ScepException thrown = assertThrows(ScepException.class,
-                () -> service.validateChallengePassword("", false));
-        assertEquals(FailInfo.BAD_MESSAGE_CHECK, thrown.getFailInfo());
-    }
-
-    /**
-     * The waiver only covers an <em>absent</em> password. A renewal that does supply one must still
-     * match, so a wrong shared secret is never silently ignored.
-     */
-    @Test
-    void mismatchedRequestPassword_authenticatedRenewal_stillRejected() {
-        when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
-
-        ScepException thrown = assertThrows(ScepException.class,
-                () -> service.validateChallengePassword("wrong", true));
         assertEquals(FailInfo.BAD_MESSAGE_CHECK, thrown.getFailInfo());
     }
 }

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplChallengePasswordTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplChallengePasswordTest.java
@@ -1,0 +1,98 @@
+package com.otilm.core.service.scep.impl;
+
+import com.otilm.api.exception.ScepException;
+import com.otilm.api.model.core.scep.FailInfo;
+import com.otilm.core.dao.entity.scep.ScepProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the challenge password gate {@link ScepServiceImpl#validateChallengePassword}.
+ * A renewal PKCSReq carries no challengePassword attribute (RFC 8894 §3.3.1.2) — it authenticates
+ * with the existing certificate's key instead — so the gate must tolerate an absent request
+ * password for an authenticated renewal and reject it otherwise, never dereference it blindly.
+ */
+class ScepServiceImplChallengePasswordTest {
+
+    private static final String PROFILE_PASSWORD = "mysecretpassword";
+
+    private ScepServiceImpl service;
+    private ScepProfile profile;
+
+    @BeforeEach
+    void setUp() {
+        service = new ScepServiceImpl();
+        profile = mock(ScepProfile.class);
+        ReflectionTestUtils.setField(service, "scepProfile", profile);
+    }
+
+    @Test
+    void profileWithoutChallengePassword_absentRequestPassword_passes() {
+        when(profile.getChallengePassword()).thenReturn(null);
+
+        assertDoesNotThrow(() -> service.validateChallengePassword(null, false));
+    }
+
+    @Test
+    void profileWithEmptyChallengePassword_absentRequestPassword_passes() {
+        when(profile.getChallengePassword()).thenReturn("");
+
+        assertDoesNotThrow(() -> service.validateChallengePassword(null, false));
+    }
+
+    @Test
+    void matchingRequestPassword_passes() {
+        when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
+
+        assertDoesNotThrow(() -> service.validateChallengePassword(PROFILE_PASSWORD, false));
+    }
+
+    @Test
+    void mismatchedRequestPassword_rejectedWithBadMessageCheck() {
+        when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
+
+        ScepException thrown = assertThrows(ScepException.class,
+                () -> service.validateChallengePassword("wrong", false));
+        assertEquals(FailInfo.BAD_MESSAGE_CHECK, thrown.getFailInfo());
+    }
+
+    /**
+     * The reported crash (issue #1887): a renewal-style PKCSReq without a challengePassword against a
+     * profile that has one configured must yield a SCEP rejection, not a {@code NullPointerException}.
+     */
+    @Test
+    void absentRequestPassword_notARenewal_rejectedWithBadMessageCheck() {
+        when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
+
+        ScepException thrown = assertThrows(ScepException.class,
+                () -> service.validateChallengePassword(null, false));
+        assertEquals(FailInfo.BAD_MESSAGE_CHECK, thrown.getFailInfo());
+    }
+
+    @Test
+    void absentRequestPassword_authenticatedRenewal_passes() {
+        when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
+
+        assertDoesNotThrow(() -> service.validateChallengePassword(null, true));
+    }
+
+    /**
+     * The waiver only covers an <em>absent</em> password. A renewal that does supply one must still
+     * match, so a wrong shared secret is never silently ignored.
+     */
+    @Test
+    void mismatchedRequestPassword_authenticatedRenewal_stillRejected() {
+        when(profile.getChallengePassword()).thenReturn(PROFILE_PASSWORD);
+
+        ScepException thrown = assertThrows(ScepException.class,
+                () -> service.validateChallengePassword("wrong", true));
+        assertEquals(FailInfo.BAD_MESSAGE_CHECK, thrown.getFailInfo());
+    }
+}

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplPkiOperationFailureTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplPkiOperationFailureTest.java
@@ -1,0 +1,59 @@
+package com.otilm.core.service.scep.impl;
+
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.dao.entity.scep.ScepProfile;
+import com.otilm.core.service.scep.ScepMessageTestData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the PKIOperation failure guard: an unexpected runtime failure must not escape as an
+ * {@code application/json} error body, since a SCEP client cannot parse one.
+ *
+ * <p>The profile here has no CA certificate, so processing fails immediately <em>and</em> the SCEP failure
+ * response cannot be signed — the CA key is reached through the token connector. That is the degraded corner
+ * of the contract: a bare status, never a JSON body, and nothing propagating out of the method.</p>
+ */
+class ScepServiceImplPkiOperationFailureTest {
+
+    private ScepServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ScepServiceImpl();
+
+        ScepProfile profile = mock(ScepProfile.class);
+        when(profile.getName()).thenReturn("scep-profile");
+        RaProfile raProfile = new RaProfile();
+        raProfile.setUuid(UUID.randomUUID());
+        raProfile.setName("ra-profile");
+
+        ReflectionTestUtils.setField(service, "scepProfile", profile);
+        ReflectionTestUtils.setField(service, "raProfile", raProfile);
+    }
+
+    @Test
+    void unexpectedFailure_answersWithABareStatusAndNeverAJsonBody() throws Exception {
+        byte[] body = ScepMessageTestData.passwordEnvelopedPkcsReq();
+
+        ResponseEntity<Object> response = invokePkiOperation(body);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNull(response.getBody(), "the response must carry no error body a SCEP client cannot parse");
+    }
+
+    @SuppressWarnings("unchecked")
+    private ResponseEntity<Object> invokePkiOperation(byte[] body) {
+        return (ResponseEntity<Object>) ReflectionTestUtils.invokeMethod(service, "pkiOperation", body);
+    }
+}

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplRenewalAuthenticationTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplRenewalAuthenticationTest.java
@@ -186,6 +186,20 @@ class ScepServiceImplRenewalAuthenticationTest {
         assertTrue(service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
     }
 
+    /**
+     * A validation status of FAILED means the platform could not reach a CRL or OCSP responder. That is not
+     * evidence against the certificate, so the renewal is not rejected — but it is not evidence for it
+     * either, so the shared secret is required instead of waived.
+     */
+    @Test
+    void certificateWithInconclusiveValidation_doesNotEarnTheWaiver() throws Exception {
+        Certificate unvalidated = inventoryCertificate(RA_PROFILE_UUID);
+        unvalidated.setValidationStatus(CertificateValidationStatus.FAILED);
+        when(certificateService.getCertificateEntityByFingerprint(any())).thenReturn(unvalidated);
+
+        assertFalse(service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
+    }
+
     @Test
     void certificateWithPendingIssue_isRejected() throws Exception {
         Certificate pending = inventoryCertificate(RA_PROFILE_UUID);
@@ -252,16 +266,39 @@ class ScepServiceImplRenewalAuthenticationTest {
         when(certificateService.getCertificateEntityByFingerprint(any()))
                 .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
 
-        assertFalse(service.authenticateRenewal(renewalRequestWithSans("extra.example.com")));
+        assertFalse(service.authenticateRenewal(renewalRequestWithSans(dnsSan("extra.example.com"))));
     }
 
     @Test
     void requestAskingForHeldSans_isAnAuthenticatedRenewal() throws Exception {
-        clientCertificate = selfSignedCertificate(clientKeyPair, SUBJECT_DN, "held.example.com");
+        clientCertificate = selfSignedCertificate(clientKeyPair, SUBJECT_DN, dnsSan("held.example.com"));
         when(certificateService.getCertificateEntityByFingerprint(any()))
                 .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
 
-        assertTrue(service.authenticateRenewal(renewalRequestWithSans("held.example.com")));
+        assertTrue(service.authenticateRenewal(renewalRequestWithSans(dnsSan("held.example.com"))));
+    }
+
+    /**
+     * An IP address SAN must compare equal across the two sides, or the waiver is silently withheld from
+     * network devices renewing on an address they already hold — and a renewal carries no challenge password
+     * to fall back on.
+     */
+    @Test
+    void requestAskingForHeldIpAddressSan_isAnAuthenticatedRenewal() throws Exception {
+        clientCertificate = selfSignedCertificate(clientKeyPair, SUBJECT_DN, ipSan("192.168.0.1"));
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
+
+        assertTrue(service.authenticateRenewal(renewalRequestWithSans(ipSan("192.168.0.1"))));
+    }
+
+    @Test
+    void requestAskingForAnUnheldIpAddressSan_doesNotEarnTheWaiver() throws Exception {
+        clientCertificate = selfSignedCertificate(clientKeyPair, SUBJECT_DN, ipSan("192.168.0.1"));
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
+
+        assertFalse(service.authenticateRenewal(renewalRequestWithSans(ipSan("10.0.0.9"))));
     }
 
     /** An unverifiable signature is a rejection, not a crash, and reports the integrity failure. */
@@ -326,34 +363,38 @@ class ScepServiceImplRenewalAuthenticationTest {
     private ScepRequest renewalRequest(String csrSubjectDn, boolean signatureVerifies) throws Exception {
         ScepRequest request = mock(ScepRequest.class);
         when(request.getSignerCertificate()).thenReturn(clientCertificate);
-        when(request.getPkcs10Request()).thenReturn(certificationRequest(csrSubjectDn, null));
+        when(request.getPkcs10Request()).thenReturn(certificationRequest(csrSubjectDn, (GeneralNames) null));
         when(request.verifySignature(any(PublicKey.class))).thenReturn(signatureVerifies);
         return request;
     }
 
-    private ScepRequest renewalRequestWithSans(String dnsName) throws Exception {
+    private ScepRequest renewalRequestWithSans(GeneralNames sans) throws Exception {
         ScepRequest request = mock(ScepRequest.class);
         when(request.getSignerCertificate()).thenReturn(clientCertificate);
-        when(request.getPkcs10Request()).thenReturn(certificationRequest(SUBJECT_DN, dnsName));
+        when(request.getPkcs10Request()).thenReturn(certificationRequest(SUBJECT_DN, sans));
         when(request.verifySignature(any(PublicKey.class))).thenReturn(true);
         return request;
     }
 
-    private JcaPKCS10CertificationRequest certificationRequest(String subjectDn, String dnsName) throws Exception {
+    private JcaPKCS10CertificationRequest certificationRequest(String subjectDn, GeneralNames sans) throws Exception {
         ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
                 .setProvider(BouncyCastleProvider.PROVIDER_NAME).build(clientKeyPair.getPrivate());
         JcaPKCS10CertificationRequestBuilder builder =
                 new JcaPKCS10CertificationRequestBuilder(new X500Name(subjectDn), clientKeyPair.getPublic());
-        if (dnsName != null) {
+        if (sans != null) {
             ExtensionsGenerator extensions = new ExtensionsGenerator();
-            extensions.addExtension(Extension.subjectAlternativeName, false, dnsNames(dnsName));
+            extensions.addExtension(Extension.subjectAlternativeName, false, sans);
             builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extensions.generate());
         }
         return new JcaPKCS10CertificationRequest(builder.build(signer));
     }
 
-    private static GeneralNames dnsNames(String dnsName) {
+    private static GeneralNames dnsSan(String dnsName) {
         return new GeneralNames(new GeneralName(GeneralName.dNSName, dnsName));
+    }
+
+    private static GeneralNames ipSan(String ipAddress) {
+        return new GeneralNames(new GeneralName(GeneralName.iPAddress, ipAddress));
     }
 
     private static KeyPair generateRsaKeyPair() throws Exception {
@@ -363,17 +404,17 @@ class ScepServiceImplRenewalAuthenticationTest {
     }
 
     private static X509Certificate selfSignedCertificate(KeyPair keyPair, String subjectDn) throws Exception {
-        return selfSignedCertificate(keyPair, subjectDn, null);
+        return selfSignedCertificate(keyPair, subjectDn, (GeneralNames) null);
     }
 
-    private static X509Certificate selfSignedCertificate(KeyPair keyPair, String subjectDn, String dnsName) throws Exception {
+    private static X509Certificate selfSignedCertificate(KeyPair keyPair, String subjectDn, GeneralNames sans) throws Exception {
         X500Name dn = new X500Name(subjectDn);
         Date notBefore = new Date(System.currentTimeMillis() - 60_000L);
         Date notAfter = new Date(System.currentTimeMillis() + 3_600_000L);
         JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
                 dn, BigInteger.valueOf(System.currentTimeMillis()), notBefore, notAfter, dn, keyPair.getPublic());
-        if (dnsName != null) {
-            builder.addExtension(Extension.subjectAlternativeName, false, dnsNames(dnsName));
+        if (sans != null) {
+            builder.addExtension(Extension.subjectAlternativeName, false, sans);
         }
         ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
                 .setProvider(BouncyCastleProvider.PROVIDER_NAME).build(keyPair.getPrivate());

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplRenewalAuthenticationTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplRenewalAuthenticationTest.java
@@ -170,6 +170,20 @@ class ScepServiceImplRenewalAuthenticationTest {
         assertTrue(service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
     }
 
+    /**
+     * A nullable validation status must not crash the renewal-window check on the configured-threshold
+     * branch: the renewable-state gate lets a null status through, so the timeframe policy must not
+     * dereference it.
+     */
+    @Test
+    void certificateWithoutValidationStatus_isAnAuthenticatedRenewal() throws Exception {
+        Certificate uncheckedCertificate = inventoryCertificate(RA_PROFILE_UUID);
+        uncheckedCertificate.setValidationStatus(null);
+        when(certificateService.getCertificateEntityByFingerprint(any())).thenReturn(uncheckedCertificate);
+
+        assertTrue(service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
+    }
+
     @Test
     void certificateWithPendingIssue_isRejected() throws Exception {
         Certificate pending = inventoryCertificate(RA_PROFILE_UUID);

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplRenewalAuthenticationTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplRenewalAuthenticationTest.java
@@ -10,7 +10,12 @@ import com.otilm.core.dao.entity.RaProfile;
 import com.otilm.core.dao.entity.scep.ScepProfile;
 import com.otilm.core.service.CertificateInternalService;
 import com.otilm.core.service.scep.message.ScepRequest;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.ExtensionsGenerator;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -20,6 +25,7 @@ import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigInteger;
@@ -37,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -126,6 +133,121 @@ class ScepServiceImplRenewalAuthenticationTest {
         assertFalse(service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
     }
 
+    /**
+     * The waiver must never be earned by a certificate that is no longer usable. With no renewal threshold
+     * configured — the default — `checkRenewalTimeframe` skips its revoked/expired branch entirely, so the
+     * state gate has to stand on its own.
+     */
+    @Test
+    void revokedCertificate_isRejected_withDefaultRenewalThreshold() throws Exception {
+        when(profile.getRenewalThreshold()).thenReturn(null);
+        Certificate revoked = inventoryCertificate(RA_PROFILE_UUID);
+        revoked.setState(CertificateState.REVOKED);
+        revoked.setValidationStatus(CertificateValidationStatus.REVOKED);
+        when(certificateService.getCertificateEntityByFingerprint(any())).thenReturn(revoked);
+
+        ScepException thrown = assertThrows(ScepException.class,
+                () -> service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
+        assertEquals(FailInfo.BAD_REQUEST, thrown.getFailInfo());
+    }
+
+    @Test
+    void expiredCertificate_isRejected_withDefaultRenewalThreshold() throws Exception {
+        when(profile.getRenewalThreshold()).thenReturn(null);
+        Certificate expired = inventoryCertificate(RA_PROFILE_UUID);
+        expired.setValidationStatus(CertificateValidationStatus.EXPIRED);
+        when(certificateService.getCertificateEntityByFingerprint(any())).thenReturn(expired);
+
+        assertThrows(ScepException.class, () -> service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
+    }
+
+    @Test
+    void healthyCertificate_isAnAuthenticatedRenewal_withDefaultRenewalThreshold() throws Exception {
+        when(profile.getRenewalThreshold()).thenReturn(null);
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
+
+        assertTrue(service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
+    }
+
+    @Test
+    void certificateWithPendingIssue_isRejected() throws Exception {
+        Certificate pending = inventoryCertificate(RA_PROFILE_UUID);
+        pending.setState(CertificateState.PENDING_ISSUE);
+        when(certificateService.getCertificateEntityByFingerprint(any())).thenReturn(pending);
+
+        assertThrows(ScepException.class, () -> service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
+    }
+
+    @Test
+    void certificateWithPendingRevoke_isRejected() throws Exception {
+        Certificate pending = inventoryCertificate(RA_PROFILE_UUID);
+        pending.setState(CertificateState.PENDING_REVOKE);
+        when(certificateService.getCertificateEntityByFingerprint(any())).thenReturn(pending);
+
+        assertThrows(ScepException.class, () -> service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
+    }
+
+    @Test
+    void certificateWithoutRaProfile_doesNotEarnTheWaiver() throws Exception {
+        Certificate unassociated = inventoryCertificate(RA_PROFILE_UUID);
+        unassociated.setRaProfileUuid(null);
+        when(certificateService.getCertificateEntityByFingerprint(any())).thenReturn(unassociated);
+
+        assertFalse(service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
+    }
+
+    /**
+     * Pins the ordering the waiver rests on: possession of the key is proven before any state of the
+     * renewed certificate is reported, so a client replaying a certificate it does not own learns nothing
+     * beyond the signature failure.
+     */
+    @Test
+    void archivedCertificateWithFailingSignature_reportsBadMessageCheck() throws Exception {
+        Certificate archived = inventoryCertificate(RA_PROFILE_UUID);
+        archived.setArchived(true);
+        when(certificateService.getCertificateEntityByFingerprint(any())).thenReturn(archived);
+
+        ScepException thrown = assertThrows(ScepException.class,
+                () -> service.authenticateRenewal(renewalRequest(SUBJECT_DN, false)));
+        assertEquals(FailInfo.BAD_MESSAGE_CHECK, thrown.getFailInfo());
+    }
+
+    /** The signature must be verified against the signer certificate's key, not some other key. */
+    @Test
+    void signatureIsVerifiedAgainstTheSignerCertificateKey() throws Exception {
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
+        ScepRequest request = renewalRequest(SUBJECT_DN, true);
+
+        service.authenticateRenewal(request);
+
+        ArgumentCaptor<PublicKey> verifiedKey = ArgumentCaptor.forClass(PublicKey.class);
+        verify(request).verifySignature(verifiedKey.capture());
+        assertEquals(clientCertificate.getPublicKey(), verifiedKey.getValue());
+    }
+
+    /**
+     * A waived renewal must not be able to obtain names the renewed certificate does not already carry;
+     * asking for more withholds the waiver, so the shared secret is required instead.
+     */
+    @Test
+    void requestAskingForAdditionalSans_doesNotEarnTheWaiver() throws Exception {
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
+
+        assertFalse(service.authenticateRenewal(renewalRequestWithSans("extra.example.com")));
+    }
+
+    @Test
+    void requestAskingForHeldSans_isAnAuthenticatedRenewal() throws Exception {
+        clientCertificate = selfSignedCertificate(clientKeyPair, SUBJECT_DN, "held.example.com");
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
+
+        assertTrue(service.authenticateRenewal(renewalRequestWithSans("held.example.com")));
+    }
+
     @Test
     void archivedCertificate_isRejected() throws Exception {
         Certificate archived = inventoryCertificate(RA_PROFILE_UUID);
@@ -159,17 +281,34 @@ class ScepServiceImplRenewalAuthenticationTest {
     private ScepRequest renewalRequest(String csrSubjectDn, boolean signatureVerifies) throws Exception {
         ScepRequest request = mock(ScepRequest.class);
         when(request.getSignerCertificate()).thenReturn(clientCertificate);
-        when(request.getPkcs10Request()).thenReturn(certificationRequest(csrSubjectDn));
+        when(request.getPkcs10Request()).thenReturn(certificationRequest(csrSubjectDn, null));
         when(request.verifySignature(any(PublicKey.class))).thenReturn(signatureVerifies);
         return request;
     }
 
-    private JcaPKCS10CertificationRequest certificationRequest(String subjectDn) throws Exception {
+    private ScepRequest renewalRequestWithSans(String dnsName) throws Exception {
+        ScepRequest request = mock(ScepRequest.class);
+        when(request.getSignerCertificate()).thenReturn(clientCertificate);
+        when(request.getPkcs10Request()).thenReturn(certificationRequest(SUBJECT_DN, dnsName));
+        when(request.verifySignature(any(PublicKey.class))).thenReturn(true);
+        return request;
+    }
+
+    private JcaPKCS10CertificationRequest certificationRequest(String subjectDn, String dnsName) throws Exception {
         ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
                 .setProvider(BouncyCastleProvider.PROVIDER_NAME).build(clientKeyPair.getPrivate());
-        return new JcaPKCS10CertificationRequest(
-                new JcaPKCS10CertificationRequestBuilder(new X500Name(subjectDn), clientKeyPair.getPublic())
-                        .build(signer));
+        JcaPKCS10CertificationRequestBuilder builder =
+                new JcaPKCS10CertificationRequestBuilder(new X500Name(subjectDn), clientKeyPair.getPublic());
+        if (dnsName != null) {
+            ExtensionsGenerator extensions = new ExtensionsGenerator();
+            extensions.addExtension(Extension.subjectAlternativeName, false, dnsNames(dnsName));
+            builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extensions.generate());
+        }
+        return new JcaPKCS10CertificationRequest(builder.build(signer));
+    }
+
+    private static GeneralNames dnsNames(String dnsName) {
+        return new GeneralNames(new GeneralName(GeneralName.dNSName, dnsName));
     }
 
     private static KeyPair generateRsaKeyPair() throws Exception {
@@ -179,11 +318,18 @@ class ScepServiceImplRenewalAuthenticationTest {
     }
 
     private static X509Certificate selfSignedCertificate(KeyPair keyPair, String subjectDn) throws Exception {
+        return selfSignedCertificate(keyPair, subjectDn, null);
+    }
+
+    private static X509Certificate selfSignedCertificate(KeyPair keyPair, String subjectDn, String dnsName) throws Exception {
         X500Name dn = new X500Name(subjectDn);
         Date notBefore = new Date(System.currentTimeMillis() - 60_000L);
         Date notAfter = new Date(System.currentTimeMillis() + 3_600_000L);
         JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
                 dn, BigInteger.valueOf(System.currentTimeMillis()), notBefore, notAfter, dn, keyPair.getPublic());
+        if (dnsName != null) {
+            builder.addExtension(Extension.subjectAlternativeName, false, dnsNames(dnsName));
+        }
         ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
                 .setProvider(BouncyCastleProvider.PROVIDER_NAME).build(keyPair.getPrivate());
         return new JcaX509CertificateConverter()

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplRenewalAuthenticationTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplRenewalAuthenticationTest.java
@@ -1,0 +1,192 @@
+package com.otilm.core.service.scep.impl;
+
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.exception.ScepException;
+import com.otilm.api.model.core.certificate.CertificateState;
+import com.otilm.api.model.core.certificate.CertificateValidationStatus;
+import com.otilm.api.model.core.scep.FailInfo;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.dao.entity.scep.ScepProfile;
+import com.otilm.core.service.CertificateInternalService;
+import com.otilm.core.service.scep.message.ScepRequest;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ScepServiceImpl#authenticateRenewal}, the positive renewal classification that
+ * decides whether a request may enroll without the profile's challenge password. The waiver requires the
+ * request to prove possession of an existing certificate's key (RFC 8894 §3.3.1.2), so an unresolvable
+ * or foreign signer certificate must never earn it.
+ */
+class ScepServiceImplRenewalAuthenticationTest {
+
+    private static final String SUBJECT_DN = "CN=renewal-client";
+    private static final UUID RA_PROFILE_UUID = UUID.randomUUID();
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    private ScepServiceImpl service;
+    private ScepProfile profile;
+    private CertificateInternalService certificateService;
+    private KeyPair clientKeyPair;
+    private X509Certificate clientCertificate;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        service = new ScepServiceImpl();
+        profile = mock(ScepProfile.class);
+        certificateService = mock(CertificateInternalService.class);
+
+        RaProfile raProfile = new RaProfile();
+        raProfile.setUuid(RA_PROFILE_UUID);
+
+        ReflectionTestUtils.setField(service, "scepProfile", profile);
+        ReflectionTestUtils.setField(service, "raProfile", raProfile);
+        ReflectionTestUtils.setField(service, "certificateService", certificateService);
+
+        when(profile.getRenewalThreshold()).thenReturn(30);
+
+        clientKeyPair = generateRsaKeyPair();
+        clientCertificate = selfSignedCertificate(clientKeyPair, SUBJECT_DN);
+    }
+
+    @Test
+    void noSignerCertificate_isNotARenewal() throws Exception {
+        ScepRequest request = mock(ScepRequest.class);
+        when(request.getSignerCertificate()).thenReturn(null);
+
+        assertFalse(service.authenticateRenewal(request));
+    }
+
+    @Test
+    void signerCertificateNotInInventory_isNotARenewal() throws Exception {
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenThrow(new NotFoundException(Certificate.class, "fingerprint"));
+
+        assertFalse(service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
+    }
+
+    @Test
+    void resolvedCertificateWithVerifiedSignature_isAnAuthenticatedRenewal() throws Exception {
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
+
+        assertTrue(service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
+    }
+
+    @Test
+    void failedSignatureVerification_rejectedWithBadMessageCheck() throws Exception {
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
+
+        ScepException thrown = assertThrows(ScepException.class,
+                () -> service.authenticateRenewal(renewalRequest(SUBJECT_DN, false)));
+        assertEquals(FailInfo.BAD_MESSAGE_CHECK, thrown.getFailInfo());
+    }
+
+    /**
+     * The signer certificate belongs to a different RA profile, so it is not entitled to this SCEP
+     * profile's enrollment without the shared secret: renewal policy still applies, but the challenge
+     * password waiver is withheld.
+     */
+    @Test
+    void certificateOfAnotherRaProfile_doesNotEarnTheWaiver() throws Exception {
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenReturn(inventoryCertificate(UUID.randomUUID()));
+
+        assertFalse(service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
+    }
+
+    @Test
+    void archivedCertificate_isRejected() throws Exception {
+        Certificate archived = inventoryCertificate(RA_PROFILE_UUID);
+        archived.setArchived(true);
+        when(certificateService.getCertificateEntityByFingerprint(any())).thenReturn(archived);
+
+        assertThrows(ScepException.class, () -> service.authenticateRenewal(renewalRequest(SUBJECT_DN, true)));
+    }
+
+    @Test
+    void subjectDnMismatch_isRejected() throws Exception {
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
+
+        assertThrows(ScepException.class, () -> service.authenticateRenewal(renewalRequest("CN=somebody-else", true)));
+    }
+
+    private Certificate inventoryCertificate(UUID raProfileUuid) {
+        Certificate certificate = new Certificate();
+        certificate.setUuid(UUID.randomUUID());
+        certificate.setSubjectDn(SUBJECT_DN);
+        certificate.setState(CertificateState.ISSUED);
+        certificate.setValidationStatus(CertificateValidationStatus.VALID);
+        certificate.setRaProfileUuid(raProfileUuid);
+        // 10 days left of a 40-day validity: inside the profile's 30-day renewal threshold.
+        certificate.setNotBefore(new Date(System.currentTimeMillis() - 30L * 24 * 3600 * 1000));
+        certificate.setNotAfter(new Date(System.currentTimeMillis() + 10L * 24 * 3600 * 1000));
+        return certificate;
+    }
+
+    private ScepRequest renewalRequest(String csrSubjectDn, boolean signatureVerifies) throws Exception {
+        ScepRequest request = mock(ScepRequest.class);
+        when(request.getSignerCertificate()).thenReturn(clientCertificate);
+        when(request.getPkcs10Request()).thenReturn(certificationRequest(csrSubjectDn));
+        when(request.verifySignature(any(PublicKey.class))).thenReturn(signatureVerifies);
+        return request;
+    }
+
+    private JcaPKCS10CertificationRequest certificationRequest(String subjectDn) throws Exception {
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME).build(clientKeyPair.getPrivate());
+        return new JcaPKCS10CertificationRequest(
+                new JcaPKCS10CertificationRequestBuilder(new X500Name(subjectDn), clientKeyPair.getPublic())
+                        .build(signer));
+    }
+
+    private static KeyPair generateRsaKeyPair() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static X509Certificate selfSignedCertificate(KeyPair keyPair, String subjectDn) throws Exception {
+        X500Name dn = new X500Name(subjectDn);
+        Date notBefore = new Date(System.currentTimeMillis() - 60_000L);
+        Date notAfter = new Date(System.currentTimeMillis() + 3_600_000L);
+        JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                dn, BigInteger.valueOf(System.currentTimeMillis()), notBefore, notAfter, dn, keyPair.getPublic());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME).build(keyPair.getPrivate());
+        return new JcaX509CertificateConverter()
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME).getCertificate(builder.build(signer));
+    }
+}

--- a/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplRenewalAuthenticationTest.java
+++ b/src/test/java/com/otilm/core/service/scep/impl/ScepServiceImplRenewalAuthenticationTest.java
@@ -17,6 +17,7 @@ import org.bouncycastle.asn1.x509.ExtensionsGenerator;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cms.CMSException;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -260,6 +262,35 @@ class ScepServiceImplRenewalAuthenticationTest {
                 .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
 
         assertTrue(service.authenticateRenewal(renewalRequestWithSans("held.example.com")));
+    }
+
+    /** An unverifiable signature is a rejection, not a crash, and reports the integrity failure. */
+    @Test
+    void signatureVerificationError_rejectedWithBadMessageCheck() throws Exception {
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
+        ScepRequest request = mock(ScepRequest.class);
+        when(request.getSignerCertificate()).thenReturn(clientCertificate);
+        when(request.verifySignature(any(PublicKey.class))).thenThrow(new CMSException("broken signature"));
+
+        ScepException thrown = assertThrows(ScepException.class, () -> service.authenticateRenewal(request));
+        assertEquals(FailInfo.BAD_MESSAGE_CHECK, thrown.getFailInfo());
+    }
+
+    /** Names that cannot be read withhold the waiver rather than being assumed harmless. */
+    @Test
+    void unreadableCertificationRequest_doesNotEarnTheWaiver() throws Exception {
+        when(certificateService.getCertificateEntityByFingerprint(any()))
+                .thenReturn(inventoryCertificate(RA_PROFILE_UUID));
+        JcaPKCS10CertificationRequest unreadable = mock(JcaPKCS10CertificationRequest.class);
+        when(unreadable.getSubject()).thenReturn(new X500Name(SUBJECT_DN));
+        when(unreadable.getEncoded()).thenThrow(new IOException("unreadable"));
+        ScepRequest request = mock(ScepRequest.class);
+        when(request.getSignerCertificate()).thenReturn(clientCertificate);
+        when(request.getPkcs10Request()).thenReturn(unreadable);
+        when(request.verifySignature(any(PublicKey.class))).thenReturn(true);
+
+        assertFalse(service.authenticateRenewal(request));
     }
 
     @Test


### PR DESCRIPTION
Closes #1887.

## Problem

A renewal PKCSReq is signed with the key of the certificate it replaces and carries no `challengePassword` attribute (RFC 8894 §3.3.1.2). The challenge-password gate dereferenced the request-side value without a null check, so every renewal against a profile with a password configured threw `NullPointerException`:

```
Cannot invoke "String.equals(Object)" because "challengePassword" is null
```

Being unchecked, it bypassed the `ScepException` → SCEP-response shaping and landed in the generic handler, so the client got a 36-byte JSON 500 it cannot parse. Broken since `21e6d0ccf` (2023) — renewal was never exercised until QA hit it on 2.18.x.

## What changed

**Classify before enforcing the shared secret.** `authenticateRenewal` resolves the signer certificate from the inventory, verifies the CMS signature against it, then applies the renewal checks. The challenge password is waived only for a positively authenticated renewal. A password that is *present* must still match, so a wrong shared secret is never silently accepted; a blank attribute counts as absent, which is what clients commonly send on renewal.

Signature verification now runs **ahead** of the certificate-state checks, so a client replaying a certificate it does not own cannot probe inventory state — it only ever sees the signature failure.

**Waiver conditions.** Proven key possession, plus a certificate in a renewable state whose subject DN matches the request. On top of that, the waiver itself requires the certificate to be associated with this profile's RA profile, its validation to be conclusive, and the request to ask for no subject alternative name the certificate does not already carry — those three only *withhold* the waiver, so a client that does supply the password is unaffected. A subject DN mismatch, an archived, pending, revoked, expired or invalid certificate, and a request outside the renewal window all *reject* the renewal, which is the behaviour that predates the waiver.

Subject alternative names are compared as DER structures rather than as rendered strings, because the two sides render an iPAddress differently (decoded text from the certificate, a hex octet string from the request) — comparing the renderings would silently withhold the waiver from a device renewing on an address it already holds.

**Renewable-state gate.** `checkRenewalTimeframe` only tests for revoked and expired certificates on the branch where a renewal threshold is configured, so with the default (unset) threshold that test never ran. Combined with the waiver, the key holder of a revoked certificate would have enrolled without the shared secret. The state and validation-status check now runs for every configuration, before the timeframe policy.

**Protocol-format responses.** `PKIOperation` answers unexpected runtime failures with a SCEP FAILURE carrying a generic `failInfoText`, mirroring the CMP fix in #1888. Request parsing sits inside the guard (malformed DER surfaces as an unchecked exception), the recovery path is itself guarded (building the failure needs the CA key through the token connector, which may be what failed), and the transaction is rolled back before answering so a failed attempt commits nothing. A checked `ScepException` from `decryptData` is now answered in the SCEP format too, instead of reaching the generic handler as JSON.

**Also fixed:** a latent `NullPointerException` in `ScepRequest.decryptData` when a password-enveloped request meets a profile with no challenge password; a no-op `assert` that let a recipient-less `EnvelopedData` reach the PKCS#10 parse with no content; a BouncyCastle exception message forwarded to the wire in the signature-failure text; missing `failInfo` values on `validateRenewal` rejections. The shared secret is compared with `MessageDigest.isEqual`. `verifyRequest` became private `verifyProofOfPossession` — renewal validation no longer runs there.

## Testing

41 SCEP unit tests and the SCEP integration test pass. New coverage: the reported crash, the waiver and its withholding conditions, revoked and expired certificates under the default null threshold, pending states, signature-before-state ordering, and an `ArgumentCaptor` assertion that the signature is verified against the signer certificate's key rather than any key.

The defect was reproduced against the pre-fix code before the fix was written, yielding the issue's exact message.

**Not covered:** the `pkiOperation` RuntimeException-to-FAILURE conversion. A unit test cannot reach it — `buildResponse` needs the token connector and the CA key — and the existing integration test has no provisioned SCEP profile.

## Known residuals

- If a nested `@Transactional` collaborator has already marked the transaction *globally* rollback-only, the commit still fails and the client gets a 500. Reproduced while writing tests: an issuance failure inside `generateCsr` triggers it, so this is reachable rather than theoretical.
- The guard covers PKIOperation once the message has parsed. A message that does not parse, and the profile-level errors from `init` / `validateProfile` (profile not found, disabled, no CA certificate), still answer as the platform's JSON error — there is no transaction id or nonce to echo, so no SCEP response can be formed. A full guarantee needs the error boundary outside the transaction, which means changes to the controller and the `ScepExternalService` contract in `interfaces`.
- Every runtime fault now answers `200` with `badRequest`, which sscep reads as permanent, and the endpoint no longer emits 5xx for genuine server faults. Deliberate, for CMP parity.
- The waiver trusts the RA-profile association, which an operator can set on a certificate the platform never issued — tracked in #1903.

## Follow-ups filed

- #1901 — `RENEWAL_REQ` (message type 17) is validated but then dispatched to "Unsupported Operation"; `GetCACaps` advertises `Renewal`.
- #1902 — QA: verify end-to-end that sscep and jscep can decrypt a password-enveloped `CertRep` to an EC signer.
- #1903 — tighten the waiver to proven issuance provenance.
- OmniTrustILM/documentation#337 — the SCEP pages still describe the pre-fix challenge-password rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


