### PR TITLE
Exclude the real JMS producers from the component scan in ProducerMocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>core</artifactId>
-    <version>2.19.0</version>
+    <version>2.20.0-SNAPSHOT</version>
     <name>core</name>
 
     <properties>

--- a/src/test/java/com/otilm/core/architecture/ContextSignature.java
+++ b/src/test/java/com/otilm/core/architecture/ContextSignature.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
  * - nested @TestConfiguration class simple-names,
  * - verbatim @SpringBootTest arguments,
  * - @AutoConfigure* annotation names, and
- * - @TypeExcludeFilters filter-class names.
+ * - @TypeExcludeFilters filter-class names of the NEAREST declaration in the chain.
  *
  * Two classes with equal signatures are expected to share one cached context. Import order is not a signature axis
  */
@@ -64,7 +64,10 @@ final class ContextSignature {
                 configs.addAll(t.configs());
                 springBootTest.addAll(t.springBootTest());
                 autoconfig.addAll(t.autoconfig());
-                typeExcludeFilters.addAll(t.typeExcludeFilters());
+                // Spring resolves @TypeExcludeFilters to the NEAREST declaration only.
+                if (typeExcludeFilters.isEmpty()) {
+                    typeExcludeFilters.addAll(t.typeExcludeFilters());
+                }
             }
             simple = extendsGraph.get(simple);
         }

--- a/src/test/java/com/otilm/core/architecture/ContextSignature.java
+++ b/src/test/java/com/otilm/core/architecture/ContextSignature.java
@@ -17,8 +17,9 @@ import java.util.stream.Stream;
  * - @TestPropertySource args,
  * - @DirtiesContext mode,
  * - nested @TestConfiguration class simple-names,
- * - verbatim @SpringBootTest arguments, and
- * - @AutoConfigure* annotation names.
+ * - verbatim @SpringBootTest arguments,
+ * - @AutoConfigure* annotation names, and
+ * - @TypeExcludeFilters filter-class names.
  *
  * Two classes with equal signatures are expected to share one cached context. Import order is not a signature axis
  */
@@ -47,6 +48,7 @@ final class ContextSignature {
         TreeSet<String> configs = new TreeSet<>();
         TreeSet<String> springBootTest = new TreeSet<>();
         TreeSet<String> autoconfig = new TreeSet<>();
+        TreeSet<String> typeExcludeFilters = new TreeSet<>();
 
         String simple = startSimpleName;
         int hops = 0;
@@ -62,13 +64,15 @@ final class ContextSignature {
                 configs.addAll(t.configs());
                 springBootTest.addAll(t.springBootTest());
                 autoconfig.addAll(t.autoconfig());
+                typeExcludeFilters.addAll(t.typeExcludeFilters());
             }
             simple = extendsGraph.get(simple);
         }
         return "imports=" + imports + ";mocks=" + mocks + ";profiles=" + profiles
                 + ";props=" + props + ";dirties=" + dirties
                 + ";configs=" + configs + ";sbt=" + springBootTest
