### PR TITLE
Resolve OAuth2 username from the configured claim and normalize forwarded token claims

### DIFF
--- a/src/main/java/com/otilm/core/auth/oauth2/AuthenticationSnapshotRequestFilter.java
+++ b/src/main/java/com/otilm/core/auth/oauth2/AuthenticationSnapshotRequestFilter.java
@@ -1,0 +1,33 @@
+package com.otilm.core.auth.oauth2;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Bounds the lifetime of {@link AuthenticationSnapshotRequestHolder} to a single request.
+ *
+ * <p>Registered as the outermost filter so that it encloses every filter chain that can publish a snapshot -
+ * the resource-server chain that runs {@link PlatformJwtDecoder} for bearer tokens and the TSP chain that calls
+ * the decoder directly. It clears on the way in as well as in a {@code finally} block on the way out, so the
+ * holder is empty both before any component of this request can read it and after this request is done with the
+ * pooled thread, whatever the outcome of the chain.
+ */
+public class AuthenticationSnapshotRequestFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        AuthenticationSnapshotRequestHolder.clear();
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            AuthenticationSnapshotRequestHolder.clear();
+        }
+    }
+}

--- a/src/main/java/com/otilm/core/auth/oauth2/AuthenticationSnapshotRequestHolder.java
+++ b/src/main/java/com/otilm/core/auth/oauth2/AuthenticationSnapshotRequestHolder.java
@@ -1,0 +1,37 @@
+package com.otilm.core.auth.oauth2;
+
+import com.otilm.core.settings.AuthenticationSettingsSnapshot;
+
+/**
+ * Carries the authentication-settings snapshot that {@link PlatformJwtDecoder} validated a token against to the
+ * components that resolve the identity from that token later in the same request.
+ *
+ * <p>Token validation (JWK set, audiences, clock skew) and identity resolution (username claim, cache generation)
+ * happen in two separate components. Reading the snapshot twice would let a concurrent settings update slip
+ * between them, validating under one provider configuration and resolving the identity under another. The decoder
+ * therefore publishes the snapshot it used, and the identity resolvers consume it.
+ *
+ * <p>The value is bound to the request-handling thread, which is pooled, so it must never outlive the request
+ * that published it: {@link AuthenticationSnapshotRequestFilter} clears it around every request.
+ */
+public final class AuthenticationSnapshotRequestHolder {
+
+    private static final ThreadLocal<AuthenticationSettingsSnapshot> CURRENT = new ThreadLocal<>();
+
+    private AuthenticationSnapshotRequestHolder() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static void set(AuthenticationSettingsSnapshot snapshot) {
+        CURRENT.set(snapshot);
+    }
+
+    /** Returns the snapshot published for the current thread, or {@code null} when nothing was published. */
+    public static AuthenticationSettingsSnapshot get() {
+        return CURRENT.get();
+    }
+
+    public static void clear() {
+        CURRENT.remove();
+    }
+}

--- a/src/main/java/com/otilm/core/auth/oauth2/OAuth2LoginFilter.java
+++ b/src/main/java/com/otilm/core/auth/oauth2/OAuth2LoginFilter.java
@@ -1,7 +1,6 @@
 package com.otilm.core.auth.oauth2;
 
 import com.otilm.api.model.core.logging.enums.*;
-import com.otilm.api.model.core.settings.SettingsSection;
 import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDto;
 import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsDto;
 import com.otilm.core.logging.LoggingHelper;
@@ -11,6 +10,7 @@ import com.otilm.core.security.authn.PlatformUserDetails;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.authn.client.PlatformAuthenticationClient;
 import com.otilm.core.service.AuditLogInternalService;
+import com.otilm.core.settings.AuthenticationSettingsSnapshot;
 import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.util.OAuth2Constants;
 import com.otilm.core.util.OAuth2Util;
@@ -81,8 +81,9 @@ public class OAuth2LoginFilter extends OncePerRequestFilter {
         if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
             LoggingHelper.putActorInfoWhenNull(ActorType.USER, AuthMethod.SESSION);
 
+            AuthenticationSettingsSnapshot snapshot = SettingsCache.getAuthenticationSnapshot();
             OAuth2AccessToken oauth2AccessToken = (OAuth2AccessToken) request.getSession().getAttribute(OAuth2Constants.ACCESS_TOKEN_SESSION_ATTRIBUTE);
-            OAuth2ProviderSettingsDto providerSettings = getProviderSettings(oauthToken.getAuthorizedClientRegistrationId(), request.getSession(), oauth2AccessToken);
+            OAuth2ProviderSettingsDto providerSettings = getProviderSettings(snapshot.settings(), oauthToken.getAuthorizedClientRegistrationId(), request.getSession(), oauth2AccessToken);
 
             ClientRegistration clientRegistration = clientRegistrationRepository.findByRegistrationId(oauthToken.getAuthorizedClientRegistrationId());
             OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(clientRegistration, oauthToken.getName(), oauth2AccessToken, (OAuth2RefreshToken) request.getSession().getAttribute(OAuth2Constants.REFRESH_TOKEN_SESSION_ATTRIBUTE));
@@ -125,7 +126,7 @@ public class OAuth2LoginFilter extends OncePerRequestFilter {
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
                 return;
             }
-            authenticate(request, claims, clientRegistration);
+            authenticate(request, claims, clientRegistration, snapshot.generation());
         }
 
         try {
@@ -136,10 +137,10 @@ public class OAuth2LoginFilter extends OncePerRequestFilter {
         }
     }
 
