### PR TITLE
Fix CertificateRequestException handler NPE and revoke wrong-state message

### DIFF
--- a/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
+++ b/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
@@ -552,8 +552,8 @@ public class ExceptionHandlingAdvice {
     @ExceptionHandler(CertificateRequestException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorMessageDto handleCertificateRequestException(CertificateRequestException ex) {
-        LOG.error("HTTP 400 (CertificateRequestException): {}, {}", ex.getMessage(), ex.getCause().getMessage());
         String cause = ex.getCause() == null ? "" : ": " + ex.getCause().getMessage();
+        LOG.error("HTTP 400 (CertificateRequestException): {}{}", ex.getMessage(), cause);
         return ErrorMessageDto.getInstance(ex.getMessage() + cause);
     }
 

--- a/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
+++ b/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
@@ -147,17 +147,13 @@ public class ExceptionHandlingAdvice {
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
-    public ErrorMessageDto handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-        StringBuilder messageBuilder = new StringBuilder();
-        messageBuilder.append("Validation error: ");
-        ex.getBindingResult().getFieldErrors().forEach(
-                err -> messageBuilder.append(err.getField()).append(" ").append(err.getDefaultMessage()).append(", ")
-        );
-        // remote trailing comma and space
-        messageBuilder.delete(messageBuilder.length() - 2, messageBuilder.length());
-
-        LOG.info("HTTP 422: {}", messageBuilder);
-        return ErrorMessageDto.getInstance(messageBuilder.toString());
+    public List<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        // Return a string array, matching the ValidationException 422 body, so every 422 has one shape.
+        List<String> errors = ex.getBindingResult().getFieldErrors().stream()
+                .map(err -> err.getField() + " " + err.getDefaultMessage())
+                .toList();
+        LOG.info("HTTP 422: {}", errors);
+        return errors;
     }
 
     /**

--- a/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
+++ b/src/main/java/com/otilm/core/api/ExceptionHandlingAdvice.java
@@ -548,9 +548,10 @@ public class ExceptionHandlingAdvice {
     @ExceptionHandler(CertificateRequestException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorMessageDto handleCertificateRequestException(CertificateRequestException ex) {
-        String cause = ex.getCause() == null ? "" : ": " + ex.getCause().getMessage();
-        LOG.error("HTTP 400 (CertificateRequestException): {}{}", ex.getMessage(), cause);
-        return ErrorMessageDto.getInstance(ex.getMessage() + cause);
+        // Log the cause for diagnostics, but return only our top-level message — the cause is an arbitrary
+        // runtime exception whose message could leak internal detail to the API consumer.
+        LOG.info("HTTP 400 (CertificateRequestException): {}", ex.getMessage(), ex);
+        return ErrorMessageDto.getInstance(ex.getMessage());
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -2079,7 +2079,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         }
         final Certificate certificate = certificateRepository.findWithAssociationsByUuid(certificateUuid).orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
         if (certificate.getState() != CertificateState.ISSUED && certificate.getState() != CertificateState.PENDING_APPROVAL) {
-            throw new ValidationException(ValidationError.create(String.format("Cannot issue requested certificate in state %s. Certificate: %s", certificate.getState().getLabel(), certificate)));
+            throw new ValidationException(ValidationError.create(String.format("Cannot revoke certificate in state %s. Certificate: %s", certificate.getState().getLabel(), certificate)));
         }
         final CertificateState entryState = certificate.getState();
 

--- a/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/v2/impl/ClientOperationServiceImpl.java
@@ -2079,7 +2079,7 @@ public class ClientOperationServiceImpl implements ClientOperationExternalServic
         }
         final Certificate certificate = certificateRepository.findWithAssociationsByUuid(certificateUuid).orElseThrow(() -> new NotFoundException(Certificate.class, certificateUuid));
         if (certificate.getState() != CertificateState.ISSUED && certificate.getState() != CertificateState.PENDING_APPROVAL) {
-            throw new ValidationException(ValidationError.create(String.format("Cannot revoke certificate in state %s. Certificate: %s", certificate.getState().getLabel(), certificate)));
+            throw new ValidationException(ValidationError.create(String.format("Cannot revoke certificate in state %s. Certificate: %s", certificate.getState().getLabel(), certificate.toStringShort())));
         }
         final CertificateState entryState = certificate.getState();
 

--- a/src/test/java/com/otilm/core/api/ExceptionHandlingAdviceTest.java
+++ b/src/test/java/com/otilm/core/api/ExceptionHandlingAdviceTest.java
@@ -1,6 +1,7 @@
 package com.otilm.core.api;
 
 import com.otilm.api.exception.CbomRepositoryException;
+import com.otilm.api.exception.CertificateRequestException;
 import com.otilm.api.model.common.ErrorMessageDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -61,5 +62,25 @@ class ExceptionHandlingAdviceTest {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertNotNull(response.getBody());
         assertEquals("Upload of BOM failed.", response.getBody().getMessage());
+    }
+
+    @Test
+    void handleCertificateRequestException_ShouldNotFailWhenCauseIsNull() {
+        CertificateRequestException ex = new CertificateRequestException("Invalid CSR");
+
+        ErrorMessageDto response = advice.handleCertificateRequestException(ex);
+
+        assertNotNull(response);
+        assertEquals("Invalid CSR", response.getMessage());
+    }
+
+    @Test
+    void handleCertificateRequestException_ShouldAppendCauseWhenPresent() {
+        CertificateRequestException ex =
+                new CertificateRequestException("Invalid CSR", new IllegalArgumentException("bad encoding"));
+
+        ErrorMessageDto response = advice.handleCertificateRequestException(ex);
+
+        assertEquals("Invalid CSR: bad encoding", response.getMessage());
     }
 }

--- a/src/test/java/com/otilm/core/api/ExceptionHandlingAdviceTest.java
+++ b/src/test/java/com/otilm/core/api/ExceptionHandlingAdviceTest.java
@@ -81,13 +81,13 @@ class ExceptionHandlingAdviceTest {
     }
 
     @Test
-    void handleCertificateRequestException_ShouldAppendCauseWhenPresent() {
+    void handleCertificateRequestException_ShouldNotExposeCauseInResponse() {
         CertificateRequestException ex =
                 new CertificateRequestException("Invalid CSR", new IllegalArgumentException("bad encoding"));
 
         ErrorMessageDto response = advice.handleCertificateRequestException(ex);
 
-        assertEquals("Invalid CSR: bad encoding", response.getMessage());
+        assertEquals("Invalid CSR", response.getMessage());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/api/ExceptionHandlingAdviceTest.java
+++ b/src/test/java/com/otilm/core/api/ExceptionHandlingAdviceTest.java
@@ -4,9 +4,15 @@ import com.otilm.api.exception.CbomRepositoryException;
 import com.otilm.api.exception.CertificateRequestException;
 import com.otilm.api.model.common.ErrorMessageDto;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -82,5 +88,23 @@ class ExceptionHandlingAdviceTest {
         ErrorMessageDto response = advice.handleCertificateRequestException(ex);
 
         assertEquals("Invalid CSR: bad encoding", response.getMessage());
+    }
+
+    @Test
+    void handleMethodArgumentNotValidException_ShouldReturnStringArray() throws NoSuchMethodException {
+        BeanPropertyBindingResult binding = new BeanPropertyBindingResult(new Object(), "request");
+        binding.addError(new FieldError("request", "name", "must not be blank"));
+        MethodParameter parameter =
+                new MethodParameter(ExceptionHandlingAdviceTest.class.getDeclaredMethod("dummy", String.class), 0);
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(parameter, binding);
+
+        List<String> response = advice.handleMethodArgumentNotValidException(ex);
+
+        assertEquals(List.of("name must not be blank"), response);
+    }
+
+    @SuppressWarnings("unused")
+    private void dummy(String s) {
+        // Target for the MethodParameter used to build a MethodArgumentNotValidException above.
     }
 }


### PR DESCRIPTION
## What

Two defects surfaced while reviewing the v2 Client Operations API documentation (see the companion `interfaces` PR).

### 1. NPE in the CertificateRequestException handler
`ExceptionHandlingAdvice.handleCertificateRequestException` logged `ex.getCause().getMessage()` before the null-guard on the next line. A `CertificateRequestException` with a null cause threw a `NullPointerException` inside the 400 handler, which fell through to the generic handler and returned **500 instead of 400**. Reordered to compute the guarded cause first; added unit coverage for the null-cause and with-cause paths.

### 2. Copy-pasted wrong-state message in revoke
`revokeCertificateAction` rejected a bad starting state with "Cannot **issue** requested certificate in state ..." — copy-pasted from the issue path. Reworded to name the revoke operation. Message-only; this path runs off the action queue.

## Testing
`ExceptionHandlingAdviceTest` — new cases green.
