### PR TITLE
Record CMP Profile UUID in certificate protocol associations

### DIFF
--- a/src/main/java/com/otilm/core/dao/entity/CertificateProtocolAssociation.java
+++ b/src/main/java/com/otilm/core/dao/entity/CertificateProtocolAssociation.java
@@ -33,7 +33,7 @@ public class CertificateProtocolAssociation extends UniquelyIdentified implement
     @Enumerated(EnumType.STRING)
     private CertificateProtocol protocol;
 
-    @Column(name = "protocol_profile_uuid", nullable = false)
+    @Column(name = "protocol_profile_uuid")
     private UUID protocolProfileUuid;
 
     @Column(name = "additional_protocol_uuid")

--- a/src/main/java/com/otilm/core/service/cmp/message/handler/CrmfIrCrMessageHandler.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/handler/CrmfIrCrMessageHandler.java
@@ -86,7 +86,7 @@ public class CrmfIrCrMessageHandler implements MessageHandler<ClientCertificateD
             return clientOperationService.issueCertificate(
                     SecuredParentUUID.fromUUID(raProfile.getAuthorityInstanceReferenceUuid()),
                     raProfile.getSecuredUuid(),
-                    dto, CertificateProtocolInfo.Cmp(raProfile.getUuid()));
+                    dto, CertificateProtocolInfo.Cmp(configuration.getCmpProfile().getUuid()));
         } catch (RequestAttributePolicyViolationException e) {
             throw new CmpCrmfValidationException(tid, request.getBody().getType(), PKIFailureInfo.badCertTemplate, e.getMessage());
         } catch (CertificateRequestException | NotFoundException | CertificateException | IOException |

--- a/src/main/resources/db/migration/V202607301000__nullable_protocol_profile_uuid.sql
+++ b/src/main/resources/db/migration/V202607301000__nullable_protocol_profile_uuid.sql
@@ -1,0 +1,6 @@
+-- CMP-issued certificates recorded the RA Profile UUID as the protocol profile.
+-- The original CMP Profile cannot be reconstructed reliably (the CMP Profile <-> RA Profile
+-- binding is mutable), so the column becomes nullable and known-wrong CMP values are cleared.
+ALTER TABLE certificate_protocol_association ALTER COLUMN protocol_profile_uuid DROP NOT NULL;
+
+UPDATE certificate_protocol_association SET protocol_profile_uuid = NULL WHERE protocol = 'CMP';

--- a/src/test/java/com/otilm/core/integration/service/cmp/message/handler/CrmfIrCrRequestAttributeValidationITest.java
+++ b/src/test/java/com/otilm/core/integration/service/cmp/message/handler/CrmfIrCrRequestAttributeValidationITest.java
@@ -3,6 +3,7 @@ package com.otilm.core.integration.service.cmp.message.handler;
 import com.otilm.api.interfaces.core.cmp.error.CmpCrmfValidationException;
 import com.otilm.core.certificate.request.RequestAttributePolicyViolationException;
 import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.dao.entity.cmp.CmpProfile;
 import com.otilm.core.service.cmp.CmpEntityUtil;
 import com.otilm.core.service.cmp.CmpTestUtil;
 import com.otilm.core.service.cmp.configurations.variants.Mobile3gppProfileContext;
@@ -53,11 +54,12 @@ class CrmfIrCrRequestAttributeValidationITest extends BaseSpringBootTest {
         PKIMessage request = CmpTestUtil.createSignatureBasedMessage("888", keyPair.getPrivate(), body).toASN1Structure();
         RaProfile raProfile = CmpEntityUtil.createRaProfile();
         raProfile.setAuthorityInstanceReferenceUuid(UUID.randomUUID());
+        CmpProfile cmpProfile = CmpEntityUtil.createCmpProfile(raProfile, "sharedSecret");
 
         // when / then — the handler shapes the policy violation into a CmpCrmfValidationException carrying
         // the safe, platform-authored message and no internal identifiers
         assertThatThrownBy(() -> crmfIrCrMessageHandler.handle(request,
-                new Mobile3gppProfileContext(null, raProfile, request, certificateKeyService, null, null)))
+                new Mobile3gppProfileContext(cmpProfile, raProfile, request, certificateKeyService, null, null)))
                 .isInstanceOf(CmpCrmfValidationException.class)
                 .hasMessageContaining(policyMessage)
                 .satisfies(ex -> assertThat(ex.getMessage())

--- a/src/test/java/com/otilm/core/service/cmp/message/handler/CrmfIrCrMessageHandlerTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/handler/CrmfIrCrMessageHandlerTest.java
@@ -1,0 +1,99 @@
+package com.otilm.core.service.cmp.message.handler;
+
+import com.otilm.api.model.core.enums.CertificateProtocol;
+import com.otilm.api.model.core.v2.ClientCertificateDataResponseDto;
+import com.otilm.api.model.core.v2.ClientCertificateIssueRequestDto;
+import com.otilm.core.dao.entity.RaProfile;
+import com.otilm.core.dao.entity.cmp.CmpProfile;
+import com.otilm.core.model.auth.CertificateProtocolInfo;
+import com.otilm.core.security.authz.SecuredParentUUID;
+import com.otilm.core.security.authz.SecuredUUID;
+import com.otilm.core.service.cmp.configurations.ConfigurationContext;
+import com.otilm.core.service.v2.ClientOperationInternalService;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.cmp.PKIBody;
+import org.bouncycastle.asn1.cmp.PKIHeader;
+import org.bouncycastle.asn1.cmp.PKIHeaderBuilder;
+import org.bouncycastle.asn1.cmp.PKIMessage;
+import org.bouncycastle.asn1.crmf.CertReqMessages;
+import org.bouncycastle.asn1.crmf.CertReqMsg;
+import org.bouncycastle.asn1.crmf.CertRequest;
+import org.bouncycastle.asn1.crmf.CertTemplateBuilder;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link CrmfIrCrMessageHandler} (issue #1884).
+ */
+class CrmfIrCrMessageHandlerTest {
+
+    private ClientOperationInternalService clientOperationService;
+    private CrmfIrCrMessageHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        clientOperationService = mock(ClientOperationInternalService.class);
+        handler = new CrmfIrCrMessageHandler();
+        handler.setClientOperationService(clientOperationService);
+    }
+
+    @Test
+    void recordsCmpProfileUuidAsProtocolProfile() throws Exception {
+        UUID cmpProfileUuid = UUID.randomUUID();
+        UUID raProfileUuid = UUID.randomUUID();
+        ConfigurationContext configuration = configuration(cmpProfileUuid, raProfileUuid);
+        when(clientOperationService.issueCertificate(
+                any(SecuredParentUUID.class), any(SecuredUUID.class),
+                any(ClientCertificateIssueRequestDto.class), any(CertificateProtocolInfo.class)))
+                .thenReturn(new ClientCertificateDataResponseDto());
+
+        handler.handle(irMessage(), configuration);
+
+        ArgumentCaptor<CertificateProtocolInfo> protocolInfo = ArgumentCaptor.forClass(CertificateProtocolInfo.class);
+        verify(clientOperationService).issueCertificate(
+                any(SecuredParentUUID.class), any(SecuredUUID.class),
+                any(ClientCertificateIssueRequestDto.class), protocolInfo.capture());
+        assertThat(protocolInfo.getValue().getProtocol()).isEqualTo(CertificateProtocol.CMP);
+        assertThat(protocolInfo.getValue().getProtocolProfileUuid()).isEqualTo(cmpProfileUuid);
+    }
+
+    private static ConfigurationContext configuration(UUID cmpProfileUuid, UUID raProfileUuid) {
+        CmpProfile cmpProfile = new CmpProfile();
+        cmpProfile.setUuid(cmpProfileUuid);
+        RaProfile raProfile = new RaProfile();
+        raProfile.setUuid(raProfileUuid);
+        raProfile.setAuthorityInstanceReferenceUuid(UUID.randomUUID());
+        ConfigurationContext configuration = mock(ConfigurationContext.class);
+        when(configuration.getCmpProfile()).thenReturn(cmpProfile);
+        when(configuration.getRaProfile()).thenReturn(raProfile);
+        return configuration;
+    }
+
+    private static PKIMessage irMessage() {
+        PKIHeader header = new PKIHeaderBuilder(
+                PKIHeader.CMP_2000,
+                new GeneralName(new X500Name("CN=test-sender")),
+                new GeneralName(new X500Name("CN=test-recipient")))
+                .setTransactionID(new DEROctetString(new byte[]{1, 2, 3, 4}))
+                .setSenderNonce(new DEROctetString(new byte[]{5, 6, 7, 8}))
+                .build();
+        CertRequest certRequest = new CertRequest(
+                new ASN1Integer(0),
+                new CertTemplateBuilder().setSubject(new X500Name("CN=cmp-certificate")).build(),
+                null);
+        CertReqMessages certReqMessages = new CertReqMessages(new CertReqMsg(certRequest, null, null));
+        return new PKIMessage(header, new PKIBody(PKIBody.TYPE_INIT_REQ, certReqMessages));
+    }
+}

--- a/src/test/java/com/otilm/core/service/cmp/message/handler/CrmfIrCrMessageHandlerTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/handler/CrmfIrCrMessageHandlerTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link CrmfIrCrMessageHandler} (issue #1884).
+ * Unit tests for {@link CrmfIrCrMessageHandler}.
  */
 class CrmfIrCrMessageHandlerTest {
 


### PR DESCRIPTION
Fixes #1884
Also made the protocol UUID optional in https://github.com/OmniTrustILM/interfaces/pull/795, to be consistent with the DB changes.