-    private void authenticate(HttpServletRequest request, Map<String, Object> claims, ClientRegistration clientRegistration) {
+    private void authenticate(HttpServletRequest request, Map<String, Object> claims, ClientRegistration clientRegistration, long settingsGeneration) {
         AuthenticationInfo authInfo;
         try {
-            authInfo = authenticationClient.authenticateByToken(claims);
+            authInfo = authenticationClient.authenticateByToken(claims, settingsGeneration);
             PlatformAuthenticationToken authenticationToken = new PlatformAuthenticationToken(new PlatformUserDetails(authInfo));
             SecurityContextHolder.getContext().setAuthentication(authenticationToken);
             LOGGER.debug("Session of user '{}' logged using OAuth2 Provider '{}' has been successfully validated.", authenticationToken.getPrincipal().getUsername(), clientRegistration.getRegistrationId());
@@ -168,17 +169,8 @@ public class OAuth2LoginFilter extends OncePerRequestFilter {
             // Save the refreshed authorized client with refreshed access token
             if (authorizedClient != null) {
 
-                // Use configurable username claim name from provider settings, with fallback to default
-                String usernameClaimName = providerSettings.getUsernameClaim() != null && !providerSettings.getUsernameClaim().isEmpty()
-                        ? providerSettings.getUsernameClaim()
-                        : OAuth2Constants.TOKEN_USERNAME_CLAIM_NAME;
-
-                Object usernameClaim = oauthToken.getPrincipal().getAttribute(usernameClaimName);
-                if (usernameClaim == null) {
-                    throw new PlatformAuthenticationException("Missing username claim '%s' in token attributes.".formatted(usernameClaimName));
-                }
-
-                LOGGER.debug("OAuth2 Access Token has been refreshed for user {}.", usernameClaim);
+                String username = OAuth2Util.resolveUsernameOrNull(providerSettings, oauthToken.getPrincipal().getAttributes());
+                LOGGER.debug("OAuth2 Access Token has been refreshed for user {}.", username);
                 session.setAttribute(OAuth2Constants.ACCESS_TOKEN_SESSION_ATTRIBUTE, authorizedClient.getAccessToken());
                 session.setAttribute(OAuth2Constants.REFRESH_TOKEN_SESSION_ATTRIBUTE, authorizedClient.getRefreshToken());
             } else {
@@ -190,8 +182,7 @@ public class OAuth2LoginFilter extends OncePerRequestFilter {
         return authorizedClient;
     }
 
-    private OAuth2ProviderSettingsDto getProviderSettings(String clientRegistrationId, HttpSession session, OAuth2AccessToken oauth2AccessToken) {
-        AuthenticationSettingsDto authenticationSettings = SettingsCache.getSettings(SettingsSection.AUTHENTICATION);
+    private OAuth2ProviderSettingsDto getProviderSettings(AuthenticationSettingsDto authenticationSettings, String clientRegistrationId, HttpSession session, OAuth2AccessToken oauth2AccessToken) {
         OAuth2ProviderSettingsDto providerSettings = authenticationSettings.getOAuth2Providers().get(clientRegistrationId);
         if (providerSettings == null) {
             session.invalidate();

--- a/src/main/java/com/otilm/core/auth/oauth2/PlatformAuthenticationSuccessHandler.java
+++ b/src/main/java/com/otilm/core/auth/oauth2/PlatformAuthenticationSuccessHandler.java
@@ -60,14 +60,9 @@ public class PlatformAuthenticationSuccessHandler implements AuthenticationSucce
             throw new PlatformAuthenticationException(message);
         }
 
-        // Get username using configurable claim name from provider settings
-        String usernameClaimName = providerSettings.getUsernameClaim();
-        if (usernameClaimName == null || usernameClaimName.isEmpty()) {
-            usernameClaimName = OAuth2Constants.TOKEN_USERNAME_CLAIM_NAME;
-        }
-        Object username = oidcUser.getAttribute(usernameClaimName);
+        String username = OAuth2Util.resolveUsernameOrNull(providerSettings, oidcUser.getAttributes());
         if (username != null) {
-            LoggingHelper.putActorInfoWhenNull(null, null, username.toString());
+            LoggingHelper.putActorInfoWhenNull(null, null, username);
         }
         try {
             OAuth2Util.validateAudiences(authorizedClient.getAccessToken(), providerSettings);

--- a/src/main/java/com/otilm/core/auth/oauth2/PlatformJwtAuthenticationConverter.java
+++ b/src/main/java/com/otilm/core/auth/oauth2/PlatformJwtAuthenticationConverter.java
@@ -49,7 +49,7 @@ public class PlatformJwtAuthenticationConverter implements Converter<Jwt, Abstra
             return (AbstractAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
         }
 
-        AuthenticationSettingsSnapshot snapshot = SettingsCache.getAuthenticationSnapshot();
+        AuthenticationSettingsSnapshot snapshot = validatedSnapshot();
         OAuth2ProviderSettingsDto providerSettings = OAuth2Util.findProviderByIssuer(
                 snapshot.settings(), source.getIssuer() == null ? null : source.getIssuer().toString());
 
@@ -66,5 +66,15 @@ public class PlatformJwtAuthenticationConverter implements Converter<Jwt, Abstra
         // Provider settings will not be null, otherwise converter would not have been reached from decoder
         logger.debug("User '{}' has been authenticated using JWT from OAuth2 Provider '{}'.", userDetails.getUsername(), providerSettings == null ? " " : providerSettings.getName());
         return new PlatformAuthenticationToken(userDetails);
+    }
+
+    /**
+     * Returns the snapshot {@link PlatformJwtDecoder} validated the token against, so the identity is resolved
+     * under the very provider configuration that accepted the token. Falls back to the current settings when
+     * nothing was published, which keeps the converter usable when it is invoked without the decoder.
+     */
+    private static AuthenticationSettingsSnapshot validatedSnapshot() {
+        AuthenticationSettingsSnapshot published = AuthenticationSnapshotRequestHolder.get();
+        return published != null ? published : SettingsCache.getAuthenticationSnapshot();
     }
 }

--- a/src/main/java/com/otilm/core/auth/oauth2/PlatformJwtAuthenticationConverter.java
+++ b/src/main/java/com/otilm/core/auth/oauth2/PlatformJwtAuthenticationConverter.java
@@ -2,8 +2,6 @@ package com.otilm.core.auth.oauth2;
 
 import com.otilm.api.model.core.logging.enums.Operation;
 import com.otilm.api.model.core.logging.enums.OperationResult;
-import com.otilm.api.model.core.settings.SettingsSection;
-import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDto;
 import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsDto;
 import com.otilm.core.security.authn.PlatformAuthenticationException;
 import com.otilm.core.security.authn.PlatformAuthenticationToken;
@@ -11,6 +9,7 @@ import com.otilm.core.security.authn.PlatformUserDetails;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.authn.client.PlatformAuthenticationClient;
 import com.otilm.core.service.AuditLogInternalService;
+import com.otilm.core.settings.AuthenticationSettingsSnapshot;
 import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.util.OAuth2Util;
 import jakarta.annotation.Nullable;
@@ -50,8 +49,9 @@ public class PlatformJwtAuthenticationConverter implements Converter<Jwt, Abstra
             return (AbstractAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
         }
 
-        AuthenticationSettingsDto authenticationSettings = SettingsCache.getSettings(SettingsSection.AUTHENTICATION);
-        OAuth2ProviderSettingsDto providerSettings = authenticationSettings.getOAuth2Providers().values().stream().filter(p -> p.getIssuerUrl().equals(source.getIssuer().toString())).findFirst().orElse(null);
+        AuthenticationSettingsSnapshot snapshot = SettingsCache.getAuthenticationSnapshot();
+        OAuth2ProviderSettingsDto providerSettings = OAuth2Util.findProviderByIssuer(
+                snapshot.settings(), source.getIssuer() == null ? null : source.getIssuer().toString());
 
         Map<String, Object> claims;
         try {
@@ -61,7 +61,7 @@ public class PlatformJwtAuthenticationConverter implements Converter<Jwt, Abstra
             throw e;
         }
 
-        AuthenticationInfo authInfo = authenticationClient.authenticateByToken(claims);
+        AuthenticationInfo authInfo = authenticationClient.authenticateByToken(claims, snapshot.generation());
         PlatformUserDetails userDetails = new PlatformUserDetails(authInfo);
         // Provider settings will not be null, otherwise converter would not have been reached from decoder
         logger.debug("User '{}' has been authenticated using JWT from OAuth2 Provider '{}'.", userDetails.getUsername(), providerSettings == null ? " " : providerSettings.getName());

--- a/src/main/java/com/otilm/core/auth/oauth2/PlatformJwtDecoder.java
+++ b/src/main/java/com/otilm/core/auth/oauth2/PlatformJwtDecoder.java
@@ -1,13 +1,12 @@
 package com.otilm.core.auth.oauth2;
 
 import com.otilm.api.model.core.logging.enums.*;
-import com.otilm.api.model.core.settings.SettingsSection;
-import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDto;
 import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsDto;
 import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.security.authn.PlatformAnonymousToken;
 import com.otilm.core.security.authn.PlatformAuthenticationException;
 import com.otilm.core.service.AuditLogInternalService;
+import com.otilm.core.settings.AuthenticationSettingsSnapshot;
 import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.util.AuthHelper;
 import com.otilm.core.util.OAuth2Util;
@@ -49,6 +48,11 @@ public class PlatformJwtDecoder implements JwtDecoder {
         this.auditLogService = auditLogService;
     }
 
+    /**
+     * Validates the token against the provider configuration of a single authentication-settings snapshot and
+     * publishes that snapshot through {@link AuthenticationSnapshotRequestHolder}, so the identity resolution
+     * that follows in the same request cannot run against a concurrently updated configuration.
+     */
     @Override
     public Jwt decode(String token) throws JwtException {
         if (!isAuthenticationNeeded()) {
@@ -78,8 +82,9 @@ public class PlatformJwtDecoder implements JwtDecoder {
             throw new PlatformAuthenticationException(message);
         }
 
-        AuthenticationSettingsDto authenticationSettings = SettingsCache.getSettings(SettingsSection.AUTHENTICATION);
-        OAuth2ProviderSettingsDto providerSettings = OAuth2Util.findProviderByIssuer(authenticationSettings, issuerUri);
+        AuthenticationSettingsSnapshot snapshot = SettingsCache.getAuthenticationSnapshot();
+        AuthenticationSnapshotRequestHolder.set(snapshot);
+        OAuth2ProviderSettingsDto providerSettings = OAuth2Util.findProviderByIssuer(snapshot.settings(), issuerUri);
 
         if (providerSettings == null) {
             String message = "No OAuth2 Provider with issuer URI '%s' configured for authentication with JWT token".formatted(issuerUri);

--- a/src/main/java/com/otilm/core/auth/oauth2/PlatformJwtDecoder.java
+++ b/src/main/java/com/otilm/core/auth/oauth2/PlatformJwtDecoder.java
@@ -10,6 +10,7 @@ import com.otilm.core.security.authn.PlatformAuthenticationException;
 import com.otilm.core.service.AuditLogInternalService;
 import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.util.AuthHelper;
+import com.otilm.core.util.OAuth2Util;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.slf4j.Logger;
@@ -78,7 +79,7 @@ public class PlatformJwtDecoder implements JwtDecoder {
         }
 
         AuthenticationSettingsDto authenticationSettings = SettingsCache.getSettings(SettingsSection.AUTHENTICATION);
-        OAuth2ProviderSettingsDto providerSettings = authenticationSettings.getOAuth2Providers().values().stream().filter(p -> p.getIssuerUrl().equals(issuerUri)).findFirst().orElse(null);
+        OAuth2ProviderSettingsDto providerSettings = OAuth2Util.findProviderByIssuer(authenticationSettings, issuerUri);
 
         if (providerSettings == null) {
             String message = "No OAuth2 Provider with issuer URI '%s' configured for authentication with JWT token".formatted(issuerUri);
@@ -120,7 +121,7 @@ public class PlatformJwtDecoder implements JwtDecoder {
 
         // Add audience validation
         if (!audiences.isEmpty()) {
-            audienceValidator = new JwtClaimValidator<List<String>>("aud", aud -> aud.stream().anyMatch(audiences::contains));
+            audienceValidator = new JwtClaimValidator<>("aud", (List<String> aud) -> aud.stream().anyMatch(audiences::contains));
         }
 
         return JwtValidators.createDefaultWithValidators(List.of(new JwtIssuerValidator(issuerUri), clockSkewValidator, audienceValidator));

--- a/src/main/java/com/otilm/core/config/WebAppConfig.java
+++ b/src/main/java/com/otilm/core/config/WebAppConfig.java
@@ -3,6 +3,7 @@ package com.otilm.core.config;
 import com.otilm.api.model.client.dashboard.SigningRecordStatisticsPeriod;
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
 import com.otilm.api.model.core.oid.OidCategory;
+import com.otilm.core.auth.oauth2.AuthenticationSnapshotRequestFilter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,6 +14,7 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -110,6 +112,21 @@ public class WebAppConfig implements WebMvcConfigurer {
         });
         registry.addConverter(String.class, OidCategory.class,
                 source -> StringUtils.isBlank(source) ? null : OidCategory.fromCode(source));
+    }
+
+    /**
+     * Registered ahead of every other filter, including the Spring Security chains, so that no component can
+     * observe an authentication-settings snapshot published by an earlier request on the same pooled thread.
+     */
+    @Bean
+    public FilterRegistrationBean<AuthenticationSnapshotRequestFilter> authenticationSnapshotRequestFilter() {
+        FilterRegistrationBean<AuthenticationSnapshotRequestFilter> registrationBean = new FilterRegistrationBean<>();
+
+        registrationBean.setFilter(new AuthenticationSnapshotRequestFilter());
+        registrationBean.addUrlPatterns("/*");
+        registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+
+        return registrationBean;
     }
 
     @Bean

--- a/src/main/java/com/otilm/core/dao/repository/SettingRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/SettingRepository.java
@@ -2,6 +2,7 @@ package com.otilm.core.dao.repository;
 
 import com.otilm.api.model.core.settings.SettingsSection;
 import com.otilm.core.dao.entity.Setting;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -22,4 +23,9 @@ public interface SettingRepository extends SecurityFilterRepository<Setting, UUI
     void deleteBySectionAndCategory(SettingsSection section, String category);
 
     Long deleteBySectionAndCategoryAndName(SettingsSection section, String category, String name);
+
+    // Transaction-scoped advisory lock serializing OAuth2 provider settings writes so that concurrent
+    // updates cannot both pass the in-process issuer-uniqueness check before either commits.
+    @Query(value = "SELECT pg_advisory_xact_lock(hashtext('oauth2-provider-settings'))", nativeQuery = true)
+    Object lockOAuth2ProviderWrites();
 }

--- a/src/main/java/com/otilm/core/security/authn/client/AuthenticationCache.java
+++ b/src/main/java/com/otilm/core/security/authn/client/AuthenticationCache.java
@@ -40,17 +40,21 @@ public interface AuthenticationCache {
 
     /**
      * Returns cached authentication for a bearer-token request, or invokes {@code loader} and caches the result.
-     * Cached by authentication-settings generation plus the {@code jti} claim. The generation must come from
-     * the same settings snapshot the claims were resolved against, so a settings change makes every previously
-     * cached identity unreachable and an in-flight authentication can never publish a stale identity under the
-     * new generation. Tokens without a {@code jti} are never cached.
+     * Cached by authentication-settings generation plus the issuer and the {@code jti} claim. A {@code jti} is
+     * only unique within the issuer that minted it, so two configured providers may legitimately issue tokens
+     * carrying the same {@code jti}; keying on the issuer as well keeps their identities apart. The generation
+     * must come from the same settings snapshot the claims were resolved against, so a settings change makes
+     * every previously cached identity unreachable and an in-flight authentication can never publish a stale
+     * identity under the new generation. Tokens whose issuer or {@code jti} is missing are never cached, because
+     * an incomplete key cannot distinguish one token from another.
      *
+     * @param issuer             the {@code iss} claim of the access token; {@code null} or blank skips caching
      * @param jti                the {@code jti} claim of the access token; {@code null} skips caching
      * @param settingsGeneration generation of the authentication-settings snapshot used to resolve the claims
      * @param loader             called on a cache miss to produce the {@link AuthenticationInfo}
      * @return the cached or freshly loaded {@link AuthenticationInfo}
      */
-    AuthenticationInfo getOrAuthenticateByToken(String jti, long settingsGeneration, Supplier<AuthenticationInfo> loader);
+    AuthenticationInfo getOrAuthenticateByToken(String issuer, String jti, long settingsGeneration, Supplier<AuthenticationInfo> loader);
 
     /**
      * Evicts all auth cache entries for a single user: their UUID entry, all token entries tracked

--- a/src/main/java/com/otilm/core/security/authn/client/AuthenticationCache.java
+++ b/src/main/java/com/otilm/core/security/authn/client/AuthenticationCache.java
@@ -40,15 +40,17 @@ public interface AuthenticationCache {
 
     /**
      * Returns cached authentication for a bearer-token request, or invokes {@code loader} and caches the result.
-     * Cached by the {@code jti} claim, which is unique per token issuance. All requests that carry the same
-     * access token share one cache entry for its lifetime. When the token is refreshed, a new {@code jti}
-     * causes a cache miss, triggering a fresh auth-service call. Tokens without a {@code jti} are never cached.
+     * Cached by authentication-settings generation plus the {@code jti} claim. The generation must come from
+     * the same settings snapshot the claims were resolved against, so a settings change makes every previously
+     * cached identity unreachable and an in-flight authentication can never publish a stale identity under the
+     * new generation. Tokens without a {@code jti} are never cached.
      *
-     * @param jti    the {@code jti} claim of the access token, used as the cache key; {@code null} skips caching
-     * @param loader called on a cache miss to produce the {@link AuthenticationInfo}
+     * @param jti                the {@code jti} claim of the access token; {@code null} skips caching
+     * @param settingsGeneration generation of the authentication-settings snapshot used to resolve the claims
+     * @param loader             called on a cache miss to produce the {@link AuthenticationInfo}
      * @return the cached or freshly loaded {@link AuthenticationInfo}
      */
-    AuthenticationInfo getOrAuthenticateByToken(String jti, Supplier<AuthenticationInfo> loader);
+    AuthenticationInfo getOrAuthenticateByToken(String jti, long settingsGeneration, Supplier<AuthenticationInfo> loader);
 
     /**
      * Evicts all auth cache entries for a single user: their UUID entry, all token entries tracked

--- a/src/main/java/com/otilm/core/security/authn/client/PlatformAuthenticationCache.java
+++ b/src/main/java/com/otilm/core/security/authn/client/PlatformAuthenticationCache.java
@@ -61,18 +61,19 @@ public class PlatformAuthenticationCache implements AuthenticationCache {
     // Manual caching (instead of @Cacheable) keeps tokenJtiIndex in sync, enabling targeted
     // per-user eviction via evictTokensByUserUuid().
     @Override
-    public AuthenticationInfo getOrAuthenticateByToken(String jti, Supplier<AuthenticationInfo> loader) {
+    public AuthenticationInfo getOrAuthenticateByToken(String jti, long settingsGeneration, Supplier<AuthenticationInfo> loader) {
         if (jti == null) {
             return loader.get();
         }
-        Cache.ValueWrapper cached = tokenCache.get(jti);
+        String cacheKey = settingsGeneration + ":" + jti;
+        Cache.ValueWrapper cached = tokenCache.get(cacheKey);
         if (cached != null) {
             return (AuthenticationInfo) cached.get();
         }
         AuthenticationInfo result = loader.get();
         if (!result.isAnonymous()) {
-            tokenCache.put(jti, result);
-            tokenJtiIndex.add(UUID.fromString(result.getUserUuid()), jti);
+            tokenCache.put(cacheKey, result);
+            tokenJtiIndex.add(UUID.fromString(result.getUserUuid()), cacheKey);
         }
         return result;
     }

--- a/src/main/java/com/otilm/core/security/authn/client/PlatformAuthenticationCache.java
+++ b/src/main/java/com/otilm/core/security/authn/client/PlatformAuthenticationCache.java
@@ -1,6 +1,7 @@
 package com.otilm.core.security.authn.client;
 
 import com.otilm.core.config.cache.CacheConfig;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -61,11 +62,11 @@ public class PlatformAuthenticationCache implements AuthenticationCache {
     // Manual caching (instead of @Cacheable) keeps tokenJtiIndex in sync, enabling targeted
     // per-user eviction via evictTokensByUserUuid().
     @Override
-    public AuthenticationInfo getOrAuthenticateByToken(String jti, long settingsGeneration, Supplier<AuthenticationInfo> loader) {
-        if (jti == null) {
+    public AuthenticationInfo getOrAuthenticateByToken(String issuer, String jti, long settingsGeneration, Supplier<AuthenticationInfo> loader) {
+        if (jti == null || StringUtils.isBlank(issuer)) {
             return loader.get();
         }
-        String cacheKey = settingsGeneration + ":" + jti;
+        String cacheKey = tokenCacheKey(issuer, jti, settingsGeneration);
         Cache.ValueWrapper cached = tokenCache.get(cacheKey);
         if (cached != null) {
             return (AuthenticationInfo) cached.get();
@@ -76,6 +77,20 @@ public class PlatformAuthenticationCache implements AuthenticationCache {
             tokenJtiIndex.add(UUID.fromString(result.getUserUuid()), cacheKey);
         }
         return result;
+    }
+
+    /**
+     * Builds the token cache key as {@code generation:issuerLength:issuer:jti}.
+     * The generation is decimal digits and therefore self-delimiting, but an issuer URL contains colons and
+     * slashes and a {@code jti} is an opaque string chosen by the issuer, so a plain separator would let one
+     * (generation, issuer, jti) triple render as the key of another - issuer {@code https://a} with
+     * {@code jti} {@code x:y} and issuer {@code https://a:x} with {@code jti} {@code y} would collide.
+     * Prefixing the issuer with its character length makes the split deterministic: the digits before the
+     * second colon give the issuer length, the next that many characters are the issuer, and everything after
+     * the following colon is the {@code jti}. Every distinct triple therefore yields a distinct key.
+     */
+    private static String tokenCacheKey(String issuer, String jti, long settingsGeneration) {
+        return settingsGeneration + ":" + issuer.length() + ":" + issuer + ":" + jti;
     }
 
     @Override

--- a/src/main/java/com/otilm/core/security/authn/client/PlatformAuthenticationClient.java
+++ b/src/main/java/com/otilm/core/security/authn/client/PlatformAuthenticationClient.java
@@ -74,10 +74,10 @@ public class PlatformAuthenticationClient extends PlatformBaseAuthenticationClie
                 certificateThumbprint, () -> authenticate(AuthMethod.CERTIFICATE, rawCertHeader, false)));
     }
 
-    public AuthenticationInfo authenticateByToken(Map<String, Object> claims) {
+    public AuthenticationInfo authenticateByToken(Map<String, Object> claims, long settingsGeneration) {
         String jti = (String) claims.get("jti");
         return restoreActorMdc(authenticationCache.getOrAuthenticateByToken(
-                jti, () -> authenticate(AuthMethod.TOKEN, claims, false)));
+                jti, settingsGeneration, () -> authenticate(AuthMethod.TOKEN, claims, false)));
     }
 
     /**

--- a/src/main/java/com/otilm/core/security/authn/client/PlatformAuthenticationClient.java
+++ b/src/main/java/com/otilm/core/security/authn/client/PlatformAuthenticationClient.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
@@ -75,9 +76,19 @@ public class PlatformAuthenticationClient extends PlatformBaseAuthenticationClie
     }
 
     public AuthenticationInfo authenticateByToken(Map<String, Object> claims, long settingsGeneration) {
-        String jti = (String) claims.get("jti");
         return restoreActorMdc(authenticationCache.getOrAuthenticateByToken(
-                jti, settingsGeneration, () -> authenticate(AuthMethod.TOKEN, claims, false)));
+                stringClaim(claims, JwtClaimNames.ISS), stringClaim(claims, JwtClaimNames.JTI),
+                settingsGeneration, () -> authenticate(AuthMethod.TOKEN, claims, false)));
+    }
+
+    /**
+     * Returns the claim value when it is a string, {@code null} otherwise. The token cache is keyed on the
+     * issuer and the {@code jti}; a claim of any other shape leaves the key incomplete, and an incomplete key
+     * must skip the cache rather than let one token share an entry with another.
+     */
+    private static String stringClaim(Map<String, Object> claims, String claimName) {
+        Object value = claims.get(claimName);
+        return value instanceof String text ? text : null;
     }
 
     /**

--- a/src/main/java/com/otilm/core/security/authn/client/TokenJtiIndex.java
+++ b/src/main/java/com/otilm/core/security/authn/client/TokenJtiIndex.java
@@ -9,7 +9,9 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Secondary index: userUuid → set of JTI claims cached for that user.
+ * Secondary index: userUuid → set of opaque token-cache keys cached for that user. Each key is the
+ * {@code settingsGeneration + ":" + jti} composite used by {@link PlatformAuthenticationCache}; this
+ * index treats it as an opaque string and never parses it.
  * Enables per-user token eviction when only the userUuid is known.
  * Kept in sync automatically via the Caffeine removal listener registered in CacheConfig.
  */
@@ -21,21 +23,21 @@ public class TokenJtiIndex implements RemovalListener<Object, Object> {
     /** Called by Caffeine on every token cache eviction (TTL, size pressure, explicit, replace). */
     @Override
     public void onRemoval(Object key, Object value, RemovalCause cause) {
-        if (!(key instanceof String jti) || !(value instanceof AuthenticationInfo info) || info.getUserUuid() == null) return;
-        index.computeIfPresent(UUID.fromString(info.getUserUuid()), (uuid, jtis) -> {
-            jtis.remove(jti);
-            return jtis.isEmpty() ? null : jtis;
+        if (!(key instanceof String cacheKey) || !(value instanceof AuthenticationInfo info) || info.getUserUuid() == null) return;
+        index.computeIfPresent(UUID.fromString(info.getUserUuid()), (uuid, cacheKeys) -> {
+            cacheKeys.remove(cacheKey);
+            return cacheKeys.isEmpty() ? null : cacheKeys;
         });
     }
 
-    public void add(UUID userUuid, String jti) {
+    public void add(UUID userUuid, String cacheKey) {
         if (userUuid == null) {
             throw new IllegalStateException("Authenticated result must contain a non-null userUuid");
         }
-        index.computeIfAbsent(userUuid, k -> ConcurrentHashMap.newKeySet()).add(jti);
+        index.computeIfAbsent(userUuid, k -> ConcurrentHashMap.newKeySet()).add(cacheKey);
     }
 
-    /** Removes and returns all JTIs for the given user, or null if none. */
+    /** Removes and returns all composite cache keys for the given user, or null if none. */
     public Set<String> removeUser(UUID userUuid) {
         return index.remove(userUuid);
     }

--- a/src/main/java/com/otilm/core/security/authn/client/TokenJtiIndex.java
+++ b/src/main/java/com/otilm/core/security/authn/client/TokenJtiIndex.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Secondary index: userUuid → set of opaque token-cache keys cached for that user. Each key is the
- * {@code settingsGeneration + ":" + jti} composite used by {@link PlatformAuthenticationCache}; this
+ * settings-generation, issuer and {@code jti} composite built by {@link PlatformAuthenticationCache}; this
  * index treats it as an opaque string and never parses it.
  * Enables per-user token eviction when only the userUuid is known.
  * Kept in sync automatically via the Caffeine removal listener registered in CacheConfig.

--- a/src/main/java/com/otilm/core/security/authn/tsp/BearerTokenAuthenticator.java
+++ b/src/main/java/com/otilm/core/security/authn/tsp/BearerTokenAuthenticator.java
@@ -2,6 +2,7 @@ package com.otilm.core.security.authn.tsp;
 
 import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsDto;
 import com.otilm.api.model.core.signing.TspAuthenticationMethod;
+import com.otilm.core.auth.oauth2.AuthenticationSnapshotRequestHolder;
 import com.otilm.core.auth.oauth2.PlatformJwtDecoder;
 import com.otilm.core.model.signing.TspProfileModel;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
@@ -51,11 +52,11 @@ public class BearerTokenAuthenticator implements TspAuthenticator {
     public boolean authenticate(HttpServletRequest request, TspProfileModel profile) {
         String token = request.getHeader(HttpHeaders.AUTHORIZATION).substring(BEARER_PREFIX.length()).trim();
         try {
-            AuthenticationSettingsSnapshot snapshot = SettingsCache.getAuthenticationSnapshot();
             Jwt jwt = jwtDecoder.decode(token);
             if (jwt == null) {
                 return false;
             }
+            AuthenticationSettingsSnapshot snapshot = validatedSnapshot();
             OAuth2ProviderSettingsDto provider = OAuth2Util.findProviderByIssuer(
                     snapshot.settings(), jwt.getIssuer() == null ? null : jwt.getIssuer().toString());
             Map<String, Object> claims = new HashMap<>(jwt.getClaims());
@@ -66,5 +67,15 @@ public class BearerTokenAuthenticator implements TspAuthenticator {
             log.warn("TSP authentication: bearer-token authentication failed: {}", e.getMessage());
             return false;
         }
+    }
+
+    /**
+     * Returns the snapshot the decoder validated the token against, so the username claim and the cache
+     * generation come from the very provider configuration that accepted the token. Falls back to the current
+     * settings only when the decoder published nothing.
+     */
+    private static AuthenticationSettingsSnapshot validatedSnapshot() {
+        AuthenticationSettingsSnapshot published = AuthenticationSnapshotRequestHolder.get();
+        return published != null ? published : SettingsCache.getAuthenticationSnapshot();
     }
 }

--- a/src/main/java/com/otilm/core/security/authn/tsp/BearerTokenAuthenticator.java
+++ b/src/main/java/com/otilm/core/security/authn/tsp/BearerTokenAuthenticator.java
@@ -1,15 +1,23 @@
 package com.otilm.core.security.authn.tsp;
 
+import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsDto;
 import com.otilm.api.model.core.signing.TspAuthenticationMethod;
 import com.otilm.core.auth.oauth2.PlatformJwtDecoder;
 import com.otilm.core.model.signing.TspProfileModel;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.authn.client.PlatformAuthenticationClient;
+import com.otilm.core.settings.AuthenticationSettingsSnapshot;
+import com.otilm.core.settings.SettingsCache;
+import com.otilm.core.util.OAuth2Constants;
+import com.otilm.core.util.OAuth2Util;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /** Authenticates a TSP request presenting an OAuth2 bearer token in the {@code Authorization} header. */
 public class BearerTokenAuthenticator implements TspAuthenticator {
@@ -43,11 +51,16 @@ public class BearerTokenAuthenticator implements TspAuthenticator {
     public boolean authenticate(HttpServletRequest request, TspProfileModel profile) {
         String token = request.getHeader(HttpHeaders.AUTHORIZATION).substring(BEARER_PREFIX.length()).trim();
         try {
+            AuthenticationSettingsSnapshot snapshot = SettingsCache.getAuthenticationSnapshot();
             Jwt jwt = jwtDecoder.decode(token);
             if (jwt == null) {
                 return false;
             }
-            AuthenticationInfo authInfo = authClient.authenticateByToken(jwt.getClaims());
+            OAuth2ProviderSettingsDto provider = OAuth2Util.findProviderByIssuer(
+                    snapshot.settings(), jwt.getIssuer() == null ? null : jwt.getIssuer().toString());
+            Map<String, Object> claims = new HashMap<>(jwt.getClaims());
+            claims.put(OAuth2Constants.TOKEN_USERNAME_CLAIM_NAME, OAuth2Util.resolveUsername(provider, claims));
+            AuthenticationInfo authInfo = authClient.authenticateByToken(claims, snapshot.generation());
             return contextWriter.setFromAuthInfo(authInfo);
         } catch (RuntimeException e) {
             log.warn("TSP authentication: bearer-token authentication failed: {}", e.getMessage());

--- a/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
@@ -474,13 +474,28 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
         settingRepository.save(disableLocalhostSetting);
 
         if (authenticationSettingsDto.getOAuth2Providers() != null) {
+            Set<String> issuerUrls = new HashSet<>();
+            for (OAuth2ProviderSettingsDto providerDto : authenticationSettingsDto.getOAuth2Providers()) {
+                if (providerDto.getIssuerUrl() != null && !issuerUrls.add(providerDto.getIssuerUrl())) {
+                    throw new ValidationException(
+                            "Multiple OAuth2 providers in the request use issuer URL '%s'. Issuer URLs must be unique across providers.".formatted(providerDto.getIssuerUrl()));
+                }
+            }
+
+            // Validate every provider (this performs a real HTTP fetch for jwkSetUrl-based providers)
+            // before acquiring the advisory lock below, so the lock never spans an external call.
+            for (OAuth2ProviderSettingsDto providerDto : authenticationSettingsDto.getOAuth2Providers()) {
+                validateOAuth2ProviderSettings(providerDto, false);
+            }
+
+            settingRepository.lockOAuth2ProviderWrites();
             settingRepository.deleteBySectionAndCategory(SettingsSection.AUTHENTICATION, SettingsSectionCategory.OAUTH2_PROVIDER.getCode());
 
             for (OAuth2ProviderSettingsDto providerDto : authenticationSettingsDto.getOAuth2Providers()) {
-                updateOAuth2ProviderSettings(providerDto.getName(), providerDto);
+                persistOAuth2Provider(providerDto.getName(), providerDto);
             }
         }
-        settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, getAuthenticationSettings(true));
+        cacheAfterCommit(() -> settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, getAuthenticationSettings(true)));
     }
 
     @Override
@@ -503,7 +518,17 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
     @Override
     @ExternalAuthorization(resource = Resource.SETTINGS, action = ResourceAction.UPDATE)
     public void updateOAuth2ProviderSettings(String providerName, OAuth2ProviderSettingsUpdateDto settingsDto) {
+        // Validation performs a real HTTP fetch for jwkSetUrl-based providers; it must complete
+        // before the advisory lock below is acquired so the lock never spans an external call.
         validateOAuth2ProviderSettings(settingsDto, false);
+
+        settingRepository.lockOAuth2ProviderWrites();
+        validateIssuerUniqueness(providerName, settingsDto.getIssuerUrl());
+
+        persistOAuth2Provider(providerName, settingsDto);
+    }
+
+    private void persistOAuth2Provider(String providerName, OAuth2ProviderSettingsUpdateDto settingsDto) {
         Setting settingForRegistrationId = settingRepository.findBySectionAndCategoryAndName(SettingsSection.AUTHENTICATION, SettingsSectionCategory.OAUTH2_PROVIDER.getCode(), providerName);
         boolean isNewProvider = settingForRegistrationId == null;
 
@@ -540,15 +565,29 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
         }
         settingRepository.save(setting);
 
-        settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, getAuthenticationSettings(true));
+        cacheAfterCommit(() -> settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, getAuthenticationSettings(true)));
     }
 
     @Override
     @ExternalAuthorization(resource = Resource.SETTINGS, action = ResourceAction.UPDATE)
     public void removeOAuth2Provider(String providerName) {
+        settingRepository.lockOAuth2ProviderWrites();
+
         Long deleted = settingRepository.deleteBySectionAndCategoryAndName(SettingsSection.AUTHENTICATION, SettingsSectionCategory.OAUTH2_PROVIDER.getCode(), providerName);
         if (deleted > 0) {
-            settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, getAuthenticationSettings(true));
+            cacheAfterCommit(() -> settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, getAuthenticationSettings(true)));
+        }
+    }
+
+    private void validateIssuerUniqueness(String providerName, String issuerUrl) {
+        if (issuerUrl == null) {
+            return;
+        }
+        for (Map.Entry<String, OAuth2ProviderSettingsDto> entry : getAuthenticationSettings(true).getOAuth2Providers().entrySet()) {
+            if (!entry.getKey().equals(providerName) && issuerUrl.equals(entry.getValue().getIssuerUrl())) {
+                throw new ValidationException(
+                        "OAuth2 provider '%s' already uses issuer URL '%s'. Issuer URLs must be unique across providers.".formatted(entry.getKey(), issuerUrl));
+            }
         }
     }
 

--- a/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/SettingServiceImpl.java
@@ -526,6 +526,7 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
         validateIssuerUniqueness(providerName, settingsDto.getIssuerUrl());
 
         persistOAuth2Provider(providerName, settingsDto);
+        cacheAfterCommit(() -> settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, getAuthenticationSettings(true)));
     }
 
     private void persistOAuth2Provider(String providerName, OAuth2ProviderSettingsUpdateDto settingsDto) {
@@ -564,8 +565,6 @@ public class SettingServiceImpl implements SettingExternalService, SettingIntern
             throw new ValidationException("Cannot serialize OAuth2 provider settings for provider '%s'.".formatted(providerName));
         }
         settingRepository.save(setting);
-
-        cacheAfterCommit(() -> settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, getAuthenticationSettings(true)));
     }
 
     @Override

--- a/src/main/java/com/otilm/core/settings/AuthenticationSettingsSnapshot.java
+++ b/src/main/java/com/otilm/core/settings/AuthenticationSettingsSnapshot.java
@@ -1,0 +1,11 @@
+package com.otilm.core.settings;
+
+import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDto;
+
+/**
+ * Immutable pairing of the authentication settings with the generation that produced them.
+ * A token-authentication flow captures one snapshot at entry so the identity it resolves and
+ * the cache generation it stores under always describe the same settings.
+ */
+public record AuthenticationSettingsSnapshot(AuthenticationSettingsDto settings, long generation) {
+}

--- a/src/main/java/com/otilm/core/settings/SettingsCache.java
+++ b/src/main/java/com/otilm/core/settings/SettingsCache.java
@@ -2,24 +2,45 @@ package com.otilm.core.settings;
 
 import com.otilm.api.model.core.settings.SettingsDto;
 import com.otilm.api.model.core.settings.SettingsSection;
+import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDto;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Component
 public class SettingsCache {
 
-    // In-memory cache
+    // In-memory cache for all sections except AUTHENTICATION
     private static final Map<SettingsSection, SettingsDto> cache = new ConcurrentHashMap<>();
+
+    // The single authoritative holder for AUTHENTICATION: settings paired with a generation
+    // that changes only when the settings change.
+    private static final AtomicReference<AuthenticationSettingsSnapshot> authenticationSnapshot =
+            new AtomicReference<>(new AuthenticationSettingsSnapshot(null, 0L));
 
     // Get a setting value by key
     public static <T extends SettingsDto> T getSettings(SettingsSection settingsSection) {
+        if (settingsSection == SettingsSection.AUTHENTICATION) {
+            return (T) authenticationSnapshot.get().settings();
+        }
         return (T) cache.get(settingsSection);
+    }
+
+    public static AuthenticationSettingsSnapshot getAuthenticationSnapshot() {
+        return authenticationSnapshot.get();
     }
 
     // Cache settings
     public void cacheSettings(SettingsSection settingsSection, SettingsDto settingsDto) {
+        if (settingsSection == SettingsSection.AUTHENTICATION) {
+            authenticationSnapshot.updateAndGet(current -> Objects.equals(current.settings(), settingsDto)
+                    ? current
+                    : new AuthenticationSettingsSnapshot((AuthenticationSettingsDto) settingsDto, current.generation() + 1));
+            return;
+        }
         cache.put(settingsSection, settingsDto);
     }
 }

--- a/src/main/java/com/otilm/core/util/OAuth2Util.java
+++ b/src/main/java/com/otilm/core/util/OAuth2Util.java
@@ -116,7 +116,7 @@ public class OAuth2Util {
      * (two providers sharing an issuer) fails authentication instead of silently picking one.
      */
     public static OAuth2ProviderSettingsDto findProviderByIssuer(AuthenticationSettingsDto settings, String issuerUri) {
-        if (settings == null || issuerUri == null) {
+        if (settings == null || issuerUri == null || settings.getOAuth2Providers() == null) {
             return null;
         }
         List<OAuth2ProviderSettingsDto> matches = settings.getOAuth2Providers().values().stream()

--- a/src/main/java/com/otilm/core/util/OAuth2Util.java
+++ b/src/main/java/com/otilm/core/util/OAuth2Util.java
@@ -110,6 +110,65 @@ public class OAuth2Util {
         return mergedClaims;
     }
 
+    /**
+     * Finds the OAuth2 provider whose issuer URL equals the given issuer, or {@code null} when none
+     * matches. The provider's username claim decides the user's identity, so an ambiguous match
+     * (two providers sharing an issuer) fails authentication instead of silently picking one.
+     */
+    public static OAuth2ProviderSettingsDto findProviderByIssuer(AuthenticationSettingsDto settings, String issuerUri) {
+        if (settings == null || issuerUri == null) {
+            return null;
+        }
+        List<OAuth2ProviderSettingsDto> matches = settings.getOAuth2Providers().values().stream()
+                .filter(p -> issuerUri.equals(p.getIssuerUrl()))
+                .toList();
+        if (matches.size() > 1) {
+            throw new PlatformAuthenticationException(
+                    "Multiple OAuth2 providers are configured with issuer '%s'; provider selection is ambiguous.".formatted(issuerUri));
+        }
+        return matches.isEmpty() ? null : matches.getFirst();
+    }
+
+    /**
+     * Returns the claim name that identifies the user for the given provider: the provider's
+     * configured username claim when non-blank, otherwise {@link OAuth2Constants#TOKEN_USERNAME_CLAIM_NAME}.
+     */
+    public static String effectiveUsernameClaim(OAuth2ProviderSettingsDto providerSettings) {
+        return providerSettings != null && StringUtils.isNotBlank(providerSettings.getUsernameClaim())
+                ? providerSettings.getUsernameClaim()
+                : OAuth2Constants.TOKEN_USERNAME_CLAIM_NAME;
+    }
+
+    /**
+     * Resolves the platform identity from token claims. The identity is the value of the effective
+     * username claim and must be a non-blank string. There is deliberately no fallback to any other
+     * claim: which claim identifies the user is an operator decision made via the provider settings.
+     *
+     * @throws PlatformAuthenticationException when the claim is absent, blank, or not a string
+     */
+    public static String resolveUsername(OAuth2ProviderSettingsDto providerSettings, Map<String, Object> claims) {
+        String claimName = effectiveUsernameClaim(providerSettings);
+        Object value = claims == null ? null : claims.get(claimName);
+        if (value == null) {
+            throw new PlatformAuthenticationException(
+                    "Username claim '%s' not found in token claims.".formatted(claimName));
+        }
+        if (!(value instanceof String username) || StringUtils.isBlank(username)) {
+            throw new PlatformAuthenticationException(
+                    "Username claim '%s' must be a non-blank string value.".formatted(claimName));
+        }
+        return username;
+    }
+
+    /**
+     * Lenient variant of {@link #resolveUsername(OAuth2ProviderSettingsDto, Map)} for logging
+     * contexts where a missing username must not fail the request.
+     */
+    public static String resolveUsernameOrNull(OAuth2ProviderSettingsDto providerSettings, Map<String, Object> claims) {
+        Object value = claims == null ? null : claims.get(effectiveUsernameClaim(providerSettings));
+        return value instanceof String username && StringUtils.isNotBlank(username) ? username : null;
+    }
+
     public static Map<String, Object> getAllClaimsAvailable(OAuth2ProviderSettingsDto providerSettings, String accessTokenValue, OidcIdToken idToken) {
         Map<String, Object> userInfoClaims = null;
         if (providerSettings != null && providerSettings.getUserInfoUrl() != null) {
@@ -129,16 +188,8 @@ public class OAuth2Util {
         }
 
         Map<String, Object> claims = mergeClaims(accessTokenClaims, idToken == null ? null : idToken.getClaims(), userInfoClaims);
-        // Use configurable username claim name from provider settings, with fallback to default
-        String usernameClaimName = providerSettings != null && providerSettings.getUsernameClaim() != null && !providerSettings.getUsernameClaim().isEmpty()
-                ? providerSettings.getUsernameClaim()
-                : OAuth2Constants.TOKEN_USERNAME_CLAIM_NAME;
-
-        if (!claims.containsKey(usernameClaimName)) {
-            String message = "The username claim '%s' could not be retrieved from the Access Token, User Info Endpoint, or ID Token claims for user authenticating with Access Token. Claims %s, Token: %s".formatted(usernameClaimName, StringUtils.join(claims), accessTokenValue);
-            throw new PlatformAuthenticationException(message);
-        }
-
+        String username = resolveUsername(providerSettings, claims);
+        claims.put(OAuth2Constants.TOKEN_USERNAME_CLAIM_NAME, username);
         return claims;
     }
 

--- a/src/test/java/com/otilm/core/auth/oauth2/AuthenticationSnapshotRequestFilterTest.java
+++ b/src/test/java/com/otilm/core/auth/oauth2/AuthenticationSnapshotRequestFilterTest.java
@@ -1,0 +1,80 @@
+package com.otilm.core.auth.oauth2;
+
+import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDto;
+import com.otilm.core.settings.AuthenticationSettingsSnapshot;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AuthenticationSnapshotRequestFilterTest {
+
+    private final AuthenticationSnapshotRequestFilter filter = new AuthenticationSnapshotRequestFilter();
+
+    @BeforeEach
+    @AfterEach
+    void clearHolder() {
+        AuthenticationSnapshotRequestHolder.clear();
+    }
+
+    @Test
+    void snapshotPublishedByOneRequest_isNotVisibleToTheNextOneOnTheSameThread() throws Exception {
+        // given - the first request publishes a snapshot, as the JWT decoder does
+        List<AuthenticationSettingsSnapshot> observedOnEntry = new ArrayList<>();
+        FilterChain publishing = (request, response) -> {
+            observedOnEntry.add(AuthenticationSnapshotRequestHolder.get());
+            AuthenticationSnapshotRequestHolder.set(snapshot(1L));
+        };
+
+        // when - two requests are served in sequence on the same thread
+        filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), publishing);
+        assertThat(AuthenticationSnapshotRequestHolder.get()).isNull();
+        filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), publishing);
+
+        // then - neither request started with the other's snapshot, and nothing is left behind
+        assertThat(observedOnEntry).hasSize(2).containsOnlyNulls();
+        assertThat(AuthenticationSnapshotRequestHolder.get()).isNull();
+    }
+
+    @Test
+    void snapshotIsClearedEvenWhenTheChainFails() {
+        // given - a request that publishes a snapshot and then fails
+        FilterChain failing = (request, response) -> {
+            AuthenticationSnapshotRequestHolder.set(snapshot(2L));
+            throw new ServletException("downstream failure");
+        };
+
+        // when / then - the failure propagates but the thread is left clean
+        assertThatThrownBy(() -> filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), failing))
+                .isInstanceOf(ServletException.class);
+        assertThat(AuthenticationSnapshotRequestHolder.get()).isNull();
+    }
+
+    @Test
+    void snapshotPublishedOutsideAnyRequest_isNotVisibleInsideTheChain() throws IOException, ServletException {
+        // given - a snapshot left on the thread by something that did not go through this filter
+        AuthenticationSnapshotRequestHolder.set(snapshot(3L));
+        List<AuthenticationSettingsSnapshot> observedOnEntry = new ArrayList<>();
+        FilterChain observing = (request, response) -> observedOnEntry.add(AuthenticationSnapshotRequestHolder.get());
+
+        // when
+        filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), observing);
+
+        // then
+        assertThat(observedOnEntry).hasSize(1).containsOnlyNulls();
+    }
+
+    private static AuthenticationSettingsSnapshot snapshot(long generation) {
+        return new AuthenticationSettingsSnapshot(new AuthenticationSettingsDto(), generation);
+    }
+}

