### PR TITLE
Reject key creation for disabled Token Profiles

### DIFF
--- a/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
@@ -352,7 +352,7 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
                         tokenProfileUuid)
                 .orElseThrow(
                         () -> new NotFoundException(
-                                TokenInstanceReference.class,
+                                TokenProfile.class,
                                 tokenProfileUuid
                         )
                 );

--- a/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
@@ -356,6 +356,9 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
                                 tokenProfileUuid
                         )
                 );
+        if (!Boolean.TRUE.equals(tokenProfile.getEnabled())) {
+            throw new ValidationException(ValidationError.create("Token Profile is disabled"));
+        }
 
         attributeEngine.validateCustomAttributesContent(Resource.CRYPTOGRAPHIC_KEY, request.getCustomAttributes());
         mergeAndValidateAttributes(type, tokenInstanceReference, request.getAttributes());

--- a/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicKeyServiceImpl.java
@@ -356,9 +356,7 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
                                 tokenProfileUuid
                         )
                 );
-        if (!Boolean.TRUE.equals(tokenProfile.getEnabled())) {
-            throw new ValidationException(ValidationError.create("Token Profile is disabled"));
-        }
+        validateTokenProfileEnabled(tokenProfile);
 
         attributeEngine.validateCustomAttributesContent(Resource.CRYPTOGRAPHIC_KEY, request.getCustomAttributes());
         mergeAndValidateAttributes(type, tokenInstanceReference, request.getAttributes());
@@ -411,28 +409,31 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
         if (tokenInstanceUuid != null)
             authorizationEnforcer.enforce(Resource.TOKEN, ResourceAction.MEMBERS, SecuredUUID.fromUUID(tokenInstanceUuid));
 
-        attributeEngine.validateCustomAttributesContent(Resource.CRYPTOGRAPHIC_KEY, request.getCustomAttributes());
-
-        if (request.getName() != null && !request.getName().isEmpty()) key.setName(request.getName());
-        if (request.getDescription() != null) key.setDescription(request.getDescription());
+        TokenProfile requestedTokenProfile = null;
         if (request.getTokenProfileUuid() != null) {
-            TokenProfile tokenProfile = tokenProfileRepository.findByUuid(
+            requestedTokenProfile = tokenProfileRepository.findByUuid(
                             SecuredUUID.fromString(request.getTokenProfileUuid()))
                     .orElseThrow(
                             () -> new NotFoundException(
-                                    TokenInstanceReference.class,
+                                    TokenProfile.class,
                                     request.getTokenProfileUuid()
                             )
                     );
-            if (!tokenProfile.getTokenInstanceReferenceUuid().equals(key.getTokenInstanceReferenceUuid())) {
+            if (!requestedTokenProfile.getTokenInstanceReferenceUuid().equals(key.getTokenInstanceReferenceUuid())) {
                 throw new ValidationException(
                         ValidationError.create(
                                 "Cannot assign Token Profile from different provider"
                         )
                 );
             }
-            key.setTokenProfile(tokenProfile);
+            validateTokenProfileEnabled(requestedTokenProfile);
         }
+
+        attributeEngine.validateCustomAttributesContent(Resource.CRYPTOGRAPHIC_KEY, request.getCustomAttributes());
+
+        if (request.getName() != null && !request.getName().isEmpty()) key.setName(request.getName());
+        if (request.getDescription() != null) key.setDescription(request.getDescription());
+        if (requestedTokenProfile != null) key.setTokenProfile(requestedTokenProfile);
         key = cryptographicKeyRepository.save(key);
         key.getItems().forEach(item -> evictKeyItemCache(item.getUuid()));
 
@@ -761,6 +762,7 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
                                 tokenProfileUuid
                         )
                 );
+        validateTokenProfileEnabled(tokenProfile);
         logger.debug("Token profile details: {}", tokenProfile);
         List<BaseAttribute> attributes;
         ApiClientConnectorInfo connectorDto = connectorService.getConnectorForApiClient(tokenProfile.getTokenInstanceReference().getConnectorUuid());
