### PR TITLE
Import discovered certificates when an action trigger fails

### DIFF
--- a/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
+++ b/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
@@ -428,17 +428,21 @@ public class ExceptionHandlingAdvice {
     /**
      * Handler for {@link UnsupportedAuthorityVersionException}.
      *
-     * <p>400 rather than 500: a connector reporting a version the platform does not recognise is registrable
-     * configuration, and the caller selected the authority it reached this through, so another selection can
-     * succeed. The message is platform-authored and carries only a version string and an authority identifier.
+     * <p>400 rather than 500: an unrecognised connector interface version is caller-fixable configuration.
+     *
+     * <p>The body is fixed rather than the exception's message. That message names the authority and the version
+     * string the connector itself reported, which is stored unvalidated -- so forwarding it would put a
+     * connector-controlled value and an entity identifier in front of a caller who asked about something else.
+     * Logged at warn with the exception, because reaching this means a connector is registered that the platform
+     * cannot dispatch to.
      *
      * @return
      */
     @ExceptionHandler(UnsupportedAuthorityVersionException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorMessageDto handleUnsupportedAuthorityVersionException(UnsupportedAuthorityVersionException ex) {
-        LOG.info("HTTP 400: {}", ex.getMessage());
-        return ErrorMessageDto.getInstance(ex.getMessage());
+        LOG.warn("HTTP 400: {}", ex.getMessage(), ex);
+        return ErrorMessageDto.getInstance("The authority's connector interface version is not supported.");
     }
 
     /**

--- a/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
+++ b/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
@@ -5,6 +5,7 @@ import com.otilm.api.model.common.AuthenticationServiceExceptionDto;
 import com.otilm.api.model.common.ErrorMessageDto;
 import com.otilm.api.model.core.acme.ProblemDocument;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.core.exception.UnsupportedAuthorityVersionException;
 import com.otilm.core.security.authn.PlatformAuthenticationException;
 import com.otilm.core.security.exception.AuthenticationServiceException;
 import com.otilm.core.util.AuthHelper;
@@ -420,6 +421,22 @@ public class ExceptionHandlingAdvice {
     @ExceptionHandler(CertificateOperationException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorMessageDto handleCertificateOperationException(CertificateOperationException ex) {
+        LOG.info("HTTP 400: {}", ex.getMessage());
+        return ErrorMessageDto.getInstance(ex.getMessage());
+    }
+
+    /**
+     * Handler for {@link UnsupportedAuthorityVersionException}.
+     *
+     * <p>400 rather than 500: a connector reporting a version the platform does not recognise is registrable
+     * configuration, and the caller selected the authority it reached this through, so another selection can
+     * succeed. The message is platform-authored and carries only a version string and an authority identifier.
+     *
+     * @return
+     */
+    @ExceptionHandler(UnsupportedAuthorityVersionException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorMessageDto handleUnsupportedAuthorityVersionException(UnsupportedAuthorityVersionException ex) {
         LOG.info("HTTP 400: {}", ex.getMessage());
         return ErrorMessageDto.getInstance(ex.getMessage());
     }

--- a/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
+++ b/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
@@ -428,13 +428,9 @@ public class ExceptionHandlingAdvice {
     /**
      * Handler for {@link UnsupportedAuthorityVersionException}.
      *
-     * <p>400 rather than 500: an unrecognised connector interface version is caller-fixable configuration.
-     *
-     * <p>The body is fixed rather than the exception's message. That message names the authority and the version
-     * string the connector itself reported, which is stored unvalidated -- so forwarding it would put a
-     * connector-controlled value and an entity identifier in front of a caller who asked about something else.
-     * Logged at warn with the exception, because reaching this means a connector is registered that the platform
-     * cannot dispatch to.
+     * <p>400 rather than 500: an unrecognised connector interface version is caller-fixable configuration. The body
+     * is fixed rather than the exception's message, which names the authority and a version string the connector
+     * reported into an unvalidated column. Logged at warn -- a connector is registered that cannot be dispatched to.
      *
      * @return a fixed message that names neither the authority nor the version
      */

--- a/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
+++ b/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
@@ -436,7 +436,7 @@ public class ExceptionHandlingAdvice {
      * Logged at warn with the exception, because reaching this means a connector is registered that the platform
      * cannot dispatch to.
      *
-     * @return
+     * @return a fixed message that names neither the authority nor the version
      */
     @ExceptionHandler(UnsupportedAuthorityVersionException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/otilm/core/evaluator/TriggerEvaluator.java
+++ b/src/main/java/com/otilm/core/evaluator/TriggerEvaluator.java
@@ -453,6 +453,13 @@ public class TriggerEvaluator<T extends UniquelyIdentifiedObject> implements ITr
                 parseNameAndContentType(fieldIdentifier)[0], attributeContents);
     }
 
+    /**
+     * Publishes through the application event bus rather than to the producer directly: the listener is
+     * {@code AFTER_COMMIT}, so the message leaves only if the current transaction commits, by which point the
+     * {@code TriggerHistory} it carries is visible to whoever writes records against it. A caller that gives each
+     * trigger its own transaction therefore releases each notification as that trigger commits, and the message
+     * implies nothing about triggers evaluated after it.
+     */
     protected void performSendNotificationAction(Resource resource, ResourceEvent event, Execution execution, T object, Object data, TriggerHistory triggerHistory) {
         List<UUID> notificationProfileUuids = new ArrayList<>();
         for (ExecutionItem executionItem : execution.getItems()) {
@@ -460,8 +467,6 @@ public class TriggerEvaluator<T extends UniquelyIdentifiedObject> implements ITr
         }
 
         NotificationMessage message = new NotificationMessage(event, resource, object.getUuid(), notificationProfileUuids, null, data, triggerHistory.getUuid(), execution.getUuid());
-        // Delay publication until after the current transaction commits, so TriggerHistory is
-        // visible to the NotificationListener when it creates TriggerHistoryRecords.
         applicationEventPublisher.publishEvent(message);
     }
 

--- a/src/main/java/com/otilm/core/evaluator/TriggerEvaluator.java
+++ b/src/main/java/com/otilm/core/evaluator/TriggerEvaluator.java
@@ -454,11 +454,9 @@ public class TriggerEvaluator<T extends UniquelyIdentifiedObject> implements ITr
     }
 
     /**
-     * Publishes through the application event bus rather than to the producer directly: the listener is
-     * {@code AFTER_COMMIT}, so the message leaves only if the current transaction commits, by which point the
-     * {@code TriggerHistory} it carries is visible to whoever writes records against it. A caller that gives each
-     * trigger its own transaction therefore releases each notification as that trigger commits, and the message
-     * implies nothing about triggers evaluated after it.
+     * Published through the event bus, not to the producer: the listener is {@code AFTER_COMMIT}, so the message
+     * leaves only if this transaction commits, and the {@code TriggerHistory} it carries is visible by then. Where
+     * each trigger has its own transaction, each notification is released as that trigger commits.
      */
     protected void performSendNotificationAction(Resource resource, ResourceEvent event, Execution execution, T object, Object data, TriggerHistory triggerHistory) {
         List<UUID> notificationProfileUuids = new ArrayList<>();

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -32,6 +32,7 @@ import com.otilm.core.messaging.jms.producers.ValidationProducer;
 import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.messaging.model.ValidationMessage;
 import com.otilm.core.service.CertificateInternalService;
+import com.otilm.core.service.TriggerInternalService;
 import com.otilm.core.service.handler.CertificateHandler;
 import com.otilm.core.tasks.ScheduledJobInfo;
 import com.otilm.core.util.CertificateUtil;
@@ -83,6 +84,7 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
     private DiscoveryCertificateRepository discoveryCertificateRepository;
     private DiscoveryWriter discoveryWriter;
     private AuthorizationEnforcer authorizationEnforcer;
+    private TriggerInternalService triggerService;
 
     // Kept alongside the inherited, more loosely typed handle, for the finders SecurityFilterRepository does not
     // expose.
@@ -132,6 +134,11 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
     @Autowired
     public void setAuthorizationEnforcer(AuthorizationEnforcer authorizationEnforcer) {
         this.authorizationEnforcer = authorizationEnforcer;
+    }
+
+    @Autowired
+    public void setTriggerService(TriggerInternalService triggerService) {
+        this.triggerService = triggerService;
     }
 
     @Override
@@ -702,7 +709,8 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
     }
 
     /**
-     * A committed group's result, plus what its action triggers need once the import transaction has closed.
+     * A group's import result, plus what its action triggers need once the import transaction has closed --
+     * absent when the group imported nothing.
      *
      * @param certificateUuid   the imported certificate, or null when the group imported nothing
      * @param eventData         the trigger payload; non-null exactly when {@code certificateUuid} is
@@ -745,11 +753,38 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
             try {
                 transactionHandler.runInNewTransaction(() -> runActionTrigger(context, imported, triggerAssociation));
             } catch (Exception e) {
-                // Nothing is swallowed inside the transaction, so it rolls back cleanly and the next trigger starts
-                // from a sound one.
+                // Only a failure that escaped the trigger's own handling reaches here, and its transaction is
+                // already gone -- taking the history the evaluator wrote in it. The next trigger starts in a fresh
+                // one, and the failure is recorded in a fresh one too, so it does not exist only in the log.
                 logger.error("Action trigger {} failed for discovered certificate {}: {}",
                         triggerAssociation.getTrigger().getUuid(), imported.certificateUuid(), e.getMessage(), e);
+                recordActionTriggerFailure(context, imported, triggerAssociation, e);
             }
+        }
+    }
+
+    /**
+     * Writes the failure where an operator looks for it. The evaluator records a failed execution itself, but into
+     * the transaction the failure poisoned, so that record dies with it — leaving the trigger looking as though it
+     * never ran. This one is written in its own transaction and therefore survives.
+     */
+    private void recordActionTriggerFailure(DiscoveryRunContext context, ImportedGroup imported,
+                                            TriggerAssociation triggerAssociation, Exception failure) {
+        try {
+            transactionHandler.runInNewTransaction(() -> {
+                TriggerHistory history = triggerService.createTriggerHistory(
+                        triggerAssociation.getTrigger().getUuid(), triggerAssociation, imported.certificateUuid(),
+                        imported.referenceRowUuid(), eventHistoryFor(context, triggerAssociation),
+                        Resource.CERTIFICATE);
+                history.setConditionsMatched(true);
+                history.setActionsPerformed(false);
+                triggerService.createTriggerHistoryRecord(history.getUuid(), null, null,
+                        "The trigger's actions could not be applied: " + DiscoveryFailureReason.shape(failure));
+            });
+        } catch (Exception e) {
+            // The last place the failure could have been recorded, so the log is all that is left.
+            logger.error("Could not record the failure of action trigger {} for certificate {}: {}",
+                    triggerAssociation.getTrigger().getUuid(), imported.certificateUuid(), e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -84,8 +84,8 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
     private DiscoveryWriter discoveryWriter;
     private AuthorizationEnforcer authorizationEnforcer;
 
-    // Kept alongside the inherited, more loosely typed handle: the unconsumed-group accounting needs a
-    // certificate-specific finder that SecurityFilterRepository does not expose.
+    // Kept alongside the inherited, more loosely typed handle, for the finders SecurityFilterRepository does not
+    // expose.
     private final CertificateRepository certificateRepository;
 
     @Autowired
@@ -354,15 +354,20 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
                             "the import was interrupted before it began"), List.of(), false);
         }
         try {
-            ImportedGroup imported = transactionHandler.runInNewTransaction(() -> importContentGroup(context, group));
+            ImportedGroup imported;
+            try {
+                imported = transactionHandler.runInNewTransaction(() -> importContentGroup(context, group));
+            } catch (Exception e) {
+                logger.error("Unable to import discovered certificate content {}: {}",
+                        group.certificateContentId(), e.getMessage(), e);
+                return new GroupImportResult(group.certificateContentId(),
+                        resultsFor(rowUuids, DiscoveryCertificateOutcome.IMPORT_ROLLED_BACK,
+                                "Import rolled back: " + DiscoveryFailureReason.shape(e)), List.of(), false);
+            }
+            // Outside the catch above on purpose: the certificate has committed by here, so nothing this phase does
+            // may be reported as a rollback.
             runActionTriggersSafely(context, imported);
             return imported.result();
-        } catch (Exception e) {
-            logger.error("Unable to import discovered certificate content {}: {}",
-                    group.certificateContentId(), e.getMessage(), e);
-            return new GroupImportResult(group.certificateContentId(),
-                    resultsFor(rowUuids, DiscoveryCertificateOutcome.IMPORT_ROLLED_BACK,
-                            "Import rolled back: " + DiscoveryFailureReason.shape(e)), List.of(), false);
         } finally {
             processCertSemaphore.release();
         }
@@ -633,8 +638,6 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
                     List.of(), false));
         }
 