--- a/src/test/java/com/otilm/core/auth/oauth2/PlatformJwtAuthenticationConverterTest.java
+++ b/src/test/java/com/otilm/core/auth/oauth2/PlatformJwtAuthenticationConverterTest.java
@@ -54,11 +54,13 @@ class PlatformJwtAuthenticationConverterTest {
         converter.setAuthenticationClient(authenticationClient);
         converter.setAuditLogService(auditLogService);
         SecurityContextHolder.clearContext();
+        AuthenticationSnapshotRequestHolder.clear();
     }
 
     @AfterEach
     void tearDown() {
         SecurityContextHolder.clearContext();
+        AuthenticationSnapshotRequestHolder.clear();
     }
 
     @Test
@@ -155,6 +157,53 @@ class PlatformJwtAuthenticationConverterTest {
 
             // then - null provider settings forwarded because no configured issuer matched the JWT
             oauth2Mock.verify(() -> OAuth2Util.getAllClaimsAvailable(isNull(), eq(TOKEN_VALUE), isNull()));
+        }
+    }
+
+    @Test
+    void publishedSnapshot_isPreferredOverTheCurrentSettings() throws MalformedURLException {
+        // given - the decoder validated the token against generation 7, and the settings changed since
+        Jwt jwt = mockJwt(ISSUER_URL);
+        Map<String, Object> claims = Map.of("username", "alice", "jti", "jti-123");
+        AuthenticationSettingsDto validatedSettings = authSettingsWithProvider(ISSUER_URL);
+        AuthenticationSnapshotRequestHolder.set(new AuthenticationSettingsSnapshot(validatedSettings, 7L));
+        when(authenticationClient.authenticateByToken(any(), anyLong())).thenReturn(authenticatedInfo());
+
+        try (MockedStatic<SettingsCache> settingsMock = mockStatic(SettingsCache.class);
+             MockedStatic<OAuth2Util> oauth2Mock = mockStatic(OAuth2Util.class)) {
+            settingsMock.when(SettingsCache::getAuthenticationSnapshot)
+                    .thenReturn(new AuthenticationSettingsSnapshot(authSettingsWithProvider("https://rotated-issuer.example.com"), 8L));
+            oauth2Mock.when(() -> OAuth2Util.findProviderByIssuer(any(), anyString())).thenCallRealMethod();
+            oauth2Mock.when(() -> OAuth2Util.getAllClaimsAvailable(any(), anyString(), isNull())).thenReturn(claims);
+
+            // when
+            converter.convert(jwt);
+
+            // then - identity and cache generation come from the snapshot the token was validated against
+            verify(authenticationClient).authenticateByToken(claims, 7L);
+            oauth2Mock.verify(() -> OAuth2Util.findProviderByIssuer(same(validatedSettings), eq(ISSUER_URL)));
+        }
+    }
+
+    @Test
+    void noPublishedSnapshot_fallsBackToTheCurrentSettings() throws MalformedURLException {
+        // given - the converter is invoked without the decoder having published anything
+        Jwt jwt = mockJwt(ISSUER_URL);
+        Map<String, Object> claims = Map.of("username", "alice", "jti", "jti-123");
+        when(authenticationClient.authenticateByToken(any(), anyLong())).thenReturn(authenticatedInfo());
+
+        try (MockedStatic<SettingsCache> settingsMock = mockStatic(SettingsCache.class);
+             MockedStatic<OAuth2Util> oauth2Mock = mockStatic(OAuth2Util.class)) {
+            settingsMock.when(SettingsCache::getAuthenticationSnapshot)
+                    .thenReturn(new AuthenticationSettingsSnapshot(authSettingsWithProvider(ISSUER_URL), 5L));
+            oauth2Mock.when(() -> OAuth2Util.findProviderByIssuer(any(), anyString())).thenCallRealMethod();
+            oauth2Mock.when(() -> OAuth2Util.getAllClaimsAvailable(any(), anyString(), isNull())).thenReturn(claims);
+
+            // when
+            converter.convert(jwt);
+
+            // then
+            verify(authenticationClient).authenticateByToken(claims, 5L);
         }
     }
 

