### PR TITLE
Share one Spring test context across the management-API mock tests

### DIFF
--- a/src/test/java/com/otilm/core/architecture/ContextSignatureGuardTest.java
+++ b/src/test/java/com/otilm/core/architecture/ContextSignatureGuardTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ContextSignatureGuardTest {
 
     /** Committed baseline: the exact current distinct count. Update in lock-step with any change. */
-    static final int BASELINE = 58;
+    static final int BASELINE = 57;
 
     private static final Path TEST_ROOT = Path.of("src/test/java");
 

--- a/src/test/java/com/otilm/core/architecture/MockBeanModuleResetArchTest.java
+++ b/src/test/java/com/otilm/core/architecture/MockBeanModuleResetArchTest.java
@@ -1,0 +1,95 @@
+package com.otilm.core.architecture;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The mock modules in {@code com.otilm.core.util.mockbeans} declare their mocks as {@code @Bean @Primary} context
+ * singletons, which Spring's reset lifecycle does not touch — it only discovers {@code @MockitoBean} fields on the
+ * test class, its superclasses and its enclosing classes.
+ *
+ * {@code MockBeanResetListener} resets them instead, and {@code BaseSpringBootTest} is the only class registering it.
+ * An importer that does not inherit from there keeps its stubbings and interactions across tests sharing the cached
+ * context. This pins the two together.
+ */
+class MockBeanModuleResetArchTest {
+
+    private static final Path TEST_ROOT = Path.of("src/test/java");
+
+    private static final Path MODULE_ROOT = TEST_ROOT.resolve("com/otilm/core/util/mockbeans");
+
+    private static final String LISTENER_ROOT = "BaseSpringBootTest";
+
+    @Test
+    void everyMockModuleImporterInheritsTheMockResetListener() {
+        Set<String> modules = declaredModules();
+        Map<String, String> inheritance = TestClassTaxonomy.parseExtends(TEST_ROOT);
+
+        List<Path> importers = testSources()
+                // Only a context-loading class can hold module mocks; that also keeps meta-test fixture sources out.
+                .filter(file -> TestClassTaxonomy.loadsContext(file, inheritance))
+                .filter(file -> TestClassTaxonomy.annotationTokens(file).imports().stream().anyMatch(modules::contains))
+                .toList();
+
+        assertThat(importers)
+                .describedAs("the mock modules are expected to be in use; this guard is vacuous otherwise")
+                .isNotEmpty()
+                .describedAs("every test class importing a com.otilm.core.util.mockbeans module must extend "
+                        + LISTENER_ROOT + " — it is the only class registering MockBeanResetListener, and without "
+                        + "that listener the modules' @Bean @Primary singleton mocks keep their stubbings and "
+                        + "interactions across every test sharing the cached context")
+                .allMatch(file -> inheritsListenerRoot(file, inheritance));
+    }
+
+    /** Every module in the package counts, so a module added later is covered without touching this test. */
+    private static Set<String> declaredModules() {
+        try (Stream<Path> files = Files.list(MODULE_ROOT)) {
+            Set<String> modules = files
+                    .map(file -> file.getFileName().toString())
+                    .filter(name -> name.endsWith(".java"))
+                    .filter(name -> !name.equals("package-info.java"))
+                    .map(name -> name.substring(0, name.length() - ".java".length()))
+                    .collect(Collectors.toSet());
+            assertThat(modules)
+                    .describedAs("no mock module found under %s — the path is stale", MODULE_ROOT)
+                    .isNotEmpty();
+            return modules;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static boolean inheritsListenerRoot(Path file, Map<String, String> inheritance) {
+        String current = TestClassTaxonomy.primaryClassName(file);
+        int guard = 0;
+        while (current != null && guard++ < 50) {
+            if (LISTENER_ROOT.equals(current)) {
+                return true;
+            }
+            current = inheritance.get(current);
+        }
+        return false;
+    }
+
+    private static Stream<Path> testSources() {
+        try (Stream<Path> files = Files.walk(TEST_ROOT)) {
+            return files.filter(Files::isRegularFile)
+                    .filter(file -> file.toString().endsWith(".java"))
+                    .toList()
+                    .stream();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/src/test/java/com/otilm/core/architecture/TestClassTaxonomy.java
+++ b/src/test/java/com/otilm/core/architecture/TestClassTaxonomy.java
@@ -127,8 +127,21 @@ final class TestClassTaxonomy {
     static boolean loadsContext(Path javaFile, Map<String, String> graph) {
         String src = code(javaFile);
         if (SPRING_BOOT_TEST.matcher(src).find()) return true;
+        String primary = primaryClassName(src);
+        return primary != null && hasContextBearingAncestor(primary, graph);
+    }
+
+    /**
+     * Simple name of the file's primary type — the first {@code class} declaration, the same one
+     * {@link #parseExtends} keys the inheritance graph by — or {@code null} for a file declaring none.
+     */
+    static String primaryClassName(Path javaFile) {
+        return primaryClassName(code(javaFile));
+    }
+
+    private static String primaryClassName(String src) {
         Matcher m = CLASS_DECL.matcher(src);
-        return m.find() && hasContextBearingAncestor(m.group(2), graph);
+        return m.find() ? m.group(2) : null;
     }
 
     static boolean isRunnableTest(Path javaFile) {

--- a/src/test/java/com/otilm/core/integration/service/RoleAssignmentGuardITest.java
+++ b/src/test/java/com/otilm/core/integration/service/RoleAssignmentGuardITest.java
@@ -24,11 +24,13 @@ import com.otilm.core.service.UserManagementExternalService;
 import com.otilm.core.service.UserManagementInternalService;
 import com.otilm.core.util.AuthHelper;
 import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.mockbeans.ManagementApiMocks;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -46,6 +48,7 @@ import static org.mockito.Mockito.when;
  * role -> users ({@link RoleManagementExternalService#updateUsers}) and user -> roles
  * ({@link UserManagementExternalService#updateRoles} / {@code updateRole}).
  */
+@Import(ManagementApiMocks.class)
 class RoleAssignmentGuardITest extends BaseSpringBootTest {
 
     private static final String HUMAN_USERNAME = "operator";
@@ -62,10 +65,10 @@ class RoleAssignmentGuardITest extends BaseSpringBootTest {
     @Autowired
     private LocalAdminExternalService localAdminService;
 
-    @MockitoBean
+    @Autowired
     private RoleManagementApiClient roleManagementApiClient;
 
-    @MockitoBean
+    @Autowired
     private UserManagementApiClient userManagementApiClient;
 
     @MockitoBean

--- a/src/test/java/com/otilm/core/integration/service/RoleManagementServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/RoleManagementServiceITest.java
@@ -6,8 +6,10 @@ import com.otilm.core.security.authn.client.AuthenticationCache;
 import com.otilm.core.security.authn.client.RoleManagementApiClient;
 import com.otilm.core.service.RoleManagementExternalService;
 import com.otilm.core.util.BaseSpringBootTest;
+import com.otilm.core.util.mockbeans.ManagementApiMocks;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
@@ -18,12 +20,13 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Import(ManagementApiMocks.class)
 class RoleManagementServiceITest extends BaseSpringBootTest {
 
     @Autowired
     private RoleManagementExternalService roleManagementService;
 
-    @MockitoBean
+    @Autowired
     private RoleManagementApiClient roleManagementApiClient;
 
     @MockitoBean

--- a/src/test/java/com/otilm/core/integration/service/UserManagementServiceCacheEvictionITest.java
+++ b/src/test/java/com/otilm/core/integration/service/UserManagementServiceCacheEvictionITest.java
@@ -10,10 +10,12 @@ import com.otilm.core.service.UserManagementExternalService;
 import com.otilm.core.service.UserManagementInternalService;
 import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.SessionTableHelper;
+import com.otilm.core.util.mockbeans.ManagementApiMocks;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -25,6 +27,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Import(ManagementApiMocks.class)
 class UserManagementServiceCacheEvictionITest extends BaseSpringBootTest {
 
     @Autowired
@@ -36,10 +39,10 @@ class UserManagementServiceCacheEvictionITest extends BaseSpringBootTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
-    @MockitoBean
+    @Autowired
     private UserManagementApiClient userManagementApiClient;
 
-    @MockitoBean
+    @Autowired
     private RoleManagementApiClient roleManagementApiClient;
 
     @MockitoBean

--- a/src/test/java/com/otilm/core/util/mockbeans/ManagementApiMocks.java
+++ b/src/test/java/com/otilm/core/util/mockbeans/ManagementApiMocks.java
@@ -11,6 +11,10 @@ import static org.mockito.Mockito.mock;
 
 /**
  * Mocks the platform authentication API clients (HTTP boundary to the auth service).
+ * <p>
+ * {@code AuthenticationCache} must NOT move here. {@code AuthenticationCacheITest} imports this module and
+ * autowires the real cache as its subject, so a {@code @Primary} mock would replace what that test verifies;
+ * the tests that need it mocked declare a per-class {@code @MockitoBean}.
  */
 @TestConfiguration
 public class ManagementApiMocks {

--- a/src/test/java/com/otilm/core/util/mockbeans/package-info.java
+++ b/src/test/java/com/otilm/core/util/mockbeans/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Composable mock modules: {@code @TestConfiguration} classes that a test imports to mock an external boundary.
+ * <p>
+ * Every module here declares its mocks as {@code @Bean @Primary} context singletons, so they are shared by every
+ * test sharing the cached context. Spring's own reset lifecycle does not cover them — it only walks the test class,
+ * its superclasses and its enclosing classes for {@code @MockitoBean}/{@code @MockitoSpyBean}, and finds nothing on
+ * an {@code @Import}ed configuration. {@code MockBeanResetListener} closes that gap, and
+ * {@code BaseSpringBootTest} is the only place that registers it.
+ * <p>
+ * <b>An importer must therefore extend {@code BaseSpringBootTest}</b> (directly or transitively), or stubbings and
+ * interactions leak between tests. {@code BaseSpringBootTestNoAuth} is a separate root that does <em>not</em> extend
+ * it and so carries no listener; importing a module from there would silently lose the reset.
+ * {@code MockBeanModuleResetArchTest} fails the build on either mistake.
+ * <p>
+ * Adding a mock here is cheap only while it reuses an existing import set — each new combination of modules is a new
+ * Spring context to boot. Prefer composing the sets that tests already use.
+ */
+package com.otilm.core.util.mockbeans;


### PR DESCRIPTION
**TL;DR: three integration tests each booted their own Spring context just to mock the same two auth API clients; they now share one. `BASELINE` 58 → 57.**

Round 1 of #1934.

## What was wrong

`RoleManagementServiceITest`, `RoleAssignmentGuardITest` and `UserManagementServiceCacheEvictionITest` each declared their own `@MockitoBean` for `UserManagementApiClient` / `RoleManagementApiClient`.

Every distinct mock-set is a distinct Spring context-cache key. So these three classes sat on **two** separate signatures and booted a context each, to mock beans a shared module already provides.

## The fix

Each class now imports the existing module and autowires the mock handle:

```java
@Import(ManagementApiMocks.class)
class RoleManagementServiceITest extends BaseSpringBootTest {

    @Autowired
    private RoleManagementApiClient roleManagementApiClient;
```

All three converge on one signature — `imports=[ManagementApiMocks]`, `mocks=[AuditLogsProducer, AuthenticationCache, OpaClient]` — so they share a single cached context.

`MockBeanResetListener` already resets module-declared mocks before each test method, so stubbings do not leak between the three classes now that they share a context.

## Two things worth knowing

**`AuthenticationCache` deliberately stays a per-class `@MockitoBean`.** It looks like the obvious next thing to fold into the module, and that would break `AuthenticationCacheITest` — that test imports the same module and autowires the *real* cache as its subject, so a `@Primary` mock would replace exactly what it verifies. This PR records that in the module's Javadoc so the next round does not have to rediscover it.

**The module also supplies a mock `PlatformAuthenticationClient`**, which these three classes now inherit. None of the paths they exercise reaches it, so it is inert here.

## Scope notes

- `UserManagementServiceITest` is **not** included. Its `CertificateUploadService` mock is unshared, so importing the module would leave it on a unique signature anyway — churn with no collapse.
- The saving is **one** context, not two: `RoleAssignmentGuardITest` and `UserManagementServiceCacheEvictionITest` already shared a signature before this change.

## Verification

- Full suite green on the baseline before the change (4517 tests) and the same 4517 tests after, with one known pre-existing flake (`SigningProfileServiceImplITest`, connector communication on an ephemeral port; passes in isolation).
- `ContextSignatureGuardTest` passes at `BASELINE = 57`; the count was independently recomputed against both SHAs with the repo's own `ContextSignature` kernel.
- The five classes touching `ManagementApiMocks` plus both architecture guards: 63 tests, 0 failures.
