### PR TITLE
Attribute certificate history events to the correct user

### DIFF
--- a/src/main/java/com/otilm/core/config/CustomAuditAware.java
+++ b/src/main/java/com/otilm/core/config/CustomAuditAware.java
@@ -1,5 +1,7 @@
 package com.otilm.core.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -9,11 +11,17 @@ import java.util.Optional;
 
 public class CustomAuditAware implements AuditorAware<String> {
 
+    private static final Logger logger = LoggerFactory.getLogger(CustomAuditAware.class);
+
     @Override
     public Optional<String> getCurrentAuditor() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null)
+        if (authentication == null) {
+            // Normal for system-originated work, but also what a lost identity looks like. Debug rather than warn:
+            // unauthenticated audited writes are frequent, so a warning here would be noise.
+            logger.debug("No authentication in context while resolving auditor; audited records will be attributed to the system user.");
             return Optional.of("system");
+        }
 
         if (authentication.getPrincipal() instanceof User) {
             String username = ((User) authentication.getPrincipal()).getUsername();

--- a/src/main/java/com/otilm/core/dao/entity/workflows/TriggerHistory.java
+++ b/src/main/java/com/otilm/core/dao/entity/workflows/TriggerHistory.java
@@ -64,7 +64,7 @@ public class TriggerHistory extends UniquelyIdentified {
     @Column(name = "triggered_by")
     private UUID triggeredBy;
 
-    @Column(name = "message")
+    @Column(name = "message", columnDefinition = "TEXT")
     private String message;
 
     @OneToMany(mappedBy = "triggerHistory", fetch = FetchType.LAZY)

--- a/src/main/java/com/otilm/core/dao/entity/workflows/TriggerHistoryRecord.java
+++ b/src/main/java/com/otilm/core/dao/entity/workflows/TriggerHistoryRecord.java
@@ -41,7 +41,7 @@ public class TriggerHistoryRecord extends UniquelyIdentified {
     @ToString.Exclude
     private Execution execution;
 
-    @Column(name = "message", length = 2000)
+    @Column(name = "message", columnDefinition = "TEXT")
     private String message;
 
     public TriggerHistoryRecordDto mapToDto() {

--- a/src/main/java/com/otilm/core/events/EventHandler.java
+++ b/src/main/java/com/otilm/core/events/EventHandler.java
@@ -290,9 +290,12 @@ public abstract class EventHandler<T extends UniquelyIdentifiedObject> implement
      * FAILED.
      */
     protected void handleUser(EventContext<T> context, UUID triggeredBy) {
-        if (!Objects.equals(installedUserUuid(context), triggeredBy)) {
+        // Read from the installed principal, never from EventContext.currentUserUuid: that memo is seeded from the
+        // message and can name a user the thread does not hold, which would skip a needed impersonation.
+        UUID installedUserUuid = AuthHelper.getActingUserUuidOrNull();
+        if (!Objects.equals(installedUserUuid, triggeredBy)) {
             try {
-                logger.debug("Changing user from {} to {}", context.getCurrentUserUuid(), triggeredBy);
+                logger.debug("Changing user from {} to {}", installedUserUuid, triggeredBy);
                 if (triggeredBy == null) {
                     SecurityContextHolder.clearContext();
                 } else {
@@ -308,11 +311,4 @@ public abstract class EventHandler<T extends UniquelyIdentifiedObject> implement
         }
     }
 
-    /**
-     * The user the thread actually holds. {@link EventContext#getCurrentUserUuid()} is seeded from the message, so it
-     * can name a user that was never installed, and trusting that memo alone would skip a needed impersonation.
-     */
-    private UUID installedUserUuid(EventContext<T> context) {
-        return SecurityContextHolder.getContext().getAuthentication() == null ? null : context.getCurrentUserUuid();
-    }
 }

--- a/src/main/java/com/otilm/core/events/EventHandler.java
+++ b/src/main/java/com/otilm/core/events/EventHandler.java
@@ -4,6 +4,7 @@ import com.otilm.api.exception.EventException;
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.attribute.RequestAttribute;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.logging.enums.ActorType;
 import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.api.model.core.workflows.EventStatus;
 import com.otilm.core.dao.entity.UniquelyIdentifiedObject;
@@ -293,22 +294,33 @@ public abstract class EventHandler<T extends UniquelyIdentifiedObject> implement
         // Read from the installed principal, never from EventContext.currentUserUuid: that memo is seeded from the
         // message and can name a user the thread does not hold, which would skip a needed impersonation.
         UUID installedUserUuid = AuthHelper.getActingUserUuidOrNull();
-        if (!Objects.equals(installedUserUuid, triggeredBy)) {
-            try {
-                logger.debug("Changing user from {} to {}", installedUserUuid, triggeredBy);
-                if (triggeredBy == null) {
-                    SecurityContextHolder.clearContext();
-                } else {
-                    authHelper.authenticateAsUser(triggeredBy);
-                    requireImpersonated(triggeredBy);
-                }
-
-                context.setCurrentUserUuid(triggeredBy);
-            } catch (ValidationException e) {
-                // anonymous user
-                SecurityContextHolder.clearContext();
-                context.setCurrentUserUuid(null);
+        if (Objects.equals(installedUserUuid, triggeredBy)) {
+            // No switch needed, but the actor MDC still has to name the identity in effect: the loop clears it on
+            // entry, so without this the first trigger owned by the acting user would be audited with no actor at all.
+            if (triggeredBy != null) {
+                LoggingHelper.putActorInfoWhenNull(ActorType.USER, triggeredBy.toString(), null);
             }
+            return;
+        }
+
+        try {
+            logger.debug("Changing user from {} to {}", installedUserUuid, triggeredBy);
+            // Drop the previous owner's attribution before installing the next: authenticateAsUser only overwrites the
+            // actor uuid, and an ownerless trigger writes no actor at all, so a stale one would otherwise survive.
+            LoggingHelper.clearActorInfo();
+            if (triggeredBy == null) {
+                SecurityContextHolder.clearContext();
+            } else {
+                authHelper.authenticateAsUser(triggeredBy);
+                requireImpersonated(triggeredBy);
+            }
+
+            context.setCurrentUserUuid(triggeredBy);
+        } catch (ValidationException e) {
+            // anonymous user
+            SecurityContextHolder.clearContext();
+            LoggingHelper.clearActorInfo();
+            context.setCurrentUserUuid(null);
         }
     }
 
@@ -320,6 +332,9 @@ public abstract class EventHandler<T extends UniquelyIdentifiedObject> implement
      */
     private void requireImpersonated(UUID triggeredBy) {
         if (!triggeredBy.equals(AuthHelper.getActingUserUuidOrNull())) {
+            // Leave nothing installed for the caller to run under, independently of the loop's restore.
+            SecurityContextHolder.clearContext();
+            LoggingHelper.clearActorInfo();
             throw new PlatformAuthenticationException(
                     "User %s that associated the trigger could not be authenticated".formatted(triggeredBy));
         }

--- a/src/main/java/com/otilm/core/events/EventHandler.java
+++ b/src/main/java/com/otilm/core/events/EventHandler.java
@@ -18,6 +18,7 @@ import com.otilm.core.evaluator.TriggerEvaluator;
 import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.messaging.jms.producers.EventProducer;
 import com.otilm.core.messaging.model.EventMessage;
+import com.otilm.core.security.authn.PlatformAuthenticationException;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.util.AuthHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -284,10 +285,9 @@ public abstract class EventHandler<T extends UniquelyIdentifiedObject> implement
     }
 
     /**
-     * A deleted association owner or an unreachable auth service is deliberately not degraded here, unlike the
-     * per-message failure in {@code EventListener}: that costs only attribution, whereas a trigger evaluated without
-     * its owner's identity would run its actions under other permissions. The exception escapes, marking the event
-     * FAILED.
+     * A trigger owner that cannot be impersonated is deliberately not degraded here, unlike the per-message failure in
+     * {@code EventListener}: that costs only attribution, whereas a trigger evaluated without its owner's identity
+     * would run its actions under other permissions. The exception escapes, marking the event FAILED.
      */
     protected void handleUser(EventContext<T> context, UUID triggeredBy) {
         // Read from the installed principal, never from EventContext.currentUserUuid: that memo is seeded from the
@@ -300,6 +300,7 @@ public abstract class EventHandler<T extends UniquelyIdentifiedObject> implement
                     SecurityContextHolder.clearContext();
                 } else {
                     authHelper.authenticateAsUser(triggeredBy);
+                    requireImpersonated(triggeredBy);
                 }
 
                 context.setCurrentUserUuid(triggeredBy);
@@ -311,4 +312,16 @@ public abstract class EventHandler<T extends UniquelyIdentifiedObject> implement
         }
     }
 
+
+    /**
+     * Only an unreachable auth service makes {@code authenticateAsUser} throw. A deleted or disabled owner instead has
+     * the auth service answer "not authenticated", which the client turns into an anonymous principal - so the call
+     * returns normally and the trigger would otherwise evaluate under an identity that is neither its owner nor absent.
+     */
+    private void requireImpersonated(UUID triggeredBy) {
+        if (!triggeredBy.equals(AuthHelper.getActingUserUuidOrNull())) {
+            throw new PlatformAuthenticationException(
+                    "User %s that associated the trigger could not be authenticated".formatted(triggeredBy));
+        }
+    }
 }

--- a/src/main/java/com/otilm/core/events/EventHandler.java
+++ b/src/main/java/com/otilm/core/events/EventHandler.java
@@ -15,6 +15,7 @@ import com.otilm.core.dao.repository.SecurityFilterRepository;
 import com.otilm.core.dao.repository.workflows.EventHistoryRepository;
 import com.otilm.core.dao.repository.workflows.TriggerAssociationRepository;
 import com.otilm.core.evaluator.TriggerEvaluator;
+import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.messaging.jms.producers.EventProducer;
 import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.security.authz.SecuredUUID;
@@ -24,14 +25,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 @Component
 @Transactional
@@ -202,6 +206,13 @@ public abstract class EventHandler<T extends UniquelyIdentifiedObject> implement
     }
 
     protected void evaluateTriggers(EventContext<T> context, EventContextTriggers eventTriggers, T resourceObject, Object eventData, EventHistory eventHistory, List<RequestAttribute> pendingCustomAttributes) {
+        withActingUserRestored(context, () -> {
+            evaluateTriggerAssociations(context, eventTriggers, resourceObject, eventData, eventHistory, pendingCustomAttributes);
+            return null;
+        });
+    }
+
+    private void evaluateTriggerAssociations(EventContext<T> context, EventContextTriggers eventTriggers, T resourceObject, Object eventData, EventHistory eventHistory, List<RequestAttribute> pendingCustomAttributes) {
         for (TriggerAssociation triggerAssociation : eventTriggers.getTriggers()) {
             handleUser(context, triggerAssociation.getTriggeredBy());
             Trigger trigger = triggerAssociation.getTrigger();
@@ -219,6 +230,11 @@ public abstract class EventHandler<T extends UniquelyIdentifiedObject> implement
     }
 
     protected boolean evaluateIgnoreTriggers(EventContext<T> context, EventContextTriggers eventTriggers, T resourceObject, Object eventData, EventHistory eventHistory, List<RequestAttribute> pendingCustomAttributes) {
+        return withActingUserRestored(context, () ->
+                evaluateIgnoreTriggerAssociations(context, eventTriggers, resourceObject, eventData, eventHistory, pendingCustomAttributes));
+    }
+
+    private boolean evaluateIgnoreTriggerAssociations(EventContext<T> context, EventContextTriggers eventTriggers, T resourceObject, Object eventData, EventHistory eventHistory, List<RequestAttribute> pendingCustomAttributes) {
         // First, check the ignore triggers
         boolean isIgnored = false;
         for (TriggerAssociation triggerAssociation : eventTriggers.getIgnoreTriggers()) {
@@ -237,8 +253,44 @@ public abstract class EventHandler<T extends UniquelyIdentifiedObject> implement
         return isIgnored;
     }
 
+    /**
+     * Confines {@link #handleUser} impersonation to the trigger loop: trigger actions run as the association's owner,
+     * but the audited writes afterwards (Certificate, CertificateEventHistory) belong to the acting user, and JPA
+     * auditing stamps whoever is left in the context. Runs against a detached context because
+     * {@code authenticateAsUser} mutates the held one in place. Mirrors {@link AuthHelper#runAsSystem}.
+     */
+    private <R> R withActingUserRestored(EventContext<T> context, Supplier<R> triggerEvaluation) {
+        SecurityContext actingUserContext = SecurityContextHolder.getContext();
+        boolean actingUserWasAuthenticated = actingUserContext.getAuthentication() != null;
+        UUID actingUserUuid = context.getCurrentUserUuid();
+        Map<String, String> actingUserActor = LoggingHelper.snapshotActorInfo();
+        try {
+            SecurityContext detached = SecurityContextHolder.createEmptyContext();
+            detached.setAuthentication(actingUserContext.getAuthentication());
+            SecurityContextHolder.setContext(detached);
+            // Stops the acting user's actor name mixing with the trigger creator's uuid; restored in finally.
+            LoggingHelper.clearActorInfo();
+
+            return triggerEvaluation.get();
+        } finally {
+            if (actingUserWasAuthenticated) {
+                SecurityContextHolder.setContext(actingUserContext);
+            } else {
+                SecurityContextHolder.clearContext();
+            }
+            LoggingHelper.restoreActorInfo(actingUserActor);
+            context.setCurrentUserUuid(actingUserUuid);
+        }
+    }
+
+    /**
+     * A deleted association owner or an unreachable auth service is deliberately not degraded here, unlike the
+     * per-message failure in {@code EventListener}: that costs only attribution, whereas a trigger evaluated without
+     * its owner's identity would run its actions under other permissions. The exception escapes, marking the event
+     * FAILED.
+     */
     protected void handleUser(EventContext<T> context, UUID triggeredBy) {
-        if (!Objects.equals(context.getCurrentUserUuid(), triggeredBy)) {
+        if (!Objects.equals(installedUserUuid(context), triggeredBy)) {
             try {
                 logger.debug("Changing user from {} to {}", context.getCurrentUserUuid(), triggeredBy);
                 if (triggeredBy == null) {
@@ -254,5 +306,13 @@ public abstract class EventHandler<T extends UniquelyIdentifiedObject> implement
                 context.setCurrentUserUuid(null);
             }
         }
+    }
+
+    /**
+     * The user the thread actually holds. {@link EventContext#getCurrentUserUuid()} is seeded from the message, so it
+     * can name a user that was never installed, and trusting that memo alone would skip a needed impersonation.
+     */
+    private UUID installedUserUuid(EventContext<T> context) {
+        return SecurityContextHolder.getContext().getAuthentication() == null ? null : context.getCurrentUserUuid();
     }
 }

--- a/src/main/java/com/otilm/core/events/handlers/ApprovalClosedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/ApprovalClosedEventHandler.java
@@ -1,5 +1,6 @@
 package com.otilm.core.events.handlers;
 
+import com.otilm.api.model.client.approval.ApprovalStatusEnum;
 import com.otilm.api.model.common.events.data.ApprovalEventData;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.certificate.CertificateEvent;
@@ -16,6 +17,7 @@ import com.otilm.core.events.transaction.UpdateCertificateHistoryEvent;
 import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
+import com.otilm.core.util.AuthHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,7 +54,14 @@ public class ApprovalClosedEventHandler extends EventHandler<Approval> {
         }
     }
 
-    public static EventMessage constructEventMessage(UUID approvalUuid) {
-        return new EventMessage(ResourceEvent.APPROVAL_CLOSED, Resource.APPROVAL, approvalUuid, null);
+    /**
+     * Carries the approving or rejecting user so the certificate history row names them. A close as
+     * {@link ApprovalStatusEnum#EXPIRED} carries nobody: the expiry sweep runs as the scheduled job's user, who took
+     * no action on the approval, so that row is left to the system user.
+     */
+    public static EventMessage constructEventMessage(UUID approvalUuid, ApprovalStatusEnum closingStatus) {
+        UUID actingUser = closingStatus == ApprovalStatusEnum.EXPIRED ? null : AuthHelper.getActingUserUuidOrNull();
+        return new EventMessage(ResourceEvent.APPROVAL_CLOSED, Resource.APPROVAL, approvalUuid,
+                null, null, null, actingUser, null);
     }
 }

--- a/src/main/java/com/otilm/core/events/handlers/ApprovalRequestedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/ApprovalRequestedEventHandler.java
@@ -18,6 +18,7 @@ import com.otilm.core.events.transaction.UpdateCertificateHistoryEvent;
 import com.otilm.core.messaging.model.EventMessage;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
+import com.otilm.core.util.AuthHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,7 +64,21 @@ public class ApprovalRequestedEventHandler extends EventHandler<Approval> {
         }
     }
 
+    /**
+     * Falls back to the acting user. Callers that already know the requester should use
+     * {@link #constructEventMessage(UUID, ApprovalStepDto, UUID)} — the first step is produced on the
+     * actions-listener thread, which has no SecurityContext.
+     */
     public static EventMessage constructEventMessage(UUID approvalUuid, ApprovalStepDto approvalStepDto) {
-        return new EventMessage(ResourceEvent.APPROVAL_REQUESTED, Resource.APPROVAL, approvalUuid, approvalStepDto);
+        return constructEventMessage(approvalUuid, approvalStepDto, AuthHelper.getActingUserUuidOrNull());
+    }
+
+    /**
+     * Carries the requester so the certificate history row published by {@link #sendFollowUpEventsNotifications} names
+     * them; that row is written on a JMS listener thread with no SecurityContext of its own.
+     */
+    public static EventMessage constructEventMessage(UUID approvalUuid, ApprovalStepDto approvalStepDto, UUID requesterUuid) {
+        return new EventMessage(ResourceEvent.APPROVAL_REQUESTED, Resource.APPROVAL, approvalUuid,
+                null, null, approvalStepDto, requesterUuid, null);
     }
 }

--- a/src/main/java/com/otilm/core/events/handlers/CertificateStatusChangedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateStatusChangedEventHandler.java
@@ -51,6 +51,11 @@ public class CertificateStatusChangedEventHandler extends CertificateEventsHandl
         applicationEventPublisher.publishEvent(new UpdateCertificateHistoryEvent(certificate.getUuid(), CertificateEvent.UPDATE_VALIDATION_STATUS, CertificateEventStatus.SUCCESS, statusArrayData[0], statusArrayData[1]));
     }
 
+    /**
+     * Deliberately carries no acting user, unlike the upload and approval events: a validation-status change is
+     * produced by scheduled validation or revocation processing, not by a person, so its history row is the
+     * platform's and is correctly audited as the system user.
+     */
     public static EventMessage constructEventMessage(UUID certificateUuid, CertificateValidationStatus oldStatus, CertificateValidationStatus newStatus) {
         CertificateValidationStatus[] statusArrayData = new CertificateValidationStatus[] { oldStatus, newStatus };
         return new EventMessage(ResourceEvent.CERTIFICATE_STATUS_CHANGED, Resource.CERTIFICATE, certificateUuid, statusArrayData);

--- a/src/main/java/com/otilm/core/events/handlers/CertificateUploadedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateUploadedEventHandler.java
@@ -43,7 +43,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 
 @Component(ResourceEvent.Codes.CERTIFICATE_UPLOADED)
 public class CertificateUploadedEventHandler extends EventHandler<Certificate> {

--- a/src/main/java/com/otilm/core/events/handlers/CertificateUploadedEventHandler.java
+++ b/src/main/java/com/otilm/core/events/handlers/CertificateUploadedEventHandler.java
@@ -27,6 +27,7 @@ import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.messaging.model.NotificationRecipient;
 import com.otilm.core.service.CertificateEventHistoryInternalService;
 import com.otilm.core.service.CertificateInternalService;
+import com.otilm.core.util.AuthHelper;
 import com.otilm.core.util.CertificateUtil;
 import com.otilm.core.util.X509ObjectToString;
 import org.bouncycastle.asn1.x509.Extension;
@@ -42,6 +43,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 @Component(ResourceEvent.Codes.CERTIFICATE_UPLOADED)
 public class CertificateUploadedEventHandler extends EventHandler<Certificate> {
@@ -81,8 +83,18 @@ public class CertificateUploadedEventHandler extends EventHandler<Certificate> {
         this.certificateRepository = repository;
     }
 
+    /**
+     * Resolved on the producing thread — the consuming JMS listener thread has no SecurityContext, so the message is
+     * the only channel carrying the uploader to the audited writes.
+     * <p>
+     * This also widens authorization: the listener authenticates for the whole {@link #handleEvent} call, so trigger
+     * evaluation and the attribute engine's permission filters run as the uploader rather than unauthenticated.
+     * Nothing here is {@code @ExternalAuthorization}-gated, so an upload cannot newly be denied, and trigger actions
+     * still use the association owner's permissions via {@code handleUser}.
+     */
     public static EventMessage constructEventMessage(CertificateUploadEventMessageData data) {
-        return new EventMessage(ResourceEvent.CERTIFICATE_UPLOADED, Resource.CERTIFICATE, null, data);
+        return new EventMessage(ResourceEvent.CERTIFICATE_UPLOADED, Resource.CERTIFICATE, null,
+                null, null, data, AuthHelper.getActingUserUuidOrNull(), null);
     }
 
     @Override

--- a/src/main/java/com/otilm/core/messaging/jms/configuration/JmsConfig.java
+++ b/src/main/java/com/otilm/core/messaging/jms/configuration/JmsConfig.java
@@ -135,6 +135,9 @@ public class JmsConfig {
             factory.setSubscriptionDurable(true);
         }
         factory.setBackOff(createListenerBackOff(messagingProperties));
+        // Deliberately no transactionManager: the JPA transaction then commits inside processMessage, so AFTER_COMMIT
+        // listeners writing audited history rows still run under the message's identity, before
+        // AbstractJmsEndpointConfig clears it. Adding one would re-attribute those rows to the system user.
         return factory;
     }
 

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/AbstractJmsEndpointConfig.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/AbstractJmsEndpointConfig.java
@@ -1,5 +1,6 @@
 package com.otilm.core.messaging.jms.listeners;
 
+import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.messaging.jms.configuration.JmsRetryListener;
 import com.otilm.core.messaging.jms.configuration.MessagingProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,6 +14,7 @@ import org.springframework.jms.listener.MessageListenerContainer;
 import org.springframework.lang.NonNull;
 import org.springframework.messaging.MessagingException;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.io.IOException;
 
@@ -105,6 +107,11 @@ public abstract class AbstractJmsEndpointConfig<T> {
                     throw e; // Don't wrap, don't retry
                 } catch (Exception e) {
                     logger.error("Unexpected error in endpoint '{}'", endpointId, e);
+                } finally {
+                    // Invoker threads are long-lived: an identity installed for one message would otherwise be
+                    // inherited by the next and stamped onto its JPA-audited rows.
+                    SecurityContextHolder.clearContext();
+                    LoggingHelper.clearActorInfo();
                 }
 
                 return null;

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/EventListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/EventListener.java
@@ -2,11 +2,16 @@ package com.otilm.core.messaging.jms.listeners;
 
 import com.otilm.api.exception.EventException;
 import com.otilm.core.events.IEventHandler;
+import com.otilm.core.logging.LoggingHelper;
 import com.otilm.core.messaging.model.EventMessage;
+import com.otilm.core.security.authn.PlatformUserDetails;
+import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.util.AuthHelper;
 import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,7 +32,7 @@ public class EventListener implements MessageProcessor<EventMessage> {
     @Override
     public void processMessage(EventMessage eventMessage) {
         if (eventMessage.getUserUuid() != null) {
-            authHelper.authenticateAsUser(eventMessage.getUserUuid());
+            authenticateAsActingUser(eventMessage);
         }
 
         IEventHandler eventHandler = eventHandlers.get(eventMessage.getEvent().getCode());
@@ -36,6 +41,41 @@ public class EventListener implements MessageProcessor<EventMessage> {
         } catch (EventException e) {
             logger.error("Error in handling event {}: {}. Message: {}", eventMessage.getEvent().getLabel(), e.getMessage(), eventMessage);
         }
+    }
+
+    /**
+     * Attribution is best-effort: losing it beats losing the event, so a failure must not escape into the JMS retry
+     * template. Failure has two shapes — an unreachable auth service throws, while a user that no longer resolves
+     * comes back as {@link AuthenticationInfo#getAnonymousAuthenticationInfo()}, a principal auditing would stamp as
+     * "anonymousUser" and authorization would accept. Both are reduced to no identity at all.
+     */
+    private void authenticateAsActingUser(EventMessage eventMessage) {
+        try {
+            authHelper.authenticateAsUser(eventMessage.getUserUuid());
+            if (!resolvesToRealUser(SecurityContextHolder.getContext().getAuthentication())) {
+                logger.warn("User {} carried by event '{}' no longer resolves to a platform user. The event will be "
+                                + "handled without an identity and its audited records attributed to the system user.",
+                        eventMessage.getUserUuid(), eventMessage.getEvent().getLabel());
+                discardIdentity();
+            }
+        } catch (Exception e) {
+            logger.warn("Could not authenticate as user {} carried by event '{}'. The event will be handled without "
+                            + "an identity and its audited records attributed to the system user. Message: {}",
+                    eventMessage.getUserUuid(), eventMessage.getEvent().getLabel(), e.getMessage(), e);
+            discardIdentity();
+        }
+    }
+
+    private boolean resolvesToRealUser(Authentication authentication) {
+        return authentication != null
+                && authentication.getPrincipal() instanceof PlatformUserDetails userDetails
+                && userDetails.getUserUuid() != null;
+    }
+
+    /** Clears the actor MDC too — {@code authenticateAsUser} writes it before calling the auth service. */
+    private void discardIdentity() {
+        SecurityContextHolder.clearContext();
+        LoggingHelper.clearActorInfo();
     }
 
 }

--- a/src/main/java/com/otilm/core/service/impl/ApprovalServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/ApprovalServiceImpl.java
@@ -268,7 +268,10 @@ public class ApprovalServiceImpl implements ApprovalExternalService, ApprovalInt
                     || lastProcessedApprovalRecipient.getApprovalStep().getOrder() != nextApprovalStep.getOrder()) {
 
                 final Approval approval = findApprovalByUuid(approvalUuid);
-                final EventMessage approvalRequestedMessage = ApprovalRequestedEventHandler.constructEventMessage(approval.getUuid(), nextApprovalStep.mapToDto());
+                // The creator, not the acting user: the first step runs on the actions-listener thread, which has no
+                // SecurityContext.
+                final EventMessage approvalRequestedMessage = ApprovalRequestedEventHandler.constructEventMessage(
+                        approval.getUuid(), nextApprovalStep.mapToDto(), approval.getCreatorUuid());
                 TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                     @Override
                     public void afterCommit() {
@@ -324,7 +327,7 @@ public class ApprovalServiceImpl implements ApprovalExternalService, ApprovalInt
         actionMessage.setResourceAction(approval.getAction());
 
         // send event of approval closed
-        final EventMessage approvalClosedMessage = ApprovalClosedEventHandler.constructEventMessage(approval.getUuid());
+        final EventMessage approvalClosedMessage = ApprovalClosedEventHandler.constructEventMessage(approval.getUuid(), approvalStatus);
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override

--- a/src/main/java/com/otilm/core/util/AuthHelper.java
+++ b/src/main/java/com/otilm/core/util/AuthHelper.java
@@ -192,6 +192,22 @@ public class AuthHelper {
         }
     }
 
+    /**
+     * The acting user's UUID, or {@code null} when the thread carries no identifiable user. Resolved on the producing
+     * thread so attribution can travel with an async message, whose consumer has no SecurityContext of its own.
+     * <p>
+     * Absence has two shapes, neither an error: no authentication makes {@link #getUserIdentification()} throw, while
+     * an anonymous caller's principal is a real {@link PlatformUserDetails} whose userUuid is null. Protocol and
+     * system users (acme, scep, cmp, localhost) are ordinary auth-service users and are carried like any other.
+     */
+    public static UUID getActingUserUuidOrNull() {
+        try {
+            return NullUtil.parseUuidOrNull(getUserIdentification().getUuid());
+        } catch (ValidationException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+
     public static UserProfileDto getUserProfile() {
         UserProfileDto userProfileDto;
         try {

--- a/src/test/java/com/otilm/core/config/CustomAuditAwareTest.java
+++ b/src/test/java/com/otilm/core/config/CustomAuditAwareTest.java
@@ -1,0 +1,68 @@
+package com.otilm.core.config;
+
+import com.otilm.api.model.core.logging.enums.AuthMethod;
+import com.otilm.core.security.authn.PlatformAnonymousToken;
+import com.otilm.core.security.authn.PlatformAuthenticationToken;
+import com.otilm.core.security.authn.PlatformUserDetails;
+import com.otilm.core.security.authn.client.AuthenticationInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Characterization tests for the resolver behind every {@code @CreatedBy} / {@code @LastModifiedBy} column —
+ * it is what decides the author of a certificate and of its event-history rows.
+ */
+class CustomAuditAwareTest {
+
+    private final CustomAuditAware auditAware = new CustomAuditAware();
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void authenticatedUserIsTheAuditor() {
+        SecurityContextHolder.getContext().setAuthentication(new PlatformAuthenticationToken(
+                new PlatformUserDetails(new AuthenticationInfo(
+                        AuthMethod.USER_PROXY, UUID.randomUUID().toString(), "uploader", List.of()))));
+
+        assertThat(auditAware.getCurrentAuditor()).contains("uploader");
+    }
+
+    @Test
+    void unauthenticatedThreadIsAttributedToTheSystemUser() {
+        assertThat(auditAware.getCurrentAuditor()).contains("system");
+    }
+
+    /**
+     * The shape the platform's anonymous filter produces — a {@link PlatformUserDetails} with a null userUuid, taking
+     * the {@code instanceof User} branch. Also what is installed for a user that no longer resolves.
+     */
+    @Test
+    void platformAnonymousPrincipalIsAttributedToAnonymousUser() {
+        SecurityContextHolder.getContext().setAuthentication(new PlatformAnonymousToken(
+                UUID.randomUUID().toString(),
+                new PlatformUserDetails(AuthenticationInfo.getAnonymousAuthenticationInfo()),
+                AuthenticationInfo.getAnonymousAuthenticationInfo().getAuthorities()));
+
+        assertThat(auditAware.getCurrentAuditor()).contains("anonymousUser");
+    }
+
+    /** The string-principal branch, kept for the connector self-registration case it was written for. */
+    @Test
+    void stringAnonymousPrincipalIsAttributedToAnonymousUser() {
+        SecurityContextHolder.getContext().setAuthentication(new AnonymousAuthenticationToken(
+                "key", "anonymousUser", List.of(new SimpleGrantedAuthority("ANONYMOUS"))));
+
+        assertThat(auditAware.getCurrentAuditor()).contains("anonymousUser");
+    }
+}

--- a/src/test/java/com/otilm/core/config/CustomAuditAwareTest.java
+++ b/src/test/java/com/otilm/core/config/CustomAuditAwareTest.java
@@ -57,7 +57,7 @@ class CustomAuditAwareTest {
         assertThat(auditAware.getCurrentAuditor()).contains("anonymousUser");
     }
 
-    /** The string-principal branch, kept for the connector self-registration case it was written for. */
+    /** The string-principal branch supports connector self-registration. */
     @Test
     void stringAnonymousPrincipalIsAttributedToAnonymousUser() {
         SecurityContextHolder.getContext().setAuthentication(new AnonymousAuthenticationToken(

--- a/src/test/java/com/otilm/core/events/EventHandlerTriggerIdentityTest.java
+++ b/src/test/java/com/otilm/core/events/EventHandlerTriggerIdentityTest.java
@@ -150,6 +150,26 @@ class EventHandlerTriggerIdentityTest {
     }
 
     /**
+     * The memo can name a different user than the thread actually holds, so it must not decide whether impersonation
+     * is needed — only the installed principal can.
+     */
+    @Test
+    void impersonatesWhenTheMemoDisagreesWithTheInstalledPrincipal() {
+        UUID triggerCreatorUuid = UUID.randomUUID();
+        authenticateAs(UUID.randomUUID(), UPLOADER);
+        impersonateOnAuthenticateAsUser(triggerCreatorUuid);
+
+        TestEventHandler handler = handler();
+        // memo claims the trigger creator is already installed, while the thread actually holds the uploader
+        EventContext<Certificate> context = contextFor(triggerCreatorUuid);
+        context.getPlatformTriggers().getTriggers().add(associationCreatedBy(triggerCreatorUuid));
+
+        handler.evaluateTriggers(context, context.getPlatformTriggers(), new Certificate(), null, null);
+
+        verify(authHelper).authenticateAsUser(triggerCreatorUuid);
+    }
+
+    /**
      * {@code currentUserUuid} is seeded from the message, so it can name a user the thread never held — the listener
      * degrades to no identity when the carried user fails to authenticate.
      */

--- a/src/test/java/com/otilm/core/events/EventHandlerTriggerIdentityTest.java
+++ b/src/test/java/com/otilm/core/events/EventHandlerTriggerIdentityTest.java
@@ -1,0 +1,260 @@
+package com.otilm.core.events;
+
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.logging.enums.ActorType;
+import com.otilm.api.model.core.logging.enums.AuthMethod;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.logging.LoggingHelper;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.workflows.Trigger;
+import com.otilm.core.dao.entity.workflows.TriggerAssociation;
+import com.otilm.core.dao.entity.workflows.TriggerHistory;
+import com.otilm.core.dao.repository.SecurityFilterRepository;
+import com.otilm.core.evaluator.TriggerEvaluator;
+import com.otilm.core.messaging.model.EventMessage;
+import com.otilm.core.security.authn.PlatformAuthenticationToken;
+import com.otilm.core.security.authn.PlatformUserDetails;
+import com.otilm.core.security.authn.client.AuthenticationInfo;
+import com.otilm.core.util.AuthHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Trigger processing runs as the association's creator, so the automation carries its owner's permissions. That
+ * impersonation must end with the loop: the audited writes afterwards (Certificate, CertificateEventHistory) belong
+ * to the acting user, and JPA auditing reads whoever is left in the context.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class EventHandlerTriggerIdentityTest {
+
+    private static final String UPLOADER = "uploader";
+    private static final String TRIGGER_CREATOR = "trigger-creator";
+
+    private String usernameInsideLoop;
+    private String actorNameInsideLoop;
+
+    @Mock
+    private AuthHelper authHelper;
+
+    @Mock
+    private TriggerEvaluator<Certificate> triggerEvaluator;
+
+    @Mock
+    private SecurityFilterRepository<Certificate, UUID> repository;
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+        LoggingHelper.clearActorInfo();
+    }
+
+    @Test
+    void actingUserIsRestoredAfterTriggersAreEvaluated() {
+        UUID uploaderUuid = UUID.randomUUID();
+        UUID triggerCreatorUuid = UUID.randomUUID();
+        authenticateAs(uploaderUuid, UPLOADER);
+        impersonateOnAuthenticateAsUser(triggerCreatorUuid);
+
+        TestEventHandler handler = handler();
+        EventContext<Certificate> context = contextFor(uploaderUuid);
+        context.getPlatformTriggers().getTriggers().add(associationCreatedBy(triggerCreatorUuid));
+
+        handler.evaluateTriggers(context, context.getPlatformTriggers(), new Certificate(), null, null);
+
+        assertThat(currentUsername())
+                .as("identity after the trigger loop must be the acting user, not the trigger's creator")
+                .isEqualTo(UPLOADER);
+    }
+
+    @Test
+    void actingUserIsRestoredAfterIgnoreTriggersAreEvaluated() throws Exception {
+        UUID uploaderUuid = UUID.randomUUID();
+        UUID triggerCreatorUuid = UUID.randomUUID();
+        authenticateAs(uploaderUuid, UPLOADER);
+        impersonateOnAuthenticateAsUser(triggerCreatorUuid);
+        when(triggerEvaluator.evaluateTrigger(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(mock(TriggerHistory.class));
+
+        TestEventHandler handler = handler();
+        EventContext<Certificate> context = contextFor(uploaderUuid);
+        context.getPlatformTriggers().getIgnoreTriggers().add(associationCreatedBy(triggerCreatorUuid));
+
+        handler.evaluateIgnoreTriggers(context, context.getPlatformTriggers(), new Certificate(), null, null);
+
+        assertThat(currentUsername())
+                .as("identity after the ignore-trigger loop must be the acting user")
+                .isEqualTo(UPLOADER);
+    }
+
+    /** Without this, an implementation that cleared the context and never impersonated would pass every other test. */
+    @Test
+    void triggersAreEvaluatedAsTheAssociationCreator() throws Exception {
+        UUID uploaderUuid = UUID.randomUUID();
+        UUID triggerCreatorUuid = UUID.randomUUID();
+        authenticateAs(uploaderUuid, UPLOADER);
+        impersonateOnAuthenticateAsUser(triggerCreatorUuid);
+        recordIdentityInsideLoop();
+
+        TestEventHandler handler = handler();
+        EventContext<Certificate> context = contextFor(uploaderUuid);
+        context.getPlatformTriggers().getTriggers().add(associationCreatedBy(triggerCreatorUuid));
+
+        handler.evaluateTriggers(context, context.getPlatformTriggers(), new Certificate(), null, null);
+
+        assertThat(usernameInsideLoop)
+                .as("the trigger itself must be evaluated as its creator, not as the acting user")
+                .isEqualTo(TRIGGER_CREATOR);
+    }
+
+    /** {@code authenticateAsUser} writes the actor uuid with a null name, so a stale name would mix with it. */
+    @Test
+    void actingUsersActorAttributionDoesNotBleedIntoTheTriggerLoop() throws Exception {
+        UUID uploaderUuid = UUID.randomUUID();
+        UUID triggerCreatorUuid = UUID.randomUUID();
+        authenticateAs(uploaderUuid, UPLOADER);
+        LoggingHelper.putActorInfoWhenNull(ActorType.USER, uploaderUuid.toString(), UPLOADER);
+        impersonateOnAuthenticateAsUser(triggerCreatorUuid);
+        recordActorNameInsideLoop();
+
+        TestEventHandler handler = handler();
+        EventContext<Certificate> context = contextFor(uploaderUuid);
+        context.getPlatformTriggers().getTriggers().add(associationCreatedBy(triggerCreatorUuid));
+
+        handler.evaluateTriggers(context, context.getPlatformTriggers(), new Certificate(), null, null);
+
+        assertThat(actorNameInsideLoop)
+                .as("the acting user's actor name must not remain while the trigger creator's uuid is installed")
+                .isNotEqualTo(UPLOADER);
+        assertThat(LoggingHelper.getActorInfo().name())
+                .as("the acting user's actor must be restored after the loop")
+                .isEqualTo(UPLOADER);
+    }
+
+    /**
+     * {@code currentUserUuid} is seeded from the message, so it can name a user the thread never held — the listener
+     * degrades to no identity when the carried user fails to authenticate.
+     */
+    @Test
+    void impersonatesEvenWhenTheContextMemoAlreadyNamesTheTriggerCreator() {
+        UUID triggerCreatorUuid = UUID.randomUUID();
+        SecurityContextHolder.clearContext();
+        impersonateOnAuthenticateAsUser(triggerCreatorUuid);
+
+        TestEventHandler handler = handler();
+        EventContext<Certificate> context = contextFor(triggerCreatorUuid);
+        context.getPlatformTriggers().getTriggers().add(associationCreatedBy(triggerCreatorUuid));
+
+        handler.evaluateTriggers(context, context.getPlatformTriggers(), new Certificate(), null, null);
+
+        verify(authHelper)
+                .authenticateAsUser(triggerCreatorUuid);
+    }
+
+    @Test
+    void unauthenticatedCallerStaysUnauthenticatedAfterTriggersAreEvaluated() {
+        UUID triggerCreatorUuid = UUID.randomUUID();
+        impersonateOnAuthenticateAsUser(triggerCreatorUuid);
+
+        TestEventHandler handler = handler();
+        EventContext<Certificate> context = contextFor(null);
+        context.getPlatformTriggers().getTriggers().add(associationCreatedBy(triggerCreatorUuid));
+
+        handler.evaluateTriggers(context, context.getPlatformTriggers(), new Certificate(), null, null);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication())
+                .as("an event with no acting user must not inherit the trigger creator's identity")
+                .isNull();
+    }
+
+    private void recordIdentityInsideLoop() throws Exception {
+        doAnswer(invocation -> {
+            usernameInsideLoop = currentUsername();
+            return null;
+        }).when(triggerEvaluator).evaluateTrigger(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    private void recordActorNameInsideLoop() throws Exception {
+        doAnswer(invocation -> {
+            actorNameInsideLoop = LoggingHelper.hasActorInfo() ? LoggingHelper.getActorInfo().name() : null;
+            return null;
+        }).when(triggerEvaluator).evaluateTrigger(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    private TestEventHandler handler() {
+        TestEventHandler handler = new TestEventHandler(repository, triggerEvaluator);
+        handler.setAuthHelper(authHelper);
+        return handler;
+    }
+
+    private EventContext<Certificate> contextFor(UUID actingUserUuid) {
+        EventMessage message = new EventMessage(ResourceEvent.CERTIFICATE_UPLOADED, Resource.CERTIFICATE,
+                null, null, null, null, actingUserUuid, null);
+        return new EventContext<>(message, triggerEvaluator, new Certificate(), null);
+    }
+
+    private TriggerAssociation associationCreatedBy(UUID triggeredBy) {
+        Trigger trigger = mock(Trigger.class);
+        when(trigger.getName()).thenReturn("SomeTrigger");
+
+        TriggerAssociation association = mock(TriggerAssociation.class);
+        when(association.getTriggeredBy()).thenReturn(triggeredBy);
+        when(association.getTrigger()).thenReturn(trigger);
+        return association;
+    }
+
+    private void impersonateOnAuthenticateAsUser(UUID userUuid) {
+        doAnswer(invocation -> {
+            authenticateAs(userUuid, TRIGGER_CREATOR);
+            return null;
+        }).when(authHelper).authenticateAsUser(userUuid);
+    }
+
+    private void authenticateAs(UUID userUuid, String username) {
+        AuthenticationInfo info =
+                new AuthenticationInfo(AuthMethod.USER_PROXY, userUuid.toString(), username, List.of());
+        SecurityContextHolder.getContext()
+                .setAuthentication(new PlatformAuthenticationToken(new PlatformUserDetails(info)));
+    }
+
+    private String currentUsername() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication == null ? null : ((User) authentication.getPrincipal()).getUsername();
+    }
+
+    private static class TestEventHandler extends EventHandler<Certificate> {
+
+        TestEventHandler(SecurityFilterRepository<Certificate, UUID> repository,
+                         TriggerEvaluator<Certificate> triggerEvaluator) {
+            super(repository, triggerEvaluator);
+        }
+
+        @Override
+        protected Object getEventData(Certificate object, Object eventMessageData) {
+            return null;
+        }
+
+        @Override
+        public void handleEvent(EventMessage eventMessage) {
+            // not exercised by these tests
+        }
+    }
+}

--- a/src/test/java/com/otilm/core/events/EventHandlerTriggerIdentityTest.java
+++ b/src/test/java/com/otilm/core/events/EventHandlerTriggerIdentityTest.java
@@ -164,7 +164,6 @@ class EventHandlerTriggerIdentityTest {
         impersonateOnAuthenticateAsUser(triggerCreatorUuid);
 
         TestEventHandler handler = handler();
-        // memo claims the trigger creator is already installed, while the thread actually holds the uploader
         EventContext<Certificate> context = contextFor(triggerCreatorUuid);
         context.getPlatformTriggers().getTriggers().add(associationCreatedBy(triggerCreatorUuid));
 
@@ -262,6 +261,50 @@ class EventHandlerTriggerIdentityTest {
         handler.evaluateTriggers(context, context.getPlatformTriggers(), new Certificate(), null, null);
 
         assertThat(actorUuidsSeen).containsExactly(firstOwner.toString(), secondOwner.toString());
+    }
+
+    /** An association owned by the acting user needs no switch, but its trigger must still be audited as them. */
+    @Test
+    void actorAttributionIsRestatedWhenTheOwnerIsAlreadyInstalled() throws Exception {
+        UUID uploaderUuid = UUID.randomUUID();
+        authenticateAs(uploaderUuid, UPLOADER);
+        List<String> actorUuidsSeen = recordActorUuidsInsideLoop();
+
+        TestEventHandler handler = handler();
+        EventContext<Certificate> context = contextFor(uploaderUuid);
+        context.getPlatformTriggers().getTriggers().add(associationCreatedBy(uploaderUuid));
+
+        handler.evaluateTriggers(context, context.getPlatformTriggers(), new Certificate(), null, null);
+
+        assertThat(actorUuidsSeen).containsExactly(uploaderUuid.toString());
+    }
+
+    /** An ownerless association clears the principal, so it must clear the previous owner's attribution too. */
+    @Test
+    void actorAttributionIsClearedWhenAnOwnerlessAssociationFollowsAnOwnedOne() throws Exception {
+        UUID ownerUuid = UUID.randomUUID();
+        authenticateAs(UUID.randomUUID(), UPLOADER);
+        impersonateOnAuthenticateAsUser(ownerUuid);
+        List<String> actorUuidsSeen = recordActorUuidsInsideLoop();
+
+        TestEventHandler handler = handler();
+        EventContext<Certificate> context = contextFor(null);
+        context.getPlatformTriggers().getTriggers().add(associationCreatedBy(ownerUuid));
+        context.getPlatformTriggers().getTriggers().add(associationCreatedBy(null));
+
+        handler.evaluateTriggers(context, context.getPlatformTriggers(), new Certificate(), null, null);
+
+        assertThat(actorUuidsSeen).containsExactly(ownerUuid.toString(), null);
+    }
+
+    private List<String> recordActorUuidsInsideLoop() throws Exception {
+        List<String> seen = new ArrayList<>();
+        doAnswer(invocation -> {
+            seen.add(LoggingHelper.hasActorInfo() && LoggingHelper.getActorInfo().uuid() != null
+                    ? LoggingHelper.getActorInfo().uuid().toString() : null);
+            return null;
+        }).when(triggerEvaluator).evaluateTrigger(any(), any(), any(), any(), any(), any(), any());
+        return seen;
     }
 
     private void recordIdentityInsideLoop() throws Exception {

--- a/src/test/java/com/otilm/core/events/EventHandlerTriggerIdentityTest.java
+++ b/src/test/java/com/otilm/core/events/EventHandlerTriggerIdentityTest.java
@@ -12,6 +12,7 @@ import com.otilm.core.dao.entity.workflows.TriggerHistory;
 import com.otilm.core.dao.repository.SecurityFilterRepository;
 import com.otilm.core.evaluator.TriggerEvaluator;
 import com.otilm.core.messaging.model.EventMessage;
+import com.otilm.core.security.authn.PlatformAuthenticationException;
 import com.otilm.core.security.authn.PlatformAuthenticationToken;
 import com.otilm.core.security.authn.PlatformUserDetails;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
@@ -27,13 +28,16 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -205,6 +209,61 @@ class EventHandlerTriggerIdentityTest {
                 .isNull();
     }
 
+    /**
+     * A deleted or disabled owner does not make {@code authenticateAsUser} throw — the auth service answers "not
+     * authenticated" and the client installs an anonymous principal. Evaluating the trigger's actions under that
+     * principal is the wrong-permissions outcome the impersonation exists to prevent.
+     */
+    @Test
+    void failsRatherThanEvaluatingATriggerWhoseOwnerNoLongerResolves() throws Exception {
+        UUID deletedOwnerUuid = UUID.randomUUID();
+        authenticateAs(UUID.randomUUID(), UPLOADER);
+        doAnswer(invocation -> {
+            AuthenticationInfo anonymous = AuthenticationInfo.getAnonymousAuthenticationInfo();
+            SecurityContextHolder.getContext()
+                    .setAuthentication(new PlatformAuthenticationToken(new PlatformUserDetails(anonymous)));
+            return null;
+        }).when(authHelper).authenticateAsUser(deletedOwnerUuid);
+
+        TestEventHandler handler = handler();
+        EventContext<Certificate> context = contextFor(null);
+        context.getPlatformTriggers().getTriggers().add(associationCreatedBy(deletedOwnerUuid));
+
+        assertThatThrownBy(() ->
+                handler.evaluateTriggers(context, context.getPlatformTriggers(), new Certificate(), null, null))
+                .as("the event must fail rather than evaluate the trigger under an anonymous principal")
+                .isInstanceOf(PlatformAuthenticationException.class);
+
+        verify(triggerEvaluator, never()).evaluateTrigger(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    /**
+     * Two associations owned by different users: the second must not inherit the first owner's actor attribution.
+     */
+    @Test
+    void actorAttributionDoesNotCarryBetweenAssociationOwners() throws Exception {
+        UUID firstOwner = UUID.randomUUID();
+        UUID secondOwner = UUID.randomUUID();
+        authenticateAs(UUID.randomUUID(), UPLOADER);
+        impersonateOnAuthenticateAsUser(firstOwner);
+        impersonateOnAuthenticateAsUser(secondOwner);
+        List<String> actorUuidsSeen = new ArrayList<>();
+        doAnswer(invocation -> {
+            actorUuidsSeen.add(LoggingHelper.hasActorInfo() && LoggingHelper.getActorInfo().uuid() != null
+                    ? LoggingHelper.getActorInfo().uuid().toString() : null);
+            return null;
+        }).when(triggerEvaluator).evaluateTrigger(any(), any(), any(), any(), any(), any(), any());
+
+        TestEventHandler handler = handler();
+        EventContext<Certificate> context = contextFor(null);
+        context.getPlatformTriggers().getTriggers().add(associationCreatedBy(firstOwner));
+        context.getPlatformTriggers().getTriggers().add(associationCreatedBy(secondOwner));
+
+        handler.evaluateTriggers(context, context.getPlatformTriggers(), new Certificate(), null, null);
+
+        assertThat(actorUuidsSeen).containsExactly(firstOwner.toString(), secondOwner.toString());
+    }
+
     private void recordIdentityInsideLoop() throws Exception {
         doAnswer(invocation -> {
             usernameInsideLoop = currentUsername();
@@ -241,8 +300,10 @@ class EventHandlerTriggerIdentityTest {
         return association;
     }
 
+    /** Mirrors production {@code AuthHelper.authenticateAsUser}: installs the principal AND writes the actor MDC. */
     private void impersonateOnAuthenticateAsUser(UUID userUuid) {
         doAnswer(invocation -> {
+            LoggingHelper.putActorInfoWhenNull(ActorType.USER, userUuid.toString(), null);
             authenticateAs(userUuid, TRIGGER_CREATOR);
             return null;
         }).when(authHelper).authenticateAsUser(userUuid);

--- a/src/test/java/com/otilm/core/events/handlers/ApprovalEventMessageTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/ApprovalEventMessageTest.java
@@ -1,0 +1,104 @@
+package com.otilm.core.events.handlers;
+
+import com.otilm.api.model.client.approval.ApprovalStatusEnum;
+import com.otilm.api.model.client.approvalprofile.ApprovalStepDto;
+import com.otilm.api.model.core.logging.enums.AuthMethod;
+import com.otilm.core.messaging.model.EventMessage;
+import com.otilm.core.security.authn.PlatformAuthenticationToken;
+import com.otilm.core.security.authn.PlatformUserDetails;
+import com.otilm.core.security.authn.client.AuthenticationInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Both approval events publish an {@code UpdateCertificateHistoryEvent}, so the certificate's history gains a row
+ * for the request and for the close. Those rows are written on a JMS listener thread, so the acting user has to
+ * travel in the event message or the row ends up attributed to the system user.
+ */
+class ApprovalEventMessageTest {
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    /**
+     * The "Approval requested" row is written only for the first step, produced from {@code createApproval} on the
+     * actions-listener thread, which returns before that listener authenticates — so the requester must be supplied.
+     */
+    @Test
+    void requestedEventCarriesTheSuppliedRequesterOnAnUnauthenticatedThread() {
+        UUID requester = UUID.randomUUID();
+        SecurityContextHolder.clearContext();
+
+        EventMessage message = ApprovalRequestedEventHandler.constructEventMessage(
+                UUID.randomUUID(), new ApprovalStepDto(), requester);
+
+        assertThat(message.getUserUuid()).isEqualTo(requester);
+    }
+
+    @Test
+    void requestedEventFallsBackToTheActingUserWhenNoRequesterIsSupplied() {
+        UUID requester = UUID.randomUUID();
+        authenticateAs(requester);
+
+        EventMessage message =
+                ApprovalRequestedEventHandler.constructEventMessage(UUID.randomUUID(), new ApprovalStepDto());
+
+        assertThat(message.getUserUuid()).isEqualTo(requester);
+    }
+
+    @Test
+    void closedEventCarriesTheApprovingUser() {
+        UUID approver = UUID.randomUUID();
+        authenticateAs(approver);
+
+        EventMessage message = ApprovalClosedEventHandler.constructEventMessage(
+                UUID.randomUUID(), ApprovalStatusEnum.APPROVED);
+
+        assertThat(message.getUserUuid()).isEqualTo(approver);
+    }
+
+    @Test
+    void closedEventCarriesTheRejectingUser() {
+        UUID rejecter = UUID.randomUUID();
+        authenticateAs(rejecter);
+
+        EventMessage message = ApprovalClosedEventHandler.constructEventMessage(
+                UUID.randomUUID(), ApprovalStatusEnum.REJECTED);
+
+        assertThat(message.getUserUuid()).isEqualTo(rejecter);
+    }
+
+    /** An approval that lapsed was closed by nobody; the sweep's job user took no action on it. */
+    @Test
+    void expiredEventCarriesNoUserEvenWhenTheSweepIsAuthenticated() {
+        authenticateAs(UUID.randomUUID());
+
+        EventMessage message = ApprovalClosedEventHandler.constructEventMessage(
+                UUID.randomUUID(), ApprovalStatusEnum.EXPIRED);
+
+        assertThat(message.getUserUuid()).isNull();
+    }
+
+    @Test
+    void eventsCarryNoUserWhenNobodyIsAuthenticated() {
+        assertThat(ApprovalRequestedEventHandler
+                .constructEventMessage(UUID.randomUUID(), new ApprovalStepDto()).getUserUuid()).isNull();
+        assertThat(ApprovalClosedEventHandler
+                .constructEventMessage(UUID.randomUUID(), ApprovalStatusEnum.APPROVED).getUserUuid()).isNull();
+    }
+
+    private void authenticateAs(UUID userUuid) {
+        AuthenticationInfo info =
+                new AuthenticationInfo(AuthMethod.USER_PROXY, userUuid.toString(), "actor", List.of());
+        SecurityContextHolder.getContext()
+                .setAuthentication(new PlatformAuthenticationToken(new PlatformUserDetails(info)));
+    }
+}

--- a/src/test/java/com/otilm/core/events/handlers/CertificateUploadedEventHandlerMessageTest.java
+++ b/src/test/java/com/otilm/core/events/handlers/CertificateUploadedEventHandlerMessageTest.java
@@ -1,0 +1,59 @@
+package com.otilm.core.events.handlers;
+
+import com.otilm.api.model.core.logging.enums.AuthMethod;
+import com.otilm.core.messaging.model.CertificateUploadEventMessageData;
+import com.otilm.core.messaging.model.EventMessage;
+import com.otilm.core.security.authn.PlatformAuthenticationToken;
+import com.otilm.core.security.authn.PlatformUserDetails;
+import com.otilm.core.security.authn.client.AuthenticationInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The async endpoint answers on the request thread, but the certificate and its history event are written later on a
+ * JMS listener thread. The event message is the only channel that can carry the uploader across that boundary.
+ */
+class CertificateUploadedEventHandlerMessageTest {
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void constructedEventMessageCarriesTheActingUser() {
+        UUID userUuid = UUID.randomUUID();
+        authenticateAs(userUuid, "uploader");
+
+        EventMessage message = CertificateUploadedEventHandler.constructEventMessage(uploadData());
+
+        assertThat(message.getUserUuid()).isEqualTo(userUuid);
+    }
+
+    @Test
+    void constructedEventMessageHasNoActingUserWhenNobodyIsAuthenticated() {
+        EventMessage message = CertificateUploadedEventHandler.constructEventMessage(uploadData());
+
+        assertThat(message.getUserUuid()).isNull();
+    }
+
+    private CertificateUploadEventMessageData uploadData() {
+        return CertificateUploadEventMessageData.builder()
+                .certificateContent("cert-content")
+                .customAttributes(List.of())
+                .build();
+    }
+
+    private void authenticateAs(UUID userUuid, String username) {
+        AuthenticationInfo info =
+                new AuthenticationInfo(AuthMethod.USER_PROXY, userUuid.toString(), username, List.of());
+        SecurityContextHolder.getContext()
+                .setAuthentication(new PlatformAuthenticationToken(new PlatformUserDetails(info)));
+    }
+}

--- a/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
+++ b/src/test/java/com/otilm/core/integration/events/EventHandlersITest.java
@@ -269,13 +269,17 @@ class EventHandlersITest extends BaseSpringBootTest {
         historyList = certificateEventHistoryService.getCertificateEventHistory(certificate.getUuid());
         Assertions.assertEquals(2, historyList.size());
         Assertions.assertEquals(CertificateEvent.APPROVAL_REQUEST, historyList.getFirst().getEvent());
+        Assertions.assertEquals("tst-user", historyList.getFirst().getCreatedBy(),
+                "the approval-request history row must name the acting user, not the system user");
 
         Assertions.assertDoesNotThrow(() -> certificateActionPerformedEventHandler.handleEvent(CertificateActionPerformedEventHandler.constructEventMessage(certificate.getUuid(), ResourceAction.REVOKE)));
 
-        approvalClosedEventHandler.handleEvent(ApprovalClosedEventHandler.constructEventMessage(approval.getUuid()));
+        approvalClosedEventHandler.handleEvent(ApprovalClosedEventHandler.constructEventMessage(approval.getUuid(), ApprovalStatusEnum.APPROVED));
         historyList = certificateEventHistoryService.getCertificateEventHistory(certificate.getUuid());
         Assertions.assertEquals(3, historyList.size());
         Assertions.assertEquals(CertificateEvent.APPROVAL_CLOSE, historyList.getFirst().getEvent());
+        Assertions.assertEquals("tst-user", historyList.getFirst().getCreatedBy(),
+                "the approval-close history row must name the approving user, not the system user");
     }
 
     private void createCertificateTriggerAssociation(ResourceEvent event, Resource eventResource, UUID eventObjectUuid, boolean ignoreTrigger) throws AttributeException, AlreadyExistException, NotFoundException {

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/EventListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/EventListenerTest.java
@@ -1,0 +1,134 @@
+package com.otilm.core.messaging.jms.listeners;
+
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.logging.enums.ActorType;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.events.IEventHandler;
+import com.otilm.core.logging.LoggingHelper;
+import com.otilm.core.messaging.model.EventMessage;
+import com.otilm.core.security.authn.PlatformAuthenticationException;
+import com.otilm.core.security.authn.PlatformAuthenticationToken;
+import com.otilm.core.security.authn.PlatformUserDetails;
+import com.otilm.core.security.authn.client.AuthenticationInfo;
+import com.otilm.core.util.AuthHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EventListenerTest {
+
+    @Mock
+    private AuthHelper authHelper;
+
+    @Mock
+    private IEventHandler eventHandler;
+
+    private Authentication authenticationSeenByHandler;
+    private boolean actorInfoSeenByHandler;
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+        LoggingHelper.clearActorInfo();
+    }
+
+    @Test
+    void authenticatesAsTheUserCarriedByTheMessage() throws Exception {
+        UUID userUuid = UUID.randomUUID();
+
+        listener().processMessage(uploadMessageFrom(userUuid));
+
+        verify(authHelper).authenticateAsUser(userUuid);
+        verify(eventHandler).handleEvent(any());
+    }
+
+    /** Losing attribution is acceptable; losing the event is not, so the failure must not reach the retry template. */
+    @Test
+    void stillHandlesTheEventWhenTheCarriedUserCannotBeAuthenticated() throws Exception {
+        UUID userUuid = UUID.randomUUID();
+        doThrow(new PlatformAuthenticationException("user is gone"))
+                .when(authHelper).authenticateAsUser(userUuid);
+
+        EventListener listener = listener();
+
+        assertThatNoException().isThrownBy(() -> listener.processMessage(uploadMessageFrom(userUuid)));
+        verify(eventHandler).handleEvent(any());
+    }
+
+    /**
+     * {@code authenticateAsUser} writes the actor MDC before calling the auth service, so a failure would otherwise
+     * leave audit logs naming a user the platform could not authenticate while the DB columns say "system".
+     */
+    @Test
+    void leavesNoActorAttributionBehindWhenAuthenticationFails() throws Exception {
+        UUID userUuid = UUID.randomUUID();
+        doAnswer(invocation -> {
+            LoggingHelper.putActorInfoWhenNull(ActorType.USER, userUuid.toString(), null);
+            throw new PlatformAuthenticationException("user is gone");
+        }).when(authHelper).authenticateAsUser(userUuid);
+        recordWhatTheHandlerSees();
+
+        listener().processMessage(uploadMessageFrom(userUuid));
+
+        assertThat(actorInfoSeenByHandler)
+                .as("no actor attribution may survive a failed authentication")
+                .isFalse();
+    }
+
+    /**
+     * For a deleted user the auth service answers "not authenticated" rather than failing, so
+     * {@code authenticateAsUser} returns normally having installed an anonymous principal — which auditing would
+     * stamp as "anonymousUser" and OPA would treat as genuine. The event must run with no identity instead.
+     */
+    @Test
+    void discardsTheAnonymousPrincipalInstalledForAUserThatNoLongerResolves() throws Exception {
+        UUID userUuid = UUID.randomUUID();
+        doAnswer(invocation -> {
+            AuthenticationInfo anonymous = AuthenticationInfo.getAnonymousAuthenticationInfo();
+            SecurityContextHolder.getContext()
+                    .setAuthentication(new PlatformAuthenticationToken(new PlatformUserDetails(anonymous)));
+            return null;
+        }).when(authHelper).authenticateAsUser(userUuid);
+        recordWhatTheHandlerSees();
+
+        listener().processMessage(uploadMessageFrom(userUuid));
+
+        verify(eventHandler).handleEvent(any());
+        assertThat(authenticationSeenByHandler)
+                .as("an unresolvable user must leave no principal, so audited rows fall back to the system user")
+                .isNull();
+    }
+
+    private void recordWhatTheHandlerSees() throws Exception {
+        doAnswer(invocation -> {
+            authenticationSeenByHandler = SecurityContextHolder.getContext().getAuthentication();
+            actorInfoSeenByHandler = LoggingHelper.hasActorInfo();
+            return null;
+        }).when(eventHandler).handleEvent(any());
+    }
+
+    private EventListener listener() {
+        return new EventListener(authHelper,
+                Map.of(ResourceEvent.CERTIFICATE_UPLOADED.getCode(), eventHandler));
+    }
+
+    private EventMessage uploadMessageFrom(UUID userUuid) {
+        return new EventMessage(ResourceEvent.CERTIFICATE_UPLOADED, Resource.CERTIFICATE,
+                null, null, null, "payload", userUuid, null);
+    }
+}

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/JmsEndpointSecurityContextTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/JmsEndpointSecurityContextTest.java
@@ -1,0 +1,98 @@
+package com.otilm.core.messaging.jms.listeners;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.otilm.core.messaging.jms.configuration.MessagingProperties;
+import jakarta.jms.TextMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jms.config.SimpleJmsListenerEndpoint;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * A container thread serves many messages in sequence, so an identity installed for one must not outlive it —
+ * otherwise the next message's JPA-audited rows are stamped under a previous message's user.
+ */
+class JmsEndpointSecurityContextTest {
+
+    private final List<Authentication> authenticationSeenAtEntry = new ArrayList<>();
+
+    @AfterEach
+    void clearLeftoverContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void securityContextIsClearedAfterMessageIsProcessed() throws Exception {
+        SimpleJmsListenerEndpoint endpoint = endpointWithProcessor(message ->
+                SecurityContextHolder.getContext().setAuthentication(authenticationFor("discovery-user")));
+
+        endpoint.getMessageListener().onMessage(textMessage("\"first\""));
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void identityFromOneMessageDoesNotLeakIntoTheNext() throws Exception {
+        SimpleJmsListenerEndpoint endpoint = endpointWithProcessor(message -> {
+            authenticationSeenAtEntry.add(SecurityContextHolder.getContext().getAuthentication());
+            SecurityContextHolder.getContext().setAuthentication(authenticationFor("discovery-user"));
+        });
+
+        endpoint.getMessageListener().onMessage(textMessage("\"first\""));
+        endpoint.getMessageListener().onMessage(textMessage("\"second\""));
+
+        assertThat(authenticationSeenAtEntry).hasSize(2);
+        assertThat(authenticationSeenAtEntry.get(0)).isNull();
+        assertThat(authenticationSeenAtEntry.get(1))
+                .as("second message must not inherit the identity installed while handling the first")
+                .isNull();
+    }
+
+    @Test
+    void securityContextIsClearedEvenWhenTheHandlerThrows() throws Exception {
+        SimpleJmsListenerEndpoint endpoint = endpointWithProcessor(message -> {
+            SecurityContextHolder.getContext().setAuthentication(authenticationFor("discovery-user"));
+            throw new IllegalStateException("handler blew up");
+        });
+
+        endpoint.getMessageListener().onMessage(textMessage("\"first\""));
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    private SimpleJmsListenerEndpoint endpointWithProcessor(MessageProcessor<String> processor) {
+        MessagingProperties properties = mock(MessagingProperties.class);
+        when(properties.brokerType()).thenReturn(MessagingProperties.BrokerType.RABBITMQ);
+
+        AbstractJmsEndpointConfig<String> config =
+                new AbstractJmsEndpointConfig<>(new ObjectMapper(), processor, new RetryTemplate(), properties) {
+                    @Override
+                    public SimpleJmsListenerEndpoint listenerEndpoint() {
+                        return listenerEndpointInternal(
+                                "testListener", "/queues/test", "test", null, "1", String.class);
+                    }
+                };
+
+        return config.listenerEndpoint();
+    }
+
+    private TextMessage textMessage(String json) throws Exception {
+        TextMessage message = mock(TextMessage.class);
+        when(message.getText()).thenReturn(json);
+        return message;
+    }
+
+    private Authentication authenticationFor(String username) {
+        return new TestingAuthenticationToken(username, "n/a");
+    }
+}

--- a/src/test/java/com/otilm/core/util/AuthHelperTest.java
+++ b/src/test/java/com/otilm/core/util/AuthHelperTest.java
@@ -1,13 +1,21 @@
 package com.otilm.core.util;
 
 import com.otilm.api.model.core.logging.enums.ActorType;
+import com.otilm.api.model.core.logging.enums.AuthMethod;
 import com.otilm.api.model.core.logging.records.ActorRecord;
 import com.otilm.core.logging.LoggingHelper;
+import com.otilm.core.security.authn.PlatformAnonymousToken;
+import com.otilm.core.security.authn.PlatformAuthenticationToken;
+import com.otilm.core.security.authn.PlatformUserDetails;
+import com.otilm.core.security.authn.client.AuthenticationInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -97,6 +105,36 @@ class AuthHelperTest {
         assertEquals(ActorType.USER, after.type(), "caller's actor type must be restored, not left as the system identity");
         assertEquals("operator-jane", after.name(), "caller's actor name must be restored");
         assertEquals(callerUuid, after.uuid().toString(), "caller's actor uuid must be restored, not left stale");
+    }
+
+    /**
+     * An anonymous caller's principal IS a {@link PlatformUserDetails}, with a null userUuid, so
+     * {@code getUserIdentification()} succeeds rather than throwing and the uuid must be treated as absent.
+     */
+    @Test
+    void getActingUserUuidOrNull_returnsNullForAnonymousPrincipal() {
+        AuthenticationInfo anonymous = AuthenticationInfo.getAnonymousAuthenticationInfo();
+        SecurityContextHolder.getContext().setAuthentication(new PlatformAnonymousToken(
+                UUID.randomUUID().toString(), new PlatformUserDetails(anonymous), anonymous.getAuthorities()));
+
+        assertNull(AuthHelper.getActingUserUuidOrNull());
+    }
+
+    @Test
+    void getActingUserUuidOrNull_returnsNullWhenNobodyIsAuthenticated() {
+        SecurityContextHolder.clearContext();
+
+        assertNull(AuthHelper.getActingUserUuidOrNull());
+    }
+
+    @Test
+    void getActingUserUuidOrNull_returnsTheAuthenticatedUsersUuid() {
+        UUID userUuid = UUID.randomUUID();
+        SecurityContextHolder.getContext().setAuthentication(new PlatformAuthenticationToken(
+                new PlatformUserDetails(new AuthenticationInfo(
+                        AuthMethod.USER_PROXY, userUuid.toString(), "operator", List.of()))));
+
+        assertEquals(userUuid, AuthHelper.getActingUserUuidOrNull());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1910.

A certificate's "Certificate uploaded" history event named an unrelated real user — deterministically, on every upload.

## Root cause

JMS listener container threads are long-lived and nothing cleared `SecurityContextHolder` between messages. Discovery events are the only ones that carried a user, so consuming one authenticated the consumer thread; every later certificate upload — whose event message carried no user — inherited that identity, and JPA auditing (`@CreatedBy` → `CustomAuditAware`) stamped it onto the certificate and its history rows. On a freshly restarted pod, before any discovery had run, the same path attributed them to `system` instead.

Reproduced on 2.18.0 and on main. Confirmed by restart test: `system` before any discovery, the discovery initiator's name after.

## What changed

- **`AbstractJmsEndpointConfig`** — reset the SecurityContext and actor MDC per message in the shared dispatch wrapper, so no identity outlives the message that installed it. Covers every endpoint, not just the events queue.
- **Acting user carried in the event message** for the events whose handlers write audited rows on the consuming thread: certificate upload, approval requested, approval closed. Resolved on the producing thread via `AuthHelper.getActingUserUuidOrNull()`.
  - Approval-requested takes the requester as an argument instead: its history row is written only for the first step, produced from `createApproval` on the actions-listener thread *before* that listener authenticates, so the thread cannot supply it. The approval's creator is passed explicitly.
  - An approval closed as `EXPIRED` is left unattributed — the expiry sweep runs as the scheduled job's user, who took no action on it.
- **`EventListener`** — authenticating as the carried user is best-effort, because losing attribution beats losing the event. Both failure shapes are reduced to no identity: an unreachable auth service throws, while a user that no longer resolves comes back as an anonymous principal that auditing would stamp as `anonymousUser` and authorization would accept as genuine.
- **`EventHandler`** — the trigger-association impersonation from #1063 is confined to the trigger loop. Actions still run with the association owner's permissions, but the audited writes afterwards belong to the acting user. `EventContext.currentUserUuid` is no longer trusted as proof that an identity is installed.
- **`TriggerHistory.message` / `TriggerHistoryRecord.message`** mapped as `TEXT`, matching the unbounded `VARCHAR` the migrations declare; the Hibernate-generated test schema defaulted them to `varchar(255)`.

## Authorization impact

Carrying the user widens the authorization context: the listener authenticates for the whole `handleEvent` call, so trigger evaluation and the attribute engine's object-permission filters now run as the acting user rather than unauthenticated. Neither the upload nor the approval path contains any `@ExternalAuthorization`-gated call, so an operation cannot newly be denied. Trigger actions keep the association owner's permissions.

Side effect worth knowing: custom attributes on an async upload were previously dropped on an unauthenticated thread (deny-all object filter → swallowed `AttributeException`). They now evaluate against the uploader, consistent with the validation the request thread already performed.

## Notes for review

- `throwsNotUploaded_whenIgnoreTriggerMatches` was previously green for the wrong reason: `authenticateAsUser` always failed in that ITest, marking the event FAILED and producing the asserted exception without the ignore trigger mattering. It now exercises the path it names. Other ITests may lean on the same accident.
- `jmsListenerContainerFactory` must stay without a `transactionManager` — the JPA transaction commits inside `processMessage`, so the `AFTER_COMMIT` listeners writing audited history rows still run under the message's identity, before the dispatch wrapper clears it. A comment records this; adding one later would silently re-break the bug with no test failing.
- A deleted trigger-association owner is deliberately *not* degraded the way a per-message failure is: that costs only attribution, whereas a trigger without its owner's identity would run actions under other permissions.

## Testing

Six new test classes, 32 unit tests, each watched fail before the fix. Verified green on this tree: the 32 unit tests, `EventHandlersITest` (22), `CertificateServiceITest` (161), `ApprovalServiceITest` (15), `RevocationApprovalRejectedITest` (2). A full-suite run (4381 tests) was green on an earlier revision of this branch; the final tree relies on CI for full coverage.

## Follow-up not included

A SET_FIELD trigger action mutating the certificate inside the trigger loop can auto-flush and stamp `Certificate.author` as the trigger owner, leaving the entity clean so the post-restore commit never re-stamps it. Confirming it needs a new fixture (only `seedIgnoreTrigger` exists today), and it only affects deployments with field-setting upload triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
