### PR TITLE
Replace stale czertainly references with ilm in TSP test and prebuild script

### DIFF
--- a/prebuild_image_script
+++ b/prebuild_image_script
@@ -3,8 +3,8 @@
 echo "Pre-build ILM CORE docker image"
 
 echo "Cleaning containers if exists"
-docker rm ilmcont
-docker rmi prebuild
+docker rm -f ilmcont 2>/dev/null || true
+docker rmi -f prebuild 2>/dev/null || true
 
 echo "Refreshing directory for data from container"
 rm -r data

--- a/prebuild_image_script
+++ b/prebuild_image_script
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-echo "Pre-build CZERTAINLY CORE docker image"
+echo "Pre-build ILM CORE docker image"
 
 echo "Cleaning containers if exists"
-docker rm czertainlycont
+docker rm ilmcont
 docker rmi prebuild
 
 echo "Refreshing directory for data from container"
@@ -22,14 +22,14 @@ fi
 echo "MVN Build"
 if [[ "$OSTYPE" == "darwin"* ]]; then
   echo "MacOS detected, using TESTCONTAINERS_HOST_OVERRIDE"
-  docker run -e TESTCONTAINERS_HOST_OVERRIDE=docker.for.mac.host.internal -v /var/run/docker.sock:/var/run/docker.sock --name czertainlycont -i prebuild mvn -f /home/app/pom.xml -U clean package $MVN_OPTS
+  docker run -e TESTCONTAINERS_HOST_OVERRIDE=docker.for.mac.host.internal -v /var/run/docker.sock:/var/run/docker.sock --name ilmcont -i prebuild mvn -f /home/app/pom.xml -U clean package $MVN_OPTS
 else
-  docker run -v /var/run/docker.sock:/var/run/docker.sock --name czertainlycont -i prebuild mvn -f /home/app/pom.xml -U clean package $MVN_OPTS
+  docker run -v /var/run/docker.sock:/var/run/docker.sock --name ilmcont -i prebuild mvn -f /home/app/pom.xml -U clean package $MVN_OPTS
 fi
 
-echo "Starting czertainlycont"
-docker start czertainlycont
+echo "Starting ilmcont"
+docker start ilmcont
 
 echo "Copy jar back to Tmp"
-docker cp czertainlycont:/home/app/target data/target
-docker cp czertainlycont:/home/app/docker data/docker
+docker cp ilmcont:/home/app/target data/target
+docker cp ilmcont:/home/app/docker data/docker

--- a/src/test/java/com/otilm/core/util/TspProtocolUrlFactoryTest.java
+++ b/src/test/java/com/otilm/core/util/TspProtocolUrlFactoryTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class TspProtocolUrlFactoryTest {
 
-    private static final String BASE_URL = "https://czertainly.example.com";
+    private static final String BASE_URL = "https://ilm.example.com";
 
     @Test
     void forTspProfile_composesProtocolPathWithProfileName() {
@@ -23,7 +23,7 @@ class TspProtocolUrlFactoryTest {
         String url = TspProtocolUrlFactory.forTspProfile(BASE_URL, tspProfileName);
 
         // then
-        assertEquals("https://czertainly.example.com/v1/protocols/tsp/my-tsp-profile", url);
+        assertEquals("https://ilm.example.com/v1/protocols/tsp/my-tsp-profile", url);
     }
 
     @Test
@@ -35,7 +35,7 @@ class TspProtocolUrlFactoryTest {
         String url = TspProtocolUrlFactory.forSigningProfile(BASE_URL, signingProfileName);
 
         // then
-        assertEquals("https://czertainly.example.com/v1/protocols/tsp/signingProfiles/my-signing-profile", url);
+        assertEquals("https://ilm.example.com/v1/protocols/tsp/signingProfiles/my-signing-profile", url);
     }
 
     @Test
@@ -55,12 +55,12 @@ class TspProtocolUrlFactoryTest {
     @Test
     void forTspProfile_concatenatesBaseUrlVerbatimWithoutNormalization() {
         // given a base URL carrying a context path; the web layer is responsible for supplying it clean
-        var baseUrlWithContextPath = "https://czertainly.example.com/api";
+        var baseUrlWithContextPath = "https://ilm.example.com/api";
 
         // when
         String url = TspProtocolUrlFactory.forTspProfile(baseUrlWithContextPath, "profile");
 
         // then
-        assertEquals("https://czertainly.example.com/api/v1/protocols/tsp/profile", url);
+        assertEquals("https://ilm.example.com/api/v1/protocols/tsp/profile", url);
     }
 }


### PR DESCRIPTION
## What

Removed leftover `czertainly` references:

- `TspProtocolUrlFactoryTest.java` — test base URL `czertainly.example.com` → `ilm.example.com` (5 occurrences).
- `prebuild_image_script` — echo `CZERTAINLY CORE` → `ILM CORE`; docker container name `czertainlycont` → `ilmcont` (7 occurrences).

## Why

Cosmetic leftovers from the org rename. No behavior change — test URL is an arbitrary literal; container name is internal to the prebuild script.

## Verification

`mvn -Dtest=TspProtocolUrlFactoryTest test` — 4 run, 0 failures.