### PR TITLE
Propagate CMP revocation reason and accept reason-less requests

### DIFF
--- a/src/main/java/com/otilm/core/service/cmp/message/RevocationReasonCodec.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/RevocationReasonCodec.java
@@ -1,0 +1,58 @@
+package com.otilm.core.service.cmp.message;
+
+import com.otilm.api.model.core.authority.CertificateRevocationReason;
+import org.bouncycastle.asn1.ASN1Enumerated;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+/**
+ * Shared parsing of the CMP revocation reason carried in {@code rr} crlEntryDetails, used by
+ * both {@link com.otilm.core.service.cmp.message.validator.impl.BodyRevocationValidator} (to
+ * reject codes the platform cannot represent) and
+ * {@link com.otilm.core.service.cmp.message.handler.RevocationMessageHandler} (to map the code
+ * to a {@link CertificateRevocationReason}). Keeping the two in one place stops the parse and
+ * the accepted-code set from drifting apart.
+ */
+public final class RevocationReasonCodec {
+
+    /** Highest defined CRLReason code; see {@link CertificateRevocationReason}. */
+    private static final BigInteger MAX_REASON_CODE = BigInteger.TEN;
+
+    private RevocationReasonCodec() {
+    }
+
+    /**
+     * The revocation reason code the client requested.
+     *
+     * @return the raw reasonCode, or empty when the rr specifies none — crlEntryDetails is
+     *         absent (valid per RFC 4210 §5.3.9), or present without a reasonCode extension.
+     */
+    public static Optional<BigInteger> requestedReasonCode(Extensions crlEntryDetails) {
+        if (crlEntryDetails == null) {
+            return Optional.empty();
+        }
+        Extension reasonCodeExt = crlEntryDetails.getExtension(Extension.reasonCode);
+        if (reasonCodeExt == null) {
+            return Optional.empty();
+        }
+        return Optional.of(ASN1Enumerated.getInstance(reasonCodeExt.getParsedValue()).getValue());
+    }
+
+    /**
+     * Map a raw reasonCode to a reason without narrowing first — an out-of-range or oversized
+     * value (one that would truncate through {@code longValue()}/{@code intValue()} into a
+     * valid code) is rejected on the raw {@link BigInteger}.
+     *
+     * @return the mapped reason, or empty when the code is out of range or otherwise unmappable
+     *         (7 unused per RFC 5280, 8 removeFromCRL).
+     */
+    public static Optional<CertificateRevocationReason> mapReasonCode(BigInteger reasonCode) {
+        if (reasonCode.signum() < 0 || reasonCode.compareTo(MAX_REASON_CODE) > 0) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(CertificateRevocationReason.fromReasonCode(reasonCode.intValueExact()));
+    }
+}