@@ -777,6 +779,12 @@ public class CryptographicKeyServiceImpl implements CryptographicKeyExternalServ
         }
         logger.debug("Attributes for the new creation: {}", attributes);
         return attributes;
+    }
+
+    private void validateTokenProfileEnabled(TokenProfile tokenProfile) {
+        if (!Boolean.TRUE.equals(tokenProfile.getEnabled())) {
+            throw new ValidationException(ValidationError.create("Token Profile is disabled"));
+        }
     }
 
     @Override

--- a/src/main/java/com/otilm/core/service/impl/CryptographicOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CryptographicOperationServiceImpl.java
@@ -484,6 +484,9 @@ public class CryptographicOperationServiceImpl implements CryptographicOperation
                     )
             );
         }
+        if (!Boolean.TRUE.equals(key.getTokenProfile().getEnabled())) {
+            throw new ValidationException(ValidationError.create("Token Profile is disabled"));
+        }
         CryptographicKeyItem privateKeyItem = null;
         CryptographicKeyItem publicKeyItem = null;
 

--- a/src/test/java/com/otilm/core/integration/service/CryptographicKeyServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicKeyServiceITest.java
@@ -316,12 +316,15 @@ class CryptographicKeyServiceITest extends BaseSpringBootTest {
         KeyRequestDto request = new KeyRequestDto();
         request.setName("keyOnDisabledTokenProfile");
         request.setAttributes(List.of());
+        UUID tokenInstanceUuid = tokenInstanceReference.getUuid();
+        SecuredParentUUID tokenProfileUuid = tokenProfile.getSecuredParentUuid();
+        mockServer.resetRequests();
 
         ValidationException exception = Assertions.assertThrows(
                 ValidationException.class,
                 () -> cryptographicKeyService.createKey(
-                        tokenInstanceReference.getUuid(),
-                        tokenProfile.getSecuredParentUuid(),
+                        tokenInstanceUuid,
+                        tokenProfileUuid,
                         KeyRequestType.SECRET,
                         request
                 )
@@ -329,6 +332,26 @@ class CryptographicKeyServiceITest extends BaseSpringBootTest {
         Assertions.assertTrue(exception.getMessage().contains("Token Profile"));
         Assertions.assertTrue(exception.getMessage().contains("disabled"));
         mockServer.verify(0, WireMock.anyRequestedFor(WireMock.anyUrl()));
+    }
+
+    @Test
+    void testAddKey_tokenProfileNotFound() {
+        KeyRequestDto request = new KeyRequestDto();
+        request.setName("keyOnMissingTokenProfile");
+        UUID tokenInstanceUuid = tokenInstanceReference.getUuid();
+        SecuredParentUUID missingTokenProfileUuid = SecuredParentUUID.fromUUID(UUID.randomUUID());
+
+        NotFoundException exception = Assertions.assertThrows(
+                NotFoundException.class,
+                () -> cryptographicKeyService.createKey(
+                        tokenInstanceUuid,
+                        missingTokenProfileUuid,
+                        KeyRequestType.SECRET,
+                        request
+                )
+        );
+
+        Assertions.assertTrue(exception.getMessage().contains(TokenProfile.class.getSimpleName()));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/CryptographicKeyServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicKeyServiceITest.java
@@ -294,22 +294,6 @@ class CryptographicKeyServiceITest extends BaseSpringBootTest {
 
     @Test
     void testAddKey_disabledTokenProfile() {
-        mockServer.stubFor(WireMock
-                .get(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/keys/secret/attributes"))
-                .willReturn(WireMock.okJson("[]")));
-        mockServer.stubFor(WireMock
-                .get(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+"))
-                .willReturn(WireMock.okJson("{}")));
-        mockServer.stubFor(WireMock
-                .get(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/status"))
-                .willReturn(WireMock.okJson("{}")));
-        mockServer.stubFor(WireMock
-                .post(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/keys/secret/attributes/validate"))
-                .willReturn(WireMock.ok()));
-        mockServer.stubFor(WireMock
-                .post(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/keys/secret"))
-                .willReturn(WireMock.okJson("{\"name\":\"disabledProfileKey\", \"uuid\":\"249db149-8c51-11ed-a1eb-0242ac120003\", \"keyData\":{\"type\":\"Secret\", \"algorithm\":\"RSA\", \"format\":\"Raw\", \"value\":\"secret\"}}")));
-
         tokenProfile.setEnabled(false);
         tokenProfileRepository.saveAndFlush(tokenProfile);
 
@@ -318,7 +302,6 @@ class CryptographicKeyServiceITest extends BaseSpringBootTest {
         request.setAttributes(List.of());
         UUID tokenInstanceUuid = tokenInstanceReference.getUuid();
         SecuredParentUUID tokenProfileUuid = tokenProfile.getSecuredParentUuid();
-        mockServer.resetRequests();
 
         ValidationException exception = Assertions.assertThrows(
                 ValidationException.class,
@@ -562,6 +545,63 @@ class CryptographicKeyServiceITest extends BaseSpringBootTest {
         EditKeyRequestDto requestEmpty = new EditKeyRequestDto();
         keyDetailDto = cryptographicKeyService.editKey(key.getSecuredUuid(), requestEmpty);
         Assertions.assertEquals("updatedName", keyDetailDto.getName());
+    }
+
+    @Test
+    void testUpdateKey_tokenProfileNotFound() {
+        EditKeyRequestDto request = new EditKeyRequestDto();
+        request.setTokenProfileUuid(UUID.randomUUID().toString());
+        SecuredUUID keyUuid = key.getSecuredUuid();
+
+        NotFoundException exception = Assertions.assertThrows(
+                NotFoundException.class,
+                () -> cryptographicKeyService.editKey(keyUuid, request)
+        );
+
+        Assertions.assertTrue(exception.getMessage().contains(TokenProfile.class.getSimpleName()));
+    }
+
+    @Test
+    void testUpdateKey_disabledTokenProfile() {
+        tokenProfile2.setEnabled(false);
+        tokenProfileRepository.saveAndFlush(tokenProfile2);
+        UUID originalTokenProfileUuid = key.getTokenProfileUuid();
+        String originalName = key.getName();
+        String originalDescription = key.getDescription();
+        EditKeyRequestDto request = new EditKeyRequestDto();
+        request.setName("rejectedName");
+        request.setDescription("rejectedDescription");
+        request.setTokenProfileUuid(tokenProfile2.getUuid().toString());
+        SecuredUUID keyUuid = key.getSecuredUuid();
+
+        Assertions.assertThrows(
+                ValidationException.class,
+                () -> cryptographicKeyService.editKey(keyUuid, request)
+        );
+
+        CryptographicKey persistedKey = cryptographicKeyRepository.findByUuid(key.getUuid()).orElseThrow();
+        Assertions.assertEquals(originalTokenProfileUuid, persistedKey.getTokenProfileUuid());
+        Assertions.assertEquals(originalName, persistedKey.getName());
+        Assertions.assertEquals(originalDescription, persistedKey.getDescription());
+    }
+
+    @Test
+    void testListCreateKeyAttributes_disabledTokenProfile() {
+        tokenProfile.setEnabled(false);
+        tokenProfileRepository.saveAndFlush(tokenProfile);
+        UUID tokenInstanceUuid = tokenInstanceReference.getUuid();
+        SecuredParentUUID tokenProfileUuid = tokenProfile.getSecuredParentUuid();
+
+        Assertions.assertThrows(
+                ValidationException.class,
+                () -> cryptographicKeyService.listCreateKeyAttributes(
+                        tokenInstanceUuid,
+                        tokenProfileUuid,
+                        KeyRequestType.SECRET
+                )
+        );
+
+        mockServer.verify(0, WireMock.anyRequestedFor(WireMock.anyUrl()));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/CryptographicKeyServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicKeyServiceITest.java
@@ -293,6 +293,45 @@ class CryptographicKeyServiceITest extends BaseSpringBootTest {
     }
 
     @Test
+    void testAddKey_disabledTokenProfile() {
+        mockServer.stubFor(WireMock
+                .get(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/keys/secret/attributes"))
+                .willReturn(WireMock.okJson("[]")));
+        mockServer.stubFor(WireMock
+                .get(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+"))
+                .willReturn(WireMock.okJson("{}")));
+        mockServer.stubFor(WireMock
+                .get(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/status"))
+                .willReturn(WireMock.okJson("{}")));
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/keys/secret/attributes/validate"))
+                .willReturn(WireMock.ok()));
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/v1/cryptographyProvider/tokens/[^/]+/keys/secret"))
+                .willReturn(WireMock.okJson("{\"name\":\"disabledProfileKey\", \"uuid\":\"249db149-8c51-11ed-a1eb-0242ac120003\", \"keyData\":{\"type\":\"Secret\", \"algorithm\":\"RSA\", \"format\":\"Raw\", \"value\":\"secret\"}}")));
+
+        tokenProfile.setEnabled(false);
+        tokenProfileRepository.saveAndFlush(tokenProfile);
+
+        KeyRequestDto request = new KeyRequestDto();
+        request.setName("keyOnDisabledTokenProfile");
+        request.setAttributes(List.of());
+
+        ValidationException exception = Assertions.assertThrows(
+                ValidationException.class,
+                () -> cryptographicKeyService.createKey(
+                        tokenInstanceReference.getUuid(),
+                        tokenProfile.getSecuredParentUuid(),
+                        KeyRequestType.SECRET,
+                        request
+                )
+        );
+        Assertions.assertTrue(exception.getMessage().contains("Token Profile"));
+        Assertions.assertTrue(exception.getMessage().contains("disabled"));
+        mockServer.verify(0, WireMock.anyRequestedFor(WireMock.anyUrl()));
+    }
+
+    @Test
     void testAddKey_validationFail() {
         KeyRequestDto request = new KeyRequestDto();
 

--- a/src/test/java/com/otilm/core/integration/service/CryptographicOperationServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicOperationServiceITest.java
@@ -859,6 +859,31 @@ class CryptographicOperationServiceITest extends BaseSpringBootTest {
         Assertions.assertNotNull(Arrays.stream(pkcs10CertificationRequest.getAttributes()).filter(attribute -> attribute.getAttrType().equals(Extension.altSignatureValue)));
     }
 
+    @Test
+    void testGenerateCsr_disabledTokenProfile() {
+        tokenProfile.setEnabled(false);
+        tokenProfileRepository.saveAndFlush(tokenProfile);
+        UUID keyUuid = key.getUuid();
+        UUID tokenProfileUuid = tokenProfile.getUuid();
+        X500Principal principal = new X500Principal("CN=disabled");
+
+        Assertions.assertThrows(
+                ValidationException.class,
+                () -> cryptographicOperationInternalService.generateCsr(
+                        keyUuid,
+                        tokenProfileUuid,
+                        principal,
+                        null,
+                        List.of(),
+                        null,
+                        null,
+                        List.of()
+                )
+        );
+
+        mockServer.verify(0, WireMock.anyRequestedFor(WireMock.anyUrl()));
+    }
+
     private void mockSignResponse(String keyUuid, String signature) {
         mockServer.stubFor(WireMock
                 .post(WireMock.urlPathEqualTo("/v1/cryptographyProvider/tokens/%s/keys/%s/sign".formatted(tokenInstanceReference.getTokenInstanceUuid(), keyUuid)))


### PR DESCRIPTION
## Summary
- reject key creation when the Token Profile is disabled
- return a controlled validation error before connector processing
- cover the behavior with an integration regression test that verifies zero connector traffic

## Test plan
- `mvn --quiet '-Dtest=CryptographicKeyServiceITest#testAddKey_disabledTokenProfile' test`

Closes #1395