-                + ";autoconfig=" + autoconfig;
+                + ";autoconfig=" + autoconfig
+                + ";typeExcludeFilters=" + typeExcludeFilters;
     }
 
     static int distinctCount(Path testRoot) {

--- a/src/test/java/com/otilm/core/architecture/ContextSignatureTest.java
+++ b/src/test/java/com/otilm/core/architecture/ContextSignatureTest.java
@@ -184,8 +184,8 @@ class ContextSignatureTest {
     }
 
     @Test
-    void typeExcludeFiltersAreUnionedAcrossTheInheritanceChain(@TempDir Path dir) throws IOException {
-        // @TypeExcludeFilters is @Inherited, so a base class's filters apply to every subclass.
+    void typeExcludeFiltersAreInheritedWhenTheSubclassDeclaresNone(@TempDir Path dir) throws IOException {
+        // @TypeExcludeFilters is @Inherited, so a base class's filters apply to a subclass that declares none.
         write(dir, "BaseFilteredTest.java", """
                 @SpringBootTest
                 @TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class)
@@ -203,6 +203,36 @@ class ContextSignatureTest {
         Map<String, Path> byName = ContextSignature.filesBySimpleName(dir);
         assertThat(ContextSignature.of("ChildITest", graph, byName))
                 .isEqualTo(ContextSignature.of("StandaloneITest", graph, byName));
+    }
+
+    @Test
+    void aSubclassTypeExcludeFiltersDeclarationShadowsTheAncestors(@TempDir Path dir) throws IOException {
+        // TypeExcludeFiltersContextCustomizerFactory resolves the NEAREST @TypeExcludeFilters declaration and uses
+        // only its value(), so the base class's filter A does not reach the context at all.
+        write(dir, "BaseFilteredTest.java", """
+                @SpringBootTest
+                @TypeExcludeFilters(AMocks.ExcludeFilter.class)
+                abstract class BaseFilteredTest {}
+                """);
+        write(dir, "ShadowingITest.java", """
+                @TypeExcludeFilters(BMocks.ExcludeFilter.class)
+                class ShadowingITest extends BaseFilteredTest {}
+                """);
+        write(dir, "OnlyBITest.java", """
+                @SpringBootTest
+                @TypeExcludeFilters(BMocks.ExcludeFilter.class)
+                class OnlyBITest {}
+                """);
+        write(dir, "BothFiltersITest.java", """
+                @SpringBootTest
+                @TypeExcludeFilters({AMocks.ExcludeFilter.class, BMocks.ExcludeFilter.class})
+                class BothFiltersITest {}
+                """);
+        Map<String, String> graph = TestClassTaxonomy.parseExtends(dir);
+        Map<String, Path> byName = ContextSignature.filesBySimpleName(dir);
+        assertThat(ContextSignature.of("ShadowingITest", graph, byName))
+                .isEqualTo(ContextSignature.of("OnlyBITest", graph, byName))
+                .isNotEqualTo(ContextSignature.of("BothFiltersITest", graph, byName));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/architecture/ContextSignatureTest.java
+++ b/src/test/java/com/otilm/core/architecture/ContextSignatureTest.java
@@ -121,6 +121,91 @@ class ContextSignatureTest {
     }
 
     @Test
+    void typeExcludeFiltersForkSignature(@TempDir Path dir) throws IOException {
+        Path filtered = write(dir, "FilteredITest.java", """
+                @SpringBootTest
+                @Import(ProducerMocks.class)
+                @TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class)
+                class FilteredITest {}
+                """);
+        write(dir, "UnfilteredITest.java", """
+                @SpringBootTest
+                @Import(ProducerMocks.class)
+                class UnfilteredITest {}
+                """);
+        assertThat(TestClassTaxonomy.annotationTokens(filtered).typeExcludeFilters())
+                .containsExactly("ProducerMocks.MockedProducersTypeExcludeFilter");
+
+        Map<String, String> graph = TestClassTaxonomy.parseExtends(dir);
+        Map<String, Path> byName = ContextSignature.filesBySimpleName(dir);
+        assertThat(ContextSignature.of("FilteredITest", graph, byName))
+                .isNotEqualTo(ContextSignature.of("UnfilteredITest", graph, byName));
+    }
+
+    @Test
+    void typeExcludeFilterOrderIsNotASignatureAxis(@TempDir Path dir) throws IOException {
+        // TypeExcludeFiltersContextCustomizer's equals/hashCode are the filter SET, so order cannot fork the context.
+        write(dir, "AbFilterITest.java", """
+                @SpringBootTest
+                @TypeExcludeFilters({ProducerMocks.MockedProducersTypeExcludeFilter.class, PollMocks.PollFilter.class})
+                class AbFilterITest {}
+                """);
+        write(dir, "BaFilterITest.java", """
+                @SpringBootTest
+                @TypeExcludeFilters({PollMocks.PollFilter.class, ProducerMocks.MockedProducersTypeExcludeFilter.class})
+                class BaFilterITest {}
+                """);
+        Map<String, String> graph = TestClassTaxonomy.parseExtends(dir);
+        Map<String, Path> byName = ContextSignature.filesBySimpleName(dir);
+        assertThat(ContextSignature.of("AbFilterITest", graph, byName))
+                .isEqualTo(ContextSignature.of("BaFilterITest", graph, byName));
+    }
+
+    @Test
+    void typeExcludeFiltersKeepTheirOuterClassQualifier(@TempDir Path dir) throws IOException {
+        // Two modules may each declare a same-named nested filter; dropping the qualifier would collapse them.
+        Path a = write(dir, "AModuleITest.java", """
+                @SpringBootTest
+                @TypeExcludeFilters(AMocks.ExcludeFilter.class)
+                class AModuleITest {}
+                """);
+        write(dir, "BModuleITest.java", """
+                @SpringBootTest
+                @TypeExcludeFilters(BMocks.ExcludeFilter.class)
+                class BModuleITest {}
+                """);
+        assertThat(TestClassTaxonomy.annotationTokens(a).typeExcludeFilters())
+                .containsExactly("AMocks.ExcludeFilter");
+
+        Map<String, String> graph = TestClassTaxonomy.parseExtends(dir);
+        Map<String, Path> byName = ContextSignature.filesBySimpleName(dir);
+        assertThat(ContextSignature.of("AModuleITest", graph, byName))
+                .isNotEqualTo(ContextSignature.of("BModuleITest", graph, byName));
+    }
+
+    @Test
+    void typeExcludeFiltersAreUnionedAcrossTheInheritanceChain(@TempDir Path dir) throws IOException {
+        // @TypeExcludeFilters is @Inherited, so a base class's filters apply to every subclass.
+        write(dir, "BaseFilteredTest.java", """
+                @SpringBootTest
+                @TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class)
+                abstract class BaseFilteredTest {}
+                """);
+        write(dir, "ChildITest.java", """
+                class ChildITest extends BaseFilteredTest {}
+                """);
+        write(dir, "StandaloneITest.java", """
+                @SpringBootTest
+                @TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class)
+                class StandaloneITest {}
+                """);
+        Map<String, String> graph = TestClassTaxonomy.parseExtends(dir);
+        Map<String, Path> byName = ContextSignature.filesBySimpleName(dir);
+        assertThat(ContextSignature.of("ChildITest", graph, byName))
+                .isEqualTo(ContextSignature.of("StandaloneITest", graph, byName));
+    }
+
+    @Test
     void textBlockFixtureContentIsNotParsedAsRealAnnotations(@TempDir Path dir) throws IOException {
         // A meta-test whose only "annotations" live inside a text block (fixture data), like this very
         // class. code() strips text blocks, so these must not be misread as real context annotations.

--- a/src/test/java/com/otilm/core/architecture/ProducerMocksExclusionArchTest.java
+++ b/src/test/java/com/otilm/core/architecture/ProducerMocksExclusionArchTest.java
@@ -1,0 +1,72 @@
+package com.otilm.core.architecture;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code ProducerMocks} mocks the JMS producers, but {@code @Primary} only shadows them — the real
+ * {@code @Component}s stay scanned and instantiated.
+ *
+ * The module therefore has to be imported together with the {@code @TypeExcludeFilters} that drops those classes
+ * from the component scan. This pins them together.
+ */
+class ProducerMocksExclusionArchTest {
+
+    private static final Path TEST_ROOT = Path.of("src/test/java");
+
+    private static final String MODULE = "ProducerMocks";
+
+    // Line-anchored: a real annotation starts its line, so the module's own Javadoc mention does not match.
+    private static final Pattern DECLARES_EXCLUSION = Pattern.compile(
+            "(?m)^[ \\t]*@TypeExcludeFilters\\(\\s*ProducerMocks\\.MockedProducersTypeExcludeFilter\\.class\\s*\\)");
+
+    @Test
+    void everyProducerMocksImportAlsoExcludesTheRealProducersFromTheScan() {
+        Map<String, String> inheritance = TestClassTaxonomy.parseExtends(TEST_ROOT);
+        List<Path> importers = testSources()
+                // Only a context-loading class can be affected; that also keeps meta-test fixture sources out.
+                .filter(file -> TestClassTaxonomy.loadsContext(file, inheritance))
+                .filter(file -> TestClassTaxonomy.annotationTokens(file).imports().contains(MODULE))
+                .toList();
+
+        assertThat(importers)
+                .describedAs("ProducerMocks is expected to be in use; this guard is vacuous otherwise")
+                .isNotEmpty();
+
+        assertThat(importers)
+                .describedAs("every test class importing ProducerMocks must also declare "
+                        + "@TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class) — without it "
+                        + "the real producers stay in the component scan, so NotificationProducer's "
+                        + "@TransactionalEventListener can still dispatch real JMS sends after a commit")
+                .allMatch(file -> DECLARES_EXCLUSION.matcher(read(file)).find());
+    }
+
+    private static Stream<Path> testSources() {
+        try (Stream<Path> files = Files.walk(TEST_ROOT)) {
+            return files.filter(Files::isRegularFile)
+                    .filter(file -> file.toString().endsWith(".java"))
+                    .toList()
+                    .stream();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static String read(Path file) {
+        try {
+            return Files.readString(file);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/src/test/java/com/otilm/core/architecture/ProducerMocksExclusionArchTest.java
+++ b/src/test/java/com/otilm/core/architecture/ProducerMocksExclusionArchTest.java
@@ -8,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,9 +25,7 @@ class ProducerMocksExclusionArchTest {
 
     private static final String MODULE = "ProducerMocks";
 
-    // Line-anchored: a real annotation starts its line, so the module's own Javadoc mention does not match.
-    private static final Pattern DECLARES_EXCLUSION = Pattern.compile(
-            "(?m)^[ \\t]*@TypeExcludeFilters\\(\\s*ProducerMocks\\.MockedProducersTypeExcludeFilter\\.class\\s*\\)");
+    private static final String EXCLUSION_FILTER = "ProducerMocks.MockedProducersTypeExcludeFilter";
 
     @Test
     void everyProducerMocksImportAlsoExcludesTheRealProducersFromTheScan() {
@@ -41,14 +38,18 @@ class ProducerMocksExclusionArchTest {
 
         assertThat(importers)
                 .describedAs("ProducerMocks is expected to be in use; this guard is vacuous otherwise")
-                .isNotEmpty();
-
-        assertThat(importers)
+                .isNotEmpty()
                 .describedAs("every test class importing ProducerMocks must also declare "
                         + "@TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class) — without it "
                         + "the real producers stay in the component scan, so NotificationProducer's "
                         + "@TransactionalEventListener can still dispatch real JMS sends after a commit")
-                .allMatch(file -> DECLARES_EXCLUSION.matcher(read(file)).find());
+                .allMatch(ProducerMocksExclusionArchTest::declaresExclusion);
+    }
+
+    /** Any declaration form counts: an array of filters, wrapped lines, or a fully-qualified filter reference. */
+    private static boolean declaresExclusion(Path file) {
+        return TestClassTaxonomy.annotationTokens(file).typeExcludeFilters().stream()
+                .anyMatch(filter -> filter.endsWith(EXCLUSION_FILTER));
     }
 
     private static Stream<Path> testSources() {
@@ -57,14 +58,6 @@ class ProducerMocksExclusionArchTest {
                     .filter(file -> file.toString().endsWith(".java"))
                     .toList()
                     .stream();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    private static String read(Path file) {
-        try {
-            return Files.readString(file);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/src/test/java/com/otilm/core/architecture/TestClassTaxonomy.java
+++ b/src/test/java/com/otilm/core/architecture/TestClassTaxonomy.java
@@ -78,6 +78,12 @@ final class TestClassTaxonomy {
     private static final Pattern SPRING_BOOT_TEST_ARGS = Pattern.compile("@SpringBootTest\\b\\s*(?:\\(([^)]*)\\))?");
     // @AutoConfigure* slice/test annotations (e.g. @AutoConfigureMockMvc) fork the context cache key.
     private static final Pattern AUTOCONFIGURE = Pattern.compile("@(AutoConfigure\\w+)\\b");
+    // @TypeExcludeFilters becomes a TypeExcludeFiltersContextCustomizer whose equals/hashCode are the filter SET,
+    // so the filter classes fork the context cache key and their declaration order does not.
+    private static final Pattern TYPE_EXCLUDE_FILTERS = Pattern.compile("@TypeExcludeFilters\\s*\\(([^)]*)\\)");
+    // Filter class references keep their outer-class qualifier: the filters here are nested types, and two modules
+    // could each declare a same-named nested filter.
+    private static final Pattern FILTER_CLASS = Pattern.compile("((?:\\w+\\.)*\\w+)\\.class");
 
     private TestClassTaxonomy() {
     }
@@ -145,7 +151,8 @@ final class TestClassTaxonomy {
             List<String> dirties,
             List<String> configs,
             List<String> springBootTest,
-            List<String> autoconfig) {
+            List<String> autoconfig,
+            List<String> typeExcludeFilters) {
     }
 
     static ContextTokens annotationTokens(Path javaFile) {
@@ -164,7 +171,8 @@ final class TestClassTaxonomy {
                 parseDirties(src),
                 allMatches(NESTED_CONFIG, 1, src),
                 normalizedArgs(SPRING_BOOT_TEST_ARGS, src),
-                allMatches(AUTOCONFIGURE, 1, src));
+                allMatches(AUTOCONFIGURE, 1, src),
+                parseTypeExcludeFilters(src));
     }
 
     /** Every {@code group} capture across all matches of {@code p} in {@code src}. */
@@ -198,6 +206,14 @@ final class TestClassTaxonomy {
         Matcher inherit = INHERIT.matcher(args);
         profiles.add("inheritProfiles=" + (inherit.find() ? inherit.group(1) : "true"));
         return profiles;
+    }
+
+    private static List<String> parseTypeExcludeFilters(String src) {
+        List<String> filters = new ArrayList<>();
+        for (String args : allMatches(TYPE_EXCLUDE_FILTERS, 1, src)) {
+            filters.addAll(allMatches(FILTER_CLASS, 1, args.replaceAll("\\s+", "")));
+        }
+        return filters;
     }
 
     private static List<String> parseDirties(String src) {

--- a/src/test/java/com/otilm/core/architecture/TestClassTaxonomy.java
+++ b/src/test/java/com/otilm/core/architecture/TestClassTaxonomy.java
@@ -141,7 +141,8 @@ final class TestClassTaxonomy {
 
     /**
      * Context-affecting annotation tokens parsed from ONE file (not its ancestors). Each list is an axis of the
-     * Spring context cache key; {@link ContextSignature} unions the axes across the inheritance chain.
+     * Spring context cache key; {@link ContextSignature} combines the axes across the inheritance chain — unioning
+     * the inherited ones, and taking only the nearest declaration where Spring itself does (see {@link #typeExcludeFilters()}).
      */
     record ContextTokens(
             List<String> imports,

--- a/src/test/java/com/otilm/core/integration/mockbeans/MockBeanModuleWiringITest.java
+++ b/src/test/java/com/otilm/core/integration/mockbeans/MockBeanModuleWiringITest.java
@@ -14,12 +14,15 @@ import com.otilm.core.util.mockbeans.PollMocks;
 import com.otilm.core.util.mockbeans.ProducerMocks;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Import;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mockingDetails;
 
 @Import({ProducerMocks.class, ManagementApiMocks.class, PollMocks.class})
+@TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class)
 class MockBeanModuleWiringITest extends BaseSpringBootTest {
 
     @Autowired NotificationProducer notificationProducer;
@@ -30,6 +33,7 @@ class MockBeanModuleWiringITest extends BaseSpringBootTest {
     @Autowired RoleManagementApiClient roleManagementApiClient;
     @Autowired PlatformAuthenticationClient authenticationClient;
     @Autowired PollFeature pollFeature;
+    @Autowired ApplicationContext applicationContext;
 
     @Test
     void allModuleBeansAreMocks() {
@@ -41,5 +45,17 @@ class MockBeanModuleWiringITest extends BaseSpringBootTest {
         assertThat(mockingDetails(roleManagementApiClient).isMock()).isTrue();
         assertThat(mockingDetails(authenticationClient).isMock()).isTrue();
         assertThat(mockingDetails(pollFeature).isMock()).isTrue();
+    }
+
+    @Test
+    void producerModuleLeavesNoRealProducerBeanBehind() {
+        assertThat(applicationContext.getBeanNamesForType(NotificationProducer.class))
+                .containsExactly("mockNotificationProducer");
+        assertThat(applicationContext.getBeanNamesForType(ActionProducer.class))
+                .containsExactly("mockActionProducer");
+        assertThat(applicationContext.getBeanNamesForType(EventProducer.class))
+                .containsExactly("mockEventProducer");
+        assertThat(applicationContext.getBeanNamesForType(ValidationProducer.class))
+                .containsExactly("mockValidationProducer");
     }
 }

--- a/src/test/java/com/otilm/core/integration/service/CryptographicKeyItemCacheITest.java
+++ b/src/test/java/com/otilm/core/integration/service/CryptographicKeyItemCacheITest.java
@@ -31,6 +31,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Import;
@@ -50,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * and evicted after mutations that change the key item's observable state.
  */
 @Import(ProducerMocks.class)
+@TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class)
 class CryptographicKeyItemCacheITest extends BaseSpringBootTest {
 
     @Autowired

--- a/src/test/java/com/otilm/core/integration/service/SigningCertificateCacheITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SigningCertificateCacheITest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Import;
@@ -59,6 +60,7 @@ import static org.mockito.Mockito.verify;
  * Must NOT be {@code @Transactional} — afterCommit eviction callbacks need an actual commit to fire.
  */
 @Import(ProducerMocks.class)
+@TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class)
 class SigningCertificateCacheITest extends BaseSpringBootTest {
 
     @Autowired

--- a/src/test/java/com/otilm/core/integration/service/SigningCertificateParityITest.java
+++ b/src/test/java/com/otilm/core/integration/service/SigningCertificateParityITest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.filter.TypeExcludeFilters;
 import org.springframework.context.annotation.Import;
 
 import java.security.KeyPair;
@@ -55,6 +56,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
  * reproduces the signer inputs available from the live {@code Certificate} entity graph.
  */
 @Import(ProducerMocks.class)
+@TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class)
 class SigningCertificateParityITest extends BaseSpringBootTest {
 
     @Autowired

--- a/src/test/java/com/otilm/core/util/mockbeans/ProducerMocks.java
+++ b/src/test/java/com/otilm/core/util/mockbeans/ProducerMocks.java
@@ -4,14 +4,28 @@ import com.otilm.core.messaging.jms.producers.ActionProducer;
 import com.otilm.core.messaging.jms.producers.EventProducer;
 import com.otilm.core.messaging.jms.producers.NotificationProducer;
 import com.otilm.core.messaging.jms.producers.ValidationProducer;
+import org.springframework.boot.context.TypeExcludeFilter;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
 
 /**
  * Mocks the JMS producers (external-boundary I/O that tests never exercise for real).
+ * <p>
+ * Import it together with the component-scan exclusion it needs:
+ * <pre>
+ * &#64;Import(ProducerMocks.class)
+ * &#64;TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class)
+ * </pre>
+ * Both are required, and {@code ProducerMocksExclusionArchTest} fails the build if one is missing.
  */
 @TestConfiguration
 public class ProducerMocks {
@@ -38,5 +52,35 @@ public class ProducerMocks {
     @Primary
     ValidationProducer mockValidationProducer() {
         return mock(ValidationProducer.class);
+    }
+
+    /**
+     * Keeps the classes mocked above out of the component scan. Named in {@code @TypeExcludeFilters} on each
+     * importing test class, which registers it before the context refreshes — a {@code @Bean} here would be
+     * registered only after the scan has already run.
+     * <p>
+     * {@code equals}/{@code hashCode} are stateless on purpose: they keep every test declaring this filter on one context-cache key.
+     */
+    public static final class MockedProducersTypeExcludeFilter extends TypeExcludeFilter {
+
+        private static final Set<String> EXCLUDED_CLASS_NAMES = Stream
+                .of(NotificationProducer.class, ActionProducer.class, EventProducer.class, ValidationProducer.class)
+                .map(Class::getName)
+                .collect(Collectors.toUnmodifiableSet());
+
+        @Override
+        public boolean match(MetadataReader metadataReader, MetadataReaderFactory metadataReaderFactory) {
+            return EXCLUDED_CLASS_NAMES.contains(metadataReader.getClassMetadata().getClassName());
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj != null && getClass() == obj.getClass();
+        }
+
+        @Override
+        public int hashCode() {
+            return getClass().hashCode();
+        }
     }
 }


### PR DESCRIPTION
**TL;DR: `ProducerMocks` only *shadowed* the real JMS producers, so the real `NotificationProducer` stayed alive and could still send real JMS messages; this excludes those classes from the component scan instead.**

Closes #1932. Follow-up to the review finding on #1836 ([`ProducerMocks.java`](https://github.com/OmniTrustILM/core/pull/1836#pullrequestreview-4750901814)).

## What was wrong

`@Bean @Primary` **shadows** a bean; it does not **replace** it.

The real `NotificationProducer` is still `@Component`-scanned and instantiated. Its `@TransactionalEventListener(phase = AFTER_COMMIT, fallbackExecution = true)` therefore stays registered. Any test that imports the module, commits, and publishes a `NotificationMessage` would get a real `jmsTemplate.convertAndSend` — the exact I/O the mock exists to suppress.

**Not a live break today.** No test importing `ProducerMocks` publishes that event, so the listener never fires. It was latent, and the fix is to remove the definition rather than hide it.

## The fix

`MockedProducersTypeExcludeFilter` drops all four producer classes from the component scan. Each importing test class declares it:

```java
@Import(ProducerMocks.class)
@TypeExcludeFilters(ProducerMocks.MockedProducersTypeExcludeFilter.class)
```

Two details worth knowing:

- **A `@Bean TypeExcludeFilter` inside the module does not work.** Component scanning happens in the configuration-class *parse* phase; `@Bean` definitions are loaded *after* it, so the filter would never be consulted. `@TypeExcludeFilters` registers it as a singleton before the context refreshes, which is the supported hook.
- **`equals`/`hashCode` on the filter are stateless on purpose.** They keep every declaring test on one context-cache key, so no new context is booted. Spring Boot also rejects a `TypeExcludeFilter` that leaves them at identity.

`@Primary` stays as a fallback.

## Guarding it

The two annotations are separate declarations, so a new test can apply one and forget the other. Two tests cover that:

- `ProducerMocksExclusionArchTest` — fails the build if a context-loading test imports `ProducerMocks` without the exclusion.
- `MockBeanModuleWiringITest.producerModuleLeavesNoRealProducerBeanBehind` — asserts the mock is the *only* bean of each producer type, so the exclusion cannot silently lapse back to shadowing.

## Verification

- Full test suite passes.
- `ContextSignatureGuardTest.BASELINE` is unchanged at 58 — no new context combination is purchased.
- Removing the annotation from one test class was confirmed to fail the new arch guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