--- a/src/test/java/com/otilm/core/auth/oauth2/PlatformJwtAuthenticationConverterTest.java
+++ b/src/test/java/com/otilm/core/auth/oauth2/PlatformJwtAuthenticationConverterTest.java
@@ -3,7 +3,6 @@ package com.otilm.core.auth.oauth2;
 import com.otilm.api.model.core.logging.enums.AuthMethod;
 import com.otilm.api.model.core.logging.enums.Operation;
 import com.otilm.api.model.core.logging.enums.OperationResult;
-import com.otilm.api.model.core.settings.SettingsSection;
 import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDto;
 import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsDto;
 import com.otilm.core.security.authn.PlatformAuthenticationException;
@@ -11,6 +10,7 @@ import com.otilm.core.security.authn.PlatformAuthenticationToken;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.authn.client.PlatformAuthenticationClient;
 import com.otilm.core.service.AuditLogInternalService;
+import com.otilm.core.settings.AuthenticationSettingsSnapshot;
 import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.util.OAuth2Util;
 import org.junit.jupiter.api.AfterEach;
@@ -92,12 +92,13 @@ class PlatformJwtAuthenticationConverterTest {
         // given
         Jwt jwt = mockJwt(ISSUER_URL);
         Map<String, Object> claims = Map.of("username", "alice", "jti", "jti-123");
-        when(authenticationClient.authenticateByToken(claims)).thenReturn(authenticatedInfo());
+        when(authenticationClient.authenticateByToken(claims, 1L)).thenReturn(authenticatedInfo());
 
         try (MockedStatic<SettingsCache> settingsMock = mockStatic(SettingsCache.class);
              MockedStatic<OAuth2Util> oauth2Mock = mockStatic(OAuth2Util.class)) {
-            settingsMock.when(() -> SettingsCache.getSettings(SettingsSection.AUTHENTICATION))
-                    .thenReturn(authSettingsWithProvider(ISSUER_URL));
+            settingsMock.when(SettingsCache::getAuthenticationSnapshot)
+                    .thenReturn(new AuthenticationSettingsSnapshot(authSettingsWithProvider(ISSUER_URL), 1L));
+            oauth2Mock.when(() -> OAuth2Util.findProviderByIssuer(any(), anyString())).thenCallRealMethod();
             oauth2Mock.when(() -> OAuth2Util.getAllClaimsAvailable(
                             argThat(p -> p != null && ISSUER_URL.equals(p.getIssuerUrl())),
                             eq(TOKEN_VALUE), isNull()))
@@ -107,7 +108,7 @@ class PlatformJwtAuthenticationConverterTest {
             AbstractAuthenticationToken result = converter.convert(jwt);
 
             // then
-            verify(authenticationClient).authenticateByToken(claims);
+            verify(authenticationClient).authenticateByToken(claims, 1L);
             assertInstanceOf(PlatformAuthenticationToken.class, result);
         }
     }
@@ -120,8 +121,9 @@ class PlatformJwtAuthenticationConverterTest {
 
         try (MockedStatic<SettingsCache> settingsMock = mockStatic(SettingsCache.class);
              MockedStatic<OAuth2Util> oauth2Mock = mockStatic(OAuth2Util.class)) {
-            settingsMock.when(() -> SettingsCache.getSettings(SettingsSection.AUTHENTICATION))
-                    .thenReturn(authSettingsWithProvider(ISSUER_URL));
+            settingsMock.when(SettingsCache::getAuthenticationSnapshot)
+                    .thenReturn(new AuthenticationSettingsSnapshot(authSettingsWithProvider(ISSUER_URL), 1L));
+            oauth2Mock.when(() -> OAuth2Util.findProviderByIssuer(any(), anyString())).thenCallRealMethod();
             oauth2Mock.when(() -> OAuth2Util.getAllClaimsAvailable(any(), anyString(), isNull()))
                     .thenThrow(cause);
 
@@ -138,12 +140,13 @@ class PlatformJwtAuthenticationConverterTest {
         // given - JWT issuer does not match the single configured provider
         Jwt jwt = mockJwt("https://unknown-issuer.example.com");
         Map<String, Object> claims = Map.of("username", "alice");
-        when(authenticationClient.authenticateByToken(any())).thenReturn(authenticatedInfo());
+        when(authenticationClient.authenticateByToken(any(), anyLong())).thenReturn(authenticatedInfo());
 
         try (MockedStatic<SettingsCache> settingsMock = mockStatic(SettingsCache.class);
              MockedStatic<OAuth2Util> oauth2Mock = mockStatic(OAuth2Util.class)) {
-            settingsMock.when(() -> SettingsCache.getSettings(SettingsSection.AUTHENTICATION))
-                    .thenReturn(authSettingsWithProvider(ISSUER_URL));
+            settingsMock.when(SettingsCache::getAuthenticationSnapshot)
+                    .thenReturn(new AuthenticationSettingsSnapshot(authSettingsWithProvider(ISSUER_URL), 1L));
+            oauth2Mock.when(() -> OAuth2Util.findProviderByIssuer(any(), anyString())).thenCallRealMethod();
             oauth2Mock.when(() -> OAuth2Util.getAllClaimsAvailable(isNull(), eq(TOKEN_VALUE), isNull()))
                     .thenReturn(claims);
 

--- a/src/test/java/com/otilm/core/integration/config/SecurityConfigITest.java
+++ b/src/test/java/com/otilm/core/integration/config/SecurityConfigITest.java
@@ -227,12 +227,57 @@ class SecurityConfigITest extends BaseSpringBootTestNoAuth {
         Assertions.assertTrue(resultRefresh.getResponse().getContentAsString().contains(refreshedUserName));
     }
 
+    @Test
+    void testOAuth2LoginRefreshingTokenWithoutUsernameInPrincipalAttributes() throws Exception {
+        cacheProviderSettings(null);
+        String oauth2Token = OAuth2TestUtil.createJwtTokenValue(privateKey, null, null, null, "oldUsername");
+        OAuth2AccessToken oauth2AccessTokenToRefresh = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, oauth2Token, Instant.now(), Instant.now().plusMillis(1));
+        MockHttpSession mockHttpSession = new MockHttpSession();
+        mockHttpSession.setAttribute(OAuth2Constants.ACCESS_TOKEN_SESSION_ATTRIBUTE, oauth2AccessTokenToRefresh);
+        OAuth2RefreshToken oAuth2RefreshToken = new OAuth2RefreshToken("random", Instant.now());
+        mockHttpSession.setAttribute(OAuth2Constants.REFRESH_TOKEN_SESSION_ATTRIBUTE, oAuth2RefreshToken);
+        String refreshedUserName = "refreshed-user-no-principal-claim";
+        String refreshedUserUuid = UUID.randomUUID().toString();
+        addAuthPostStub("{\"iss\":\"newInfo\",\"sub\":\"user\",\"username\":\"%s\"}".formatted(refreshedUserName), refreshedUserUuid, refreshedUserName);
+        addAuthGetSub(refreshedUserUuid, refreshedUserName);
+        addTokenEndpointStub(OAuth2TestUtil.createJwtTokenValue(privateKey, null, "newInfo", null, refreshedUserName));
+        // Deliberately no idToken claim customization: the OIDC principal attributes established at
+        // login time lack the effective username claim, while the refreshed access token carries it.
+        MvcResult resultRefresh = mvc.perform(get(ServletUriComponentsBuilder.fromCurrentContextPath().build().getPath() + "/v1/auth/profile").with(oidcLogin()).session(mockHttpSession)).andReturn();
+        Assertions.assertTrue(resultRefresh.getResponse().getContentAsString().contains(refreshedUserName));
+    }
+
+    @Test
+    void testOauth2LoginNormalizesConfiguredUsernameClaimIntoTokenUserClaims() throws Exception {
+        String usernameClaim = "preferred_username";
+        String username = "preferred-username-login-user";
+        cacheProviderSettingsWithUsernameClaim(usernameClaim);
+
+        String userUuid = UUID.randomUUID().toString();
+        addAuthPostStub("\"%s\":\"%s\"".formatted(OAuth2Constants.TOKEN_USERNAME_CLAIM_NAME, username), userUuid, username);
+        addAuthGetSub(userUuid, username);
+
+        String oauth2Token = OAuth2TestUtil.createJwtTokenValue(privateKey, null, null, null, usernameClaim, username);
+        MockHttpSession mockHttpSession = new MockHttpSession();
+        OAuth2AccessToken oauth2AccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, oauth2Token, Instant.now(), Instant.MAX);
+        mockHttpSession.setAttribute(OAuth2Constants.ACCESS_TOKEN_SESSION_ATTRIBUTE, oauth2AccessToken);
+
+        MvcResult result = mvc.perform(get(ServletUriComponentsBuilder.fromCurrentContextPath().build().getPath() + "/v1/auth/profile").with(oidcLogin()).session(mockHttpSession)).andReturn();
+        Assertions.assertTrue(result.getResponse().getContentAsString().contains(username));
+    }
+
     void cacheProviderSettings(String userInfoUrl) {
         cacheProviderSettings(userInfoUrl, null);
     }
 
     void cacheProviderSettings(String userInfoUrl, String issuerUrl) {
         AuthenticationSettingsDto authenticationSettingsDto = OAuth2TestUtil.getAuthenticationSettings(userInfoUrl, mockServer.port(), new ArrayList<>(), issuerUrl);
+        settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, authenticationSettingsDto);
+    }
+
+    void cacheProviderSettingsWithUsernameClaim(String usernameClaim) {
+        AuthenticationSettingsDto authenticationSettingsDto = OAuth2TestUtil.getAuthenticationSettings(null, mockServer.port(), new ArrayList<>(), null);
+        authenticationSettingsDto.getOAuth2Providers().get("test").setUsernameClaim(usernameClaim);
         settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, authenticationSettingsDto);
     }
 
@@ -280,7 +325,10 @@ class SecurityConfigITest extends BaseSpringBootTestNoAuth {
                   "scope":"create"
                 }
                 """.formatted(tokenValue);
-        mockServer.stubFor(WireMock.post("/token").willReturn(WireMock.okJson(responseJson).withHeader("contentType", "application/json")));
+        // "Connection: close" tells the pooled HTTP client used for the token refresh call not to keep
+        // this connection alive; otherwise a later test's fresh WireMockServer instance on the same
+        // port can be handed a stale pooled connection from an earlier test's now-stopped server.
+        mockServer.stubFor(WireMock.post("/token").willReturn(WireMock.okJson(responseJson).withHeader("contentType", "application/json").withHeader("Connection", "close")));
     }
 
     void addUserInfoStub(String userInfoUsername) {

--- a/src/test/java/com/otilm/core/integration/security/authn/client/PlatformAuthenticationCacheITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authn/client/PlatformAuthenticationCacheITest.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -172,8 +173,8 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         Supplier<AuthenticationInfo> loader = loaderReturning(authenticatedInfo(UUID.randomUUID().toString(), "tokenUser"));
 
         // when - call twice with a null jti to verify that caching is always skipped
-        authenticationCache.getOrAuthenticateByToken(null, loader);
-        authenticationCache.getOrAuthenticateByToken(null, loader);
+        authenticationCache.getOrAuthenticateByToken(null, 1L, loader);
+        authenticationCache.getOrAuthenticateByToken(null, 1L, loader);
 
         // then - verify that the loader was called both times because null-jti tokens bypass the cache
         verify(loader, times(2)).get();
@@ -186,7 +187,7 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         Supplier<AuthenticationInfo> loader = loaderReturning(expected);
 
         // when - first call to authenticate by token jti
-        AuthenticationInfo result = authenticationCache.getOrAuthenticateByToken("jti-123", loader);
+        AuthenticationInfo result = authenticationCache.getOrAuthenticateByToken("jti-123", 1L, loader);
 
         // then - verify that the loader was called and the result is as expected
         assertEquals(expected, result);
@@ -199,10 +200,10 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         AuthenticationInfo expected = authenticatedInfo(UUID.randomUUID().toString(), "tokenUser");
         Supplier<AuthenticationInfo> loader = loaderReturning(expected);
         // first call to authenticate the user - this will populate the cache
-        authenticationCache.getOrAuthenticateByToken("jti-123", loader);
+        authenticationCache.getOrAuthenticateByToken("jti-123", 1L, loader);
 
         // when - second call with the same jti - the cache should be used
-        AuthenticationInfo result = authenticationCache.getOrAuthenticateByToken("jti-123", loader);
+        AuthenticationInfo result = authenticationCache.getOrAuthenticateByToken("jti-123", 1L, loader);
 
         // then - verify that the loader was not called again and the result is the same as expected
         assertEquals(expected, result);
@@ -215,11 +216,28 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         Supplier<AuthenticationInfo> loader = loaderReturning(AuthenticationInfo.getAnonymousAuthenticationInfo());
 
         // when - call twice to verify that the loader is called both times due to the non-caching of anonymous results
-        authenticationCache.getOrAuthenticateByToken("jti-anon", loader);
-        authenticationCache.getOrAuthenticateByToken("jti-anon", loader);
+        authenticationCache.getOrAuthenticateByToken("jti-anon", 1L, loader);
+        authenticationCache.getOrAuthenticateByToken("jti-anon", 1L, loader);
 
         // then - verify that the loader was called twice because anonymous results bypass the cache
         verify(loader, times(2)).get();
+    }
+
+    @Test
+    void tokenEntriesBecomeUnreachableWhenSettingsGenerationChanges() {
+        AuthenticationInfo expected = authenticatedInfo(UUID.randomUUID().toString(), "user1");
+        AtomicInteger loaderCalls = new AtomicInteger();
+        Supplier<AuthenticationInfo> loader = () -> {
+            loaderCalls.incrementAndGet();
+            return expected;
+        };
+
+        authenticationCache.getOrAuthenticateByToken("jti-gen", 1L, loader);
+        authenticationCache.getOrAuthenticateByToken("jti-gen", 1L, loader);
+        assertEquals(1, loaderCalls.get());      // second call under the same generation is a cache hit
+
+        authenticationCache.getOrAuthenticateByToken("jti-gen", 2L, loader);
+        assertEquals(2, loaderCalls.get());      // new generation misses and reloads
     }
 
     // --- evictByUserUuid ---
@@ -241,20 +259,21 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
 
     @Test
     void evictByUserUuid_evictsAllTokensForUser() {
-        // given - two separate tokens for the same user are both tracked in the jti index
+        // given - the same jti cached under two different settings generations for the same user; each
+        // generation produces a distinct composite cache key, and both must be tracked in the jti index
         UUID userUuid = UUID.randomUUID();
         AuthenticationInfo info = authenticatedInfo(userUuid.toString(), "user");
         Supplier<AuthenticationInfo> loaderA = loaderReturning(info);
         Supplier<AuthenticationInfo> loaderB = loaderReturning(info);
-        authenticationCache.getOrAuthenticateByToken("jti-A", loaderA);
-        authenticationCache.getOrAuthenticateByToken("jti-B", loaderB);
+        authenticationCache.getOrAuthenticateByToken("jti-A", 1L, loaderA);
+        authenticationCache.getOrAuthenticateByToken("jti-A", 2L, loaderB);
 
         // when - evict all cache entries for this user
         authenticationCache.evictByUserUuid(userUuid);
 
-        // then - verify that both token entries were evicted via the jti index and the loaders are called again
-        authenticationCache.getOrAuthenticateByToken("jti-A", loaderA);
-        authenticationCache.getOrAuthenticateByToken("jti-B", loaderB);
+        // then - verify that both generation-keyed entries were evicted via the jti index and the loaders are called again
+        authenticationCache.getOrAuthenticateByToken("jti-A", 1L, loaderA);
+        authenticationCache.getOrAuthenticateByToken("jti-A", 2L, loaderB);
         verify(loaderA, times(2)).get();
         verify(loaderB, times(2)).get();
     }
@@ -299,15 +318,15 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         UUID userUuidB = UUID.randomUUID();
         Supplier<AuthenticationInfo> loaderA = loaderReturning(authenticatedInfo(userUuidA.toString(), "userA"));
         Supplier<AuthenticationInfo> loaderB = loaderReturning(authenticatedInfo(userUuidB.toString(), "userB"));
-        authenticationCache.getOrAuthenticateByToken("jti-userA", loaderA);
-        authenticationCache.getOrAuthenticateByToken("jti-userB", loaderB);
+        authenticationCache.getOrAuthenticateByToken("jti-userA", 1L, loaderA);
+        authenticationCache.getOrAuthenticateByToken("jti-userB", 1L, loaderB);
 
         // when - evict only userA
         authenticationCache.evictByUserUuid(userUuidA);
 
         // then - verify that userA token was evicted and userB token is still cached
-        authenticationCache.getOrAuthenticateByToken("jti-userA", loaderA);
-        authenticationCache.getOrAuthenticateByToken("jti-userB", loaderB);
+        authenticationCache.getOrAuthenticateByToken("jti-userA", 1L, loaderA);
+        authenticationCache.getOrAuthenticateByToken("jti-userB", 1L, loaderB);
         verify(loaderA, times(2)).get();
         verify(loaderB, times(1)).get();
     }
@@ -327,7 +346,7 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         authenticationCache.getOrAuthenticateSystemUser("superadmin", systemUserLoader);
         authenticationCache.getOrAuthenticateByUserUuid(UUID.fromString(userUuid), uuidLoader);
         authenticationCache.getOrAuthenticateByCertificate("fingerprint", certLoader);
-        authenticationCache.getOrAuthenticateByToken("jti-all", tokenLoader);
+        authenticationCache.getOrAuthenticateByToken("jti-all", 1L, tokenLoader);
 
         // when - evict all entries across all caches
         authenticationCache.evictAll();
@@ -336,7 +355,7 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         authenticationCache.getOrAuthenticateSystemUser("superadmin", systemUserLoader);
         authenticationCache.getOrAuthenticateByUserUuid(UUID.fromString(userUuid), uuidLoader);
         authenticationCache.getOrAuthenticateByCertificate("fingerprint", certLoader);
-        authenticationCache.getOrAuthenticateByToken("jti-all", tokenLoader);
+        authenticationCache.getOrAuthenticateByToken("jti-all", 1L, tokenLoader);
 
         verify(systemUserLoader, times(2)).get();
         verify(uuidLoader, times(2)).get();

--- a/src/test/java/com/otilm/core/integration/security/authn/client/PlatformAuthenticationCacheITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authn/client/PlatformAuthenticationCacheITest.java
@@ -19,6 +19,9 @@ import static org.mockito.Mockito.*;
 
 class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
 
+    private static final String ISSUER = "https://issuer.example.com";
+    private static final String OTHER_ISSUER = "https://other-issuer.example.com";
+
     @Autowired
     private AuthenticationCache authenticationCache;
 
@@ -173,8 +176,8 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         Supplier<AuthenticationInfo> loader = loaderReturning(authenticatedInfo(UUID.randomUUID().toString(), "tokenUser"));
 
         // when - call twice with a null jti to verify that caching is always skipped
-        authenticationCache.getOrAuthenticateByToken(null, 1L, loader);
-        authenticationCache.getOrAuthenticateByToken(null, 1L, loader);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, null, 1L, loader);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, null, 1L, loader);
 
         // then - verify that the loader was called both times because null-jti tokens bypass the cache
         verify(loader, times(2)).get();
@@ -187,7 +190,7 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         Supplier<AuthenticationInfo> loader = loaderReturning(expected);
 
         // when - first call to authenticate by token jti
-        AuthenticationInfo result = authenticationCache.getOrAuthenticateByToken("jti-123", 1L, loader);
+        AuthenticationInfo result = authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-123", 1L, loader);
 
         // then - verify that the loader was called and the result is as expected
         assertEquals(expected, result);
@@ -200,10 +203,10 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         AuthenticationInfo expected = authenticatedInfo(UUID.randomUUID().toString(), "tokenUser");
         Supplier<AuthenticationInfo> loader = loaderReturning(expected);
         // first call to authenticate the user - this will populate the cache
-        authenticationCache.getOrAuthenticateByToken("jti-123", 1L, loader);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-123", 1L, loader);
 
         // when - second call with the same jti - the cache should be used
-        AuthenticationInfo result = authenticationCache.getOrAuthenticateByToken("jti-123", 1L, loader);
+        AuthenticationInfo result = authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-123", 1L, loader);
 
         // then - verify that the loader was not called again and the result is the same as expected
         assertEquals(expected, result);
@@ -216,8 +219,8 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         Supplier<AuthenticationInfo> loader = loaderReturning(AuthenticationInfo.getAnonymousAuthenticationInfo());
 
         // when - call twice to verify that the loader is called both times due to the non-caching of anonymous results
-        authenticationCache.getOrAuthenticateByToken("jti-anon", 1L, loader);
-        authenticationCache.getOrAuthenticateByToken("jti-anon", 1L, loader);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-anon", 1L, loader);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-anon", 1L, loader);
 
         // then - verify that the loader was called twice because anonymous results bypass the cache
         verify(loader, times(2)).get();
@@ -232,12 +235,73 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
             return expected;
         };
 
-        authenticationCache.getOrAuthenticateByToken("jti-gen", 1L, loader);
-        authenticationCache.getOrAuthenticateByToken("jti-gen", 1L, loader);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-gen", 1L, loader);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-gen", 1L, loader);
         assertEquals(1, loaderCalls.get());      // second call under the same generation is a cache hit
 
-        authenticationCache.getOrAuthenticateByToken("jti-gen", 2L, loader);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-gen", 2L, loader);
         assertEquals(2, loaderCalls.get());      // new generation misses and reloads
+    }
+
+    @Test
+    void getOrAuthenticateByToken_sameJtiFromDifferentIssuers_resolvedIndependently() {
+        // given - a jti is only unique within its issuer, so two providers can mint the same one
+        AuthenticationInfo aliceAtOneIssuer = authenticatedInfo(UUID.randomUUID().toString(), "alice");
+        AuthenticationInfo bobAtOtherIssuer = authenticatedInfo(UUID.randomUUID().toString(), "bob");
+        Supplier<AuthenticationInfo> aliceLoader = loaderReturning(aliceAtOneIssuer);
+        Supplier<AuthenticationInfo> bobLoader = loaderReturning(bobAtOtherIssuer);
+
+        // when - the same jti under the same generation arrives from each issuer
+        AuthenticationInfo first = authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-shared", 1L, aliceLoader);
+        AuthenticationInfo second = authenticationCache.getOrAuthenticateByToken(OTHER_ISSUER, "jti-shared", 1L, bobLoader);
+
+        // then - neither token is served the other issuer's identity
+        assertEquals(aliceAtOneIssuer, first);
+        assertEquals(bobAtOtherIssuer, second);
+        verify(aliceLoader, times(1)).get();
+        verify(bobLoader, times(1)).get();
+
+        // and - each issuer keeps its own entry, so a repeat of either is a hit
+        assertEquals(aliceAtOneIssuer, authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-shared", 1L, aliceLoader));
+        assertEquals(bobAtOtherIssuer, authenticationCache.getOrAuthenticateByToken(OTHER_ISSUER, "jti-shared", 1L, bobLoader));
+        verify(aliceLoader, times(1)).get();
+        verify(bobLoader, times(1)).get();
+    }
+
+    @Test
+    void getOrAuthenticateByToken_missingIssuer_loaderAlwaysCalled() {
+        // given - without an issuer the key cannot distinguish one issuer's jti from another's, so caching is skipped
+        Supplier<AuthenticationInfo> nullIssuerLoader = loaderReturning(authenticatedInfo(UUID.randomUUID().toString(), "tokenUser"));
+        Supplier<AuthenticationInfo> blankIssuerLoader = loaderReturning(authenticatedInfo(UUID.randomUUID().toString(), "tokenUser"));
+
+        // when
+        authenticationCache.getOrAuthenticateByToken(null, "jti-no-issuer", 1L, nullIssuerLoader);
+        authenticationCache.getOrAuthenticateByToken(null, "jti-no-issuer", 1L, nullIssuerLoader);
+        authenticationCache.getOrAuthenticateByToken("  ", "jti-blank-issuer", 1L, blankIssuerLoader);
+        authenticationCache.getOrAuthenticateByToken("  ", "jti-blank-issuer", 1L, blankIssuerLoader);
+
+        // then
+        verify(nullIssuerLoader, times(2)).get();
+        verify(blankIssuerLoader, times(2)).get();
+    }
+
+    @Test
+    void getOrAuthenticateByToken_issuerAndJtiWithAmbiguousSplit_doNotShareEntry() {
+        // given - two triples that a plain "generation:issuer:jti" key would render identically
+        AuthenticationInfo shortIssuerUser = authenticatedInfo(UUID.randomUUID().toString(), "shortIssuerUser");
+        AuthenticationInfo longIssuerUser = authenticatedInfo(UUID.randomUUID().toString(), "longIssuerUser");
+        Supplier<AuthenticationInfo> shortIssuerLoader = loaderReturning(shortIssuerUser);
+        Supplier<AuthenticationInfo> longIssuerLoader = loaderReturning(longIssuerUser);
+
+        // when
+        AuthenticationInfo first = authenticationCache.getOrAuthenticateByToken("https://a", "x:y", 1L, shortIssuerLoader);
+        AuthenticationInfo second = authenticationCache.getOrAuthenticateByToken("https://a:x", "y", 1L, longIssuerLoader);
+
+        // then - the length-prefixed issuer keeps the two keys apart
+        assertEquals(shortIssuerUser, first);
+        assertEquals(longIssuerUser, second);
+        verify(shortIssuerLoader, times(1)).get();
+        verify(longIssuerLoader, times(1)).get();
     }
 
     // --- evictByUserUuid ---
@@ -265,15 +329,15 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         AuthenticationInfo info = authenticatedInfo(userUuid.toString(), "user");
         Supplier<AuthenticationInfo> loaderA = loaderReturning(info);
         Supplier<AuthenticationInfo> loaderB = loaderReturning(info);
-        authenticationCache.getOrAuthenticateByToken("jti-A", 1L, loaderA);
-        authenticationCache.getOrAuthenticateByToken("jti-A", 2L, loaderB);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-A", 1L, loaderA);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-A", 2L, loaderB);
 
         // when - evict all cache entries for this user
         authenticationCache.evictByUserUuid(userUuid);
 
         // then - verify that both generation-keyed entries were evicted via the jti index and the loaders are called again
-        authenticationCache.getOrAuthenticateByToken("jti-A", 1L, loaderA);
-        authenticationCache.getOrAuthenticateByToken("jti-A", 2L, loaderB);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-A", 1L, loaderA);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-A", 2L, loaderB);
         verify(loaderA, times(2)).get();
         verify(loaderB, times(2)).get();
     }
@@ -318,15 +382,15 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         UUID userUuidB = UUID.randomUUID();
         Supplier<AuthenticationInfo> loaderA = loaderReturning(authenticatedInfo(userUuidA.toString(), "userA"));
         Supplier<AuthenticationInfo> loaderB = loaderReturning(authenticatedInfo(userUuidB.toString(), "userB"));
-        authenticationCache.getOrAuthenticateByToken("jti-userA", 1L, loaderA);
-        authenticationCache.getOrAuthenticateByToken("jti-userB", 1L, loaderB);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-userA", 1L, loaderA);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-userB", 1L, loaderB);
 
         // when - evict only userA
         authenticationCache.evictByUserUuid(userUuidA);
 
         // then - verify that userA token was evicted and userB token is still cached
-        authenticationCache.getOrAuthenticateByToken("jti-userA", 1L, loaderA);
-        authenticationCache.getOrAuthenticateByToken("jti-userB", 1L, loaderB);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-userA", 1L, loaderA);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-userB", 1L, loaderB);
         verify(loaderA, times(2)).get();
         verify(loaderB, times(1)).get();
     }
@@ -346,7 +410,7 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         authenticationCache.getOrAuthenticateSystemUser("superadmin", systemUserLoader);
         authenticationCache.getOrAuthenticateByUserUuid(UUID.fromString(userUuid), uuidLoader);
         authenticationCache.getOrAuthenticateByCertificate("fingerprint", certLoader);
-        authenticationCache.getOrAuthenticateByToken("jti-all", 1L, tokenLoader);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-all", 1L, tokenLoader);
 
         // when - evict all entries across all caches
         authenticationCache.evictAll();
@@ -355,7 +419,7 @@ class PlatformAuthenticationCacheITest extends BaseSpringBootTest {
         authenticationCache.getOrAuthenticateSystemUser("superadmin", systemUserLoader);
         authenticationCache.getOrAuthenticateByUserUuid(UUID.fromString(userUuid), uuidLoader);
         authenticationCache.getOrAuthenticateByCertificate("fingerprint", certLoader);
-        authenticationCache.getOrAuthenticateByToken("jti-all", 1L, tokenLoader);
+        authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-all", 1L, tokenLoader);
 
         verify(systemUserLoader, times(2)).get();
         verify(uuidLoader, times(2)).get();

--- a/src/test/java/com/otilm/core/integration/security/authn/client/PlatformAuthenticationClientITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authn/client/PlatformAuthenticationClientITest.java
@@ -31,6 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PlatformAuthenticationClientITest extends BaseSpringBootTest {
+
+    private static final String ISSUER = "https://issuer.example.com";
+    private static final String OTHER_ISSUER = "https://other-issuer.example.com";
+
     private static MockWebServer authServiceMock;
 
     private PlatformAuthenticationClient authenticationClient;
@@ -237,7 +241,7 @@ class PlatformAuthenticationClientITest extends BaseSpringBootTest {
     void authenticateByToken_cacheMiss_callsAuthService() {
         // given
         setUpSuccessfulAuthenticationResponse();
-        Map<String, Object> claims = Map.of("jti", "jti-test-123");
+        Map<String, Object> claims = Map.of("iss", ISSUER, "jti", "jti-test-123");
 
         // when
         AuthenticationInfo result = authenticationClient.authenticateByToken(claims, 1L);
@@ -251,7 +255,7 @@ class PlatformAuthenticationClientITest extends BaseSpringBootTest {
     void authenticateByToken_cacheHit_doesNotCallAuthService() {
         // given
         setUpSuccessfulAuthenticationResponse();
-        Map<String, Object> claims = Map.of("jti", "jti-test-123");
+        Map<String, Object> claims = Map.of("iss", ISSUER, "jti", "jti-test-123");
         authenticationClient.authenticateByToken(claims, 1L); // prime the cache
 
         // when
@@ -266,7 +270,7 @@ class PlatformAuthenticationClientITest extends BaseSpringBootTest {
         // given - same jti cached under generation 1L; a settings-generation bump must miss the cache
         setUpSuccessfulAuthenticationResponse();
         setUpSuccessfulAuthenticationResponse();
-        Map<String, Object> claims = Map.of("jti", "jti-test-123");
+        Map<String, Object> claims = Map.of("iss", ISSUER, "jti", "jti-test-123");
 
         // when
         authenticationClient.authenticateByToken(claims, 1L); // cache miss under generation 1L
@@ -282,13 +286,44 @@ class PlatformAuthenticationClientITest extends BaseSpringBootTest {
         // given - tokens without a jti claim cannot be uniquely identified, so caching is always skipped
         setUpSuccessfulAuthenticationResponse();
         setUpSuccessfulAuthenticationResponse();
-        Map<String, Object> claimsWithoutJti = Map.of("sub", "user-123");
+        Map<String, Object> claimsWithoutJti = Map.of("iss", ISSUER, "sub", "user-123");
 
         // when
         authenticationClient.authenticateByToken(claimsWithoutJti, 1L);
         authenticationClient.authenticateByToken(claimsWithoutJti, 1L);
 
         // then
+        assertEquals(2, authServiceMock.getRequestCount());
+    }
+
+    @Test
+    void authenticateByToken_missingIssuerClaim_alwaysCallsAuthService() {
+        // given - a jti is unique only within its issuer, so without an iss claim the token cannot be cached
+        setUpSuccessfulAuthenticationResponse();
+        setUpSuccessfulAuthenticationResponse();
+        Map<String, Object> claimsWithoutIssuer = Map.of("jti", "jti-no-issuer");
+
+        // when
+        authenticationClient.authenticateByToken(claimsWithoutIssuer, 1L);
+        authenticationClient.authenticateByToken(claimsWithoutIssuer, 1L);
+
+        // then
+        assertEquals(2, authServiceMock.getRequestCount());
+    }
+
+    @Test
+    void authenticateByToken_sameJtiFromDifferentIssuers_authenticatesEachSeparately() {
+        // given - two providers minting the same jti must not share a cache entry, and therefore an identity
+        setUpSuccessfulAuthenticationResponse();
+        setUpSuccessfulAuthenticationResponse();
+        Map<String, Object> claims = Map.of("iss", ISSUER, "jti", "jti-collision");
+        Map<String, Object> claimsFromOtherIssuer = Map.of("iss", OTHER_ISSUER, "jti", "jti-collision");
+
+        // when
+        authenticationClient.authenticateByToken(claims, 1L);
+        authenticationClient.authenticateByToken(claimsFromOtherIssuer, 1L);
+
+        // then - the second token was authenticated on its own instead of reusing the first issuer's entry
         assertEquals(2, authServiceMock.getRequestCount());
     }
 
@@ -353,7 +388,7 @@ class PlatformAuthenticationClientITest extends BaseSpringBootTest {
     void authenticateByToken_cacheHit_restoresActorMdc() {
         // given
         setUpSuccessfulAuthenticationResponse();
-        Map<String, Object> claims = Map.of("jti", "jti-mdc-test");
+        Map<String, Object> claims = Map.of("iss", ISSUER, "jti", "jti-mdc-test");
         authenticationClient.authenticateByToken(claims, 1L);
         MDC.clear();
 

--- a/src/test/java/com/otilm/core/integration/security/authn/client/PlatformAuthenticationClientITest.java
+++ b/src/test/java/com/otilm/core/integration/security/authn/client/PlatformAuthenticationClientITest.java
@@ -240,7 +240,7 @@ class PlatformAuthenticationClientITest extends BaseSpringBootTest {
         Map<String, Object> claims = Map.of("jti", "jti-test-123");
 
         // when
-        AuthenticationInfo result = authenticationClient.authenticateByToken(claims);
+        AuthenticationInfo result = authenticationClient.authenticateByToken(claims, 1L);
 
         // then
         assertEquals("FrantisekJednicka", result.getUsername());
@@ -252,13 +252,29 @@ class PlatformAuthenticationClientITest extends BaseSpringBootTest {
         // given
         setUpSuccessfulAuthenticationResponse();
         Map<String, Object> claims = Map.of("jti", "jti-test-123");
-        authenticationClient.authenticateByToken(claims); // prime the cache
+        authenticationClient.authenticateByToken(claims, 1L); // prime the cache
 
         // when
-        authenticationClient.authenticateByToken(claims);
+        authenticationClient.authenticateByToken(claims, 1L);
 
         // then
         assertEquals(1, authServiceMock.getRequestCount());
+    }
+
+    @Test
+    void authenticateByToken_differentGeneration_missesAndCallsAuthServiceAgain() {
+        // given - same jti cached under generation 1L; a settings-generation bump must miss the cache
+        setUpSuccessfulAuthenticationResponse();
+        setUpSuccessfulAuthenticationResponse();
+        Map<String, Object> claims = Map.of("jti", "jti-test-123");
+
+        // when
+        authenticationClient.authenticateByToken(claims, 1L); // cache miss under generation 1L
+        authenticationClient.authenticateByToken(claims, 1L); // cache hit under generation 1L
+        authenticationClient.authenticateByToken(claims, 2L); // cache miss under generation 2L
+
+        // then - only the two misses reach the auth service
+        assertEquals(2, authServiceMock.getRequestCount());
     }
 
     @Test
@@ -269,8 +285,8 @@ class PlatformAuthenticationClientITest extends BaseSpringBootTest {
         Map<String, Object> claimsWithoutJti = Map.of("sub", "user-123");
 
         // when
-        authenticationClient.authenticateByToken(claimsWithoutJti);
-        authenticationClient.authenticateByToken(claimsWithoutJti);
+        authenticationClient.authenticateByToken(claimsWithoutJti, 1L);
+        authenticationClient.authenticateByToken(claimsWithoutJti, 1L);
 
         // then
         assertEquals(2, authServiceMock.getRequestCount());
@@ -338,11 +354,11 @@ class PlatformAuthenticationClientITest extends BaseSpringBootTest {
         // given
         setUpSuccessfulAuthenticationResponse();
         Map<String, Object> claims = Map.of("jti", "jti-mdc-test");
-        authenticationClient.authenticateByToken(claims);
+        authenticationClient.authenticateByToken(claims, 1L);
         MDC.clear();
 
         // when
-        authenticationClient.authenticateByToken(claims);
+        authenticationClient.authenticateByToken(claims, 1L);
 
         // then
         assertEquals(1, authServiceMock.getRequestCount());

--- a/src/test/java/com/otilm/core/integration/security/oauth2/JwtDecoderITest.java
+++ b/src/test/java/com/otilm/core/integration/security/oauth2/JwtDecoderITest.java
@@ -4,6 +4,7 @@ import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.core.settings.SettingsSection;
 import com.otilm.api.model.core.settings.SettingsSectionCategory;
 import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsUpdateDto;
+import com.otilm.core.auth.oauth2.AuthenticationSnapshotRequestHolder;
 import com.otilm.core.auth.oauth2.LoginController;
 import com.otilm.core.dao.entity.Setting;
 import com.otilm.core.dao.repository.SettingRepository;
@@ -12,6 +13,7 @@ import com.otilm.core.security.authn.PlatformAuthenticationException;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.oauth2.OAuth2TestUtil;
 import com.otilm.core.service.SettingExternalService;
+import com.otilm.core.settings.AuthenticationSettingsSnapshot;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -117,8 +119,9 @@ class JwtDecoderITest extends BaseSpringBootTest {
     }
 
     @AfterEach
-    void stopServer() {
+    void tearDown() {
         mockServer.stop();
+        AuthenticationSnapshotRequestHolder.clear();
     }
 
     @Test
@@ -134,6 +137,20 @@ class JwtDecoderITest extends BaseSpringBootTest {
 
         authentication.setAccessingPermitAllEndpoint(true);
         Assertions.assertNull(jwtDecoder.decode(tokenValue));
+    }
+
+    @Test
+    void publishesSnapshotUsedForValidation() {
+        SecurityContextHolder.clearContext();
+        AuthenticationSnapshotRequestHolder.clear();
+
+        Jwt jwt = jwtDecoder.decode(tokenValue);
+
+        // the settings the token was validated against are handed to the identity resolution that follows
+        AuthenticationSettingsSnapshot published = AuthenticationSnapshotRequestHolder.get();
+        Assertions.assertNotNull(jwt);
+        Assertions.assertNotNull(published);
+        Assertions.assertEquals(ISSUER_URL, published.settings().getOAuth2Providers().get(PROVIDER_NAME).getIssuerUrl());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/security/oauth2/PlatformJwtConvertorITest.java
+++ b/src/test/java/com/otilm/core/integration/security/oauth2/PlatformJwtConvertorITest.java
@@ -102,7 +102,7 @@ class PlatformJwtConvertorITest extends BaseSpringBootTest {
                 .claim("claim", "claim")
                 .build();
         Exception exception = Assertions.assertThrows(PlatformAuthenticationException.class, () ->  jwtAuthenticationConverter.convert(jwtNoUsername));
-        Assertions.assertTrue(exception.getMessage().contains("could not be retrieved"));
+        Assertions.assertTrue(exception.getMessage().contains("not found in token claims"));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/AuthenticationCacheITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AuthenticationCacheITest.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.*;
 @Import(ManagementApiMocks.class)
 class AuthenticationCacheITest extends BaseSpringBootTest {
 
+    private static final String ISSUER = "https://issuer.example.com";
+
     @Autowired
     private AuthenticationCache authenticationCache;
 
@@ -82,15 +84,15 @@ class AuthenticationCacheITest extends BaseSpringBootTest {
             String userUuid = UUID.randomUUID().toString();
             Supplier<AuthenticationInfo> loaderA = loaderReturning(authenticatedInfo(userUuid, "user"));
             Supplier<AuthenticationInfo> loaderB = loaderReturning(authenticatedInfo(userUuid, "user"));
-            authenticationCache.getOrAuthenticateByToken("jti-A", 1L, loaderA);
-            authenticationCache.getOrAuthenticateByToken("jti-B", 1L, loaderB);
+            authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-A", 1L, loaderA);
+            authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-B", 1L, loaderB);
 
             // when
             userManagementService.deleteUser(userUuid);
 
             // then - both token entries are evicted via the JTI index
-            authenticationCache.getOrAuthenticateByToken("jti-A", 1L, loaderA);
-            authenticationCache.getOrAuthenticateByToken("jti-B", 1L, loaderB);
+            authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-A", 1L, loaderA);
+            authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-B", 1L, loaderB);
             verify(loaderA, times(2)).get();
             verify(loaderB, times(2)).get();
         }
@@ -148,7 +150,7 @@ class AuthenticationCacheITest extends BaseSpringBootTest {
             Supplier<AuthenticationInfo> tokenLoader = loaderReturning(authenticatedInfo(userUuidC, "tokenUser"));
             authenticationCache.getOrAuthenticateByUserUuid(userUuidA, uuidLoader);
             authenticationCache.getOrAuthenticateByCertificate("fp-B", certLoader);
-            authenticationCache.getOrAuthenticateByToken("jti-C", 1L, tokenLoader);
+            authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-C", 1L, tokenLoader);
 
             // when - a role is deleted, which may affect the permissions of any user that held it
             roleManagementService.deleteRole(UUID.randomUUID().toString());
@@ -156,7 +158,7 @@ class AuthenticationCacheITest extends BaseSpringBootTest {
             // then - all entries are gone; every loader is invoked again
             authenticationCache.getOrAuthenticateByUserUuid(userUuidA, uuidLoader);
             authenticationCache.getOrAuthenticateByCertificate("fp-B", certLoader);
-            authenticationCache.getOrAuthenticateByToken("jti-C", 1L, tokenLoader);
+            authenticationCache.getOrAuthenticateByToken(ISSUER, "jti-C", 1L, tokenLoader);
             verify(uuidLoader, times(2)).get();
             verify(certLoader, times(2)).get();
             verify(tokenLoader, times(2)).get();

--- a/src/test/java/com/otilm/core/integration/service/AuthenticationCacheITest.java
+++ b/src/test/java/com/otilm/core/integration/service/AuthenticationCacheITest.java
@@ -82,15 +82,15 @@ class AuthenticationCacheITest extends BaseSpringBootTest {
             String userUuid = UUID.randomUUID().toString();
             Supplier<AuthenticationInfo> loaderA = loaderReturning(authenticatedInfo(userUuid, "user"));
             Supplier<AuthenticationInfo> loaderB = loaderReturning(authenticatedInfo(userUuid, "user"));
-            authenticationCache.getOrAuthenticateByToken("jti-A", loaderA);
-            authenticationCache.getOrAuthenticateByToken("jti-B", loaderB);
+            authenticationCache.getOrAuthenticateByToken("jti-A", 1L, loaderA);
+            authenticationCache.getOrAuthenticateByToken("jti-B", 1L, loaderB);
 
             // when
             userManagementService.deleteUser(userUuid);
 
             // then - both token entries are evicted via the JTI index
-            authenticationCache.getOrAuthenticateByToken("jti-A", loaderA);
-            authenticationCache.getOrAuthenticateByToken("jti-B", loaderB);
+            authenticationCache.getOrAuthenticateByToken("jti-A", 1L, loaderA);
+            authenticationCache.getOrAuthenticateByToken("jti-B", 1L, loaderB);
             verify(loaderA, times(2)).get();
             verify(loaderB, times(2)).get();
         }
@@ -148,7 +148,7 @@ class AuthenticationCacheITest extends BaseSpringBootTest {
             Supplier<AuthenticationInfo> tokenLoader = loaderReturning(authenticatedInfo(userUuidC, "tokenUser"));
             authenticationCache.getOrAuthenticateByUserUuid(userUuidA, uuidLoader);
             authenticationCache.getOrAuthenticateByCertificate("fp-B", certLoader);
-            authenticationCache.getOrAuthenticateByToken("jti-C", tokenLoader);
+            authenticationCache.getOrAuthenticateByToken("jti-C", 1L, tokenLoader);
 
             // when - a role is deleted, which may affect the permissions of any user that held it
             roleManagementService.deleteRole(UUID.randomUUID().toString());
@@ -156,7 +156,7 @@ class AuthenticationCacheITest extends BaseSpringBootTest {
             // then - all entries are gone; every loader is invoked again
             authenticationCache.getOrAuthenticateByUserUuid(userUuidA, uuidLoader);
             authenticationCache.getOrAuthenticateByCertificate("fp-B", certLoader);
-            authenticationCache.getOrAuthenticateByToken("jti-C", tokenLoader);
+            authenticationCache.getOrAuthenticateByToken("jti-C", 1L, tokenLoader);
             verify(uuidLoader, times(2)).get();
             verify(certLoader, times(2)).get();
             verify(tokenLoader, times(2)).get();

--- a/src/test/java/com/otilm/core/integration/service/SettingServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SettingServiceITest.java
@@ -4,11 +4,10 @@ import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.other.ResourceEvent;
-import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
-import com.otilm.api.model.common.attribute.common.properties.DataAttributeProperties;
 import com.otilm.api.model.common.attribute.v3.DataAttributeV3;
 import com.otilm.api.model.core.settings.*;
 import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsUpdateDto;
+import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsDto;
 import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsResponseDto;
 import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsUpdateDto;
 import com.otilm.core.attribute.CsrAttributes;
@@ -31,6 +30,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.*;
 
@@ -244,6 +247,83 @@ class SettingServiceITest extends BaseSpringBootTest {
         eventSettingsDto.setTriggerUuids(List.of(UUID.fromString("3a1db3f5-f9eb-4fbf-92c9-c4c1499bfca8")));
 
         Assertions.assertThrows(NotFoundException.class, () -> settingService.updateEventSettings(eventSettingsDto), "Updating non-existing trigger event settings should throw NotFoundException");
+    }
+
+    @Test
+    void updateOAuth2ProviderSettings_duplicateIssuer_rejected() throws Exception {
+        OAuth2ProviderSettingsUpdateDto first = createProviderUpdateDto();
+        first.setIssuerUrl("https://shared-issuer.example.com");
+        settingService.updateOAuth2ProviderSettings("provider-one", first);
+
+        OAuth2ProviderSettingsUpdateDto second = createProviderUpdateDto();
+        second.setIssuerUrl("https://shared-issuer.example.com");
+        Assertions.assertThrows(ValidationException.class,
+                () -> settingService.updateOAuth2ProviderSettings("provider-two", second));
+    }
+
+    @Test
+    void updateOAuth2ProviderSettings_sameProviderKeepsItsOwnIssuer() throws Exception {
+        OAuth2ProviderSettingsUpdateDto dto = createProviderUpdateDto();
+        dto.setIssuerUrl("https://unique-issuer.example.com");
+        settingService.updateOAuth2ProviderSettings("provider-one", dto);
+        Assertions.assertDoesNotThrow(() -> settingService.updateOAuth2ProviderSettings("provider-one", dto));
+    }
+
+    @Test
+    void updateOAuth2ProviderSettings_changingIssuerIntoExistingOnes_rejected() throws Exception {
+        OAuth2ProviderSettingsUpdateDto first = createProviderUpdateDto();
+        first.setIssuerUrl("https://issuer-one.example.com");
+        settingService.updateOAuth2ProviderSettings("provider-one", first);
+
+        OAuth2ProviderSettingsUpdateDto second = createProviderUpdateDto();
+        second.setIssuerUrl("https://issuer-two.example.com");
+        settingService.updateOAuth2ProviderSettings("provider-two", second);
+
+        second.setIssuerUrl("https://issuer-one.example.com");   // update provider-two into a collision
+        Assertions.assertThrows(ValidationException.class,
+                () -> settingService.updateOAuth2ProviderSettings("provider-two", second));
+    }
+
+    @Test
+    void updateAuthenticationSettings_batchWithInternalDuplicateIssuer_rejected() throws Exception {
+        OAuth2ProviderSettingsDto p1 = createProviderDto("provider-one");
+        p1.setIssuerUrl("https://dup.example.com");
+        OAuth2ProviderSettingsDto p2 = createProviderDto("provider-two");
+        p2.setIssuerUrl("https://dup.example.com");
+        AuthenticationSettingsUpdateDto update = new AuthenticationSettingsUpdateDto();
+        update.setOAuth2Providers(List.of(p1, p2));
+        Assertions.assertThrows(ValidationException.class,
+                () -> settingService.updateAuthenticationSettings(update));
+    }
+
+    private static String encodedJwkSet() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+        RSAKey rsaKey = new RSAKey.Builder((RSAPublicKey) keyPair.getPublic()).keyID("test-key").build();
+        return Base64.getEncoder().encodeToString(
+                new JWKSet(rsaKey).toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static OAuth2ProviderSettingsUpdateDto createProviderUpdateDto() throws Exception {
+        OAuth2ProviderSettingsUpdateDto dto = new OAuth2ProviderSettingsUpdateDto();
+        dto.setClientId("client");
+        dto.setClientSecret("secret");
+        dto.setAuthorizationUrl("http://auth.example.com");
+        dto.setTokenUrl("http://token.example.com");
+        dto.setJwkSet(encodedJwkSet());
+        return dto;
+    }
+
+    private static OAuth2ProviderSettingsDto createProviderDto(String name) throws Exception {
+        OAuth2ProviderSettingsDto dto = new OAuth2ProviderSettingsDto();
+        dto.setName(name);
+        dto.setClientId("client");
+        dto.setClientSecret("secret");
+        dto.setAuthorizationUrl("http://auth.example.com");
+        dto.setTokenUrl("http://token.example.com");
+        dto.setJwkSet(encodedJwkSet());
+        return dto;
     }
 
 }

--- a/src/test/java/com/otilm/core/integration/service/SettingServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SettingServiceITest.java
@@ -279,7 +279,7 @@ class SettingServiceITest extends BaseSpringBootTest {
         second.setIssuerUrl("https://issuer-two.example.com");
         settingService.updateOAuth2ProviderSettings("provider-two", second);
 
-        second.setIssuerUrl("https://issuer-one.example.com");   // update provider-two into a collision
+        second.setIssuerUrl("https://issuer-one.example.com");
         Assertions.assertThrows(ValidationException.class,
                 () -> settingService.updateOAuth2ProviderSettings("provider-two", second));
     }

--- a/src/test/java/com/otilm/core/security/authn/tsp/TspAuthenticationFilterTest.java
+++ b/src/test/java/com/otilm/core/security/authn/tsp/TspAuthenticationFilterTest.java
@@ -3,6 +3,8 @@ package com.otilm.core.security.authn.tsp;
 import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.core.logging.enums.ActorType;
 import com.otilm.api.model.core.logging.enums.AuthMethod;
+import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDto;
+import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsDto;
 import com.otilm.api.model.connector.secrets.content.BasicAuthSecretContent;
 import com.otilm.api.model.core.signing.TspAuthenticationMethod;
 import com.otilm.core.auth.oauth2.PlatformJwtDecoder;
@@ -13,6 +15,8 @@ import com.otilm.core.security.authn.client.CredentialVerificationCache;
 import com.otilm.core.security.authn.client.PlatformAuthenticationClient;
 import com.otilm.core.service.SigningProfileInternalService;
 import com.otilm.core.service.TspProfileInternalService;
+import com.otilm.core.settings.AuthenticationSettingsSnapshot;
+import com.otilm.core.settings.SettingsCache;
 import com.otilm.core.util.AuthHelper;
 import com.otilm.core.util.SecretsUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -21,7 +25,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -33,11 +39,19 @@ import org.slf4j.MDC;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -341,21 +355,75 @@ class TspAuthenticationFilterTest {
                     .header("alg", "none")
                     .claim("sub", "alice")
                     .claim("jti", "jti-1")
+                    .claim("username", "alice")
                     .issuedAt(issuedAt)
                     .expiresAt(issuedAt.plusSeconds(60))
                     .build();
             when(jwtDecoder.decode("the.jwt.token")).thenReturn(jwt);
-            when(authClient.authenticateByToken(any())).thenReturn(authenticatedInfo());
+            when(authClient.authenticateByToken(anyMap(), anyLong())).thenReturn(authenticatedInfo());
 
             // when
             filter.doFilter(request, response, chain);
 
             // then
             verify(jwtDecoder).decode("the.jwt.token");
-            verify(authClient).authenticateByToken(any());
+            verify(authClient).authenticateByToken(anyMap(), anyLong());
             assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
             assertThat(chain.getRequest()).isNotNull();
             assertActorIsPrincipal("uuid-1", "alice");
+        }
+
+        private BearerTokenAuthenticator bearerAuthenticator() {
+            return new BearerTokenAuthenticator(jwtDecoder, authClient, new TspSecurityContextWriter(authHelper));
+        }
+
+        @Test
+        void bearerToken_withoutEffectiveUsernameClaim_isRejected() {
+            Jwt jwt = mock(Jwt.class);
+            when(jwtDecoder.decode(anyString())).thenReturn(jwt);
+            when(jwt.getClaims()).thenReturn(Map.of("sub", "abc", "jti", "jti-1"));
+            request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer some-token");
+
+            assertThat(bearerAuthenticator().authenticate(request, mock(TspProfileModel.class))).isFalse();
+            verifyNoInteractions(authClient);
+        }
+
+        @Test
+        void bearerToken_forwardsNormalizedUsername() {
+            Jwt jwt = mock(Jwt.class);
+            when(jwtDecoder.decode(anyString())).thenReturn(jwt);
+            when(jwt.getClaims()).thenReturn(Map.of("username", "alice", "jti", "jti-2"));
+            when(authClient.authenticateByToken(anyMap(), anyLong()))
+                    .thenReturn(authenticatedInfo());
+            request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer some-token");
+
+            assertThat(bearerAuthenticator().authenticate(request, mock(TspProfileModel.class))).isTrue();
+            verify(authClient).authenticateByToken(argThat(claims -> "alice".equals(claims.get("username"))), anyLong());
+        }
+
+        @Test
+        void bearerToken_resolvesConfiguredClaimFromMatchingProvider() throws Exception {
+            Jwt jwt = mock(Jwt.class);
+            when(jwtDecoder.decode(anyString())).thenReturn(jwt);
+            when(jwt.getIssuer()).thenReturn(java.net.URI.create("https://issuer.example.com").toURL());
+            when(jwt.getClaims()).thenReturn(Map.of("preferred_username", "alice", "jti", "jti-3"));
+            when(authClient.authenticateByToken(anyMap(), anyLong())).thenReturn(authenticatedInfo());
+            request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer some-token");
+
+            OAuth2ProviderSettingsDto provider = new OAuth2ProviderSettingsDto();
+            provider.setName("entra");
+            provider.setIssuerUrl("https://issuer.example.com");
+            provider.setUsernameClaim("preferred_username");
+            AuthenticationSettingsDto settings = new AuthenticationSettingsDto();
+            settings.setOAuth2Providers(Map.of("entra", provider));
+
+            try (MockedStatic<SettingsCache> settingsMock = mockStatic(SettingsCache.class)) {
+                settingsMock.when(SettingsCache::getAuthenticationSnapshot)
+                        .thenReturn(new AuthenticationSettingsSnapshot(settings, 7L));
+
+                assertThat(bearerAuthenticator().authenticate(request, mock(TspProfileModel.class))).isTrue();
+            }
+            verify(authClient).authenticateByToken(argThat(claims -> "alice".equals(claims.get("username"))), eq(7L));
         }
     }
 
@@ -541,7 +609,7 @@ class TspAuthenticationFilterTest {
             assertThat(response.getStatus()).isEqualTo(401);
             assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
             assertThat(chain.getRequest()).isNull();
-            verify(authClient, never()).authenticateByToken(any());
+            verify(authClient, never()).authenticateByToken(anyMap(), anyLong());
         }
 
         @Test
@@ -561,7 +629,7 @@ class TspAuthenticationFilterTest {
             assertThat(response.getStatus()).isEqualTo(401);
             assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
             assertThat(chain.getRequest()).isNull();
-            verify(authClient, never()).authenticateByToken(any());
+            verify(authClient, never()).authenticateByToken(anyMap(), anyLong());
         }
 
         @Test

--- a/src/test/java/com/otilm/core/security/authn/tsp/TspAuthenticationFilterTest.java
+++ b/src/test/java/com/otilm/core/security/authn/tsp/TspAuthenticationFilterTest.java
@@ -7,6 +7,7 @@ import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDt
 import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsDto;
 import com.otilm.api.model.connector.secrets.content.BasicAuthSecretContent;
 import com.otilm.api.model.core.signing.TspAuthenticationMethod;
+import com.otilm.core.auth.oauth2.AuthenticationSnapshotRequestHolder;
 import com.otilm.core.auth.oauth2.PlatformJwtDecoder;
 import com.otilm.core.model.signing.TspProfileModel;
 import com.otilm.core.security.authn.PlatformAuthenticationException;
@@ -36,6 +37,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.slf4j.MDC;
 
+import java.net.URI;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
@@ -93,12 +95,14 @@ class TspAuthenticationFilterTest {
         response = new MockHttpServletResponse();
         chain = new MockFilterChain();
         SecurityContextHolder.clearContext();
+        AuthenticationSnapshotRequestHolder.clear();
         MDC.clear();
     }
 
     @AfterEach
     void clearContext() {
         SecurityContextHolder.clearContext();
+        AuthenticationSnapshotRequestHolder.clear();
         MDC.clear();
     }
 
@@ -405,7 +409,7 @@ class TspAuthenticationFilterTest {
         void bearerToken_resolvesConfiguredClaimFromMatchingProvider() throws Exception {
             Jwt jwt = mock(Jwt.class);
             when(jwtDecoder.decode(anyString())).thenReturn(jwt);
-            when(jwt.getIssuer()).thenReturn(java.net.URI.create("https://issuer.example.com").toURL());
+            when(jwt.getIssuer()).thenReturn(URI.create("https://issuer.example.com").toURL());
             when(jwt.getClaims()).thenReturn(Map.of("preferred_username", "alice", "jti", "jti-3"));
             when(authClient.authenticateByToken(anyMap(), anyLong())).thenReturn(authenticatedInfo());
             request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer some-token");
@@ -424,6 +428,31 @@ class TspAuthenticationFilterTest {
                 assertThat(bearerAuthenticator().authenticate(request, mock(TspProfileModel.class))).isTrue();
             }
             verify(authClient).authenticateByToken(argThat(claims -> "alice".equals(claims.get("username"))), eq(7L));
+        }
+
+        @Test
+        void bearerToken_resolvesIdentityFromTheSnapshotTheDecoderValidatedAgainst() throws Exception {
+            OAuth2ProviderSettingsDto provider = new OAuth2ProviderSettingsDto();
+            provider.setName("entra");
+            provider.setIssuerUrl("https://issuer.example.com");
+            provider.setUsernameClaim("preferred_username");
+            AuthenticationSettingsDto validatedSettings = new AuthenticationSettingsDto();
+            validatedSettings.setOAuth2Providers(Map.of("entra", provider));
+
+            Jwt jwt = mock(Jwt.class);
+            when(jwt.getIssuer()).thenReturn(URI.create("https://issuer.example.com").toURL());
+            when(jwt.getClaims()).thenReturn(Map.of("preferred_username", "alice", "jti", "jti-4"));
+            // the decoder publishes the snapshot it validated against, as the real one does
+            when(jwtDecoder.decode(anyString())).thenAnswer(invocation -> {
+                AuthenticationSnapshotRequestHolder.set(new AuthenticationSettingsSnapshot(validatedSettings, 9L));
+                return jwt;
+            });
+            when(authClient.authenticateByToken(anyMap(), anyLong())).thenReturn(authenticatedInfo());
+            request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer some-token");
+
+            // no SettingsCache stubbing: only the published snapshot knows this provider and this generation
+            assertThat(bearerAuthenticator().authenticate(request, mock(TspProfileModel.class))).isTrue();
+            verify(authClient).authenticateByToken(argThat(claims -> "alice".equals(claims.get("username"))), eq(9L));
         }
     }
 

--- a/src/test/java/com/otilm/core/security/oauth2/OAuth2TestUtil.java
+++ b/src/test/java/com/otilm/core/security/oauth2/OAuth2TestUtil.java
@@ -22,10 +22,14 @@ import java.util.Map;
 public class OAuth2TestUtil {
 
     public static String createJwtTokenValue(PrivateKey privateKey, Integer expiryInMilliseconds, String issuerUrl, String audience, String username) throws JOSEException {
+        return createJwtTokenValue(privateKey, expiryInMilliseconds, issuerUrl, audience, OAuth2Constants.TOKEN_USERNAME_CLAIM_NAME, username);
+    }
+
+    public static String createJwtTokenValue(PrivateKey privateKey, Integer expiryInMilliseconds, String issuerUrl, String audience, String claimName, String claimValue) throws JOSEException {
         JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
                 .audience(audience)
                 .expirationTime(expiryInMilliseconds == null ? null : new Date(System.currentTimeMillis() + expiryInMilliseconds))
-                .claim(OAuth2Constants.TOKEN_USERNAME_CLAIM_NAME, username)
+                .claim(claimName, claimValue)
                 .issuer(issuerUrl)
                 .build();
 

--- a/src/test/java/com/otilm/core/security/oauth2/OAuth2UsernameResolutionTest.java
+++ b/src/test/java/com/otilm/core/security/oauth2/OAuth2UsernameResolutionTest.java
@@ -1,0 +1,188 @@
+package com.otilm.core.security.oauth2;
+
+import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDto;
+import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsDto;
+import com.otilm.core.security.authn.PlatformAuthenticationException;
+import com.otilm.core.util.OAuth2Util;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OAuth2UsernameResolutionTest {
+
+    private static OAuth2ProviderSettingsDto providerWithClaim(String usernameClaim) {
+        OAuth2ProviderSettingsDto provider = new OAuth2ProviderSettingsDto();
+        provider.setName("test");
+        provider.setUsernameClaim(usernameClaim);
+        return provider;
+    }
+
+    @Test
+    void configuredClaimPresent_returnsItsValue() {
+        Map<String, Object> claims = Map.of("preferred_username", "alice", "username", "bob");
+        assertEquals("alice", OAuth2Util.resolveUsername(providerWithClaim("preferred_username"), claims));
+    }
+
+    @Test
+    void configuredClaimAbsent_throwsWithoutFallback() {
+        Map<String, Object> claims = Map.of("username", "bob", "preferred_username", "alice");
+        OAuth2ProviderSettingsDto provider = providerWithClaim("upn");
+        PlatformAuthenticationException e = assertThrows(PlatformAuthenticationException.class,
+                () -> OAuth2Util.resolveUsername(provider, claims));
+        assertTrue(e.getMessage().contains("upn"));
+    }
+
+    @Test
+    void unconfigured_usesDefaultUsernameClaim() {
+        Map<String, Object> claims = Map.of("username", "bob");
+        assertEquals("bob", OAuth2Util.resolveUsername(providerWithClaim(null), claims));
+    }
+
+    @Test
+    void unconfigured_preferredUsernameAloneIsNotAccepted() {
+        Map<String, Object> claims = Map.of("preferred_username", "alice");
+        OAuth2ProviderSettingsDto provider = providerWithClaim(null);
+        assertThrows(PlatformAuthenticationException.class,
+                () -> OAuth2Util.resolveUsername(provider, claims));
+    }
+
+    @Test
+    void blankConfiguredClaim_treatedAsUnset() {
+        Map<String, Object> claims = Map.of("username", "bob");
+        assertEquals("bob", OAuth2Util.resolveUsername(providerWithClaim("  "), claims));
+    }
+
+    @Test
+    void nullProviderSettings_usesDefaultClaim() {
+        Map<String, Object> claims = Map.of("username", "bob");
+        assertEquals("bob", OAuth2Util.resolveUsername(null, claims));
+    }
+
+    @Test
+    void nonStringClaimValue_throws() {
+        Map<String, Object> claims = Map.of("username", List.of("bob"));
+        assertThrows(PlatformAuthenticationException.class,
+                () -> OAuth2Util.resolveUsername(null, claims));
+    }
+
+    @Test
+    void nullClaimsMap_throwsDomainException() {
+        assertThrows(PlatformAuthenticationException.class,
+                () -> OAuth2Util.resolveUsername(null, null));
+    }
+
+    @Test
+    void blankClaimValue_throws() {
+        Map<String, Object> claims = Map.of("username", "   ");
+        assertThrows(PlatformAuthenticationException.class,
+                () -> OAuth2Util.resolveUsername(null, claims));
+    }
+
+    @Test
+    void errorMessage_neverContainsClaimValues() {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("preferred_username", "secret-value");
+        OAuth2ProviderSettingsDto provider = providerWithClaim(null);
+        PlatformAuthenticationException e = assertThrows(PlatformAuthenticationException.class,
+                () -> OAuth2Util.resolveUsername(provider, claims));
+        assertFalse(e.getMessage().contains("secret-value"));
+    }
+
+    @Test
+    void lenientVariant_returnsNullInsteadOfThrowing() {
+        assertNull(OAuth2Util.resolveUsernameOrNull(providerWithClaim("upn"), Map.of("username", "bob")));
+        assertNull(OAuth2Util.resolveUsernameOrNull(null, null));
+        assertEquals("bob", OAuth2Util.resolveUsernameOrNull(null, Map.of("username", "bob")));
+    }
+
+    @Test
+    void effectiveUsernameClaim_reflectsConfiguration() {
+        assertEquals("upn", OAuth2Util.effectiveUsernameClaim(providerWithClaim("upn")));
+        assertEquals("username", OAuth2Util.effectiveUsernameClaim(providerWithClaim(null)));
+        assertEquals("username", OAuth2Util.effectiveUsernameClaim(null));
+    }
+
+    private static String signedJwtWithClaims(Map<String, Object> tokenClaims) throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+        JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
+                .expirationTime(new Date(System.currentTimeMillis() + 60_000));
+        tokenClaims.forEach(builder::claim);
+        SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.RS256), builder.build());
+        signedJWT.sign(new RSASSASigner(keyPair.getPrivate()));
+        return signedJWT.serialize();
+    }
+
+    @Test
+    void getAllClaimsAvailable_normalizesConfiguredClaimIntoUsernameKey() throws Exception {
+        String token = signedJwtWithClaims(Map.of("preferred_username", "alice", "username", "bob"));
+        Map<String, Object> claims = OAuth2Util.getAllClaimsAvailable(
+                providerWithClaim("preferred_username"), token, null);
+        assertEquals("alice", claims.get("username"));
+    }
+
+    @Test
+    void getAllClaimsAvailable_defaultClaimPresent_keepsUsername() throws Exception {
+        String token = signedJwtWithClaims(Map.of("username", "bob"));
+        Map<String, Object> claims = OAuth2Util.getAllClaimsAvailable(providerWithClaim(null), token, null);
+        assertEquals("bob", claims.get("username"));
+    }
+
+    @Test
+    void getAllClaimsAvailable_missingEffectiveClaim_throws() throws Exception {
+        String token = signedJwtWithClaims(Map.of("preferred_username", "alice"));
+        OAuth2ProviderSettingsDto provider = providerWithClaim(null);
+        assertThrows(PlatformAuthenticationException.class,
+                () -> OAuth2Util.getAllClaimsAvailable(provider, token, null));
+    }
+
+    private static AuthenticationSettingsDto settingsWithProviders(OAuth2ProviderSettingsDto... providers) {
+        AuthenticationSettingsDto settings = new AuthenticationSettingsDto();
+        Map<String, OAuth2ProviderSettingsDto> map = new HashMap<>();
+        for (OAuth2ProviderSettingsDto p : providers) {
+            map.put(p.getName(), p);
+        }
+        settings.setOAuth2Providers(map);
+        return settings;
+    }
+
+    private static OAuth2ProviderSettingsDto providerWithIssuer(String name, String issuerUrl) {
+        OAuth2ProviderSettingsDto provider = new OAuth2ProviderSettingsDto();
+        provider.setName(name);
+        provider.setIssuerUrl(issuerUrl);
+        return provider;
+    }
+
+    @Test
+    void findProviderByIssuer_uniqueMatch() {
+        AuthenticationSettingsDto settings = settingsWithProviders(
+                providerWithIssuer("a", "https://issuer-a"), providerWithIssuer("b", "https://issuer-b"));
+        assertEquals("a", OAuth2Util.findProviderByIssuer(settings, "https://issuer-a").getName());
+    }
+
+    @Test
+    void findProviderByIssuer_noMatch_returnsNull() {
+        AuthenticationSettingsDto settings = settingsWithProviders(providerWithIssuer("a", "https://issuer-a"));
+        assertNull(OAuth2Util.findProviderByIssuer(settings, "https://other"));
+        assertNull(OAuth2Util.findProviderByIssuer(null, "https://other"));
+        assertNull(OAuth2Util.findProviderByIssuer(settings, null));
+    }
+
+    @Test
+    void findProviderByIssuer_ambiguousMatch_throws() {
+        AuthenticationSettingsDto settings = settingsWithProviders(
+                providerWithIssuer("a", "https://issuer-a"), providerWithIssuer("b", "https://issuer-a"));
+        assertThrows(PlatformAuthenticationException.class,
+                () -> OAuth2Util.findProviderByIssuer(settings, "https://issuer-a"));
+    }
+}

--- a/src/test/java/com/otilm/core/security/oauth2/OAuth2UsernameResolutionTest.java
+++ b/src/test/java/com/otilm/core/security/oauth2/OAuth2UsernameResolutionTest.java
@@ -185,4 +185,11 @@ class OAuth2UsernameResolutionTest {
         assertThrows(PlatformAuthenticationException.class,
                 () -> OAuth2Util.findProviderByIssuer(settings, "https://issuer-a"));
     }
+
+    @Test
+    void findProviderByIssuer_nullProvidersMap_returnsNull() {
+        AuthenticationSettingsDto settings = new AuthenticationSettingsDto();
+        settings.setOAuth2Providers(null);
+        assertNull(OAuth2Util.findProviderByIssuer(settings, "https://issuer-a"));
+    }
 }

--- a/src/test/java/com/otilm/core/settings/SettingsCacheTest.java
+++ b/src/test/java/com/otilm/core/settings/SettingsCacheTest.java
@@ -1,0 +1,59 @@
+package com.otilm.core.settings;
+
+import com.otilm.api.model.core.settings.SettingsSection;
+import com.otilm.api.model.core.settings.authentication.AuthenticationSettingsDto;
+import com.otilm.api.model.core.settings.authentication.OAuth2ProviderSettingsDto;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SettingsCacheTest {
+
+    private final SettingsCache settingsCache = new SettingsCache();
+
+    // Static cache state survives across tests: every test seeds settings under a unique provider
+    // name so its first cacheSettings call is always a change, regardless of execution order.
+    private static AuthenticationSettingsDto settingsWithProvider(String name, String usernameClaim) {
+        OAuth2ProviderSettingsDto provider = new OAuth2ProviderSettingsDto();
+        provider.setName(name);
+        provider.setUsernameClaim(usernameClaim);
+        AuthenticationSettingsDto settings = new AuthenticationSettingsDto();
+        settings.setOAuth2Providers(Map.of(name, provider));
+        return settings;
+    }
+
+    private static String uniqueName() {
+        return "provider-" + UUID.randomUUID();
+    }
+
+    @Test
+    void changedAuthenticationSettings_bumpGeneration() {
+        String name = uniqueName();
+        settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, settingsWithProvider(name, "username"));
+        long afterFirst = SettingsCache.getAuthenticationSnapshot().generation();
+
+        settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, settingsWithProvider(name, "preferred_username"));
+        assertEquals(afterFirst + 1, SettingsCache.getAuthenticationSnapshot().generation());
+    }
+
+    @Test
+    void equalAuthenticationSettings_keepGeneration() {
+        String name = uniqueName();
+        settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, settingsWithProvider(name, "username"));
+        long generation = SettingsCache.getAuthenticationSnapshot().generation();
+
+        settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, settingsWithProvider(name, "username"));
+        assertEquals(generation, SettingsCache.getAuthenticationSnapshot().generation());
+    }
+
+    @Test
+    void snapshotIsTheAuthoritativeStoreForAuthenticationSection() {
+        AuthenticationSettingsDto settings = settingsWithProvider(uniqueName(), "username");
+        settingsCache.cacheSettings(SettingsSection.AUTHENTICATION, settings);
+        assertEquals(settings, SettingsCache.getAuthenticationSnapshot().settings());
+        assertEquals(settings, SettingsCache.getSettings(SettingsSection.AUTHENTICATION));
+    }
+}


### PR DESCRIPTION
## Changes

- Resolve the username strictly from the provider's configured `usernameClaim` (default `username`) with no fallback to any other claim
- Normalize the resolved value into the `username` claim forwarded to the auth service on all token authentication paths (browser session, JWT bearer, TSP bearer)
- Support providers that issue `preferred_username` instead of `username` by setting `usernameClaim` to `preferred_username` on the provider
- Enforce unique issuer URLs across OAuth2 providers and fail authentication on an ambiguous issuer match
- Key cached token identities by an authentication-settings generation published as an atomic snapshot, so a settings change invalidates previously cached identities
- Stop failing token refresh when the username claim is missing from the principal attributes; the merged-claims gate remains the single enforcement point