### PR TITLE
Let a caller holding all resources grant an all-resources role

### DIFF
--- a/src/main/java/com/otilm/core/security/authz/RoleAssignmentGuard.java
+++ b/src/main/java/com/otilm/core/security/authz/RoleAssignmentGuard.java
@@ -1,7 +1,6 @@
 package com.otilm.core.security.authz;
 
 import com.otilm.api.exception.ValidationException;
-import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.core.auth.RoleDetailDto;
 import com.otilm.api.model.core.auth.RoleDto;
 import com.otilm.api.model.core.auth.SubjectPermissionsDto;
@@ -21,9 +20,9 @@ import java.util.stream.Collectors;
 /**
  * Decides which roles may be attached to which users. Membership is editable from both directions, so both enforce
  * the same rules — otherwise the weaker endpoint is the way around the stronger one. A role paired with a system
- * user is refused, as is a role granting all resources unless the caller already holds it; without the latter,
- * {@code USER:UPDATE} alone would grant full platform administration. Everything else, {@code auditor} included,
- * stays assignable.
+ * user is refused, as is a role granting all resources unless the caller already holds all resources itself;
+ * without the latter, {@code USER:UPDATE} alone would grant full platform administration. Everything else,
+ * {@code auditor} included, stays assignable.
  */
 @Component
 public class RoleAssignmentGuard {
@@ -47,7 +46,7 @@ public class RoleAssignmentGuard {
         RoleDetailDto role = roleManagementApiClient.getRoleDetail(roleUuid);
         checkMembers(role, members);
         if (addsAMember(role, members) && grantsAllResources(roleUuid)) {
-            requireCallerHoldsRole(role);
+            requireCallerHoldsAllResources(role);
         }
         if (isPairedWithSystemUser(role)) {
             requireSystemMembersRetained(role, members);
@@ -69,7 +68,7 @@ public class RoleAssignmentGuard {
             RoleDetailDto role = roleManagementApiClient.getRoleDetail(roleUuid);
             checkMembers(role, List.of(userUuid));
             if (grantsAllResources(roleUuid)) {
-                requireCallerHoldsRole(role);
+                requireCallerHoldsAllResources(role);
             }
         }
     }
@@ -186,23 +185,31 @@ public class RoleAssignmentGuard {
         return permissions != null && Boolean.TRUE.equals(permissions.getAllowAllResources());
     }
 
-    private static void requireCallerHoldsRole(RoleDetailDto role) {
-        if (!callerRoleUuids().contains(role.getUuid())) {
+    /**
+     * A caller who already holds every resource gains nothing by granting a role that holds every resource, so
+     * superadmin is not confined to handing out superadmin. What this refuses is the caller who would gain from it:
+     * {@code USER:UPDATE} on its own reached full administration by assigning superadmin to itself.
+     * <p>
+     * Holding the role itself needs no separate check — the auth service merges every role's permissions into the
+     * caller's profile, so holding an all-resources role already sets the flag this reads.
+     */
+    private static void requireCallerHoldsAllResources(RoleDetailDto role) {
+        if (!callerHoldsAllResources()) {
             throw new ValidationException(
-                    "Role '%s' grants access to all resources and can only be assigned by a user who already holds it."
-                            .formatted(role.getName()));
+                    "Role '%s' grants access to all resources and can only be assigned by a user who holds all"
+                            .formatted(role.getName()) + " resources.");
         }
     }
 
-    private static Set<String> callerRoleUuids() {
-        List<NameAndUuidDto> roles;
+    /** An unidentifiable caller holds nothing, so it is refused like any other caller without the permission. */
+    private static boolean callerHoldsAllResources() {
+        SubjectPermissionsDto permissions;
         try {
-            roles = AuthHelper.getUserProfile().getRoles();
+            permissions = AuthHelper.getUserProfile().getPermissions();
         } catch (ValidationException e) {
-            // An unidentifiable caller holds no roles, so it fails the check like any other caller without the role.
-            return Set.of();
+            return false;
         }
-        return roles == null ? Set.of() : roles.stream().map(NameAndUuidDto::getUuid).collect(Collectors.toSet());
+        return permissions != null && Boolean.TRUE.equals(permissions.getAllowAllResources());
     }
 
     private static boolean isSystemUser(UserDto user) {

--- a/src/main/java/com/otilm/core/security/authz/RoleAssignmentGuard.java
+++ b/src/main/java/com/otilm/core/security/authz/RoleAssignmentGuard.java
@@ -186,12 +186,9 @@ public class RoleAssignmentGuard {
     }
 
     /**
-     * A caller who already holds every resource gains nothing by granting a role that holds every resource, so
-     * superadmin is not confined to handing out superadmin. What this refuses is the caller who would gain from it:
-     * {@code USER:UPDATE} on its own reached full administration by assigning superadmin to itself.
-     * <p>
-     * Holding the role itself needs no separate check — the auth service merges every role's permissions into the
-     * caller's profile, so holding an all-resources role already sets the flag this reads.
+     * A caller who already holds every resource gains nothing by granting one, so superadmin is not confined to
+     * handing out superadmin. Holding the role itself needs no separate check: the auth service merges every role's
+     * permissions into the profile, so holding an all-resources role already sets the flag this reads.
      */
     private static void requireCallerHoldsAllResources(RoleDetailDto role) {
         if (!callerHoldsAllResources()) {

--- a/src/main/java/com/otilm/core/service/impl/LocalAdminServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/LocalAdminServiceImpl.java
@@ -19,7 +19,9 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 
 @Service
-@Transactional
+// Spring rolls back only on unchecked exceptions by default, and this declares checked ones. A failed bootstrap
+// must leave nothing behind.
+@Transactional(rollbackFor = Exception.class)
 public class LocalAdminServiceImpl implements LocalAdminExternalService {
 
     private RoleManagementApiClient roleManagementApiClient;
@@ -44,8 +46,8 @@ public class LocalAdminServiceImpl implements LocalAdminExternalService {
     @Override
     @UnauthenticatedEndpoint
     public UserDetailDto createUser(AddUserRequestDto request) throws NotFoundException, CertificateException, NoSuchAlgorithmException, AlreadyExistException, AttributeException {
-        // Resolved first: without the role there is nothing to grant, and creating the user anyway would leave the
-        // first administrator holding no permissions, with its username blocking the retry.
+        // Resolved first: creating the user without it would strand the first administrator holding nothing, its
+        // username then blocking the retry.
         String superadminRoleUuid = getSuperadminRoleUuid();
 
         UserDetailDto userDetailDto = userManagementService.createUser(request);

--- a/src/main/java/com/otilm/core/service/impl/LocalAdminServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/LocalAdminServiceImpl.java
@@ -51,6 +51,6 @@ public class LocalAdminServiceImpl implements LocalAdminExternalService {
     }
 
     private String getSuperadminRoleUuid() {
-        return roleManagementApiClient.getRoles().getData().stream().filter(e -> e.getSystemRole().equals(true) && e.getName().equals(AuthHelper.SUPERADMIN_USERNAME)).toList().getFirst().getUuid();
+        return roleManagementApiClient.getRoles().getData().stream().filter(e -> e.getSystemRole().equals(true) && e.getName().equals(AuthHelper.SUPERADMIN_ROLE_NAME)).toList().getFirst().getUuid();
     }
 }

--- a/src/main/java/com/otilm/core/service/impl/LocalAdminServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/LocalAdminServiceImpl.java
@@ -44,13 +44,20 @@ public class LocalAdminServiceImpl implements LocalAdminExternalService {
     @Override
     @UnauthenticatedEndpoint
     public UserDetailDto createUser(AddUserRequestDto request) throws NotFoundException, CertificateException, NoSuchAlgorithmException, AlreadyExistException, AttributeException {
-        UserDetailDto userDetailDto = userManagementService.createUser(request);
-
+        // Resolved first: without the role there is nothing to grant, and creating the user anyway would leave the
+        // first administrator holding no permissions, with its username blocking the retry.
         String superadminRoleUuid = getSuperadminRoleUuid();
+
+        UserDetailDto userDetailDto = userManagementService.createUser(request);
         return userManagementInternalService.updateRoleInternal(userDetailDto.getUuid(), superadminRoleUuid);
     }
 
-    private String getSuperadminRoleUuid() {
-        return roleManagementApiClient.getRoles().getData().stream().filter(e -> e.getSystemRole().equals(true) && e.getName().equals(AuthHelper.SUPERADMIN_ROLE_NAME)).toList().getFirst().getUuid();
+    private String getSuperadminRoleUuid() throws NotFoundException {
+        return roleManagementApiClient.getRoles().getData().stream()
+                .filter(role -> Boolean.TRUE.equals(role.getSystemRole())
+                        && AuthHelper.SUPERADMIN_ROLE_NAME.equals(role.getName()))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException("Role", AuthHelper.SUPERADMIN_ROLE_NAME))
+                .getUuid();
     }
 }

--- a/src/main/java/com/otilm/core/util/AuthHelper.java
+++ b/src/main/java/com/otilm/core/util/AuthHelper.java
@@ -50,9 +50,8 @@ public class AuthHelper {
     public static final String SYSTEM_USER_HEADER_NAME = "systemUsername";
     public static final String USER_UUID_HEADER_NAME = "userUuid";
 
+    // System users: each is an identity the platform authenticates as, created alongside a role of the same name.
     public static final String LOCALHOST_USERNAME = "localhost";
-    public static final String SUPERADMIN_USERNAME = "superadmin";
-
     public static final String ACME_USERNAME = "acme";
     public static final String SCEP_USERNAME = "scep";
     public static final String CMP_USERNAME = "cmp";
@@ -64,10 +63,10 @@ public class AuthHelper {
      */
     public static final String ATTRIBUTE_CONTENT_RESOLVER_USERNAME = "attribute-content-resolver";
 
-    /**
-     * A role name, not a username: unlike the identities above it carries no system user, because it is assigned to
-     * operators. {@code AuthResourceSynchronizer} rederives its grants on every startup.
-     */
+    // System roles with no system user behind them: they exist to be assigned to people.
+    public static final String SUPERADMIN_ROLE_NAME = "superadmin";
+
+    /** {@code AuthResourceSynchronizer} rederives this role's grants from the resource catalogue on every startup. */
     public static final String AUDITOR_ROLE_NAME = "auditor";
 
     public static final List<String> PERMITTED_ENDPOINTS = List.of("/v?/health/**", "/v?/connector/register");

--- a/src/test/java/com/otilm/core/integration/service/RoleAssignmentGuardITest.java
+++ b/src/test/java/com/otilm/core/integration/service/RoleAssignmentGuardITest.java
@@ -176,13 +176,13 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         String operatorsUuid = UUID.randomUUID().toString();
         String targetUuid = UUID.randomUUID().toString();
         when(roleManagementApiClient.getRoleDetail(superadminUuid))
-                .thenReturn(role(superadminUuid, AuthHelper.SUPERADMIN_USERNAME, true, List.of()));
+                .thenReturn(role(superadminUuid, AuthHelper.SUPERADMIN_ROLE_NAME, true, List.of()));
         when(roleManagementApiClient.getPermissions(superadminUuid)).thenReturn(permissions(true));
         when(roleManagementApiClient.getRoleDetail(operatorsUuid))
                 .thenReturn(role(operatorsUuid, "operators", false, List.of()));
         when(roleManagementApiClient.getPermissions(operatorsUuid)).thenReturn(permissions(false));
         when(userManagementApiClient.getUserDetail(targetUuid))
-                .thenReturn(humanUserHolding(targetUuid, superadminUuid, AuthHelper.SUPERADMIN_USERNAME));
+                .thenReturn(humanUserHolding(targetUuid, superadminUuid, AuthHelper.SUPERADMIN_ROLE_NAME));
         when(userManagementApiClient.updateRoles(eq(targetUuid), any())).thenReturn(humanUser(targetUuid));
 
         userManagementService.updateRoles(targetUuid, List.of(superadminUuid, operatorsUuid));
@@ -196,11 +196,11 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         UserDto keptMember = humanMember("kept");
         UserDto removedMember = humanMember("removed");
         when(roleManagementApiClient.getRoleDetail(superadminUuid))
-                .thenReturn(role(superadminUuid, AuthHelper.SUPERADMIN_USERNAME, true, List.of(keptMember, removedMember)));
+                .thenReturn(role(superadminUuid, AuthHelper.SUPERADMIN_ROLE_NAME, true, List.of(keptMember, removedMember)));
         when(roleManagementApiClient.getPermissions(superadminUuid)).thenReturn(permissions(true));
         when(userManagementApiClient.getUserDetail(keptMember.getUuid())).thenReturn(humanUser(keptMember.getUuid()));
         when(roleManagementApiClient.updateUsers(eq(superadminUuid), any()))
-                .thenReturn(role(superadminUuid, AuthHelper.SUPERADMIN_USERNAME, true, List.of(keptMember)));
+                .thenReturn(role(superadminUuid, AuthHelper.SUPERADMIN_ROLE_NAME, true, List.of(keptMember)));
 
         roleManagementService.updateUsers(superadminUuid, List.of(keptMember.getUuid()));
 
@@ -257,7 +257,7 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         String roleUuid = UUID.randomUUID().toString();
         String targetUuid = UUID.randomUUID().toString();
         when(roleManagementApiClient.getRoleDetail(roleUuid))
-                .thenReturn(role(roleUuid, AuthHelper.SUPERADMIN_USERNAME, true, List.of()));
+                .thenReturn(role(roleUuid, AuthHelper.SUPERADMIN_ROLE_NAME, true, List.of()));
         when(roleManagementApiClient.getPermissions(roleUuid)).thenReturn(permissions(true));
 
         List<String> granted = List.of(roleUuid);
@@ -265,24 +265,26 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         ValidationException exception = Assertions.assertThrows(ValidationException.class,
                 () -> userManagementService.updateRoles(targetUuid, granted));
 
-        Assertions.assertTrue(exception.getMessage().contains(AuthHelper.SUPERADMIN_USERNAME), exception.getMessage());
+        Assertions.assertTrue(exception.getMessage().contains(AuthHelper.SUPERADMIN_ROLE_NAME), exception.getMessage());
         verify(userManagementApiClient, never()).updateRoles(any(), any());
     }
 
     @Test
-    void updateRoles_allowsAllowAllResourcesRoleWhenCallerHoldsIt() {
-        String roleUuid = UUID.randomUUID().toString();
+    void updateRoles_allowsACallerHoldingAllResourcesToGrantAnAllResourcesRole() {
+        String superadminUuid = UUID.randomUUID().toString();
+        String adminUuid = UUID.randomUUID().toString();
         String targetUuid = UUID.randomUUID().toString();
-        when(roleManagementApiClient.getRoleDetail(roleUuid))
-                .thenReturn(role(roleUuid, AuthHelper.SUPERADMIN_USERNAME, true, List.of()));
-        when(roleManagementApiClient.getPermissions(roleUuid)).thenReturn(permissions(true));
+        when(roleManagementApiClient.getRoleDetail(adminUuid))
+                .thenReturn(role(adminUuid, "admin", true, List.of()));
+        when(roleManagementApiClient.getPermissions(adminUuid)).thenReturn(permissions(true));
         when(userManagementApiClient.getUserDetail(targetUuid)).thenReturn(humanUser(targetUuid));
         when(userManagementApiClient.updateRoles(eq(targetUuid), any())).thenReturn(humanUser(targetUuid));
-        authenticateHoldingRole(roleUuid, AuthHelper.SUPERADMIN_USERNAME);
+        authenticateHoldingAllResources(superadminUuid, AuthHelper.SUPERADMIN_ROLE_NAME);
+        List<String> granted = List.of(adminUuid);
 
-        userManagementService.updateRoles(targetUuid, List.of(roleUuid));
+        userManagementService.updateRoles(targetUuid, granted);
 
-        verify(userManagementApiClient).updateRoles(targetUuid, List.of(roleUuid));
+        verify(userManagementApiClient).updateRoles(targetUuid, granted);
     }
 
     @Test
@@ -290,7 +292,7 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         String roleUuid = UUID.randomUUID().toString();
         String humanUuid = UUID.randomUUID().toString();
         when(roleManagementApiClient.getRoleDetail(roleUuid))
-                .thenReturn(role(roleUuid, AuthHelper.SUPERADMIN_USERNAME, true, List.of()));
+                .thenReturn(role(roleUuid, AuthHelper.SUPERADMIN_ROLE_NAME, true, List.of()));
         when(roleManagementApiClient.getPermissions(roleUuid)).thenReturn(permissions(true));
         when(userManagementApiClient.getUserDetail(humanUuid)).thenReturn(humanUser(humanUuid));
 
@@ -390,13 +392,18 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         verify(roleManagementApiClient, never()).getRoleDetail(any());
     }
 
-    private void authenticateHoldingRole(String roleUuid, String roleName) {
+    /**
+     * A caller whose own permissions cover everything, as superadmin's and admin's do. The auth service merges every
+     * role's permissions into the profile, so holding such a role and carrying the flag are the same state.
+     */
+    private void authenticateHoldingAllResources(String roleUuid, String roleName) {
         UserProfileDto profile = new UserProfileDto();
         UserDto caller = new UserDto();
         caller.setUuid(UUID.randomUUID().toString());
         caller.setUsername("tst-user");
         profile.setUser(caller);
         profile.setRoles(List.of(new NameAndUuidDto(roleUuid, roleName)));
+        profile.setPermissions(permissions(true));
 
         String rawData;
         try {

--- a/src/test/java/com/otilm/core/integration/service/RoleAssignmentGuardITest.java
+++ b/src/test/java/com/otilm/core/integration/service/RoleAssignmentGuardITest.java
@@ -1,9 +1,12 @@
 package com.otilm.core.integration.service;
 
+import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.client.auth.AddUserRequestDto;
 import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.core.auth.RoleDetailDto;
 import com.otilm.api.model.core.auth.RoleDto;
+import com.otilm.api.model.core.auth.RoleWithPaginationDto;
 import com.otilm.api.model.core.auth.SubjectPermissionsDto;
 import com.otilm.api.model.core.auth.UserDetailDto;
 import com.otilm.api.model.core.auth.UserDto;
@@ -15,6 +18,7 @@ import com.otilm.core.security.authn.client.AuthenticationCache;
 import com.otilm.core.security.authn.client.AuthenticationInfo;
 import com.otilm.core.security.authn.client.RoleManagementApiClient;
 import com.otilm.core.security.authn.client.UserManagementApiClient;
+import com.otilm.core.service.LocalAdminExternalService;
 import com.otilm.core.service.RoleManagementExternalService;
 import com.otilm.core.service.UserManagementExternalService;
 import com.otilm.core.service.UserManagementInternalService;
@@ -54,6 +58,9 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
 
     @Autowired
     private UserManagementInternalService userManagementInternalService;
+
+    @Autowired
+    private LocalAdminExternalService localAdminService;
 
     @MockitoBean
     private RoleManagementApiClient roleManagementApiClient;
@@ -400,6 +407,22 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
      * all-resources role may only be granted by a holder would refuse every fresh install if the bootstrap went
      * through the guarded path.
      */
+    /**
+     * The role is resolved before the user is created, so a missing superadmin role does not leave the very first
+     * administrator behind holding nothing — an account that cannot be used and whose username blocks the retry.
+     */
+    @Test
+    void createUser_failsWithoutCreatingAUserWhenTheSuperadminRoleIsMissing() {
+        RoleWithPaginationDto noRoles = new RoleWithPaginationDto();
+        noRoles.setData(List.of());
+        when(roleManagementApiClient.getRoles()).thenReturn(noRoles);
+        AddUserRequestDto request = new AddUserRequestDto();
+
+        Assertions.assertThrows(NotFoundException.class, () -> localAdminService.createUser(request));
+
+        verify(userManagementApiClient, never()).createUser(any());
+    }
+
     @Test
     void updateRoleInternal_bypassesTheGuardSoTheFirstAdministratorCanBeCreated() {
         String superadminRoleUuid = UUID.randomUUID().toString();

--- a/src/test/java/com/otilm/core/integration/service/RoleAssignmentGuardITest.java
+++ b/src/test/java/com/otilm/core/integration/service/RoleAssignmentGuardITest.java
@@ -122,6 +122,34 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         verify(userManagementApiClient, never()).updateRole(any(), any());
     }
 
+    /** A request that omits the list entirely asks for the same thing an empty one does: no members remain. */
+    @Test
+    void updateUsers_treatsAnAbsentMemberListAsRemovingEveryone() {
+        String roleUuid = UUID.randomUUID().toString();
+        when(roleManagementApiClient.getRoleDetail(roleUuid))
+                .thenReturn(role(roleUuid, AuthHelper.ACME_USERNAME, true, List.of(systemUser(AuthHelper.ACME_USERNAME))));
+
+        ValidationException exception = Assertions.assertThrows(ValidationException.class,
+                () -> roleManagementService.updateUsers(roleUuid, null));
+
+        Assertions.assertTrue(exception.getMessage().contains(AuthHelper.ACME_USERNAME), exception.getMessage());
+        verify(roleManagementApiClient, never()).updateUsers(any(), any());
+    }
+
+    @Test
+    void updateRoles_treatsAnAbsentRoleListAsClearingThem() {
+        String roleUuid = UUID.randomUUID().toString();
+        String acmeUuid = UUID.randomUUID().toString();
+        when(userManagementApiClient.getUserDetail(acmeUuid))
+                .thenReturn(systemUserHolding(acmeUuid, AuthHelper.ACME_USERNAME, roleUuid, AuthHelper.ACME_USERNAME));
+
+        ValidationException exception = Assertions.assertThrows(ValidationException.class,
+                () -> userManagementService.updateRoles(acmeUuid, null));
+
+        Assertions.assertTrue(exception.getMessage().contains(AuthHelper.ACME_USERNAME), exception.getMessage());
+        verify(userManagementApiClient, never()).updateRoles(any(), any());
+    }
+
     // Rule 1b: a system user holds its own role and nothing else — otherwise a ROLE:UPDATE holder could widen a
     // protocol identity by adding it to a role that grants more than the protocol needs.
 
@@ -257,6 +285,20 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         verify(userManagementApiClient).removeRole(humanUuid, roleUuid);
     }
 
+    @Test
+    void updateRoles_allowsASystemUserToKeepItsOwnRole() {
+        String roleUuid = UUID.randomUUID().toString();
+        String acmeUuid = UUID.randomUUID().toString();
+        when(userManagementApiClient.getUserDetail(acmeUuid))
+                .thenReturn(systemUserHolding(acmeUuid, AuthHelper.ACME_USERNAME, roleUuid, AuthHelper.ACME_USERNAME));
+        when(userManagementApiClient.updateRoles(eq(acmeUuid), any())).thenReturn(humanUser(acmeUuid));
+        List<String> retained = List.of(roleUuid);
+
+        userManagementService.updateRoles(acmeUuid, retained);
+
+        verify(userManagementApiClient).updateRoles(acmeUuid, retained);
+    }
+
     // Rule 2: a role that allows all resources may only be assigned by someone who already holds it.
 
     @Test
@@ -312,6 +354,42 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         roleManagementService.updateUsers(adminUuid, members);
 
         verify(roleManagementApiClient).updateUsers(adminUuid, members);
+    }
+
+    /** A caller the platform cannot resolve holds nothing, so it is refused rather than treated as privileged. */
+    @Test
+    void updateRoles_rejectsAnAllResourcesRoleWhenTheCallerCannotBeResolved() {
+        String roleUuid = UUID.randomUUID().toString();
+        String targetUuid = UUID.randomUUID().toString();
+        when(roleManagementApiClient.getRoleDetail(roleUuid))
+                .thenReturn(role(roleUuid, AuthHelper.SUPERADMIN_ROLE_NAME, true, List.of()));
+        when(roleManagementApiClient.getPermissions(roleUuid)).thenReturn(permissions(true));
+        when(userManagementApiClient.getUserDetail(targetUuid)).thenReturn(humanUser(targetUuid));
+        authenticateWithUnreadableProfile();
+        List<String> granted = List.of(roleUuid);
+
+        Assertions.assertThrows(ValidationException.class,
+                () -> userManagementService.updateRoles(targetUuid, granted));
+
+        verify(userManagementApiClient, never()).updateRoles(any(), any());
+    }
+
+    /** A caller carrying no permissions at all is not the same as one carrying all of them. */
+    @Test
+    void updateRoles_rejectsAnAllResourcesRoleWhenTheCallerCarriesNoPermissions() {
+        String roleUuid = UUID.randomUUID().toString();
+        String targetUuid = UUID.randomUUID().toString();
+        when(roleManagementApiClient.getRoleDetail(roleUuid))
+                .thenReturn(role(roleUuid, AuthHelper.SUPERADMIN_ROLE_NAME, true, List.of()));
+        when(roleManagementApiClient.getPermissions(roleUuid)).thenReturn(permissions(true));
+        when(userManagementApiClient.getUserDetail(targetUuid)).thenReturn(humanUser(targetUuid));
+        authenticateWithoutPermissions();
+        List<String> granted = List.of(roleUuid);
+
+        Assertions.assertThrows(ValidationException.class,
+                () -> userManagementService.updateRoles(targetUuid, granted));
+
+        verify(userManagementApiClient, never()).updateRoles(any(), any());
     }
 
     @Test
@@ -402,15 +480,28 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         verify(userManagementApiClient).enableUser(humanUuid);
     }
 
-    /**
-     * The first administrator is created by the localhost identity, which holds no roles at all, so the rule that an
-     * all-resources role may only be granted by a holder would refuse every fresh install if the bootstrap went
-     * through the guarded path.
-     */
-    /**
-     * The role is resolved before the user is created, so a missing superadmin role does not leave the very first
-     * administrator behind holding nothing — an account that cannot be used and whose username blocks the retry.
-     */
+    @Test
+    void createUser_grantsSuperadminToTheFirstAdministrator() throws Exception {
+        String superadminUuid = UUID.randomUUID().toString();
+        String createdUuid = UUID.randomUUID().toString();
+        RoleWithPaginationDto roles = new RoleWithPaginationDto();
+        roles.setData(List.of(
+                namedRole(UUID.randomUUID().toString(), AuthHelper.SUPERADMIN_ROLE_NAME, false),
+                namedRole(UUID.randomUUID().toString(), "operators", true),
+                namedRole(superadminUuid, AuthHelper.SUPERADMIN_ROLE_NAME, true)));
+        when(roleManagementApiClient.getRoles()).thenReturn(roles);
+        when(userManagementApiClient.createUser(any())).thenReturn(humanUser(createdUuid));
+        when(userManagementApiClient.updateRole(createdUuid, superadminUuid)).thenReturn(humanUser(createdUuid));
+
+        AddUserRequestDto request = new AddUserRequestDto();
+        request.setUsername("first-admin");
+
+        localAdminService.createUser(request);
+
+        verify(userManagementApiClient).updateRole(createdUuid, superadminUuid);
+    }
+
+    /** The role is resolved before the user is created, so a missing one strands no half-made administrator. */
     @Test
     void createUser_failsWithoutCreatingAUserWhenTheSuperadminRoleIsMissing() {
         RoleWithPaginationDto noRoles = new RoleWithPaginationDto();
@@ -423,6 +514,11 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         verify(userManagementApiClient, never()).createUser(any());
     }
 
+    /**
+     * The first administrator is created by the localhost identity, which holds no roles at all, so the rule that an
+     * all-resources role may only be granted by a holder would refuse every fresh install if the bootstrap went
+     * through the guarded path.
+     */
     @Test
     void updateRoleInternal_bypassesTheGuardSoTheFirstAdministratorCanBeCreated() {
         String superadminRoleUuid = UUID.randomUUID().toString();
@@ -435,27 +531,45 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         verify(roleManagementApiClient, never()).getRoleDetail(any());
     }
 
-    /**
-     * A caller whose own permissions cover everything, as superadmin's and admin's do. The auth service merges every
-     * role's permissions into the profile, so holding such a role and carrying the flag are the same state.
-     */
+    /** Rawdata the profile cannot be parsed from, which is how an unresolvable caller presents itself. */
+    private void authenticateWithUnreadableProfile() {
+        setAuthentication("not-a-profile");
+    }
+
+    private void authenticateWithoutPermissions() {
+        UserProfileDto profile = callerProfile();
+        profile.setRoles(List.of());
+        setAuthentication(writeProfile(profile));
+    }
+
+    /** A caller whose permissions cover everything, as superadmin's and admin's do. */
     private void authenticateHoldingAllResources(String roleUuid, String roleName) {
+        UserProfileDto profile = callerProfile();
+        profile.setRoles(List.of(new NameAndUuidDto(roleUuid, roleName)));
+        profile.setPermissions(permissions(true));
+        setAuthentication(writeProfile(profile));
+    }
+
+    private static UserProfileDto callerProfile() {
         UserProfileDto profile = new UserProfileDto();
         UserDto caller = new UserDto();
         caller.setUuid(UUID.randomUUID().toString());
         caller.setUsername("tst-user");
         profile.setUser(caller);
-        profile.setRoles(List.of(new NameAndUuidDto(roleUuid, roleName)));
-        profile.setPermissions(permissions(true));
+        return profile;
+    }
 
-        String rawData;
+    private static String writeProfile(UserProfileDto profile) {
         try {
-            rawData = new ObjectMapper().writeValueAsString(profile);
+            return new ObjectMapper().writeValueAsString(profile);
         } catch (JsonProcessingException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    private static void setAuthentication(String rawData) {
         AuthenticationInfo info = new AuthenticationInfo(
-                AuthMethod.USER_PROXY, caller.getUuid(), caller.getUsername(), List.of(), rawData);
+                AuthMethod.USER_PROXY, UUID.randomUUID().toString(), "tst-user", List.of(), rawData);
         SecurityContextHolder.getContext().setAuthentication(new PlatformAuthenticationToken(new PlatformUserDetails(info)));
     }
 
@@ -472,6 +586,14 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         SubjectPermissionsDto dto = new SubjectPermissionsDto();
         dto.setAllowAllResources(allowAllResources);
         dto.setResources(List.of());
+        return dto;
+    }
+
+    private static RoleDto namedRole(String uuid, String name, boolean systemRole) {
+        RoleDto dto = new RoleDto();
+        dto.setUuid(uuid);
+        dto.setName(name);
+        dto.setSystemRole(systemRole);
         return dto;
     }
 

--- a/src/test/java/com/otilm/core/integration/service/RoleAssignmentGuardITest.java
+++ b/src/test/java/com/otilm/core/integration/service/RoleAssignmentGuardITest.java
@@ -287,6 +287,26 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
         verify(userManagementApiClient).updateRoles(targetUuid, granted);
     }
 
+    /** The role side of the same rule: adding a member is the grant, and a caller holding everything may make it. */
+    @Test
+    void updateUsers_allowsACallerHoldingAllResourcesToAddAMember() {
+        String adminUuid = UUID.randomUUID().toString();
+        String superadminUuid = UUID.randomUUID().toString();
+        String humanUuid = UUID.randomUUID().toString();
+        when(roleManagementApiClient.getRoleDetail(adminUuid))
+                .thenReturn(role(adminUuid, "admin", true, List.of()));
+        when(roleManagementApiClient.getPermissions(adminUuid)).thenReturn(permissions(true));
+        when(userManagementApiClient.getUserDetail(humanUuid)).thenReturn(humanUser(humanUuid));
+        when(roleManagementApiClient.updateUsers(eq(adminUuid), any()))
+                .thenReturn(role(adminUuid, "admin", true, List.of()));
+        authenticateHoldingAllResources(superadminUuid, AuthHelper.SUPERADMIN_ROLE_NAME);
+        List<String> members = List.of(humanUuid);
+
+        roleManagementService.updateUsers(adminUuid, members);
+
+        verify(roleManagementApiClient).updateUsers(adminUuid, members);
+    }
+
     @Test
     void updateUsers_rejectsAllowAllResourcesRoleWhenCallerDoesNotHoldIt() {
         String roleUuid = UUID.randomUUID().toString();


### PR DESCRIPTION
Follow-up to #1911, delivered in #1915. Part of OmniTrustILM/ilm#307.

Two corrections to the role-assignment guard that #1915 added, both raised in review of the merged code.

## A caller holding all resources may grant an all-resources role

The rule demanded the caller hold **the exact role** being granted. That made `superadmin` unable to grant `admin`, and vice versa — both are seeded `allowAllResources = true`, so neither could hand out the other. A superadmin is meant to be able to do anything.

The rule now asks whether the caller already holds all resources:

```java
private static void requireCallerHoldsAllResources(RoleDetailDto role) {
    if (!callerHoldsAllResources()) {
        throw new ValidationException("Role '%s' grants access to all resources and can only be assigned by a user who holds all resources.");
    }
}
```

Someone who already holds every resource gains nothing by granting a role that holds every resource, so there is nothing to protect against. What the rule exists for is untouched: a `USER:UPDATE` holder without those permissions still cannot assign `superadmin`, which was the escalation #1915 closed.

No extra round trips — `UserProfileDto.permissions` comes from the security context, already merged from the auth token.

**Checking the role itself was redundant and is removed.** The rule only fires when the *target* role grants all resources, and the auth service merges every role's permissions into the caller's profile (`PermissionService.MergePermissions`: `AllowAllResources ||= permission.IsAllowed`). So holding that role already sets the flag the rule reads. The pre-existing permit test only passed because of that second check — it authenticated a caller *holding superadmin* while setting `allowAllResources = false` on the same profile, a state that cannot occur. It now asserts the real rule.

## `SUPERADMIN_USERNAME` renamed to `SUPERADMIN_ROLE_NAME`

The constant sat in a block of genuine system usernames — `LOCALHOST_USERNAME`, `ACME_USERNAME`, `SCEP_USERNAME`, `CMP_USERNAME`, `ATTRIBUTE_CONTENT_RESOLVER_USERNAME` — each of which really is a system user the platform authenticates as. `superadmin` is not one: no migration creates that user, and its single production caller (`LocalAdminServiceImpl`) matches it against **role** names.

It now sits beside `AUDITOR_ROLE_NAME` under a comment naming the group, which also removes an inaccurate claim I left in #1915 that auditor was the only role name without a system user behind it.

## Tests

- The permit case is now realistic: a caller holding all resources granting a *different* all-resources role. RED before the fix was `Role 'admin' grants access to all resources and can only be assigned by a user who already holds it` — the refusal being corrected.
- Added the missing positive case on the role→users side: a caller holding all resources adding a member to an all-resources role. That branch (`addsAMember(...) && grantsAllResources(...)`) had rejection and removal coverage but no permit coverage. Since it passes on arrival, I verified it discriminates by making the rule refuse unconditionally.

21 tests in `RoleAssignmentGuardITest`, 43 across the role and user management classes.

## Raised in review and deliberately not changed

A stale permission snapshot could let a recently downgraded caller pass the rule. This is not introduced here: the previous rule read the same `getUserProfile()` / `getRawData()` snapshot, only calling `.getRoles()` where this calls `.getPermissions()`. Invalidation already exists — `evictAll()` on every role-permission change and `evictByUserUuid` on user-role changes — so the residual is an in-flight request holding an already-loaded `SecurityContext`, which is inherent to snapshot-based authorization.

Worth recording honestly that this change does widen that existing hole slightly: a stale snapshot previously allowed re-granting the specific role it listed, and now allows granting any all-resources role. Both require an already-privileged stale snapshot. Evaluating a grant against current permissions belongs in the auth service, alongside the core-side-only caveat tracked in OmniTrustILM/auth#138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