-        EventHistory discoveryEventHistory = eventHistoryRepository.getReferenceById(context.discoveryEventHistoryUuid());
-        EventHistory platformEventHistory = eventHistoryRepository.getReferenceById(context.platformEventHistoryUuid());
         UUID referenceRowUuid = rowUuids.getFirst();
 
         // Attribute conditions are keyed on the object's UUID, which only a persisted row carries: judged as the
@@ -644,9 +647,9 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
 
         List<TriggerHistory> ignoreHistories = new ArrayList<>();
         for (TriggerAssociation triggerAssociation : context.ignoreTriggers()) {
-            EventHistory eventHistory = triggerAssociation.getResource() == null ? platformEventHistory : discoveryEventHistory;
             TriggerHistory triggerHistory = context.eventContext().getTriggerEvaluator().evaluateTrigger(
-                    triggerAssociation.getTrigger(), triggerAssociation, ignoreSubject, referenceRowUuid, null, eventHistory);
+                    triggerAssociation.getTrigger(), triggerAssociation, ignoreSubject, referenceRowUuid, null,
+                    eventHistoryFor(context, triggerAssociation));
             ignoreHistories.add(triggerHistory);
             if (triggerHistory.isActionsPerformed()) {
                 return ImportedGroup.withoutActions(new GroupImportResult(group.certificateContentId(),
@@ -701,7 +704,9 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
     /**
      * A committed group's result, plus what its action triggers need once the import transaction has closed.
      *
-     * @param certificateUuid the imported certificate, or null when the group imported nothing and has no actions
+     * @param certificateUuid   the imported certificate, or null when the group imported nothing
+     * @param eventData         the trigger payload; non-null exactly when {@code certificateUuid} is
+     * @param referenceRowUuid  the row the trigger history is recorded against; non-null on the same condition
      */
     record ImportedGroup(GroupImportResult result, UUID certificateUuid,
                          CertificateDiscoveredEventData eventData, UUID referenceRowUuid) {
@@ -710,57 +715,72 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
             return new ImportedGroup(result, null, null, null);
         }
 
-        boolean hasActions() {
+        boolean isImported() {
             return certificateUuid != null;
         }
     }
 
     /**
-     * Runs the action triggers after the import transaction has committed, in one of their own.
+     * Runs the action triggers once the import has committed, one transaction per trigger.
      *
-     * <p>Not inside the import: an execution reaches services that are class-level {@code @Transactional}, so an
-     * unchecked failure in one marks the transaction it joined rollback-only before {@code performActions} can
-     * record it, and the import's commit then throws. Every group evaluates the same triggers, so one misconfigured
-     * execution cost the discovery every certificate. Running afterwards also means the actions act on a committed
-     * certificate.
+     * <p>Not inside the import transaction: an execution reaches services that are class-level
+     * {@code @Transactional}, so an unchecked failure in one marks the transaction it joined rollback-only before
+     * {@code performActions} can record it, and the import's commit then throws. Every group evaluates the same
+     * triggers, so one misconfigured execution would cost the discovery every certificate.
+     *
+     * <p>And one transaction each rather than one for the phase, for the same reason one level down: a poisoned
+     * transaction discards every write made in it, so sharing one would lose the trigger history of the triggers
+     * that succeeded, their applied changes, and their notifications — which are published on commit — along with
+     * the failing one's own record.
+     *
+     * <p>An action failure deliberately does not reach the discovery's status; trigger history is where it is
+     * reported. Note that the failing trigger's own history is written in the transaction its failure poisoned, so
+     * for an unchecked failure that record is lost with it and the log is the only trace.
      */
     private void runActionTriggersSafely(DiscoveryRunContext context, ImportedGroup imported) {
-        if (!imported.hasActions() || context.triggers().isEmpty()) {
+        if (!imported.isImported()) {
             return;
         }
-        try {
-            transactionHandler.runInNewTransaction(() -> runActionTriggers(context, imported));
-        } catch (Exception e) {
-            // The import has committed. Trigger history is where an action failure is reported, and the discovery's
-            // status deliberately does not reflect one.
-            logger.error("Action triggers failed for discovered certificate {}: {}",
-                    imported.certificateUuid(), e.getMessage(), e);
+        for (TriggerAssociation triggerAssociation : context.triggers()) {
+            try {
+                transactionHandler.runInNewTransaction(() -> runActionTrigger(context, imported, triggerAssociation));
+            } catch (Exception e) {
+                // Nothing is swallowed inside the transaction, so it rolls back cleanly and the next trigger starts
+                // from a sound one.
+                logger.error("Action trigger {} failed for discovered certificate {}: {}",
+                        triggerAssociation.getTrigger().getUuid(), imported.certificateUuid(), e.getMessage(), e);
+            }
         }
     }
 
-    private void runActionTriggers(DiscoveryRunContext context, ImportedGroup imported) {
-        // Re-resolved so this transaction manages it: an execution may set a field and rely on the flush.
+    /**
+     * Re-resolves the certificate so this transaction manages it: rule and condition evaluation reflects over its
+     * lazy associations, which a detached instance cannot serve.
+     */
+    private void runActionTrigger(DiscoveryRunContext context, ImportedGroup imported,
+                                  TriggerAssociation triggerAssociation) {
         Certificate certificate = certificateRepository.findByUuid(imported.certificateUuid()).orElse(null);
         if (certificate == null) {
-            logger.error("Discovered certificate {} vanished before its action triggers ran",
-                    imported.certificateUuid());
+            // An operator deleting it between the import and here is a race, not a platform failure.
+            logger.warn("Discovered certificate {} no longer exists, so trigger {} did not run",
+                    imported.certificateUuid(), triggerAssociation.getTrigger().getUuid());
             return;
         }
-        EventHistory discoveryEventHistory = eventHistoryRepository.getReferenceById(context.discoveryEventHistoryUuid());
-        EventHistory platformEventHistory = eventHistoryRepository.getReferenceById(context.platformEventHistoryUuid());
-
-        for (TriggerAssociation triggerAssociation : context.triggers()) {
-            EventHistory eventHistory = triggerAssociation.getResource() == null ? platformEventHistory : discoveryEventHistory;
-            try {
-                context.eventContext().getTriggerEvaluator().evaluateTrigger(triggerAssociation.getTrigger(),
-                        triggerAssociation, certificate, imported.referenceRowUuid(), imported.eventData(), eventHistory);
-            } catch (Exception e) {
-                // Per trigger, so one does not stop the rest. This transaction may already be rollback-only, which
-                // costs the remaining triggers their history -- but never the certificate.
-                logger.error("Action trigger {} failed for certificate {}: {}",
-                        triggerAssociation.getTrigger().getUuid(), certificate.getUuid(), e.getMessage(), e);
-            }
+        try {
+            context.eventContext().getTriggerEvaluator().evaluateTrigger(triggerAssociation.getTrigger(),
+                    triggerAssociation, certificate, imported.referenceRowUuid(), imported.eventData(),
+                    eventHistoryFor(context, triggerAssociation));
+        } catch (RuleException e) {
+            // Checked, so it has marked nothing: this transaction still commits and keeps the history recorded.
+            logger.error("Action trigger {} could not be evaluated for certificate {}: {}",
+                    triggerAssociation.getTrigger().getUuid(), certificate.getUuid(), e.getMessage(), e);
         }
+    }
+
+    private EventHistory eventHistoryFor(DiscoveryRunContext context, TriggerAssociation triggerAssociation) {
+        return eventHistoryRepository.getReferenceById(triggerAssociation.getResource() == null
+                ? context.platformEventHistoryUuid()
+                : context.discoveryEventHistoryUuid());
     }
 
     private static List<KeyQueueEntry> keyEntriesFor(Certificate certificate, X509Certificate x509Cert,

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -780,7 +780,8 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
                 history.setConditionsMatched(true);
                 history.setActionsPerformed(false);
                 triggerService.createTriggerHistoryRecord(history.getUuid(), null, null,
-                        "The trigger's actions could not be applied: " + DiscoveryFailureReason.shape(failure));
+                        "The trigger's actions could not be applied: "
+                                + DiscoveryFailureReason.shapeTriggerFailure(failure));
             });
         } catch (Exception e) {
             // The last place the failure could have been recorded, so the log is all that is left.

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -354,7 +354,9 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
                             "the import was interrupted before it began"), List.of(), false);
         }
         try {
-            return transactionHandler.runInNewTransaction(() -> importContentGroup(context, group));
+            ImportedGroup imported = transactionHandler.runInNewTransaction(() -> importContentGroup(context, group));
+            runActionTriggersSafely(context, imported);
+            return imported.result();
         } catch (Exception e) {
             logger.error("Unable to import discovered certificate content {}: {}",
                     group.certificateContentId(), e.getMessage(), e);
@@ -590,7 +592,7 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
      * <p>Returns its outcomes and pending key associations rather than writing to shared state, so a transaction
      * that rolls back cannot leave a queued key behind pointing at a certificate that no longer exists.
      */
-    GroupImportResult importContentGroup(DiscoveryRunContext context, DiscoveryContentGroup group) {
+    ImportedGroup importContentGroup(DiscoveryRunContext context, DiscoveryContentGroup group) {
         try {
             return importContentGroupInternal(context, group);
         } catch (RuleException e) {
@@ -603,7 +605,7 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
         }
     }
 
-    private GroupImportResult importContentGroupInternal(DiscoveryRunContext context, DiscoveryContentGroup group)
+    private ImportedGroup importContentGroupInternal(DiscoveryRunContext context, DiscoveryContentGroup group)
             throws RuleException {
         List<UUID> rowUuids = group.rows().stream().map(DiscoveryCertificate::getUuid).toList();
 
@@ -625,10 +627,10 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
         } catch (Exception e) {
             logger.error("Unable to create certificate for discovered content {}: {}",
                     group.certificateContentId(), e.getMessage(), e);
-            return new GroupImportResult(group.certificateContentId(),
+            return ImportedGroup.withoutActions(new GroupImportResult(group.certificateContentId(),
                     resultsFor(rowUuids, DiscoveryCertificateOutcome.ENTITY_CREATION_FAILED,
                             "Unable to create certificate entity: " + DiscoveryFailureReason.shape(e)),
-                    List.of(), false);
+                    List.of(), false));
         }
 
         EventHistory discoveryEventHistory = eventHistoryRepository.getReferenceById(context.discoveryEventHistoryUuid());
@@ -647,8 +649,8 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
                     triggerAssociation.getTrigger(), triggerAssociation, ignoreSubject, referenceRowUuid, null, eventHistory);
             ignoreHistories.add(triggerHistory);
             if (triggerHistory.isActionsPerformed()) {
-                return new GroupImportResult(group.certificateContentId(),
-                        resultsFor(rowUuids, DiscoveryCertificateOutcome.IGNORED, null), List.of(), true);
+                return ImportedGroup.withoutActions(new GroupImportResult(group.certificateContentId(),
+                        resultsFor(rowUuids, DiscoveryCertificateOutcome.IGNORED, null), List.of(), true));
             }
         }
 
@@ -667,10 +669,10 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
             // Checked, so no proxy marked the transaction for rollback and the shaped result can still commit.
             logger.error("Unable to create certificate entity for discovered content {}: {}",
                     group.certificateContentId(), e.getMessage(), e);
-            return new GroupImportResult(group.certificateContentId(),
+            return ImportedGroup.withoutActions(new GroupImportResult(group.certificateContentId(),
                     resultsFor(rowUuids, DiscoveryCertificateOutcome.ENTITY_CREATION_FAILED,
                             "Unable to create certificate entity: " + DiscoveryFailureReason.shape(e)),
-                    List.of(), false);
+                    List.of(), false));
         }
 
         // Always the surviving row: on a lost insert race it carries the winner's UUID, so trigger history and
@@ -688,24 +690,77 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
         // Every row carries its own per-host metadata; grouping deduplicates the certificate, not the metadata.
         group.rows().forEach(row -> certificateHandler.updateDiscoveredCertificate(DiscoverySource.of(context), certificate, row.getMeta()));
 
+        // Action triggers deliberately do not run here -- see runActionTriggersSafely.
+        return new ImportedGroup(
+                new GroupImportResult(group.certificateContentId(),
+                        resultsFor(rowUuids, DiscoveryCertificateOutcome.IMPORTED, null),
+                        keyEntriesFor(certificate, x509Cert, rowUuids), true),
+                certificate.getUuid(), eventData, referenceRowUuid);
+    }
+
+    /**
+     * A committed group's result, plus what its action triggers need once the import transaction has closed.
+     *
+     * @param certificateUuid the imported certificate, or null when the group imported nothing and has no actions
+     */
+    record ImportedGroup(GroupImportResult result, UUID certificateUuid,
+                         CertificateDiscoveredEventData eventData, UUID referenceRowUuid) {
+
+        static ImportedGroup withoutActions(GroupImportResult result) {
+            return new ImportedGroup(result, null, null, null);
+        }
+
+        boolean hasActions() {
+            return certificateUuid != null;
+        }
+    }
+
+    /**
+     * Runs the action triggers after the import transaction has committed, in one of their own.
+     *
+     * <p>Not inside the import: an execution reaches services that are class-level {@code @Transactional}, so an
+     * unchecked failure in one marks the transaction it joined rollback-only before {@code performActions} can
+     * record it, and the import's commit then throws. Every group evaluates the same triggers, so one misconfigured
+     * execution cost the discovery every certificate. Running afterwards also means the actions act on a committed
+     * certificate.
+     */
+    private void runActionTriggersSafely(DiscoveryRunContext context, ImportedGroup imported) {
+        if (!imported.hasActions() || context.triggers().isEmpty()) {
+            return;
+        }
+        try {
+            transactionHandler.runInNewTransaction(() -> runActionTriggers(context, imported));
+        } catch (Exception e) {
+            // The import has committed. Trigger history is where an action failure is reported, and the discovery's
+            // status deliberately does not reflect one.
+            logger.error("Action triggers failed for discovered certificate {}: {}",
+                    imported.certificateUuid(), e.getMessage(), e);
+        }
+    }
+
+    private void runActionTriggers(DiscoveryRunContext context, ImportedGroup imported) {
+        // Re-resolved so this transaction manages it: an execution may set a field and rely on the flush.
+        Certificate certificate = certificateRepository.findByUuid(imported.certificateUuid()).orElse(null);
+        if (certificate == null) {
+            logger.error("Discovered certificate {} vanished before its action triggers ran",
+                    imported.certificateUuid());
+            return;
+        }
+        EventHistory discoveryEventHistory = eventHistoryRepository.getReferenceById(context.discoveryEventHistoryUuid());
+        EventHistory platformEventHistory = eventHistoryRepository.getReferenceById(context.platformEventHistoryUuid());
+
         for (TriggerAssociation triggerAssociation : context.triggers()) {
             EventHistory eventHistory = triggerAssociation.getResource() == null ? platformEventHistory : discoveryEventHistory;
             try {
-                context.eventContext().getTriggerEvaluator().evaluateTrigger(triggerAssociation.getTrigger(), triggerAssociation,
-                        certificate, referenceRowUuid, eventData, eventHistory);
-            } catch (RuleException e) {
-                // Contained per trigger, and deliberately not an import failure: the certificate is already stored
-                // and trigger history is where an action failure is reported. Letting it out would roll this group
-                // back — and since every group evaluates the same triggers, one misconfigured action trigger would
-                // then lose every certificate in the discovery.
+                context.eventContext().getTriggerEvaluator().evaluateTrigger(triggerAssociation.getTrigger(),
+                        triggerAssociation, certificate, imported.referenceRowUuid(), imported.eventData(), eventHistory);
+            } catch (Exception e) {
+                // Per trigger, so one does not stop the rest. This transaction may already be rollback-only, which
+                // costs the remaining triggers their history -- but never the certificate.
                 logger.error("Action trigger {} failed for certificate {}: {}",
                         triggerAssociation.getTrigger().getUuid(), certificate.getUuid(), e.getMessage(), e);
             }
         }
-
-        return new GroupImportResult(group.certificateContentId(),
-                resultsFor(rowUuids, DiscoveryCertificateOutcome.IMPORTED, null),
-                keyEntriesFor(certificate, x509Cert, rowUuids), true);
     }
 
     private static List<KeyQueueEntry> keyEntriesFor(Certificate certificate, X509Certificate x509Cert,

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -731,20 +731,13 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
     /**
      * Runs the action triggers once the import has committed, one transaction per trigger.
      *
-     * <p>Not inside the import transaction: an execution reaches services that are class-level
-     * {@code @Transactional}, so an unchecked failure in one marks the transaction it joined rollback-only before
-     * {@code performActions} can record it, and the import's commit then throws. Every group evaluates the same
-     * triggers, so one misconfigured execution would cost the discovery every certificate.
+     * <p>An execution reaches services that are class-level {@code @Transactional}, and an unchecked failure inside
+     * one marks the transaction it joined rollback-only: sharing one with the import cost the discovery every
+     * certificate, sharing one across the phase would discard the successful triggers' writes. A notification is
+     * therefore released as its own trigger commits, and implies nothing about the triggers after it.
      *
-     * <p>And one transaction each rather than one for the phase, for the same reason one level down: a poisoned
-     * transaction discards every write made in it, so sharing one would lose the trigger history of the triggers
-     * that succeeded, their applied changes, and their notifications — which are published on commit — along with
-     * the failing one's own record. A notification is therefore released as its own trigger commits, and does not
-     * imply that the triggers ordered after it have run.
-     *
-     * <p>An action failure deliberately does not reach the discovery's status; trigger history is where it is
-     * reported. Note that the failing trigger's own history is written in the transaction its failure poisoned, so
-     * for an unchecked failure that record is lost with it and the log is the only trace.
+     * <p>Failures are reported in trigger history, not the discovery's status -- except an unchecked one, whose
+     * history is written in the transaction it poisoned and lost with it.
      */
     private void runActionTriggersSafely(DiscoveryRunContext context, ImportedGroup imported) {
         if (!imported.isImported()) {
@@ -754,9 +747,8 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
             try {
                 transactionHandler.runInNewTransaction(() -> runActionTrigger(context, imported, triggerAssociation));
             } catch (Exception e) {
-                // Only a failure that escaped the trigger's own handling reaches here, and its transaction is
-                // already gone -- taking the history the evaluator wrote in it. The next trigger starts in a fresh
-                // one, and the failure is recorded in a fresh one too, so it does not exist only in the log.
+                // Its transaction is already gone, taking the history the evaluator wrote in it -- so the failure
+                // is recorded in a fresh one rather than left in the log alone.
                 logger.error("Action trigger {} failed for discovered certificate {}: {}",
                         triggerAssociation.getTrigger().getUuid(), imported.certificateUuid(), e.getMessage(), e);
                 recordActionTriggerFailure(context, imported, triggerAssociation, e);
@@ -765,9 +757,8 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
     }
 
     /**
-     * Writes the failure where an operator looks for it. The evaluator records a failed execution itself, but into
-     * the transaction the failure poisoned, so that record dies with it — leaving the trigger looking as though it
-     * never ran. This one is written in its own transaction and therefore survives.
+     * The evaluator's own record of a failed execution goes into the transaction the failure poisoned and dies with
+     * it, leaving the trigger looking as though it never ran. This one is written in its own transaction.
      */
     private void recordActionTriggerFailure(DiscoveryRunContext context, ImportedGroup imported,
                                             TriggerAssociation triggerAssociation, Exception failure) {

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -768,6 +768,9 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
                         triggerAssociation.getTrigger().getUuid(), triggerAssociation, imported.certificateUuid(),
                         imported.referenceRowUuid(), eventHistoryFor(context, triggerAssociation),
                         Resource.CERTIFICATE);
+                // Both columns are non-nullable, so there is no "not determined". False would read as the trigger
+                // legitimately skipping this certificate and hide the failure; this pairing plus a record is how the
+                // evaluator itself reports actions that did not complete.
                 history.setConditionsMatched(true);
                 history.setActionsPerformed(false);
                 triggerService.createTriggerHistoryRecord(history.getUuid(), null, null,

--- a/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandler.java
@@ -739,7 +739,8 @@ public class CertificateDiscoveredEventHandler extends EventHandler<Certificate>
      * <p>And one transaction each rather than one for the phase, for the same reason one level down: a poisoned
      * transaction discards every write made in it, so sharing one would lose the trigger history of the triggers
      * that succeeded, their applied changes, and their notifications — which are published on commit — along with
-     * the failing one's own record.
+     * the failing one's own record. A notification is therefore released as its own trigger commits, and does not
+     * imply that the triggers ordered after it have run.
      *
      * <p>An action failure deliberately does not reach the discovery's status; trigger history is where it is
      * reported. Note that the failing trigger's own history is written in the transaction its failure poisoned, so

--- a/src/main/java/com/otilm/core/events/handlers/discovery/DiscoveryFailureReason.java
+++ b/src/main/java/com/otilm/core/events/handlers/discovery/DiscoveryFailureReason.java
@@ -24,6 +24,8 @@ import java.sql.SQLException;
 public final class DiscoveryFailureReason {
 
     private static final String GENERIC = "an unexpected error occurred";
+    private static final String IMPORT_ROLLED_BACK = "the import transaction was rolled back";
+    private static final String TRIGGER_ROLLED_BACK = "the trigger's transaction was rolled back";
     private static final int MAX_CAUSE_DEPTH = 10;
     /** SQLSTATE 23505, unique_violation. */
     private static final String UNIQUE_VIOLATION_SQL_STATE = "23505";
@@ -32,11 +34,23 @@ public final class DiscoveryFailureReason {
     }
 
     public static String shape(Throwable throwable) {
+        return shape(throwable, IMPORT_ROLLED_BACK);
+    }
+
+    /**
+     * As {@link #shape(Throwable)}, but for a failure raised once the import has committed: only the trigger's own
+     * transaction can have rolled back by then, so naming the import's would send the operator to the wrong place.
+     */
+    public static String shapeTriggerFailure(Throwable throwable) {
+        return shape(throwable, TRIGGER_ROLLED_BACK);
+    }
+
+    private static String shape(Throwable throwable, String rollbackReason) {
         // Walk the causes: a data-integrity failure usually arrives wrapped, and if the wrapper's own message
         // embeds the driver text, passing that through would leak exactly what this class exists to withhold.
         Throwable cause = throwable;
         for (int depth = 0; cause != null && depth < MAX_CAUSE_DEPTH; cause = cause.getCause(), depth++) {
-            String classified = classify(cause);
+            String classified = classify(cause, rollbackReason);
             if (classified != null) {
                 return classified;
             }
@@ -75,7 +89,7 @@ public final class DiscoveryFailureReason {
         return false;
     }
 
-    private static String classify(Throwable throwable) {
+    private static String classify(Throwable throwable, String rollbackReason) {
         // First, so it matches before the cause walk reaches whatever it wraps: the reason it carries is already
         // shaped and more specific than anything re-derived from the cause would be.
         if (throwable instanceof DiscoveryImportRollbackException && isUsable(throwable.getMessage())) {
@@ -90,7 +104,7 @@ public final class DiscoveryFailureReason {
                     : "a database constraint rejected the certificate";
         }
         if (throwable instanceof UnexpectedRollbackException) {
-            return "the import transaction was rolled back";
+            return rollbackReason;
         }
         if (throwable instanceof ValidationException) {
             return "the certificate did not pass validation";

--- a/src/main/java/com/otilm/core/messaging/jms/producers/NotificationProducer.java
+++ b/src/main/java/com/otilm/core/messaging/jms/producers/NotificationProducer.java
@@ -42,10 +42,9 @@ public class NotificationProducer {
     }
 
     /**
-     * Dispatch failures stay here rather than reaching the publisher. Spring propagates an exception thrown from an
-     * {@code AFTER_COMMIT} synchronization to whoever called commit, and by then the transaction has committed and
-     * cannot be undone -- so letting one out reports committed work as failed. The retry template has already
-     * exhausted its attempts, so the message is lost either way and the log is the only useful disposition.
+     * Spring propagates what an {@code AFTER_COMMIT} synchronization throws to whoever called commit, by which point
+     * the transaction has committed -- so letting a dispatch failure out reports committed work as failed. Retries
+     * are exhausted by here, so the log is all that is left.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void onNotificationMessage(NotificationMessage notificationMessage) {

--- a/src/main/java/com/otilm/core/messaging/jms/producers/NotificationProducer.java
+++ b/src/main/java/com/otilm/core/messaging/jms/producers/NotificationProducer.java
@@ -44,7 +44,8 @@ public class NotificationProducer {
     /**
      * Spring propagates what an {@code AFTER_COMMIT} synchronization throws to whoever called commit, by which point
      * the transaction has committed -- so letting a dispatch failure out reports committed work as failed. Retries
-     * are exhausted by here, so the log is all that is left.
+     * are exhausted by here, so the log is all that is left. Not loss-free on the {@code fallbackExecution} path
+     * though: with no transaction the listener runs inline, where the publisher could still have acted on the failure.
      */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void onNotificationMessage(NotificationMessage notificationMessage) {

--- a/src/main/java/com/otilm/core/messaging/jms/producers/NotificationProducer.java
+++ b/src/main/java/com/otilm/core/messaging/jms/producers/NotificationProducer.java
@@ -41,9 +41,21 @@ public class NotificationProducer {
         });
     }
 
+    /**
+     * Dispatch failures stay here rather than reaching the publisher. Spring propagates an exception thrown from an
+     * {@code AFTER_COMMIT} synchronization to whoever called commit, and by then the transaction has committed and
+     * cannot be undone -- so letting one out reports committed work as failed. The retry template has already
+     * exhausted its attempts, so the message is lost either way and the log is the only useful disposition.
+     */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void onNotificationMessage(NotificationMessage notificationMessage) {
-        produceMessage(notificationMessage);
+        try {
+            produceMessage(notificationMessage);
+        } catch (Exception e) {
+            logger.error("Could not dispatch the notification for event {} on {} {}: {}",
+                    notificationMessage.getEvent(), notificationMessage.getResource(),
+                    notificationMessage.getObjectUuid(), e.getMessage(), e);
+        }
     }
 
     public void produceMessage(@NonNull final NotificationMessage notificationMessage) {

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
@@ -2,6 +2,7 @@ package com.otilm.core.service.handler.authority;
 
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.ConnectorInterfaceEntity;
+import com.otilm.api.exception.ValidationException;
 import com.otilm.core.exception.UnsupportedAuthorityVersionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -35,9 +36,12 @@ public class AuthorityProviderAdapterFactory {
 
     public AuthorityProviderAdapter forAuthority(AuthorityInstanceReference authority) {
         if (authority == null) {
-            // An RA profile without an authority instance is reachable configuration, so this arrives as a domain
-            // failure rather than a NullPointerException from the dereference below.
-            throw new UnsupportedAuthorityVersionException("The RA profile has no authority instance to serve it.");
+            // Reachable configuration -- an RA profile with no authority instance -- so not a NullPointerException
+            // from the dereference below. ValidationException specifically, because the callers that can act on it
+            // already handle that type: CertificateServiceImpl.switchRaProfile catches it in place, records an event
+            // history that survives rollback and rethrows a checked exception, so the failure never crosses a
+            // @Transactional proxy to mark the caller's transaction rollback-only.
+            throw new ValidationException("No authority instance was supplied for adapter selection.");
         }
         ConnectorInterfaceEntity iface = authority.getConnectorInterface();
         if (iface == null) {

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
@@ -38,8 +38,8 @@ public class AuthorityProviderAdapterFactory {
     public AuthorityProviderAdapter forAuthority(AuthorityInstanceReference authority) {
         // A precondition, not a domain condition: callers that can legitimately hold a null reference check it
         // themselves and report it in their own terms. Deliberately not a type any caller catches -- selecting one
-        // to land in another class's handler routes this into whatever that handler means, which is how a missing
-        // authority once became "the authority refused to cancel" and stranded certificates mid-operation.
+        // to land in another class's handler makes a missing authority mean whatever that handler means, such as
+        // "the authority refused to cancel", stranding certificates mid-operation.
         Objects.requireNonNull(authority, "An authority instance is required to select an adapter.");
         ConnectorInterfaceEntity iface = authority.getConnectorInterface();
         if (iface == null) {

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
@@ -36,10 +36,9 @@ public class AuthorityProviderAdapterFactory {
     }
 
     public AuthorityProviderAdapter forAuthority(AuthorityInstanceReference authority) {
-        // A precondition, not a domain condition: callers that can legitimately hold a null reference check it
-        // themselves and report it in their own terms. Deliberately not a type any caller catches -- selecting one
-        // to land in another class's handler makes a missing authority mean whatever that handler means, such as
-        // "the authority refused to cancel", stranding certificates mid-operation.
+        // A precondition, not a domain condition: callers that can hold a null reference check it themselves. Any
+        // type a caller catches would make a missing authority mean whatever that handler means -- "the authority
+        // refused to cancel", stranding certificates mid-operation.
         Objects.requireNonNull(authority, "An authority instance is required to select an adapter.");
         ConnectorInterfaceEntity iface = authority.getConnectorInterface();
         if (iface == null) {

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
@@ -2,10 +2,11 @@ package com.otilm.core.service.handler.authority;
 
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.ConnectorInterfaceEntity;
-import com.otilm.api.exception.ValidationException;
 import com.otilm.core.exception.UnsupportedAuthorityVersionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.Objects;
 
 /**
  * Dispatches authority operations to the adapter matching the authority's connector interface
@@ -35,14 +36,11 @@ public class AuthorityProviderAdapterFactory {
     }
 
     public AuthorityProviderAdapter forAuthority(AuthorityInstanceReference authority) {
-        if (authority == null) {
-            // Reachable configuration -- an RA profile with no authority instance -- so not a NullPointerException
-            // from the dereference below. ValidationException specifically, because the callers that can act on it
-            // already handle that type: CertificateServiceImpl.switchRaProfile catches it in place, records an event
-            // history that survives rollback and rethrows a checked exception, so the failure never crosses a
-            // @Transactional proxy to mark the caller's transaction rollback-only.
-            throw new ValidationException("No authority instance was supplied for adapter selection.");
-        }
+        // A precondition, not a domain condition: callers that can legitimately hold a null reference check it
+        // themselves and report it in their own terms. Deliberately not a type any caller catches -- selecting one
+        // to land in another class's handler routes this into whatever that handler means, which is how a missing
+        // authority once became "the authority refused to cancel" and stranded certificates mid-operation.
+        Objects.requireNonNull(authority, "An authority instance is required to select an adapter.");
         ConnectorInterfaceEntity iface = authority.getConnectorInterface();
         if (iface == null) {
             // No interface row → a framework-v1 connector speaking the v2 authority protocol (see class Javadoc).

--- a/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
+++ b/src/main/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactory.java
@@ -34,6 +34,11 @@ public class AuthorityProviderAdapterFactory {
     }
 
     public AuthorityProviderAdapter forAuthority(AuthorityInstanceReference authority) {
+        if (authority == null) {
+            // An RA profile without an authority instance is reachable configuration, so this arrives as a domain
+            // failure rather than a NullPointerException from the dereference below.
+            throw new UnsupportedAuthorityVersionException("The RA profile has no authority instance to serve it.");
+        }
         ConnectorInterfaceEntity iface = authority.getConnectorInterface();
         if (iface == null) {
             // No interface row → a framework-v1 connector speaking the v2 authority protocol (see class Javadoc).

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -64,6 +64,7 @@ import com.otilm.core.model.request.CertificateRequest;
 import com.otilm.core.model.signing.SigningCertificate;
 import com.otilm.core.oid.OidHandler;
 import com.otilm.core.oid.OidRecord;
+import com.otilm.core.exception.UnsupportedAuthorityVersionException;
 import com.otilm.core.security.authn.client.AuthenticationCache;
 import com.otilm.core.security.authn.client.UserManagementApiClient;
 import com.otilm.core.security.authz.AuthorizationEnforcer;
@@ -2312,6 +2313,12 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
                 String reason = identifyRejectionReason(e);
                 certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Identification by authority of new RA profile %s rejected the certificate: %s", newRaProfile.getName(), reason), null);
                 throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Identification by authority of new RA profile %s rejected the certificate: %s. Certificate: %s", newRaProfile.getName(), reason, certificate.toStringShort()));
+            } catch (UnsupportedAuthorityVersionException e) {
+                // Caught here rather than left to escape: unchecked, it would cross this class's @Transactional
+                // proxy and mark the caller's transaction rollback-only. Rewrapped, the operator gets the same
+                // event history and 400 as the other two rejections.
+                certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Authority of new RA profile %s cannot serve this platform: %s", newRaProfile.getName(), e.getMessage()), null);
+                throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Authority of new RA profile %s cannot serve this platform: %s. Certificate: %s", newRaProfile.getName(), e.getMessage(), certificate.toStringShort()));
             }
         }
 

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -2300,6 +2300,14 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
             newRaProfileName = newRaProfile.getName();
 
             // identify certificate by new authority
+            if (newRaProfile.getAuthorityInstanceReference() == null) {
+                // Checked, and reported in the RA profile's own terms: an authority-less RA profile is
+                // configuration the operator can fix, and it is not a connector rejection -- the connector is
+                // never contacted. Unchecked here would cross this class's @Transactional proxy and doom the
+                // caller's transaction, which for a discovery action trigger costs that trigger its history.
+                certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("RA profile %s has no authority instance, so the certificate cannot be identified.", newRaProfile.getName()), null);
+                throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. RA profile %s has no authority instance, so the certificate cannot be identified. Certificate: %s", newRaProfile.getName(), certificate.toStringShort()));
+            }
             try {
                 AuthorityProviderAdapter adapter = adapterFactory.forAuthority(newRaProfile.getAuthorityInstanceReference());
                 identifiedMeta = adapter.identify(newRaProfile, certificate.getCertificateContent().getContent());
@@ -2326,7 +2334,9 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
         certificateRepository.save(certificate);
 
         // delete old metadata
-        if (currentRaProfile != null) {
+        // Null-checked on the authority too: an RA profile without one has no connector whose metadata could
+        // exist, and the same configuration is reachable on the way out as on the way in.
+        if (currentRaProfile != null && currentRaProfile.getAuthorityInstanceReference() != null) {
             attributeEngine.deleteObjectAttributesContent(AttributeType.META, ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(currentRaProfile.getAuthorityInstanceReference().getConnectorUuid()).build());
         }
 

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -2323,10 +2323,13 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
                 throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Identification by authority of new RA profile %s rejected the certificate: %s. Certificate: %s", newRaProfile.getName(), reason, certificate.toStringShort()));
             } catch (UnsupportedAuthorityVersionException e) {
                 // Caught here rather than left to escape: unchecked, it would cross this class's @Transactional
-                // proxy and mark the caller's transaction rollback-only. Rewrapped, the operator gets the same
-                // event history and 400 as the other two rejections.
-                certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Authority of new RA profile %s cannot serve this platform: %s", newRaProfile.getName(), e.getMessage()), null);
-                throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Authority of new RA profile %s cannot serve this platform: %s. Certificate: %s", newRaProfile.getName(), e.getMessage(), certificate.toStringShort()));
+                // proxy and mark the caller's transaction rollback-only. Its own message names the version the
+                // connector reported, which is stored unvalidated, so only the RA profile is reported outward and
+                // the raw text stays in the log.
+                log.warn("RA profile {} has an authority the platform cannot dispatch to: {}",
+                        newRaProfile.getName(), e.getMessage(), e);
+                certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Authority of RA profile %s uses a connector interface version this platform does not support.", newRaProfile.getName()), null);
+                throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Authority of RA profile %s uses a connector interface version this platform does not support. Certificate: %s", newRaProfile.getName(), certificate.toStringShort()));
             }
         }
 

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -2298,35 +2298,7 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
         if (raProfileUuid != null) {
             newRaProfile = raProfileRepository.findByUuid(raProfileUuid).orElseThrow(() -> new NotFoundException(RaProfile.class, raProfileUuid));
             newRaProfileName = newRaProfile.getName();
-
-            // identify certificate by new authority
-            if (newRaProfile.getAuthorityInstanceReference() == null) {
-                // Checked, and in the RA profile's own terms: the connector is never contacted, and unchecked would
-                // cross this class's @Transactional proxy and doom the caller's transaction.
-                certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("RA profile %s has no authority instance, so the certificate cannot be identified.", newRaProfile.getName()), null);
-                throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. RA profile %s has no authority instance, so the certificate cannot be identified. Certificate: %s", newRaProfile.getName(), certificate.toStringShort()));
-            }
-            try {
-                AuthorityProviderAdapter adapter = adapterFactory.forAuthority(newRaProfile.getAuthorityInstanceReference());
-                identifiedMeta = adapter.identify(newRaProfile, certificate.getCertificateContent().getContent());
-            } catch (ConnectorException e) {
-                certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Certificate not identified by authority of new RA profile %s. Certificate needs to be reissued.", newRaProfile.getName()), null);
-                throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Certificate not identified by authority of new RA profile %s. Certificate: %s", newRaProfile.getName(), certificate.toStringShort()));
-            } catch (ValidationException e) {
-                // A connector may reject identification for any policy it implements: trust
-                // anchor mismatch, validity, key usage, RA-profile attribute violation, etc.
-                // Forward the connector's own reason so the operator sees the specific cause.
-                String reason = identifyRejectionReason(e);
-                certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Identification by authority of new RA profile %s rejected the certificate: %s", newRaProfile.getName(), reason), null);
-                throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Identification by authority of new RA profile %s rejected the certificate: %s. Certificate: %s", newRaProfile.getName(), reason, certificate.toStringShort()));
-            } catch (UnsupportedAuthorityVersionException e) {
-                // Caught, not escaped: unchecked would mark the caller's transaction rollback-only. Its message
-                // names a connector-reported version stored unvalidated, so only the RA profile goes outward.
-                log.warn("RA profile {} has an authority the platform cannot dispatch to: {}",
-                        newRaProfile.getName(), e.getMessage(), e);
-                certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Authority of RA profile %s uses a connector interface version this platform does not support.", newRaProfile.getName()), null);
-                throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Authority of RA profile %s uses a connector interface version this platform does not support. Certificate: %s", newRaProfile.getName(), certificate.toStringShort()));
-            }
+            identifiedMeta = identifyByNewAuthority(certificate, newRaProfile);
         }
 
         certificate.setRaProfile(newRaProfile);
@@ -2351,6 +2323,38 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
         }
 
         certificateEventHistoryService.addEventHistory(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.SUCCESS, currentRaProfileName + " -> " + newRaProfileName, "");
+    }
+
+    /**
+     * Every failure here is reported to the operator and then raised checked, so the caller's transaction survives to
+     * keep that report -- for a discovery action trigger, an unchecked one would cost the trigger its history.
+     */
+    private List<MetadataAttribute> identifyByNewAuthority(Certificate certificate, RaProfile newRaProfile)
+            throws CertificateOperationException {
+        if (newRaProfile.getAuthorityInstanceReference() == null) {
+            // The connector is never contacted, so this is not a rejection and must not be reported as one.
+            certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("RA profile %s has no authority instance, so the certificate cannot be identified.", newRaProfile.getName()), null);
+            throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. RA profile %s has no authority instance, so the certificate cannot be identified. Certificate: %s", newRaProfile.getName(), certificate.toStringShort()));
+        }
+        try {
+            AuthorityProviderAdapter adapter = adapterFactory.forAuthority(newRaProfile.getAuthorityInstanceReference());
+            return adapter.identify(newRaProfile, certificate.getCertificateContent().getContent());
+        } catch (ConnectorException e) {
+            certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Certificate not identified by authority of new RA profile %s. Certificate needs to be reissued.", newRaProfile.getName()), null);
+            throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Certificate not identified by authority of new RA profile %s. Certificate: %s", newRaProfile.getName(), certificate.toStringShort()));
+        } catch (ValidationException e) {
+            // A connector may reject identification for any policy it implements: trust anchor mismatch, validity,
+            // key usage, RA-profile attribute violation. Forward its own reason so the operator sees the cause.
+            String reason = identifyRejectionReason(e);
+            certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Identification by authority of new RA profile %s rejected the certificate: %s", newRaProfile.getName(), reason), null);
+            throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Identification by authority of new RA profile %s rejected the certificate: %s. Certificate: %s", newRaProfile.getName(), reason, certificate.toStringShort()));
+        } catch (UnsupportedAuthorityVersionException e) {
+            // Its message names a connector-reported version stored unvalidated, so only the RA profile goes outward.
+            log.warn("RA profile {} has an authority the platform cannot dispatch to: {}",
+                    newRaProfile.getName(), e.getMessage(), e);
+            certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Authority of RA profile %s uses a connector interface version this platform does not support.", newRaProfile.getName()), null);
+            throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Authority of RA profile %s uses a connector interface version this platform does not support. Certificate: %s", newRaProfile.getName(), certificate.toStringShort()));
+        }
     }
 
     @ExternalAuthorization(resource = Resource.CERTIFICATE, action = ResourceAction.UPDATE)

--- a/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/CertificateServiceImpl.java
@@ -2301,10 +2301,8 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
 
             // identify certificate by new authority
             if (newRaProfile.getAuthorityInstanceReference() == null) {
-                // Checked, and reported in the RA profile's own terms: an authority-less RA profile is
-                // configuration the operator can fix, and it is not a connector rejection -- the connector is
-                // never contacted. Unchecked here would cross this class's @Transactional proxy and doom the
-                // caller's transaction, which for a discovery action trigger costs that trigger its history.
+                // Checked, and in the RA profile's own terms: the connector is never contacted, and unchecked would
+                // cross this class's @Transactional proxy and doom the caller's transaction.
                 certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("RA profile %s has no authority instance, so the certificate cannot be identified.", newRaProfile.getName()), null);
                 throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. RA profile %s has no authority instance, so the certificate cannot be identified. Certificate: %s", newRaProfile.getName(), certificate.toStringShort()));
             }
@@ -2322,10 +2320,8 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
                 certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Identification by authority of new RA profile %s rejected the certificate: %s", newRaProfile.getName(), reason), null);
                 throw new CertificateOperationException(String.format("Cannot switch RA profile for certificate. Identification by authority of new RA profile %s rejected the certificate: %s. Certificate: %s", newRaProfile.getName(), reason, certificate.toStringShort()));
             } catch (UnsupportedAuthorityVersionException e) {
-                // Caught here rather than left to escape: unchecked, it would cross this class's @Transactional
-                // proxy and mark the caller's transaction rollback-only. Its own message names the version the
-                // connector reported, which is stored unvalidated, so only the RA profile is reported outward and
-                // the raw text stays in the log.
+                // Caught, not escaped: unchecked would mark the caller's transaction rollback-only. Its message
+                // names a connector-reported version stored unvalidated, so only the RA profile goes outward.
                 log.warn("RA profile {} has an authority the platform cannot dispatch to: {}",
                         newRaProfile.getName(), e.getMessage(), e);
                 certificateEventHistoryService.addEventHistorySurvivingRollback(certificate.getUuid(), CertificateEvent.UPDATE_RA_PROFILE, CertificateEventStatus.FAILED, String.format("Authority of RA profile %s uses a connector interface version this platform does not support.", newRaProfile.getName()), null);
@@ -2337,8 +2333,7 @@ public class CertificateServiceImpl implements CertificateExternalService, Certi
         certificateRepository.save(certificate);
 
         // delete old metadata
-        // Null-checked on the authority too: an RA profile without one has no connector whose metadata could
-        // exist, and the same configuration is reachable on the way out as on the way in.
+        // An RA profile without an authority has no connector whose metadata could exist.
         if (currentRaProfile != null && currentRaProfile.getAuthorityInstanceReference() != null) {
             attributeEngine.deleteObjectAttributesContent(AttributeType.META, ObjectAttributeContentInfo.builder(Resource.CERTIFICATE, certificate.getUuid()).connector(currentRaProfile.getAuthorityInstanceReference().getConnectorUuid()).build());
         }

--- a/src/test/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandlerContainmentTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandlerContainmentTest.java
@@ -196,9 +196,8 @@ class CertificateDiscoveredEventHandlerContainmentTest {
     }
 
     /**
-     * One transaction per trigger, asserted structurally because no execution available to an integration test
-     * reaches a service that fails unchecked. Sharing one transaction is what let a single poisoned execution
-     * discard the trigger history and applied writes of every trigger in the group.
+     * Asserted structurally because no execution an integration test can reach fails unchecked. Sharing one
+     * transaction is what let a single poisoned execution discard every other trigger's history and writes.
      */
     @Test
     void eachActionTriggerGetsItsOwnTransaction() {
@@ -217,9 +216,8 @@ class CertificateDiscoveredEventHandlerContainmentTest {
     }
 
     /**
-     * When a trigger's transaction is lost, the evaluator's own record of the failure goes with it — so the failure
-     * is written again in a fresh one. Only reachable with a stub: no execution an integration test can configure
-     * fails unchecked, which is why the end-to-end tests cannot cover this.
+     * A lost trigger transaction takes the evaluator's own record of the failure with it, so it is written again in
+     * a fresh one. Only reachable with a stub, which is why the end-to-end tests cannot cover it.
      */
     @Test
     void aLostTriggerTransactionStillLeavesAFailureRecord() {

--- a/src/test/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandlerContainmentTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandlerContainmentTest.java
@@ -1,9 +1,12 @@
 package com.otilm.core.events.handlers;
 
 import com.otilm.core.dao.entity.DiscoveryCertificate;
+import com.otilm.core.dao.entity.workflows.Trigger;
+import com.otilm.core.dao.entity.workflows.TriggerAssociation;
 import com.otilm.core.dao.repository.CertificateRepository;
 import com.otilm.core.evaluator.CertificateTriggerEvaluator;
 import com.otilm.core.events.handlers.discovery.DiscoveryCertificateOutcome;
+import com.otilm.core.events.handlers.discovery.DiscoveryCertificateResult;
 import com.otilm.core.events.handlers.discovery.DiscoveryContentGroup;
 import com.otilm.core.events.handlers.discovery.DiscoveryImportRollbackException;
 import com.otilm.core.events.handlers.discovery.DiscoveryRunAccumulator;
@@ -15,6 +18,7 @@ import com.otilm.core.service.writer.DiscoveryWriter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
+import org.springframework.transaction.UnexpectedRollbackException;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,6 +34,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -151,12 +156,63 @@ class CertificateDiscoveredEventHandlerContainmentTest {
     }
 
     /**
+     * A failing action-trigger phase must leave the group's outcome alone. The certificate has committed by then, so
+     * reporting a rollback would put a reason on rows whose certificate is in the inventory.
+     */
+    @Test
+    void aFailingActionTriggerPhaseLeavesTheImportedResultIntact() {
+        UUID rowUuid = UUID.randomUUID();
+        UUID certificateUuid = UUID.randomUUID();
+        GroupImportResult committed = new GroupImportResult(6L,
+                List.of(new DiscoveryCertificateResult(rowUuid, DiscoveryCertificateOutcome.IMPORTED, null)),
+                List.of(), true);
+        when(transactionHandler.runInNewTransaction(
+                ArgumentMatchers.<Supplier<CertificateDiscoveredEventHandler.ImportedGroup>>any()))
+                .thenReturn(new CertificateDiscoveredEventHandler.ImportedGroup(
+                        committed, certificateUuid, null, rowUuid));
+        doThrow(new UnexpectedRollbackException("an execution poisoned the trigger transaction"))
+                .when(transactionHandler).runInNewTransaction(any(Runnable.class));
+
+        GroupImportResult result = handler.importGroupSafely(
+                runContextWithTriggers(), group(6L, rowUuid));
+
+        assertThat(result.committed())
+                .as("the import committed, so the group is imported however the triggers fared")
+                .isTrue();
+        assertThat(result.rowResults()).singleElement().satisfies(row -> {
+            assertThat(row.outcome()).isEqualTo(DiscoveryCertificateOutcome.IMPORTED);
+            assertThat(row.detail()).isNull();
+        });
+    }
+
+    /**
+     * One transaction per trigger, asserted structurally because no execution available to an integration test
+     * reaches a service that fails unchecked. Sharing one transaction is what let a single poisoned execution
+     * discard the trigger history and applied writes of every trigger in the group.
+     */
+    @Test
+    void eachActionTriggerGetsItsOwnTransaction() {
+        UUID rowUuid = UUID.randomUUID();
+        GroupImportResult committed = new GroupImportResult(7L,
+                List.of(new DiscoveryCertificateResult(rowUuid, DiscoveryCertificateOutcome.IMPORTED, null)),
+                List.of(), true);
+        when(transactionHandler.runInNewTransaction(
+                ArgumentMatchers.<Supplier<CertificateDiscoveredEventHandler.ImportedGroup>>any()))
+                .thenReturn(new CertificateDiscoveredEventHandler.ImportedGroup(
+                        committed, UUID.randomUUID(), null, rowUuid));
+
+        handler.importGroupSafely(runContextWithTriggers(3), group(7L, rowUuid));
+
+        verify(transactionHandler, times(3)).runInNewTransaction(any(Runnable.class));
+    }
+
+    /**
      * The reason a group carries out through its own rollback has to survive the shaping the orchestrator applies on
      * the way past. Shaped from an unclassified wrapper it would collapse to "an unexpected error occurred".
      */
     @Test
     void anAlreadyShapedRollbackReasonSurvivesTheOrchestratorsShaping() {
-        when(transactionHandler.runInNewTransaction(ArgumentMatchers.<Supplier<GroupImportResult>>any()))
+        when(transactionHandler.runInNewTransaction(ArgumentMatchers.<Supplier<CertificateDiscoveredEventHandler.ImportedGroup>>any()))
                 .thenThrow(new DiscoveryImportRollbackException(
                         "trigger evaluation failed: the discovered certificate could not be parsed", null));
 
@@ -187,6 +243,24 @@ class CertificateDiscoveredEventHandlerContainmentTest {
         } finally {
             Thread.interrupted();
         }
+    }
+
+    private DiscoveryRunContext runContextWithTriggers() {
+        return runContextWithTriggers(1);
+    }
+
+    private DiscoveryRunContext runContextWithTriggers(int triggerCount) {
+        List<TriggerAssociation> associations = new java.util.ArrayList<>();
+        for (int i = 0; i < triggerCount; i++) {
+            TriggerAssociation association = new TriggerAssociation();
+            Trigger trigger = new Trigger();
+            trigger.setUuid(UUID.randomUUID());
+            association.setTrigger(trigger);
+            associations.add(association);
+        }
+        return new DiscoveryRunContext(UUID.randomUUID(), "discovery", UUID.randomUUID(), "connector",
+                "kind", UUID.randomUUID(), List.of(), associations, UUID.randomUUID(), UUID.randomUUID(),
+                7, null);
     }
 
     private DiscoveryRunContext runContext() {

--- a/src/test/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandlerContainmentTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CertificateDiscoveredEventHandlerContainmentTest.java
@@ -4,6 +4,7 @@ import com.otilm.core.dao.entity.DiscoveryCertificate;
 import com.otilm.core.dao.entity.workflows.Trigger;
 import com.otilm.core.dao.entity.workflows.TriggerAssociation;
 import com.otilm.core.dao.repository.CertificateRepository;
+import com.otilm.core.dao.repository.workflows.EventHistoryRepository;
 import com.otilm.core.evaluator.CertificateTriggerEvaluator;
 import com.otilm.core.events.handlers.discovery.DiscoveryCertificateOutcome;
 import com.otilm.core.events.handlers.discovery.DiscoveryCertificateResult;
@@ -13,13 +14,16 @@ import com.otilm.core.events.handlers.discovery.DiscoveryRunAccumulator;
 import com.otilm.core.events.handlers.discovery.DiscoveryRunContext;
 import com.otilm.core.events.handlers.discovery.DiscoveryRunCounts;
 import com.otilm.core.events.handlers.discovery.GroupImportResult;
+import com.otilm.core.dao.entity.workflows.TriggerHistory;
 import com.otilm.core.events.transaction.TransactionHandler;
+import com.otilm.core.service.TriggerInternalService;
 import com.otilm.core.service.writer.DiscoveryWriter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.transaction.UnexpectedRollbackException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -30,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -48,6 +53,8 @@ class CertificateDiscoveredEventHandlerContainmentTest {
     private final DiscoveryWriter discoveryWriter = mock(DiscoveryWriter.class);
     private final CertificateRepository certificateRepository = mock(CertificateRepository.class);
     private final TransactionHandler transactionHandler = mock(TransactionHandler.class);
+    private final TriggerInternalService triggerService = mock(TriggerInternalService.class);
+    private final EventHistoryRepository eventHistoryRepository = mock(EventHistoryRepository.class);
     private final CertificateDiscoveredEventHandler handler = new CertificateDiscoveredEventHandler(
             certificateRepository, mock(CertificateTriggerEvaluator.class));
 
@@ -60,6 +67,9 @@ class CertificateDiscoveredEventHandlerContainmentTest {
 
         handler.setTransactionHandler(transactionHandler);
         handler.setDiscoveryWriter(discoveryWriter);
+        handler.setTriggerService(triggerService);
+        // The failure record resolves the event history in its own transaction, so the repository must be present.
+        handler.setEventHistoryRepository(eventHistoryRepository);
     }
 
     @Test
@@ -207,6 +217,39 @@ class CertificateDiscoveredEventHandlerContainmentTest {
     }
 
     /**
+     * When a trigger's transaction is lost, the evaluator's own record of the failure goes with it — so the failure
+     * is written again in a fresh one. Only reachable with a stub: no execution an integration test can configure
+     * fails unchecked, which is why the end-to-end tests cannot cover this.
+     */
+    @Test
+    void aLostTriggerTransactionStillLeavesAFailureRecord() {
+        UUID rowUuid = UUID.randomUUID();
+        UUID certificateUuid = UUID.randomUUID();
+        GroupImportResult committed = new GroupImportResult(8L,
+                List.of(new DiscoveryCertificateResult(rowUuid, DiscoveryCertificateOutcome.IMPORTED, null)),
+                List.of(), true);
+        when(transactionHandler.runInNewTransaction(
+                ArgumentMatchers.<Supplier<CertificateDiscoveredEventHandler.ImportedGroup>>any()))
+                .thenReturn(new CertificateDiscoveredEventHandler.ImportedGroup(
+                        committed, certificateUuid, null, rowUuid));
+        TriggerHistory history = new TriggerHistory();
+        history.setUuid(UUID.randomUUID());
+        when(triggerService.createTriggerHistory(any(), any(), any(), any(), any(), any())).thenReturn(history);
+        // The trigger's own transaction is lost; the one that records the failure is not.
+        doThrow(new UnexpectedRollbackException("an execution poisoned the trigger transaction"))
+                .doAnswer(invocation -> {
+                    invocation.getArgument(0, Runnable.class).run();
+                    return null;
+                })
+                .when(transactionHandler).runInNewTransaction(any(Runnable.class));
+
+        handler.importGroupSafely(runContextWithTriggers(), group(8L, rowUuid));
+
+        verify(triggerService).createTriggerHistory(any(), any(), eq(certificateUuid), eq(rowUuid), any(), any());
+        verify(triggerService).createTriggerHistoryRecord(eq(history.getUuid()), any(), any(), anyString());
+    }
+
+    /**
      * The reason a group carries out through its own rollback has to survive the shaping the orchestrator applies on
      * the way past. Shaped from an unclassified wrapper it would collapse to "an unexpected error occurred".
      */
@@ -250,7 +293,7 @@ class CertificateDiscoveredEventHandlerContainmentTest {
     }
 
     private DiscoveryRunContext runContextWithTriggers(int triggerCount) {
-        List<TriggerAssociation> associations = new java.util.ArrayList<>();
+        List<TriggerAssociation> associations = new ArrayList<>();
         for (int i = 0; i < triggerCount; i++) {
             TriggerAssociation association = new TriggerAssociation();
             Trigger trigger = new Trigger();

--- a/src/test/java/com/otilm/core/events/handlers/discovery/DiscoveryFailureReasonTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/discovery/DiscoveryFailureReasonTest.java
@@ -144,6 +144,26 @@ class DiscoveryFailureReasonTest {
                 .isEqualTo("the import transaction was rolled back");
     }
 
+    /**
+     * Same exception, different transaction: after the import has committed, only the trigger's own can have rolled
+     * back, and naming the import's would send the operator looking at the wrong thing.
+     */
+    @Test
+    void namesTheTriggerTransactionWhenTheImportHasAlreadyCommitted() {
+        assertThat(DiscoveryFailureReason.shapeTriggerFailure(new UnexpectedRollbackException(
+                "Transaction silently rolled back because it has been marked as rollback-only")))
+                .isEqualTo("the trigger's transaction was rolled back");
+    }
+
+    /** The scope only changes the rollback wording; every other classification is shared. */
+    @Test
+    void classifiesEverythingElseTheSameWayForATriggerFailure() {
+        assertThat(DiscoveryFailureReason.shapeTriggerFailure(new CertificateException("bad signature")))
+                .isEqualTo("the discovered certificate could not be parsed");
+        assertThat(DiscoveryFailureReason.shapeTriggerFailure(new IllegalStateException("core.cert_content.id is null")))
+                .isEqualTo("an unexpected error occurred");
+    }
+
     @Test
     void classifiesAnythingElseGenerically() {
         assertThat(DiscoveryFailureReason.shape(new IllegalStateException("core.certificate_content.id is null")))

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -52,7 +52,6 @@ import com.otilm.core.dao.entity.notifications.NotificationInstanceReference;
 import com.otilm.core.dao.entity.notifications.PendingNotification;
 import com.otilm.core.dao.entity.workflows.Trigger;
 import com.otilm.core.dao.entity.workflows.TriggerAssociation;
-import com.otilm.core.dao.entity.GroupAssociation;
 import com.otilm.core.dao.entity.workflows.TriggerHistory;
 import com.otilm.core.dao.repository.*;
 import com.otilm.core.dao.repository.notifications.NotificationInstanceReferenceRepository;
@@ -60,6 +59,7 @@ import com.otilm.core.dao.repository.notifications.PendingNotificationRepository
 import com.otilm.core.dao.entity.workflows.EventHistory;
 import com.otilm.core.dao.repository.workflows.EventHistoryRepository;
 import com.otilm.core.dao.repository.workflows.TriggerAssociationRepository;
+import com.otilm.core.dao.repository.workflows.TriggerHistoryRecordRepository;
 import com.otilm.core.dao.repository.workflows.TriggerHistoryRepository;
 import com.otilm.core.dao.repository.workflows.TriggerRepository;
 import com.otilm.core.enums.FilterField;
@@ -177,6 +177,9 @@ class EventHandlersITest extends BaseSpringBootTest {
     private EventHistoryRepository eventHistoryRepository;
     @Autowired
     private TriggerHistoryRepository triggerHistoryRepository;
+
+    @Autowired
+    private TriggerHistoryRecordRepository triggerHistoryRecordRepository;
 
     @Autowired
     private ScheduledJobsRepository scheduledJobsRepository;
@@ -652,10 +655,10 @@ class EventHandlersITest extends BaseSpringBootTest {
     /**
      * An action trigger whose execution fails must not cost the discovery its certificates.
      *
-     * <p>The failure mode is not the exception itself — {@code performActions} already records those — but where it
-     * is raised. A set-field execution calls into a class-level {@code @Transactional} service, so an unchecked
-     * failure there marks the group's transaction rollback-only before any catch runs, and the commit throws. Since
-     * every group evaluates the same triggers, one misconfigured execution loses every certificate in the run.
+     * <p>Guards where an execution failure lands: a set-field execution reaches services that are class-level
+     * {@code @Transactional}, so a failure raised inside one must not be able to take the group's import with it.
+     * This execution fails checked, so what it exercises is the containment and the surviving history — not the
+     * rollback-only path, which no execution reachable from here produces.
      */
     @Test
     void testCertificateDiscoveredImportsWhenAnActionTriggerExecutionFails() throws Exception {
@@ -677,8 +680,16 @@ class EventHandlersITest extends BaseSpringBootTest {
                         + reloaded.getProcessedError());
         // Asserted positively: every check above also holds when the trigger never ran at all, so without this the
         // test would pass on a mis-scoped association or an early return.
-        Assertions.assertFalse(triggerHistoryRepository.findAll().isEmpty(),
-                "the trigger must have been evaluated, and its history must survive the execution's failure");
+        List<TriggerHistory> histories = triggerHistoryRepository.findAll().stream()
+                .filter(history -> imported.getUuid().equals(history.getObjectUuid()))
+                .toList();
+        Assertions.assertEquals(1, histories.size(),
+                "the configured trigger must have been evaluated against the imported certificate");
+        Assertions.assertFalse(histories.getFirst().isActionsPerformed(),
+                "its execution failed, so the history must say the actions were not applied");
+        Assertions.assertTrue(triggerHistoryRecordRepository.findAll().stream()
+                        .anyMatch(record -> histories.getFirst().getUuid().equals(record.getTriggerHistoryUuid())),
+                "and must carry a record naming the failure");
         Assertions.assertNull(imported.getRaProfile(),
                 "the execution failed, so the RA profile it tried to set must not be applied");
         verify(eventProducer).produceMessage(argThat((EventMessage msg) ->
@@ -716,8 +727,9 @@ class EventHandlersITest extends BaseSpringBootTest {
     }
 
     /**
-     * One trigger per transaction, so a failing trigger costs only itself. Sharing one transaction discarded every
-     * trigger's work, including that of the ones that had already succeeded.
+     * One trigger per transaction, so a failing trigger costs only itself: a shared transaction would lose the
+     * writes of the triggers that already succeeded. This trigger fails checked, so the end-to-end path is what is
+     * asserted here; the isolation itself is pinned by {@code eachActionTriggerGetsItsOwnTransaction}.
      */
     @Test
     void testCertificateDiscoveredKeepsASucceedingTriggerWhenAnotherFails() throws Exception {
@@ -728,8 +740,9 @@ class EventHandlersITest extends BaseSpringBootTest {
         Group group = new Group();
         group.setName("SurvivesTheOtherFailure");
         group = groupRepository.save(group);
-        createFailingSetFieldActionTrigger(discovery.getUuid());
+        // The succeeding trigger first: the property at risk is that an earlier success survives a later failure.
         createSetGroupActionTrigger(discovery.getUuid(), group.getUuid());
+        createFailingSetFieldActionTrigger(discovery.getUuid());
 
         certificateDiscoveredEventHandler.handleEvent(
                 CertificateDiscoveredEventHandler.constructEventMessage(discovery.getUuid(), null, null));
@@ -776,7 +789,7 @@ class EventHandlersITest extends BaseSpringBootTest {
 
     /**
      * A SET_FIELD execution switching the RA profile to one that has no authority instance — reachable
-     * configuration, so the execution fails inside a class-level @Transactional service.
+     * configuration, so the execution fails inside the RA-profile switch.
      */
     private void createFailingSetFieldActionTrigger(UUID discoveryUuid)
             throws AlreadyExistException, NotFoundException, AttributeException {
@@ -816,7 +829,7 @@ class EventHandlersITest extends BaseSpringBootTest {
         mockAuthResponse(AuthHelper.getUserIdentification());
 
         triggerService.createTriggerAssociations(ResourceEvent.CERTIFICATE_DISCOVERED, Resource.DISCOVERY,
-                discoveryUuid, List.of(UUID.fromString(trigger.getUuid())), true);
+                discoveryUuid, List.of(UUID.fromString(trigger.getUuid())), false);
     }
 
     /**

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -653,12 +653,9 @@ class EventHandlersITest extends BaseSpringBootTest {
     }
 
     /**
-     * An action trigger whose execution fails must not cost the discovery its certificates.
-     *
-     * <p>Guards where an execution failure lands: a set-field execution reaches services that are class-level
-     * {@code @Transactional}, so a failure raised inside one must not be able to take the group's import with it.
-     * This execution fails checked, so what it exercises is the containment and the surviving history — not the
-     * rollback-only path, which no execution reachable from here produces.
+     * An action trigger whose execution fails must not cost the discovery its certificates. This execution fails
+     * checked, so it exercises the containment and the surviving history, not the rollback-only path — no execution
+     * reachable from here produces that.
      */
     @Test
     void testCertificateDiscoveredImportsWhenAnActionTriggerExecutionFails() throws Exception {
@@ -699,8 +696,7 @@ class EventHandlersITest extends BaseSpringBootTest {
 
     /**
      * The load-bearing half of running actions after the import: the certificate is re-resolved in the trigger's own
-     * transaction, so an execution's write actually persists. Only a failing execution exercised that before, which
-     * a broken re-resolution would have passed just as happily.
+     * transaction, so an execution's write persists. A broken re-resolution passes every failing-execution test.
      */
     @Test
     void testCertificateDiscoveredAppliesASucceedingActionTriggerAcrossTheTransactionBoundary() throws Exception {
@@ -727,9 +723,8 @@ class EventHandlersITest extends BaseSpringBootTest {
     }
 
     /**
-     * One trigger per transaction, so a failing trigger costs only itself: a shared transaction would lose the
-     * writes of the triggers that already succeeded. This trigger fails checked, so the end-to-end path is what is
-     * asserted here; the isolation itself is pinned by {@code eachActionTriggerGetsItsOwnTransaction}.
+     * A failing trigger costs only itself; a shared transaction would lose the writes of those that succeeded. This
+     * one fails checked, so the isolation itself is pinned by {@code eachActionTriggerGetsItsOwnTransaction}.
      */
     @Test
     void testCertificateDiscoveredKeepsASucceedingTriggerWhenAnotherFails() throws Exception {

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -646,6 +646,82 @@ class EventHandlersITest extends BaseSpringBootTest {
     }
 
     /**
+     * An action trigger whose execution fails must not cost the discovery its certificates.
+     *
+     * <p>The failure mode is not the exception itself — {@code performActions} already records those — but where it
+     * is raised. A set-field execution calls into a class-level {@code @Transactional} service, so an unchecked
+     * failure there marks the group's transaction rollback-only before any catch runs, and the commit throws. Since
+     * every group evaluates the same triggers, one misconfigured execution loses every certificate in the run.
+     */
+    @Test
+    void testCertificateDiscoveredImportsWhenAnActionTriggerExecutionFails() throws Exception {
+        DiscoveryHistory discovery = persistProcessingDiscovery();
+        X509Certificate x509 = generateSelfSignedCertificate();
+        CertificateContent content = persistContentFor(x509);
+        DiscoveryCertificate row = persistDiscoveryCertificate(discovery, content, "action-failing-host");
+        createFailingSetFieldActionTrigger(discovery.getUuid());
+
+        certificateDiscoveredEventHandler.handleEvent(
+                CertificateDiscoveredEventHandler.constructEventMessage(discovery.getUuid(), null, null));
+
+        Assertions.assertTrue(certificateRepository.findByFingerprint(CertificateUtil.getThumbprint(x509)).isPresent(),
+                "a failing action trigger must not roll back the certificate it acts on");
+        DiscoveryCertificate reloaded = discoveryCertificateRepository.findByUuid(row.getUuid()).orElseThrow();
+        Assertions.assertTrue(reloaded.isProcessed());
+        Assertions.assertNull(reloaded.getProcessedError(),
+                "an action failure belongs in trigger history, not on the discovered row: "
+                        + reloaded.getProcessedError());
+        verify(eventProducer).produceMessage(argThat((EventMessage msg) ->
+                msg.getEvent() == ResourceEvent.DISCOVERY_FINISHED
+                        && ((DiscoveryResult) msg.getData()).getDiscoveryStatus() == DiscoveryStatus.PROCESSING));
+    }
+
+    /**
+     * A SET_FIELD execution switching the RA profile to one that has no authority instance — reachable
+     * configuration, and what the reported failure hit in the field.
+     */
+    private void createFailingSetFieldActionTrigger(UUID discoveryUuid)
+            throws AlreadyExistException, NotFoundException, AttributeException {
+        RaProfile raProfile = new RaProfile();
+        raProfile.setName("ra-profile-without-authority");
+        raProfile = raProfileRepository.save(raProfile);
+
+        ExecutionItemRequestDto executionItemRequest = new ExecutionItemRequestDto();
+        executionItemRequest.setFieldSource(FilterFieldSource.PROPERTY);
+        executionItemRequest.setFieldIdentifier(FilterField.RA_PROFILE_NAME.name());
+        executionItemRequest.setData(raProfile.getUuid().toString());
+
+        ExecutionRequestDto executionRequest = new ExecutionRequestDto();
+        executionRequest.setName("SwitchToAuthoritylessRaProfile");
+        executionRequest.setResource(Resource.CERTIFICATE);
+        executionRequest.setType(ExecutionType.SET_FIELD);
+        executionRequest.setItems(List.of(executionItemRequest));
+        ExecutionDto execution = actionService.createExecution(executionRequest);
+
+        ActionRequestDto actionRequest = new ActionRequestDto();
+        actionRequest.setName("SwitchRaProfileAction");
+        actionRequest.setResource(Resource.CERTIFICATE);
+        actionRequest.setExecutionsUuids(List.of(execution.getUuid()));
+        ActionDetailDto action = actionService.createAction(actionRequest);
+
+        TriggerRequestDto triggerRequest = new TriggerRequestDto();
+        triggerRequest.setName("SwitchRaProfileTrigger");
+        triggerRequest.setType(TriggerType.EVENT);
+        triggerRequest.setEvent(ResourceEvent.CERTIFICATE_DISCOVERED);
+        triggerRequest.setResource(Resource.CERTIFICATE);
+        triggerRequest.setActionsUuids(List.of(action.getUuid()));
+        TriggerDetailDto trigger = triggerService.createTrigger(triggerRequest);
+
+        mockServer = new WireMockServer(10001);
+        mockServer.start();
+        WireMock.configureFor("localhost", mockServer.port());
+        mockAuthResponse(AuthHelper.getUserIdentification());
+
+        triggerService.createTriggerAssociations(ResourceEvent.CERTIFICATE_DISCOVERED, Resource.DISCOVERY,
+                discoveryUuid, List.of(UUID.fromString(trigger.getUuid())), true);
+    }
+
+    /**
      * An ignore trigger conditioned on the fingerprint must keep the certificate out of the inventory.
      *
      * <p>The candidate the ignore triggers evaluate is built in memory, so every field a rule can read has to be

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -52,6 +52,7 @@ import com.otilm.core.dao.entity.notifications.NotificationInstanceReference;
 import com.otilm.core.dao.entity.notifications.PendingNotification;
 import com.otilm.core.dao.entity.workflows.Trigger;
 import com.otilm.core.dao.entity.workflows.TriggerAssociation;
+import com.otilm.core.dao.entity.GroupAssociation;
 import com.otilm.core.dao.entity.workflows.TriggerHistory;
 import com.otilm.core.dao.repository.*;
 import com.otilm.core.dao.repository.notifications.NotificationInstanceReferenceRepository;
@@ -133,6 +134,9 @@ class EventHandlersITest extends BaseSpringBootTest {
 
     @Autowired
     private GroupRepository groupRepository;
+
+    @Autowired
+    private GroupAssociationRepository groupAssociationRepository;
     @Autowired
     private ResourceObjectAssociationService associationService;
 
@@ -664,21 +668,115 @@ class EventHandlersITest extends BaseSpringBootTest {
         certificateDiscoveredEventHandler.handleEvent(
                 CertificateDiscoveredEventHandler.constructEventMessage(discovery.getUuid(), null, null));
 
-        Assertions.assertTrue(certificateRepository.findByFingerprint(CertificateUtil.getThumbprint(x509)).isPresent(),
-                "a failing action trigger must not roll back the certificate it acts on");
+        Certificate imported = certificateRepository.findByFingerprint(CertificateUtil.getThumbprint(x509))
+                .orElseThrow(() -> new AssertionError("a failing action trigger must not roll back the certificate"));
         DiscoveryCertificate reloaded = discoveryCertificateRepository.findByUuid(row.getUuid()).orElseThrow();
         Assertions.assertTrue(reloaded.isProcessed());
         Assertions.assertNull(reloaded.getProcessedError(),
                 "an action failure belongs in trigger history, not on the discovered row: "
                         + reloaded.getProcessedError());
+        // Asserted positively: every check above also holds when the trigger never ran at all, so without this the
+        // test would pass on a mis-scoped association or an early return.
+        Assertions.assertFalse(triggerHistoryRepository.findAll().isEmpty(),
+                "the trigger must have been evaluated, and its history must survive the execution's failure");
+        Assertions.assertNull(imported.getRaProfile(),
+                "the execution failed, so the RA profile it tried to set must not be applied");
         verify(eventProducer).produceMessage(argThat((EventMessage msg) ->
                 msg.getEvent() == ResourceEvent.DISCOVERY_FINISHED
                         && ((DiscoveryResult) msg.getData()).getDiscoveryStatus() == DiscoveryStatus.PROCESSING));
     }
 
     /**
+     * The load-bearing half of running actions after the import: the certificate is re-resolved in the trigger's own
+     * transaction, so an execution's write actually persists. Only a failing execution exercised that before, which
+     * a broken re-resolution would have passed just as happily.
+     */
+    @Test
+    void testCertificateDiscoveredAppliesASucceedingActionTriggerAcrossTheTransactionBoundary() throws Exception {
+        DiscoveryHistory discovery = persistProcessingDiscovery();
+        X509Certificate x509 = generateSelfSignedCertificate();
+        CertificateContent content = persistContentFor(x509);
+        persistDiscoveryCertificate(discovery, content, "group-setting-host");
+        Group group = new Group();
+        group.setName("DiscoveredCertificates");
+        group = groupRepository.save(group);
+        UUID groupUuid = group.getUuid();
+        createSetGroupActionTrigger(discovery.getUuid(), groupUuid);
+
+        certificateDiscoveredEventHandler.handleEvent(
+                CertificateDiscoveredEventHandler.constructEventMessage(discovery.getUuid(), null, null));
+
+        Certificate imported = certificateRepository.findByFingerprint(CertificateUtil.getThumbprint(x509))
+                .orElseThrow();
+        List<GroupAssociation> associations = groupAssociationRepository.findByResourceAndObjectUuid(
+                Resource.CERTIFICATE, imported.getUuid());
+        Assertions.assertEquals(1, associations.size(),
+                "the execution's write must survive the transaction it ran in");
+        Assertions.assertEquals(groupUuid, associations.getFirst().getGroupUuid());
+    }
+
+    /**
+     * One trigger per transaction, so a failing trigger costs only itself. Sharing one transaction discarded every
+     * trigger's work, including that of the ones that had already succeeded.
+     */
+    @Test
+    void testCertificateDiscoveredKeepsASucceedingTriggerWhenAnotherFails() throws Exception {
+        DiscoveryHistory discovery = persistProcessingDiscovery();
+        X509Certificate x509 = generateSelfSignedCertificate();
+        CertificateContent content = persistContentFor(x509);
+        persistDiscoveryCertificate(discovery, content, "two-trigger-host");
+        Group group = new Group();
+        group.setName("SurvivesTheOtherFailure");
+        group = groupRepository.save(group);
+        createFailingSetFieldActionTrigger(discovery.getUuid());
+        createSetGroupActionTrigger(discovery.getUuid(), group.getUuid());
+
+        certificateDiscoveredEventHandler.handleEvent(
+                CertificateDiscoveredEventHandler.constructEventMessage(discovery.getUuid(), null, null));
+
+        Certificate imported = certificateRepository.findByFingerprint(CertificateUtil.getThumbprint(x509))
+                .orElseThrow();
+        Assertions.assertEquals(1, groupAssociationRepository.findByResourceAndObjectUuid(
+                        Resource.CERTIFICATE, imported.getUuid()).size(),
+                "the succeeding trigger's write must not be discarded by the failing one");
+        Assertions.assertNull(imported.getRaProfile(), "the failing execution must still not apply");
+    }
+
+    private void createSetGroupActionTrigger(UUID discoveryUuid, UUID groupUuid)
+            throws AlreadyExistException, NotFoundException {
+        ExecutionItemRequestDto executionItemRequest = new ExecutionItemRequestDto();
+        executionItemRequest.setFieldSource(FilterFieldSource.PROPERTY);
+        executionItemRequest.setFieldIdentifier(FilterField.GROUP_NAME.name());
+        executionItemRequest.setData(groupUuid.toString());
+
+        ExecutionRequestDto executionRequest = new ExecutionRequestDto();
+        executionRequest.setName("SetDiscoveredGroup");
+        executionRequest.setResource(Resource.CERTIFICATE);
+        executionRequest.setType(ExecutionType.SET_FIELD);
+        executionRequest.setItems(List.of(executionItemRequest));
+        ExecutionDto execution = actionService.createExecution(executionRequest);
+
+        ActionRequestDto actionRequest = new ActionRequestDto();
+        actionRequest.setName("SetDiscoveredGroupAction");
+        actionRequest.setResource(Resource.CERTIFICATE);
+        actionRequest.setExecutionsUuids(List.of(execution.getUuid()));
+        ActionDetailDto action = actionService.createAction(actionRequest);
+
+        TriggerRequestDto triggerRequest = new TriggerRequestDto();
+        triggerRequest.setName("SetDiscoveredGroupTrigger");
+        triggerRequest.setType(TriggerType.EVENT);
+        triggerRequest.setEvent(ResourceEvent.CERTIFICATE_DISCOVERED);
+        triggerRequest.setResource(Resource.CERTIFICATE);
+        triggerRequest.setActionsUuids(List.of(action.getUuid()));
+        TriggerDetailDto trigger = triggerService.createTrigger(triggerRequest);
+
+        triggerService.createTriggerAssociations(ResourceEvent.CERTIFICATE_DISCOVERED, Resource.DISCOVERY,
+                discoveryUuid, List.of(UUID.fromString(trigger.getUuid())), false);
+    }
+
+    /**
      * A SET_FIELD execution switching the RA profile to one that has no authority instance — reachable
-     * configuration, and what the reported failure hit in the field.
+     * configuration, so the execution fails inside a class-level @Transactional service.
      */
     private void createFailingSetFieldActionTrigger(UUID discoveryUuid)
             throws AlreadyExistException, NotFoundException, AttributeException {

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -685,7 +685,7 @@ class EventHandlersITest extends BaseSpringBootTest {
         Assertions.assertFalse(histories.getFirst().isActionsPerformed(),
                 "its execution failed, so the history must say the actions were not applied");
         Assertions.assertTrue(triggerHistoryRecordRepository.findAll().stream()
-                        .anyMatch(record -> histories.getFirst().getUuid().equals(record.getTriggerHistoryUuid())),
+                        .anyMatch(historyRecord -> histories.getFirst().getUuid().equals(historyRecord.getTriggerHistoryUuid())),
                 "and must carry a record naming the failure");
         Assertions.assertNull(imported.getRaProfile(),
                 "the execution failed, so the RA profile it tried to set must not be applied");
@@ -787,7 +787,7 @@ class EventHandlersITest extends BaseSpringBootTest {
      * configuration, so the execution fails inside the RA-profile switch.
      */
     private void createFailingSetFieldActionTrigger(UUID discoveryUuid)
-            throws AlreadyExistException, NotFoundException, AttributeException {
+            throws AlreadyExistException, NotFoundException {
         RaProfile raProfile = new RaProfile();
         raProfile.setName("ra-profile-without-authority");
         raProfile = raProfileRepository.save(raProfile);

--- a/src/test/java/com/otilm/core/messaging/jms/producers/NotificationProducerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/producers/NotificationProducerTest.java
@@ -1,0 +1,91 @@
+package com.otilm.core.messaging.jms.producers;
+
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.messaging.jms.configuration.MessagingProperties;
+import com.otilm.core.messaging.model.NotificationMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessagePostProcessor;
+import org.springframework.retry.support.RetryTemplate;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationProducerTest {
+
+    @Mock JmsTemplate jmsTemplate;
+    @Mock MessagingProperties messagingProperties;
+
+    private NotificationProducer producer;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(messagingProperties.produceDestinationNotifications()).thenReturn("/exchanges/ilm/notification");
+
+        MessagingProperties.RoutingKey routingKey = new MessagingProperties.RoutingKey(
+                "actions", "audit-logs", "event", "notification", "scheduler",
+                "validation", "time-quality.config-request", "time-quality.config",
+                "time-quality.results", "provider.status-poll"
+        );
+        lenient().when(messagingProperties.routingKey()).thenReturn(routingKey);
+
+        producer = new NotificationProducer(jmsTemplate, messagingProperties,
+                RetryTemplate.builder().maxAttempts(1).build());
+    }
+
+    private NotificationMessage message() {
+        return new NotificationMessage(ResourceEvent.CERTIFICATE_DISCOVERED, Resource.CERTIFICATE, UUID.randomUUID(),
+                List.of(UUID.randomUUID()), null, null, UUID.randomUUID(), UUID.randomUUID());
+    }
+
+    private void makeDispatchFail() {
+        doThrow(new IllegalStateException("broker unreachable"))
+                .when(jmsTemplate).convertAndSend(anyString(), any(Object.class), any(MessagePostProcessor.class));
+    }
+
+    /**
+     * The listener runs after the transaction has committed, and Spring propagates what it throws to whoever called
+     * commit -- which would report committed work as failed. Nothing may escape.
+     */
+    @Test
+    void aDispatchFailureDoesNotEscapeTheAfterCommitListener() {
+        makeDispatchFail();
+
+        assertThatCode(() -> producer.onNotificationMessage(message())).doesNotThrowAnyException();
+    }
+
+    /**
+     * The guard belongs to the listener alone: a caller that dispatches directly is still inside its own operation
+     * and can act on the failure.
+     */
+    @Test
+    void aDirectDispatchStillReportsTheFailure() {
+        makeDispatchFail();
+
+        assertThatThrownBy(() -> producer.produceMessage(message()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("broker unreachable");
+    }
+
+    @Test
+    void aMessageWithNoRecipientIsNotDispatched() {
+        NotificationMessage withoutRecipients = new NotificationMessage(ResourceEvent.CERTIFICATE_DISCOVERED,
+                Resource.CERTIFICATE, UUID.randomUUID(), List.of(), null, null, null, null);
+
+        assertThatCode(() -> producer.produceMessage(withoutRecipients)).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/otilm/core/messaging/jms/producers/NotificationProducerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/producers/NotificationProducerTest.java
@@ -22,7 +22,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationProducerTest {
@@ -75,8 +74,9 @@ class NotificationProducerTest {
     @Test
     void aDirectDispatchStillReportsTheFailure() {
         makeDispatchFail();
+        NotificationMessage message = message();
 
-        assertThatThrownBy(() -> producer.produceMessage(message()))
+        assertThatThrownBy(() -> producer.produceMessage(message))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("broker unreachable");
     }

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactoryTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactoryTest.java
@@ -2,6 +2,7 @@ package com.otilm.core.service.handler.authority;
 
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.ConnectorInterfaceEntity;
+import com.otilm.api.exception.ValidationException;
 import com.otilm.core.exception.UnsupportedAuthorityVersionException;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +34,16 @@ class AuthorityProviderAdapterFactoryTest {
                 UnsupportedAuthorityVersionException.class,
                 () -> factory.forAuthority(auth));
         assertTrue(ex.getMessage().contains("v1"));
+    }
+
+    /**
+     * ValidationException rather than the factory's own type: the callers that can act on a missing authority already
+     * handle that one in place, so the failure never crosses a transactional proxy to doom the caller's transaction.
+     */
+    @Test
+    void rejectsNullAuthority() {
+        ValidationException ex = assertThrows(ValidationException.class, () -> factory.forAuthority(null));
+        assertTrue(ex.getMessage().contains("authority instance"));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactoryTest.java
+++ b/src/test/java/com/otilm/core/service/handler/authority/AuthorityProviderAdapterFactoryTest.java
@@ -2,7 +2,6 @@ package com.otilm.core.service.handler.authority;
 
 import com.otilm.core.dao.entity.AuthorityInstanceReference;
 import com.otilm.core.dao.entity.ConnectorInterfaceEntity;
-import com.otilm.api.exception.ValidationException;
 import com.otilm.core.exception.UnsupportedAuthorityVersionException;
 import org.junit.jupiter.api.Test;
 
@@ -37,12 +36,12 @@ class AuthorityProviderAdapterFactoryTest {
     }
 
     /**
-     * ValidationException rather than the factory's own type: the callers that can act on a missing authority already
-     * handle that one in place, so the failure never crosses a transactional proxy to doom the caller's transaction.
+     * A precondition, so a plain NullPointerException with a message rather than a domain type. Any type a caller
+     * catches would route a missing authority into whatever that caller's handler means by it.
      */
     @Test
     void rejectsNullAuthority() {
-        ValidationException ex = assertThrows(ValidationException.class, () -> factory.forAuthority(null));
+        NullPointerException ex = assertThrows(NullPointerException.class, () -> factory.forAuthority(null));
         assertTrue(ex.getMessage().contains("authority instance"));
     }
 


### PR DESCRIPTION
## Problem

Running a discovery with action triggers imported **zero** certificates. Every group logged `UnexpectedRollbackException` from `CertificateDiscoveredEventHandler`, each preceded by:

```
Execution 'test-action' of action 'test-execution-2' has not been performed. Reason:
Cannot invoke "AuthorityInstanceReference.getConnectorInterface()" because "authority" is null
```

## Root cause

`CertificateTriggerEvaluator` calls `CertificateServiceImpl.switchRaProfile`, which is class-level `@Transactional` and therefore joined the import transaction as `REQUIRED`. Selecting an adapter for an RA profile whose `AuthorityInstanceReference` is null threw an NPE, and an unchecked exception crossing a *participating* proxy marks the shared physical transaction rollback-only (`globalRollbackOnParticipationFailure` defaults to true).

`TriggerEvaluator.performActions` did catch the NPE — but a catch cannot unmark a rollback-only transaction, so the group's commit threw `UnexpectedRollbackException` afterwards. Every group evaluates the same trigger list, so one misconfigured execution cost the discovery every certificate it found.

## Changes

**Containment.** Action triggers now run after the import has committed, one transaction per trigger. Not inside the import transaction, because an execution reaches services that are class-level `@Transactional`; and one transaction each rather than one for the phase, because a poisoned transaction discards every write made in it — sharing one would lose the history, applied changes and notifications of the triggers that succeeded. A trigger failure is recorded in its own fresh transaction so it does not exist only in the log.

**A missing authority is a stated precondition.** `AuthorityProviderAdapterFactory.forAuthority` uses `Objects.requireNonNull`, and callers that can legitimately hold a null reference check it themselves and report it in their own terms. Selecting a catchable type instead routes the condition into whatever another class's handler means by it — which is how a missing authority could be reported as the authority refusing to cancel, stranding certificates mid-operation.

**`UnsupportedAuthorityVersionException` answers 400, not 500.** An unrecognised connector interface version is caller-fixable configuration. The response body is fixed rather than the exception's message, which names the authority and a version string the connector reported into an unvalidated column.

**Notification dispatch failures stay in the listener.** Spring propagates an exception thrown from an `AFTER_COMMIT` synchronization to whoever called commit, by which point the transaction has committed and cannot be undone — so an unreachable broker reported committed work as failed, here as a second trigger history contradicting the committed one. The retry template has already exhausted its attempts by then, so the log is the only useful disposition. A caller dispatching directly still sees the failure.

**Operator-facing text names the right transaction.** The failure classifier reported every `UnexpectedRollbackException` as the *import* transaction rolling back. On the trigger path the import has already committed, so only the trigger's own transaction can have — and that is the dominant failure shape there.

## Testing

- `EventHandlersITest` — 25 tests, including a failing action execution, a succeeding trigger applied across the transaction boundary, and a succeeding trigger kept when another fails.
- `CertificateDiscoveredEventHandlerContainmentTest` — 10 tests, including one transaction per trigger and a failure record surviving a lost trigger transaction.
- `DiscoveryFailureReasonTest` 16, `NotificationProducerTest` 3 (new), `AuthorityProviderAdapterFactoryTest` 6, architecture gates 20, `ContextSignatureGuardTest` 2. No new Spring context signature.

Two of the three new integration tests are honest about their limits: they pass with the containment removed, because no execution an integration test can configure fails *unchecked*. Their Javadoc says so. `aLostTriggerTransactionStillLeavesAFailureRecord` genuinely fails without its fix.

## Notes and follow-ups

- A notification is released as its own trigger commits, so it no longer implies that the triggers ordered after it have run. Documented at both the publish site and the trigger phase; accepted rather than deferred, since collecting messages until the phase ended would decouple each notification from its own trigger's success.
- The `AFTER_COMMIT` dispatch guard was applied to notifications only. Six other `@TransactionalEventListener` methods share the same latent flaw — worth a sweep.
- A per-trigger transaction spans the connector's `identify` HTTP call when a SET_FIELD execution switches the
  RA profile, so a DB transaction is held for the connector's full response time. Strictly narrower than
  before -- the whole import transaction used to span the same call -- but hoisting external calls out of
  `TriggerEvaluator` is its own change.
- Stale connector-scoped certificate META rows survive an authority force-delete: the force path detaches RA profiles and cleans only `object_type='AUTHORITY'` rows. Pre-existing and unrelated to this fix (that code path previously threw an NPE), and not expressible with today's `AttributeEngine` API, which has no connector-independent delete and no column marking `RA_PROFILE` as a row's source.

Related to #1897 (the preceding per-certificate import-integrity work) and #1900.

