### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,16 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 21
           distribution: 'temurin'
       - name: Cache Maven packages
-        uses: actions/cache@v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -12,10 +12,10 @@ jobs:
     name: Compile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 21
           distribution: 'temurin'
@@ -30,7 +30,7 @@ jobs:
         run: tar -czf compiled.tar.gz target/classes target/test-classes
 
       - name: Upload compiled output
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: compiled
           path: compiled.tar.gz
@@ -45,17 +45,17 @@ jobs:
       matrix:
         group: [non-integration, integration-core, integration-service-1, integration-service-2]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 21
           distribution: 'temurin'
           cache: maven
 
       - name: Download compiled output
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: compiled
 
@@ -68,7 +68,7 @@ jobs:
         run: mvn -B -U -ntp test -Ptest-${{ matrix.group }} -Dmaven.compiler.skip=true
 
       - name: Upload coverage exec
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jacoco-exec-${{ matrix.group }}
           path: target/jacoco.exec
@@ -79,17 +79,17 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 21
           distribution: 'temurin'
           cache: maven
 
       - name: Download compiled output
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: compiled
 
@@ -97,25 +97,25 @@ jobs:
         run: tar -xzf compiled.tar.gz
 
       - name: Download non-integration coverage exec
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jacoco-exec-non-integration
           path: jacoco-partial/group1
 
       - name: Download integration-core coverage exec
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jacoco-exec-integration-core
           path: jacoco-partial/group2
 
       - name: Download integration-service-1 coverage exec
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jacoco-exec-integration-service-1
           path: jacoco-partial/group3
 
       - name: Download integration-service-2 coverage exec
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jacoco-exec-integration-service-2
           path: jacoco-partial/group4
@@ -138,21 +138,21 @@ jobs:
 
       # Upload PR number artifact
       - name: Upload PR number artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-number
           path: pr-number.txt
 
       # Upload compiled classes
       - name: Upload Compiled Classes
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: compiled-classes
           path: target/classes
 
       # Upload Jacoco XML report(s)
       - name: Upload Coverage Reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-reports
           path: target/site/jacoco/jacoco.xml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
         build-mode: none
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       # Download the PR number artifact
       - name: Download PR number
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pr-number
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,14 +26,14 @@ jobs:
       # Request GitHub API for PR data
       - name: Request GitHub API for PR data
         if: github.event.workflow_run.event == 'pull_request'
-        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
+        uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
         id: get_pr_data
         with:
           route: GET /repos/${{ github.event.repository.full_name }}/pulls/${{ steps.pr_number.outputs.content }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Checkout the PR branch
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
@@ -49,7 +49,7 @@ jobs:
           git clean -ffdx && git reset --hard HEAD
       # Download compiled classes
       - name: Download Compiled Classes
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: compiled-classes
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,14 +57,14 @@ jobs:
           path: target/classes
       # Download Jacoco XML coverage files
       - name: Download Coverage Reports
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage-reports
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
           path: target/site/jacoco
       - name: Set up JDK 21
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 21
           distribution: 'temurin'
@@ -73,7 +73,7 @@ jobs:
         id: cache-month
         run: echo "yearmonth=$(date +%Y-%m)" >> "$GITHUB_OUTPUT"
       - name: Cache SonarCloud packages
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar-${{ steps.cache-month.outputs.yearmonth }}


### PR DESCRIPTION
## Summary

Update the external GitHub Actions used by this repo's workflows to their latest
versions, pinned to full commit SHAs for supply chain security. SHA pinning
prevents tag-rewriting attacks — a floating `@v6` can be repointed at arbitrary
code by whoever controls the action repo.

## Updated actions

| Action | Previous | Updated to | Change |
|---|---|---|---|
| `actions/cache` | `v5`, `caa2961…ef25 # v5.1.0` | `55cc834…52a9 # v6.1.0` | Major update (+pinned) |
| `actions/checkout` | `v6`, `df4cb1c…0e10 # v6.0.3` | `d23441a…f803 # v6.1.0` | Pinned + updated (latest 6.x) |
| `actions/download-artifact` | `v8`, `37930b1…0131 # v7.0.0` | `3e5f45b…1e7c # v8.0.1` | Major update in sonar.yaml, pinned + updated in build_pr.yml |
| `actions/setup-java` | `v5`, `0f481fc…083a # v5.5.0` | `03ad4de…ac95 # v5.6.0` | Pinned + updated |
| `actions/upload-artifact` | `v7` | `043fb46…6a0a # v7.0.1` | Pinned |
| `github/codeql-action` (init, analyze) | `99df26d…97e9 # v4.37.0` | `f205ea1…7b38 # v4.37.4` | Updated |
| `octokit/request-action` | `dad4362…4f0d # v2.4.0` | `b91aaba…19ae # v3.0.0` | Major update |

**Files modified**: 4 — `build.yml`, `build_pr.yml`, `codeql.yml`, `sonar.yaml`
**Actions updated**: 7 unique across 30 `uses:` lines (2 minor updates, 3 major updates, 1 pin-only, 1 already-pinned patch bump)

## Major version notes

- **`actions/cache` v5 → v6** — ESM migration only, no input or output changes.
  First run after merge repopulates the Maven and Sonar caches.
- **`actions/download-artifact` v7 → v8** (sonar.yaml) — digest mismatches now
  fail the run instead of logging a warning, and non-zip downloads are no longer
  unzipped. `build_pr.yml` was already on the v8 tag, so this aligns both
  workflows on the same major.
- **`octokit/request-action` v2 → v3** — the only breaking change is the runner
  moving to Node 24. Outputs (`status`, `headers`, `data`) are unchanged, so the
  `fromJson(steps.get_pr_data.outputs.data)` expressions in `sonar.yaml` are
  unaffected.

`actions/checkout` is deliberately held at the latest 6.x (`v6.1.0`) rather than
`v7.0.1`. checkout v7 blocks checking out fork PRs under `workflow_run` and
`pull_request_target`, which is exactly the shape of `sonar.yaml`.

## Out of scope

- **`actions/create-github-app-token@v1`** in `issue-automation.yml` and
  `release-automation.yml` is left untouched. Those files are kept in sync from
  the `OmniTrustILM/.github` template, so pinning them here would only create
  drift that the next sync reverts — the fix belongs in the template, where it
  reaches every repo at once. It is worth doing: v1.12.0 dates to March 2025 and
  v3.2.0 is current.
- **First-party `OmniTrustILM/.github` refs** (4 composite actions on
  `@issue-automation-v1`, `post-release-stamping@release-automation-v1`, and the
  `containers-build-and-push.yml@main` / `containers-test.yml@main` reusable
  workflows) are intentionally tag- and branch-pinned and were not changed.