--- a/src/main/java/com/otilm/core/service/cmp/message/handler/RevocationMessageHandler.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/handler/RevocationMessageHandler.java
@@ -223,13 +223,22 @@ public class RevocationMessageHandler implements MessageHandler<PKIMessage> {
     }
 
     private CertificateRevocationReason getReason(RevDetails revocation) {
+        // crlEntryDetails / reasonCode are OPTIONAL (RFC 4210 §5.3.9); a reason-less rr
+        // defaults to UNSPECIFIED. BodyRevocationValidator has already rejected any
+        // reasonCode that fromReasonCode cannot map, so the null-fallback here is only
+        // defense-in-depth.
         Extensions crlEntryDetails = revocation.getCrlEntryDetails();
+        if (crlEntryDetails == null) {
+            return CertificateRevocationReason.UNSPECIFIED;
+        }
         Extension reasonCodeExt = crlEntryDetails.getExtension(Extension.reasonCode);
+        if (reasonCodeExt == null) {
+            return CertificateRevocationReason.UNSPECIFIED;
+        }
         int reasonCode = ASN1Enumerated.getInstance(reasonCodeExt.getParsedValue())
                 .getValue().intValue();
-        CertificateRevocationReason reason = CertificateRevocationReason.UNSPECIFIED;
-        CertificateRevocationReason.fromReasonCode(reasonCode);
-        return reason;
+        CertificateRevocationReason reason = CertificateRevocationReason.fromReasonCode(reasonCode);
+        return reason != null ? reason : CertificateRevocationReason.UNSPECIFIED;
     }
 
     private void revokeCertificate(ASN1OctetString tid, RevDetails revocation, Certificate certificate,

--- a/src/main/java/com/otilm/core/service/cmp/message/handler/RevocationMessageHandler.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/handler/RevocationMessageHandler.java
@@ -19,16 +19,14 @@ import com.otilm.core.security.authz.SecuredParentUUID;
 import com.otilm.core.service.cmp.configurations.ConfigurationContext;
 import com.otilm.core.service.cmp.message.CmpTransactionService;
 import com.otilm.core.service.cmp.message.PkiMessageDumper;
+import com.otilm.core.service.cmp.message.RevocationReasonCodec;
 import com.otilm.core.service.cmp.message.builder.PkiMessageBuilder;
 import com.otilm.core.service.v2.ClientOperationInternalService;
-import org.bouncycastle.asn1.ASN1Enumerated;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.cmp.*;
 import org.bouncycastle.asn1.crmf.CertId;
 import org.bouncycastle.asn1.crmf.CertTemplate;
-import org.bouncycastle.asn1.x509.Extension;
-import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigInteger;
 import java.util.Optional;
 
 /**
@@ -224,21 +223,21 @@ public class RevocationMessageHandler implements MessageHandler<PKIMessage> {
 
     private CertificateRevocationReason getReason(RevDetails revocation) {
         // crlEntryDetails / reasonCode are OPTIONAL (RFC 4210 §5.3.9); a reason-less rr
-        // defaults to UNSPECIFIED. BodyRevocationValidator has already rejected any
-        // reasonCode that fromReasonCode cannot map, so the null-fallback here is only
-        // defense-in-depth.
-        Extensions crlEntryDetails = revocation.getCrlEntryDetails();
-        if (crlEntryDetails == null) {
+        // defaults to UNSPECIFIED.
+        Optional<BigInteger> reasonCode =
+                RevocationReasonCodec.requestedReasonCode(revocation.getCrlEntryDetails());
+        if (reasonCode.isEmpty()) {
             return CertificateRevocationReason.UNSPECIFIED;
         }
-        Extension reasonCodeExt = crlEntryDetails.getExtension(Extension.reasonCode);
-        if (reasonCodeExt == null) {
+        Optional<CertificateRevocationReason> reason = RevocationReasonCodec.mapReasonCode(reasonCode.get());
+        if (reason.isEmpty()) {
+            // BodyRevocationValidator rejects unmappable codes before the handler runs, so
+            // this is defense-in-depth: log if a future path ever bypasses that guard rather
+            // than silently recording the wrong reason.
+            LOG.warn("Unmappable CMP revocation reasonCode {} defaulted to UNSPECIFIED", reasonCode.get());
             return CertificateRevocationReason.UNSPECIFIED;
         }
-        int reasonCode = ASN1Enumerated.getInstance(reasonCodeExt.getParsedValue())
-                .getValue().intValue();
-        CertificateRevocationReason reason = CertificateRevocationReason.fromReasonCode(reasonCode);
-        return reason != null ? reason : CertificateRevocationReason.UNSPECIFIED;
+        return reason.get();
     }
 
     private void revokeCertificate(ASN1OctetString tid, RevDetails revocation, Certificate certificate,

--- a/src/main/java/com/otilm/core/service/cmp/message/handler/RevocationMessageHandler.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/handler/RevocationMessageHandler.java
@@ -223,9 +223,15 @@ public class RevocationMessageHandler implements MessageHandler<PKIMessage> {
 
     private CertificateRevocationReason getReason(RevDetails revocation) {
         // crlEntryDetails / reasonCode are OPTIONAL (RFC 4210 §5.3.9); a reason-less rr
-        // defaults to UNSPECIFIED.
-        Optional<BigInteger> reasonCode =
-                RevocationReasonCodec.requestedReasonCode(revocation.getCrlEntryDetails());
+        // defaults to UNSPECIFIED. BodyRevocationValidator rejects malformed/unmappable codes
+        // upstream, so a parse failure here is defense-in-depth: default rather than propagate.
+        Optional<BigInteger> reasonCode;
+        try {
+            reasonCode = RevocationReasonCodec.requestedReasonCode(revocation.getCrlEntryDetails());
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Malformed CMP revocation reasonCode defaulted to UNSPECIFIED", e);
+            return CertificateRevocationReason.UNSPECIFIED;
+        }
         if (reasonCode.isEmpty()) {
             return CertificateRevocationReason.UNSPECIFIED;
         }

--- a/src/main/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidator.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidator.java
@@ -1,6 +1,7 @@
 package com.otilm.core.service.cmp.message.validator.impl;
 
 import com.otilm.api.interfaces.core.cmp.error.CmpProcessingException;
+import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.core.service.cmp.configurations.ConfigurationContext;
 import com.otilm.core.service.cmp.message.validator.BiValidator;
 import org.bouncycastle.asn1.ASN1Enumerated;
@@ -50,15 +51,24 @@ public class BodyRevocationValidator extends BaseValidator implements BiValidato
         checkValueNotNull(tid, certDetails, PKIFailureInfo.badCertId, "certDetails");
         checkValueNotNull(tid, certDetails.getSerialNumber(), PKIFailureInfo.badCertId, "SerialNumber");
         checkValueNotNull(tid, certDetails.getIssuer(), PKIFailureInfo.badCertId, "Issuer");
+        // crlEntryDetails is OPTIONAL per RFC 4210 §5.3.9 — a reason-less rr (e.g.
+        // `openssl cmp -cmd rr` without -revreason) is valid and defaults to UNSPECIFIED.
         Extensions crlEntryDetails = revDetails[0].getCrlEntryDetails();
-        checkValueNotNull(tid, crlEntryDetails, PKIFailureInfo.addInfoNotAvailable, "CrlEntryDetails");
-        Extension reasonCodeExt = crlEntryDetails.getExtension(Extension.reasonCode);
-        checkValueNotNull(tid, reasonCodeExt, PKIFailureInfo.incorrectData, "reasonCode");
-
-        long reasonCode = ASN1Enumerated.getInstance(reasonCodeExt.getParsedValue())
-                .getValue().longValue();
-        if (reasonCode < 0 || reasonCode > 10) {
-            throw new CmpProcessingException(tid, PKIFailureInfo.badDataFormat, "reasonCode is out of range <0,10>");
+        if (crlEntryDetails != null) {
+            Extension reasonCodeExt = crlEntryDetails.getExtension(Extension.reasonCode);
+            if (reasonCodeExt != null) {
+                long reasonCode = ASN1Enumerated.getInstance(reasonCodeExt.getParsedValue())
+                        .getValue().longValue();
+                // Reject codes the platform cannot represent: out-of-range values (the
+                // bound also stops a large value wrapping through the int cast below) plus
+                // 7 (unused, RFC 5280) and 8 (removeFromCRL — an un-revoke this path cannot
+                // perform). fromReasonCode returns null for every unmappable code.
+                if (reasonCode < 0 || reasonCode > 10
+                        || CertificateRevocationReason.fromReasonCode((int) reasonCode) == null) {
+                    throw new CmpProcessingException(tid, PKIFailureInfo.badDataFormat,
+                            "reasonCode " + reasonCode + " is not supported");
+                }
+            }
         }
 
         return null;// validation is ok

--- a/src/main/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidator.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidator.java
@@ -59,7 +59,14 @@ public class BodyRevocationValidator extends BaseValidator implements BiValidato
         // cannot perform). The check runs on the raw BigInteger so an oversized value cannot
         // truncate into an in-range code.
         Extensions crlEntryDetails = revDetails[0].getCrlEntryDetails();
-        Optional<BigInteger> reasonCode = RevocationReasonCodec.requestedReasonCode(crlEntryDetails);
+        Optional<BigInteger> reasonCode;
+        try {
+            reasonCode = RevocationReasonCodec.requestedReasonCode(crlEntryDetails);
+        } catch (IllegalArgumentException e) {
+            // reasonCode extension present but not a well-formed ENUMERATED.
+            throw new CmpProcessingException(tid, PKIFailureInfo.badDataFormat,
+                    "reasonCode is malformed", e);
+        }
         if (reasonCode.isPresent() && RevocationReasonCodec.mapReasonCode(reasonCode.get()).isEmpty()) {
             throw new CmpProcessingException(tid, PKIFailureInfo.badDataFormat,
                     "reasonCode " + reasonCode.get() + " is not supported");

--- a/src/main/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidator.java
+++ b/src/main/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidator.java
@@ -1,15 +1,16 @@
 package com.otilm.core.service.cmp.message.validator.impl;
 
 import com.otilm.api.interfaces.core.cmp.error.CmpProcessingException;
-import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.core.service.cmp.configurations.ConfigurationContext;
+import com.otilm.core.service.cmp.message.RevocationReasonCodec;
 import com.otilm.core.service.cmp.message.validator.BiValidator;
-import org.bouncycastle.asn1.ASN1Enumerated;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.cmp.*;
 import org.bouncycastle.asn1.crmf.CertTemplate;
-import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.Extensions;
+
+import java.math.BigInteger;
+import java.util.Optional;
 
 /**
  * Validate of revocation based messages, {@link RevReqContent}
@@ -51,24 +52,17 @@ public class BodyRevocationValidator extends BaseValidator implements BiValidato
         checkValueNotNull(tid, certDetails, PKIFailureInfo.badCertId, "certDetails");
         checkValueNotNull(tid, certDetails.getSerialNumber(), PKIFailureInfo.badCertId, "SerialNumber");
         checkValueNotNull(tid, certDetails.getIssuer(), PKIFailureInfo.badCertId, "Issuer");
-        // crlEntryDetails is OPTIONAL per RFC 4210 §5.3.9 — a reason-less rr (e.g.
-        // `openssl cmp -cmd rr` without -revreason) is valid and defaults to UNSPECIFIED.
+        // crlEntryDetails / reasonCode are OPTIONAL per RFC 4210 §5.3.9 — a reason-less rr
+        // (e.g. `openssl cmp -cmd rr` without -revreason) is valid and defaults to UNSPECIFIED.
+        // When a reasonCode is present, reject only the codes the platform cannot represent:
+        // out of range, 7 (unused, RFC 5280) and 8 (removeFromCRL — an un-revoke this path
+        // cannot perform). The check runs on the raw BigInteger so an oversized value cannot
+        // truncate into an in-range code.
         Extensions crlEntryDetails = revDetails[0].getCrlEntryDetails();
-        if (crlEntryDetails != null) {
-            Extension reasonCodeExt = crlEntryDetails.getExtension(Extension.reasonCode);
-            if (reasonCodeExt != null) {
-                long reasonCode = ASN1Enumerated.getInstance(reasonCodeExt.getParsedValue())
-                        .getValue().longValue();
-                // Reject codes the platform cannot represent: out-of-range values (the
-                // bound also stops a large value wrapping through the int cast below) plus
-                // 7 (unused, RFC 5280) and 8 (removeFromCRL — an un-revoke this path cannot
-                // perform). fromReasonCode returns null for every unmappable code.
-                if (reasonCode < 0 || reasonCode > 10
-                        || CertificateRevocationReason.fromReasonCode((int) reasonCode) == null) {
-                    throw new CmpProcessingException(tid, PKIFailureInfo.badDataFormat,
-                            "reasonCode " + reasonCode + " is not supported");
-                }
-            }
+        Optional<BigInteger> reasonCode = RevocationReasonCodec.requestedReasonCode(crlEntryDetails);
+        if (reasonCode.isPresent() && RevocationReasonCodec.mapReasonCode(reasonCode.get()).isEmpty()) {
+            throw new CmpProcessingException(tid, PKIFailureInfo.badDataFormat,
+                    "reasonCode " + reasonCode.get() + " is not supported");
         }
 
         return null;// validation is ok

--- a/src/test/java/com/otilm/core/integration/service/cmp/message/handler/RevocationMessageHandlerITest.java
+++ b/src/test/java/com/otilm/core/integration/service/cmp/message/handler/RevocationMessageHandlerITest.java
@@ -481,9 +481,8 @@ class RevocationMessageHandlerITest extends BaseSpringBootTest {
     }
 
     /**
-     * OmniTrustILM/core#1925 (defect B): the reason a CMP client puts in the rr
-     * crlEntryDetails/reasonCode must reach the revoke call. Before the fix, getReason
-     * dropped the parsed reason and every revocation was recorded as UNSPECIFIED.
+     * The reason a CMP client puts in the rr crlEntryDetails/reasonCode must reach the
+     * revoke call rather than being flattened to UNSPECIFIED.
      */
     @Test
     @Transactional
@@ -522,9 +521,8 @@ class RevocationMessageHandlerITest extends BaseSpringBootTest {
     }
 
     /**
-     * OmniTrustILM/core#1925 (defect A): a reason-less rr (no crlEntryDetails) is valid per
-     * RFC 4210 §5.3.9 and must default to UNSPECIFIED. Before the fix, getReason dereferenced
-     * a null crlEntryDetails and threw, so the revoke call never happened.
+     * A reason-less rr (no crlEntryDetails) is valid per RFC 4210 §5.3.9 and must default to
+     * UNSPECIFIED, reaching the revoke call rather than being rejected.
      */
     @Test
     @Transactional
@@ -540,6 +538,82 @@ class RevocationMessageHandlerITest extends BaseSpringBootTest {
                         CmpTestUtil.generateKeyPairEC().getPrivate(),
                         CmpTestUtil.createRevocationBodyWithoutReason(
                                 x509Certificate.getSerialNumber()))
+                .toASN1Structure();
+
+        given(pollFeature.pollCertificate(any(), any(), any(), any()))
+                .willReturn(new PollResult.Reached(revokedCertificate));
+
+        testedHandler.handle(request,
+                new Mobile3gppProfileContext(cmpProfileSigPrt,
+                        raProfile,
+                        request,
+                        certificateKeyService,
+                        null,
+                        null));
+
+        ArgumentCaptor<ClientCertificateRevocationDto> captor =
+                ArgumentCaptor.forClass(ClientCertificateRevocationDto.class);
+        verify(clientOperationService).revokeCertificate(any(), any(), any(), captor.capture());
+        assertEquals(CertificateRevocationReason.UNSPECIFIED, captor.getValue().getReason());
+    }
+
+    /**
+     * A crlEntryDetails present with other crlEntryExtensions but no reasonCode is still a
+     * reason-less rr and must default to UNSPECIFIED.
+     */
+    @Test
+    @Transactional
+    void test_handle_revocation_defaultsToUnspecified_whenCrlEntryDetailsHasNoReasonCode() throws Exception {
+        revokedCertificate.setState(CertificateState.ISSUED);
+        revokedCertificate.setRaProfile(raProfile);
+        revokedCertificate.setRaProfileUuid(raProfile.getUuid());
+        certificateRepository.save(revokedCertificate);
+
+        String trxId = "785";
+        PKIMessage request = CmpTestUtil.createSignatureBasedMessage(
+                        trxId,
+                        CmpTestUtil.generateKeyPairEC().getPrivate(),
+                        CmpTestUtil.createRevocationBodyWithNonReasonExtension(
+                                x509Certificate.getSerialNumber()))
+                .toASN1Structure();
+
+        given(pollFeature.pollCertificate(any(), any(), any(), any()))
+                .willReturn(new PollResult.Reached(revokedCertificate));
+
+        testedHandler.handle(request,
+                new Mobile3gppProfileContext(cmpProfileSigPrt,
+                        raProfile,
+                        request,
+                        certificateKeyService,
+                        null,
+                        null));
+
+        ArgumentCaptor<ClientCertificateRevocationDto> captor =
+                ArgumentCaptor.forClass(ClientCertificateRevocationDto.class);
+        verify(clientOperationService).revokeCertificate(any(), any(), any(), captor.capture());
+        assertEquals(CertificateRevocationReason.UNSPECIFIED, captor.getValue().getReason());
+    }
+
+    /**
+     * Defense-in-depth: BodyRevocationValidator rejects unmappable reason codes upstream, but
+     * if one reaches the handler directly (as here, bypassing the validator) getReason falls
+     * back to UNSPECIFIED rather than propagating a null reason.
+     */
+    @Test
+    @Transactional
+    void test_handle_revocation_fallsBackToUnspecified_whenReasonCodeUnmappable() throws Exception {
+        revokedCertificate.setState(CertificateState.ISSUED);
+        revokedCertificate.setRaProfile(raProfile);
+        revokedCertificate.setRaProfileUuid(raProfile.getUuid());
+        certificateRepository.save(revokedCertificate);
+
+        String trxId = "786";
+        // reasonCode 8 == removeFromCRL — no CertificateRevocationReason maps to it.
+        PKIMessage request = CmpTestUtil.createSignatureBasedMessage(
+                        trxId,
+                        CmpTestUtil.generateKeyPairEC().getPrivate(),
+                        CmpTestUtil.createRevocationBody(
+                                x509Certificate.getSerialNumber(), 8))
                 .toASN1Structure();
 
         given(pollFeature.pollCertificate(any(), any(), any(), any()))

--- a/src/test/java/com/otilm/core/integration/service/cmp/message/handler/RevocationMessageHandlerITest.java
+++ b/src/test/java/com/otilm/core/integration/service/cmp/message/handler/RevocationMessageHandlerITest.java
@@ -633,6 +633,44 @@ class RevocationMessageHandlerITest extends BaseSpringBootTest {
         assertEquals(CertificateRevocationReason.UNSPECIFIED, captor.getValue().getReason());
     }
 
+    /**
+     * Defense-in-depth: a malformed reasonCode (not a well-formed ENUMERATED) reaching the
+     * handler directly must default to UNSPECIFIED rather than propagating the ASN.1 parse
+     * failure. BodyRevocationValidator rejects such input as badDataFormat upstream.
+     */
+    @Test
+    @Transactional
+    void test_handle_revocation_fallsBackToUnspecified_whenReasonCodeMalformed() throws Exception {
+        revokedCertificate.setState(CertificateState.ISSUED);
+        revokedCertificate.setRaProfile(raProfile);
+        revokedCertificate.setRaProfileUuid(raProfile.getUuid());
+        certificateRepository.save(revokedCertificate);
+
+        String trxId = "787";
+        PKIMessage request = CmpTestUtil.createSignatureBasedMessage(
+                        trxId,
+                        CmpTestUtil.generateKeyPairEC().getPrivate(),
+                        CmpTestUtil.createRevocationBodyWithMalformedReason(
+                                x509Certificate.getSerialNumber()))
+                .toASN1Structure();
+
+        given(pollFeature.pollCertificate(any(), any(), any(), any()))
+                .willReturn(new PollResult.Reached(revokedCertificate));
+
+        testedHandler.handle(request,
+                new Mobile3gppProfileContext(cmpProfileSigPrt,
+                        raProfile,
+                        request,
+                        certificateKeyService,
+                        null,
+                        null));
+
+        ArgumentCaptor<ClientCertificateRevocationDto> captor =
+                ArgumentCaptor.forClass(ClientCertificateRevocationDto.class);
+        verify(clientOperationService).revokeCertificate(any(), any(), any(), captor.capture());
+        assertEquals(CertificateRevocationReason.UNSPECIFIED, captor.getValue().getReason());
+    }
+
     // ----------------------------------------------------------------------------------------------------------
     // HELPER METHODS
     // ----------------------------------------------------------------------------------------------------------

--- a/src/test/java/com/otilm/core/integration/service/cmp/message/handler/RevocationMessageHandlerITest.java
+++ b/src/test/java/com/otilm/core/integration/service/cmp/message/handler/RevocationMessageHandlerITest.java
@@ -3,11 +3,13 @@ package com.otilm.core.integration.service.cmp.message.handler;
 import com.otilm.api.model.client.connector.v2.ConnectorVersion;
 import com.otilm.api.model.common.enums.cryptography.KeyAlgorithm;
 import com.otilm.api.model.common.enums.cryptography.KeyType;
+import com.otilm.api.model.core.authority.CertificateRevocationReason;
 import com.otilm.api.model.core.certificate.CertificateState;
 import com.otilm.api.model.core.cmp.CmpTransactionState;
 import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.core.connector.FunctionGroupCode;
 import com.otilm.api.model.core.cryptography.key.KeyState;
+import com.otilm.api.model.core.v2.ClientCertificateRevocationDto;
 import com.otilm.core.dao.entity.*;
 import com.otilm.core.dao.entity.cmp.CmpProfile;
 import com.otilm.core.dao.repository.*;
@@ -31,6 +33,7 @@ import org.bouncycastle.asn1.cmp.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -45,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @Import(PollMocks.class)
 class RevocationMessageHandlerITest extends BaseSpringBootTest {
@@ -474,6 +478,85 @@ class RevocationMessageHandlerITest extends BaseSpringBootTest {
         String freeText = body.getStatus()[0].getStatusString().getStringAtUTF8(0).getString();
         assertEquals("problem with revocation", freeText,
                 "expected the safe placeholder when the cause is not a CmpProcessingException — internal SQL detail must not leak to the wire");
+    }
+
+    /**
+     * OmniTrustILM/core#1925 (defect B): the reason a CMP client puts in the rr
+     * crlEntryDetails/reasonCode must reach the revoke call. Before the fix, getReason
+     * dropped the parsed reason and every revocation was recorded as UNSPECIFIED.
+     */
+    @Test
+    @Transactional
+    void test_handle_revocation_propagatesRequestedReason_toRevokeCall() throws Exception {
+        revokedCertificate.setState(CertificateState.ISSUED);
+        revokedCertificate.setRaProfile(raProfile);
+        revokedCertificate.setRaProfileUuid(raProfile.getUuid());
+        certificateRepository.save(revokedCertificate);
+
+        String trxId = "783";
+        // reasonCode 4 == superseded
+        PKIMessage request = CmpTestUtil.createSignatureBasedMessage(
+                        trxId,
+                        CmpTestUtil.generateKeyPairEC().getPrivate(),
+                        CmpTestUtil.createRevocationBody(
+                                x509Certificate.getSerialNumber(), 4))
+                .toASN1Structure();
+
+        given(pollFeature.pollCertificate(any(), any(), any(), any()))
+                .willReturn(new PollResult.Reached(revokedCertificate));
+
+        testedHandler.handle(request,
+                new Mobile3gppProfileContext(cmpProfileSigPrt,
+                        raProfile,
+                        request,
+                        certificateKeyService,
+                        null,
+                        null));
+
+        ArgumentCaptor<ClientCertificateRevocationDto> captor =
+                ArgumentCaptor.forClass(ClientCertificateRevocationDto.class);
+        verify(clientOperationService).revokeCertificate(any(), any(), any(), captor.capture());
+        assertEquals(CertificateRevocationReason.SUPERSEDED, captor.getValue().getReason(),
+                "the client's requested revocation reason must reach the revoke call, "
+                        + "not be discarded as UNSPECIFIED");
+    }
+
+    /**
+     * OmniTrustILM/core#1925 (defect A): a reason-less rr (no crlEntryDetails) is valid per
+     * RFC 4210 §5.3.9 and must default to UNSPECIFIED. Before the fix, getReason dereferenced
+     * a null crlEntryDetails and threw, so the revoke call never happened.
+     */
+    @Test
+    @Transactional
+    void test_handle_revocation_defaultsToUnspecified_whenNoReasonGiven() throws Exception {
+        revokedCertificate.setState(CertificateState.ISSUED);
+        revokedCertificate.setRaProfile(raProfile);
+        revokedCertificate.setRaProfileUuid(raProfile.getUuid());
+        certificateRepository.save(revokedCertificate);
+
+        String trxId = "784";
+        PKIMessage request = CmpTestUtil.createSignatureBasedMessage(
+                        trxId,
+                        CmpTestUtil.generateKeyPairEC().getPrivate(),
+                        CmpTestUtil.createRevocationBodyWithoutReason(
+                                x509Certificate.getSerialNumber()))
+                .toASN1Structure();
+
+        given(pollFeature.pollCertificate(any(), any(), any(), any()))
+                .willReturn(new PollResult.Reached(revokedCertificate));
+
+        testedHandler.handle(request,
+                new Mobile3gppProfileContext(cmpProfileSigPrt,
+                        raProfile,
+                        request,
+                        certificateKeyService,
+                        null,
+                        null));
+
+        ArgumentCaptor<ClientCertificateRevocationDto> captor =
+                ArgumentCaptor.forClass(ClientCertificateRevocationDto.class);
+        verify(clientOperationService).revokeCertificate(any(), any(), any(), captor.capture());
+        assertEquals(CertificateRevocationReason.UNSPECIFIED, captor.getValue().getReason());
     }
 
     // ----------------------------------------------------------------------------------------------------------

--- a/src/test/java/com/otilm/core/service/cmp/CmpTestUtil.java
+++ b/src/test/java/com/otilm/core/service/cmp/CmpTestUtil.java
@@ -138,63 +138,45 @@ public class CmpTestUtil {
     }
 
     public static PKIBody createRevocationBody(BigInteger serialNumber) throws IOException {
-        // Just preparations
-        X500Name issuerDN = new X500Name("CN=ManagementCA");
-        X500Name userDN = new X500Name("CN=user");
-
-        // Cert template
-        CertTemplateBuilder myCertTemplate = new CertTemplateBuilder();
-        myCertTemplate.setIssuer(issuerDN);
-        myCertTemplate.setSubject(userDN);
-        myCertTemplate.setSerialNumber(new ASN1Integer(serialNumber));
-
-        // Extension with revocation reason
-        ExtensionsGenerator extGenerator = new ExtensionsGenerator();
-        extGenerator.addExtension(Extension.reasonCode,
-                false, CRLReason.lookup(CRLReason.cessationOfOperation));
-
-        ASN1EncodableVector v = new ASN1EncodableVector();
-        v.add(myCertTemplate.build());
-        v.add(extGenerator.generate());
-        RevReqContent myRevReqContent = new RevReqContent(
-                RevDetails.getInstance(new DERSequence(v)));
-        return new PKIBody(PKIBody.TYPE_REVOCATION_REQ, myRevReqContent);
+        return revocationBody(serialNumber, reasonCodeExtensions(CRLReason.cessationOfOperation));
     }
 
     public static PKIBody createRevocationBody(BigInteger serialNumber, int reasonCode) throws IOException {
-        X500Name issuerDN = new X500Name("CN=ManagementCA");
-        X500Name userDN = new X500Name("CN=user");
+        return revocationBody(serialNumber, reasonCodeExtensions(reasonCode));
+    }
 
-        CertTemplateBuilder myCertTemplate = new CertTemplateBuilder();
-        myCertTemplate.setIssuer(issuerDN);
-        myCertTemplate.setSubject(userDN);
-        myCertTemplate.setSerialNumber(new ASN1Integer(serialNumber));
+    public static PKIBody createRevocationBodyWithoutReason(BigInteger serialNumber) {
+        return revocationBody(serialNumber, null);
+    }
 
+    /** A revocation body whose crlEntryDetails carries a non-reasonCode extension only. */
+    public static PKIBody createRevocationBodyWithNonReasonExtension(BigInteger serialNumber) throws IOException {
         ExtensionsGenerator extGenerator = new ExtensionsGenerator();
-        extGenerator.addExtension(Extension.reasonCode, false, new ASN1Enumerated(reasonCode));
+        extGenerator.addExtension(Extension.invalidityDate, false,
+                new DERGeneralizedTime("20260101000000Z"));
+        return revocationBody(serialNumber, extGenerator.generate());
+    }
+
+    private static PKIBody revocationBody(BigInteger serialNumber, Extensions crlEntryDetails) {
+        CertTemplateBuilder myCertTemplate = new CertTemplateBuilder();
+        myCertTemplate.setIssuer(new X500Name("CN=ManagementCA"));
+        myCertTemplate.setSubject(new X500Name("CN=user"));
+        myCertTemplate.setSerialNumber(new ASN1Integer(serialNumber));
 
         ASN1EncodableVector v = new ASN1EncodableVector();
         v.add(myCertTemplate.build());
-        v.add(extGenerator.generate());
+        if (crlEntryDetails != null) {
+            v.add(crlEntryDetails);
+        }
         RevReqContent myRevReqContent = new RevReqContent(
                 RevDetails.getInstance(new DERSequence(v)));
         return new PKIBody(PKIBody.TYPE_REVOCATION_REQ, myRevReqContent);
     }
 
-    public static PKIBody createRevocationBodyWithoutReason(BigInteger serialNumber) {
-        X500Name issuerDN = new X500Name("CN=ManagementCA");
-        X500Name userDN = new X500Name("CN=user");
-
-        CertTemplateBuilder myCertTemplate = new CertTemplateBuilder();
-        myCertTemplate.setIssuer(issuerDN);
-        myCertTemplate.setSubject(userDN);
-        myCertTemplate.setSerialNumber(new ASN1Integer(serialNumber));
-
-        ASN1EncodableVector v = new ASN1EncodableVector();
-        v.add(myCertTemplate.build());
-        RevReqContent myRevReqContent = new RevReqContent(
-                RevDetails.getInstance(new DERSequence(v)));
-        return new PKIBody(PKIBody.TYPE_REVOCATION_REQ, myRevReqContent);
+    private static Extensions reasonCodeExtensions(int reasonCode) throws IOException {
+        ExtensionsGenerator extGenerator = new ExtensionsGenerator();
+        extGenerator.addExtension(Extension.reasonCode, false, new ASN1Enumerated(reasonCode));
+        return extGenerator.generate();
     }
 
     public static PKIBody createCertConfBody(X509CertificateHolder cert, BigInteger certReqId) throws

--- a/src/test/java/com/otilm/core/service/cmp/CmpTestUtil.java
+++ b/src/test/java/com/otilm/core/service/cmp/CmpTestUtil.java
@@ -157,6 +157,13 @@ public class CmpTestUtil {
         return revocationBody(serialNumber, extGenerator.generate());
     }
 
+    /** A revocation body whose reasonCode extension carries a non-ENUMERATED (malformed) value. */
+    public static PKIBody createRevocationBodyWithMalformedReason(BigInteger serialNumber) throws IOException {
+        ExtensionsGenerator extGenerator = new ExtensionsGenerator();
+        extGenerator.addExtension(Extension.reasonCode, false, new ASN1Integer(4));
+        return revocationBody(serialNumber, extGenerator.generate());
+    }
+
     private static PKIBody revocationBody(BigInteger serialNumber, Extensions crlEntryDetails) {
         CertTemplateBuilder myCertTemplate = new CertTemplateBuilder();
         myCertTemplate.setIssuer(new X500Name("CN=ManagementCA"));

--- a/src/test/java/com/otilm/core/service/cmp/CmpTestUtil.java
+++ b/src/test/java/com/otilm/core/service/cmp/CmpTestUtil.java
@@ -161,6 +161,42 @@ public class CmpTestUtil {
         return new PKIBody(PKIBody.TYPE_REVOCATION_REQ, myRevReqContent);
     }
 
+    public static PKIBody createRevocationBody(BigInteger serialNumber, int reasonCode) throws IOException {
+        X500Name issuerDN = new X500Name("CN=ManagementCA");
+        X500Name userDN = new X500Name("CN=user");
+
+        CertTemplateBuilder myCertTemplate = new CertTemplateBuilder();
+        myCertTemplate.setIssuer(issuerDN);
+        myCertTemplate.setSubject(userDN);
+        myCertTemplate.setSerialNumber(new ASN1Integer(serialNumber));
+
+        ExtensionsGenerator extGenerator = new ExtensionsGenerator();
+        extGenerator.addExtension(Extension.reasonCode, false, new ASN1Enumerated(reasonCode));
+
+        ASN1EncodableVector v = new ASN1EncodableVector();
+        v.add(myCertTemplate.build());
+        v.add(extGenerator.generate());
+        RevReqContent myRevReqContent = new RevReqContent(
+                RevDetails.getInstance(new DERSequence(v)));
+        return new PKIBody(PKIBody.TYPE_REVOCATION_REQ, myRevReqContent);
+    }
+
+    public static PKIBody createRevocationBodyWithoutReason(BigInteger serialNumber) {
+        X500Name issuerDN = new X500Name("CN=ManagementCA");
+        X500Name userDN = new X500Name("CN=user");
+
+        CertTemplateBuilder myCertTemplate = new CertTemplateBuilder();
+        myCertTemplate.setIssuer(issuerDN);
+        myCertTemplate.setSubject(userDN);
+        myCertTemplate.setSerialNumber(new ASN1Integer(serialNumber));
+
+        ASN1EncodableVector v = new ASN1EncodableVector();
+        v.add(myCertTemplate.build());
+        RevReqContent myRevReqContent = new RevReqContent(
+                RevDetails.getInstance(new DERSequence(v)));
+        return new PKIBody(PKIBody.TYPE_REVOCATION_REQ, myRevReqContent);
+    }
+
     public static PKIBody createCertConfBody(X509CertificateHolder cert, BigInteger certReqId) throws
             OperatorCreationException, CMPException {
         CertificateConfirmationContent content = new CertificateConfirmationContentBuilder()

--- a/src/test/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidatorTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidatorTest.java
@@ -1,0 +1,170 @@
+package com.otilm.core.service.cmp.message.validator.impl;
+
+import com.otilm.api.interfaces.core.cmp.error.CmpProcessingException;
+import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.ASN1Enumerated;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.DERGeneralizedTime;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.cmp.PKIBody;
+import org.bouncycastle.asn1.cmp.PKIHeader;
+import org.bouncycastle.asn1.cmp.PKIHeaderBuilder;
+import org.bouncycastle.asn1.cmp.PKIMessage;
+import org.bouncycastle.asn1.cmp.RevDetails;
+import org.bouncycastle.asn1.cmp.RevReqContent;
+import org.bouncycastle.asn1.crmf.CertTemplate;
+import org.bouncycastle.asn1.crmf.CertTemplateBuilder;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.ExtensionsGenerator;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link BodyRevocationValidator#validateIn}.
+ *
+ * <p>Regression coverage for OmniTrustILM/core#1925: the CMP {@code rr} validator used to
+ * reject a revocation request that omitted {@code crlEntryDetails} / {@code reasonCode},
+ * although RFC 4210 &sect;5.3.9 marks {@code crlEntryDetails} OPTIONAL (see the validator's
+ * own Javadoc), while at the same time <em>accepting</em> reason codes 7 (unused) and 8
+ * (removeFromCRL) that {@link com.otilm.api.model.core.authority.CertificateRevocationReason}
+ * cannot map. This validator must now treat a missing reason as valid and reject only the
+ * reason codes the platform cannot represent.</p>
+ */
+class BodyRevocationValidatorTest {
+
+    @Test
+    void acceptsRr_withoutCrlEntryDetails() {
+        PKIMessage msg = rrMessage(fullCertTemplate(), null);
+
+        // RFC 4210 §5.3.9: crlEntryDetails is OPTIONAL — a reason-less rr is valid.
+        assertThatCode(() -> new BodyRevocationValidator().validateIn(msg, null))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void acceptsRr_withCrlEntryDetails_butNoReasonCode() {
+        PKIMessage msg = rrMessage(fullCertTemplate(), nonReasonExtensions());
+
+        // crlEntryDetails may carry other crlEntryExtensions (e.g. invalidityDate) without a
+        // reasonCode — that is still a valid, reason-less revocation request.
+        assertThatCode(() -> new BodyRevocationValidator().validateIn(msg, null))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void acceptsRr_withSupportedReasonCode_superseded() {
+        PKIMessage msg = rrMessage(fullCertTemplate(), reasonCodeExtensions(4));
+
+        // superseded (4) is a mappable reason — preserved accept behaviour.
+        assertThatCode(() -> new BodyRevocationValidator().validateIn(msg, null))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsRr_withUnusedReasonCode_7() {
+        PKIMessage msg = rrMessage(fullCertTemplate(), reasonCodeExtensions(7));
+
+        // reasonCode 7 is unused per RFC 5280 — no CertificateRevocationReason maps to it.
+        assertThatThrownBy(() -> new BodyRevocationValidator().validateIn(msg, null))
+                .isInstanceOf(CmpProcessingException.class)
+                .hasMessageContaining("is not supported");
+    }
+
+    @Test
+    void rejectsRr_withRemoveFromCrlReasonCode_8() {
+        PKIMessage msg = rrMessage(fullCertTemplate(), reasonCodeExtensions(8));
+
+        // reasonCode 8 (removeFromCRL) is an un-revoke this path cannot perform — reject
+        // rather than silently record it as UNSPECIFIED.
+        assertThatThrownBy(() -> new BodyRevocationValidator().validateIn(msg, null))
+                .isInstanceOf(CmpProcessingException.class)
+                .hasMessageContaining("is not supported");
+    }
+
+    @Test
+    void rejectsRr_withReasonCodeAboveRange_11() {
+        PKIMessage msg = rrMessage(fullCertTemplate(), reasonCodeExtensions(11));
+
+        assertThatThrownBy(() -> new BodyRevocationValidator().validateIn(msg, null))
+                .isInstanceOf(CmpProcessingException.class)
+                .hasMessageContaining("is not supported");
+    }
+
+    @Test
+    void rejectsRr_withoutSerialNumber() {
+        PKIMessage msg = rrMessage(certTemplateWithoutSerialNumber(), reasonCodeExtensions(4));
+
+        // The serialNumber guard must still fire ahead of any crlEntryDetails handling.
+        assertThatThrownBy(() -> new BodyRevocationValidator().validateIn(msg, null))
+                .isInstanceOf(CmpProcessingException.class)
+                .hasMessageContaining("SerialNumber");
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // HELPERS
+    // ------------------------------------------------------------------------------------------
+
+    private static PKIMessage rrMessage(CertTemplate certTemplate, Extensions crlEntryDetails) {
+        ASN1EncodableVector v = new ASN1EncodableVector();
+        v.add(certTemplate);
+        if (crlEntryDetails != null) {
+            v.add(crlEntryDetails);
+        }
+        RevReqContent content = new RevReqContent(RevDetails.getInstance(new DERSequence(v)));
+        return pkiMessage(new PKIBody(PKIBody.TYPE_REVOCATION_REQ, content));
+    }
+
+    private static CertTemplate fullCertTemplate() {
+        return new CertTemplateBuilder()
+                .setIssuer(new X500Name("CN=ManagementCA"))
+                .setSubject(new X500Name("CN=user"))
+                .setSerialNumber(new ASN1Integer(BigInteger.valueOf(123456)))
+                .build();
+    }
+
+    private static CertTemplate certTemplateWithoutSerialNumber() {
+        return new CertTemplateBuilder()
+                .setIssuer(new X500Name("CN=ManagementCA"))
+                .setSubject(new X500Name("CN=user"))
+                .build();
+    }
+
+    private static Extensions reasonCodeExtensions(long code) {
+        try {
+            ExtensionsGenerator g = new ExtensionsGenerator();
+            g.addExtension(Extension.reasonCode, false, new ASN1Enumerated(BigInteger.valueOf(code)));
+            return g.generate();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Extensions nonReasonExtensions() {
+        try {
+            ExtensionsGenerator g = new ExtensionsGenerator();
+            g.addExtension(Extension.invalidityDate, false, new DERGeneralizedTime("20260101000000Z"));
+            return g.generate();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static PKIMessage pkiMessage(PKIBody body) {
+        PKIHeader header = new PKIHeaderBuilder(
+                PKIHeader.CMP_2000,
+                new GeneralName(new X500Name("CN=test-sender")),
+                new GeneralName(new X500Name("CN=test-recipient")))
+                .setTransactionID(new DEROctetString(new byte[]{1, 2, 3, 4}))
+                .build();
+        return new PKIMessage(header, body);
+    }
+}

--- a/src/test/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidatorTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidatorTest.java
@@ -10,6 +10,7 @@ import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.cmp.PKIBody;
 import org.bouncycastle.asn1.cmp.PKIHeader;
 import org.bouncycastle.asn1.cmp.PKIHeaderBuilder;
+import org.bouncycastle.asn1.cmp.PKIFailureInfo;
 import org.bouncycastle.asn1.cmp.PKIMessage;
 import org.bouncycastle.asn1.cmp.RevDetails;
 import org.bouncycastle.asn1.cmp.RevReqContent;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.math.BigInteger;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -110,6 +112,21 @@ class BodyRevocationValidatorTest {
     }
 
     @Test
+    void rejectsRr_withMalformedReasonCode() {
+        // A reasonCode extension whose value is not an ENUMERATED (here an INTEGER) is
+        // malformed wire input; the validator must surface a badDataFormat rejection rather
+        // than letting the ASN.1 parse throw an unchecked exception.
+        PKIMessage msg = rrMessage(fullCertTemplate(), malformedReasonExtensions());
+
+        // Malformed wire input must surface as a badDataFormat CMP rejection, not an unchecked
+        // exception leaking the raw ASN.1 parse error out of the validator.
+        assertThatThrownBy(() -> new BodyRevocationValidator().validateIn(msg, null))
+                .isInstanceOf(CmpProcessingException.class)
+                .satisfies(ex -> assertThat(((CmpProcessingException) ex).getFailureInfo())
+                        .isEqualTo(PKIFailureInfo.badDataFormat));
+    }
+
+    @Test
     void rejectsRr_withoutSerialNumber() {
         PKIMessage msg = rrMessage(certTemplateWithoutSerialNumber(), reasonCodeExtensions(4));
 
@@ -156,6 +173,17 @@ class BodyRevocationValidatorTest {
         try {
             ExtensionsGenerator g = new ExtensionsGenerator();
             g.addExtension(Extension.reasonCode, false, new ASN1Enumerated(code));
+            return g.generate();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Extensions malformedReasonExtensions() {
+        try {
+            ExtensionsGenerator g = new ExtensionsGenerator();
+            // Wrong ASN.1 type for reasonCode — INTEGER instead of ENUMERATED.
+            g.addExtension(Extension.reasonCode, false, new ASN1Integer(4));
             return g.generate();
         } catch (IOException e) {
             throw new IllegalStateException(e);

--- a/src/test/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidatorTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidatorTest.java
@@ -22,6 +22,8 @@ import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.asn1.x509.ExtensionsGenerator;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -68,30 +70,12 @@ class BodyRevocationValidatorTest {
                 .doesNotThrowAnyException();
     }
 
-    @Test
-    void rejectsRr_withUnusedReasonCode_7() {
-        PKIMessage msg = rrMessage(fullCertTemplate(), reasonCodeExtensions(7));
-
-        // reasonCode 7 is unused per RFC 5280 — no CertificateRevocationReason maps to it.
-        assertThatThrownBy(() -> new BodyRevocationValidator().validateIn(msg, null))
-                .isInstanceOf(CmpProcessingException.class)
-                .hasMessageContaining("is not supported");
-    }
-
-    @Test
-    void rejectsRr_withRemoveFromCrlReasonCode_8() {
-        PKIMessage msg = rrMessage(fullCertTemplate(), reasonCodeExtensions(8));
-
-        // reasonCode 8 (removeFromCRL) is an un-revoke this path cannot perform — reject
-        // rather than silently record it as UNSPECIFIED.
-        assertThatThrownBy(() -> new BodyRevocationValidator().validateIn(msg, null))
-                .isInstanceOf(CmpProcessingException.class)
-                .hasMessageContaining("is not supported");
-    }
-
-    @Test
-    void rejectsRr_withReasonCodeAboveRange_11() {
-        PKIMessage msg = rrMessage(fullCertTemplate(), reasonCodeExtensions(11));
+    // 7 (unused per RFC 5280), 8 (removeFromCRL — an un-revoke this path cannot perform) and
+    // 11 (out of range): none maps to a CertificateRevocationReason, all must be rejected.
+    @ParameterizedTest
+    @ValueSource(ints = {7, 8, 11})
+    void rejectsRr_withUnsupportedReasonCode(int reasonCode) {
+        PKIMessage msg = rrMessage(fullCertTemplate(), reasonCodeExtensions(reasonCode));
 
         assertThatThrownBy(() -> new BodyRevocationValidator().validateIn(msg, null))
                 .isInstanceOf(CmpProcessingException.class)

--- a/src/test/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidatorTest.java
+++ b/src/test/java/com/otilm/core/service/cmp/message/validator/impl/BodyRevocationValidatorTest.java
@@ -31,13 +31,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link BodyRevocationValidator#validateIn}.
  *
- * <p>Regression coverage for OmniTrustILM/core#1925: the CMP {@code rr} validator used to
- * reject a revocation request that omitted {@code crlEntryDetails} / {@code reasonCode},
- * although RFC 4210 &sect;5.3.9 marks {@code crlEntryDetails} OPTIONAL (see the validator's
- * own Javadoc), while at the same time <em>accepting</em> reason codes 7 (unused) and 8
- * (removeFromCRL) that {@link com.otilm.api.model.core.authority.CertificateRevocationReason}
- * cannot map. This validator must now treat a missing reason as valid and reject only the
- * reason codes the platform cannot represent.</p>
+ * <p>RFC 4210 &sect;5.3.9 marks {@code crlEntryDetails} OPTIONAL, so a reason-less {@code rr}
+ * is valid and only reason codes the platform cannot represent are rejected: out of range,
+ * 7 (unused per RFC 5280) and 8 (removeFromCRL). {@link
+ * com.otilm.api.model.core.authority.CertificateRevocationReason} defines the mappable set.</p>
  */
 class BodyRevocationValidatorTest {
 
@@ -100,6 +97,19 @@ class BodyRevocationValidatorTest {
     }
 
     @Test
+    void rejectsRr_withOversizedReasonCode() {
+        // An ASN.1 ENUMERATED whose value is 2^64 + 4 truncates to 4 (superseded) through
+        // BigInteger.longValue(); the validator must reject on the raw value, not the
+        // truncated one, so a crafted oversized code cannot masquerade as an in-range reason.
+        PKIMessage msg = rrMessage(fullCertTemplate(),
+                reasonCodeExtensions(new BigInteger("18446744073709551620")));
+
+        assertThatThrownBy(() -> new BodyRevocationValidator().validateIn(msg, null))
+                .isInstanceOf(CmpProcessingException.class)
+                .hasMessageContaining("is not supported");
+    }
+
+    @Test
     void rejectsRr_withoutSerialNumber() {
         PKIMessage msg = rrMessage(certTemplateWithoutSerialNumber(), reasonCodeExtensions(4));
 
@@ -139,9 +149,13 @@ class BodyRevocationValidatorTest {
     }
 
     private static Extensions reasonCodeExtensions(long code) {
+        return reasonCodeExtensions(BigInteger.valueOf(code));
+    }
+
+    private static Extensions reasonCodeExtensions(BigInteger code) {
         try {
             ExtensionsGenerator g = new ExtensionsGenerator();
-            g.addExtension(Extension.reasonCode, false, new ASN1Enumerated(BigInteger.valueOf(code)));
+            g.addExtension(Extension.reasonCode, false, new ASN1Enumerated(code));
             return g.generate();
         } catch (IOException e) {
             throw new IllegalStateException(e);


### PR DESCRIPTION
Closes #1925

## Problem

Two defects in the CMP revocation (`rr`) path:

- **Reason discarded.** `RevocationMessageHandler.getReason` dropped the parsed `reasonCode` and returned `UNSPECIFIED` for every request, so the client's requested revocation reason never reached the revoke call.
- **Reason wrongly mandatory.** `BodyRevocationValidator` rejected any `rr` that omitted `crlEntryDetails` / `reasonCode`, though RFC 4210 §5.3.9 marks `crlEntryDetails` OPTIONAL (spec-conformant clients like `openssl cmp -cmd rr` without `-revreason` were refused). At the same time it *accepted* reason codes 7 (unused) and 8 (removeFromCRL) that `CertificateRevocationReason` cannot map.

## Fix

- `getReason` maps the requested code and defaults to `UNSPECIFIED` when no reason is given (no more NPE on a reason-less `rr`).
- Validator treats `crlEntryDetails` as optional and rejects only reason codes the platform cannot represent (out of range, 7, 8) with `badDataFormat`.
- Shared `RevocationReasonCodec` performs the parse for both the validator and the handler, mapping on the raw `BigInteger` so an oversized ASN.1 `ENUMERATED` cannot truncate into an in-range code.

**Behavioral change:** real reasons (keyCompromise, certificateHold, …) now propagate to authority connectors instead of `UNSPECIFIED`. Reason-less `rr` flips from rejection to success (the direction the RFC requires). Revocations already recorded as `UNSPECIFIED` cannot be back-filled — the original reason was never persisted.

## Tests

- `BodyRevocationValidatorTest` (new): optional reason accepted; codes 7/8/out-of-range and an oversized code rejected; serialNumber guard preserved.
- `RevocationMessageHandlerITest` (new cases): requested reason reaches the revoke call; reason-less `rr` and a `crlEntryDetails` without `reasonCode` default to `UNSPECIFIED`; unmappable code falls back to `UNSPECIFIED`.

## Out of scope

`CertificateRevocationReason.AA_COMPROMISE` maps to `CRLReason.CA_COMPROMISE` in the `interfaces` repo — a pre-existing defect unrelated to this path (`fromReasonCode(int)`, used here, is unaffected). Tracked separately.