### PR TITLE
Restructure notification listener transaction boundary

### DIFF
--- a/src/main/java/com/otilm/core/dao/entity/notifications/PendingNotification.java
+++ b/src/main/java/com/otilm/core/dao/entity/notifications/PendingNotification.java
@@ -17,8 +17,12 @@ import java.util.UUID;
 @ToString
 @RequiredArgsConstructor
 @Entity
-@Table(name = "pending_notification")
+@Table(name = "pending_notification", uniqueConstraints = @UniqueConstraint(
+        name = PendingNotification.UNIQUE_SUPPRESSION_ROW_CONSTRAINT,
+        columnNames = {"notification_profile_uuid", "resource", "object_uuid", "event"}))
 public class PendingNotification  extends ResourceObjectAssociation {
+
+    public static final String UNIQUE_SUPPRESSION_ROW_CONSTRAINT = "uq_pending_notification_suppression_row";
 
     @Column(name = "notification_profile_uuid", nullable = false)
     private UUID notificationProfileUuid;

--- a/src/main/java/com/otilm/core/dao/repository/notifications/NotificationInstanceReferenceRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/notifications/NotificationInstanceReferenceRepository.java
@@ -2,6 +2,7 @@ package com.otilm.core.dao.repository.notifications;
 
 import com.otilm.core.dao.entity.notifications.NotificationInstanceReference;
 import com.otilm.core.dao.repository.SecurityFilterRepository;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,6 +12,13 @@ import java.util.UUID;
 public interface NotificationInstanceReferenceRepository extends SecurityFilterRepository<NotificationInstanceReference, UUID> {
 
     Optional<NotificationInstanceReference> findByUuid(UUID uuid);
+
+    /**
+     * Loads the reference with its mapped attributes fetched eagerly, for callers that run
+     * without an ambient transaction and would otherwise hit the lazy association detached.
+     */
+    @EntityGraph(attributePaths = "mappedAttributes")
+    Optional<NotificationInstanceReference> findWithMappedAttributesByUuid(UUID uuid);
 
     Optional<NotificationInstanceReference> findByName(String name);
 }

--- a/src/main/java/com/otilm/core/dao/repository/notifications/PendingNotificationRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/notifications/PendingNotificationRepository.java
@@ -4,6 +4,9 @@ import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.core.dao.entity.notifications.PendingNotification;
 import com.otilm.core.dao.repository.SecurityFilterRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
@@ -12,5 +15,22 @@ import java.util.UUID;
 public interface PendingNotificationRepository extends SecurityFilterRepository<PendingNotification, UUID> {
 
     PendingNotification findByNotificationProfileUuidAndResourceAndObjectUuidAndEvent(UUID notificationProfileUuid, Resource resource, UUID objectUuid, ResourceEvent event);
+
+    /**
+     * Records a successful send atomically: the first send inserts the suppression row with one
+     * repetition, every conflicting send increments the count and refreshes {@code last_sent_at}.
+     * The pinned profile {@code version} is deliberately never updated on conflict -- it anchors
+     * monitoring-stream continuity. {@code last_sent_at} is set in SQL because
+     * {@code @UpdateTimestamp} does not apply to modifying queries.
+     */
+    @Modifying
+    @Query(value = """
+            INSERT INTO {h-schema}pending_notification (uuid, notification_profile_uuid, resource, object_uuid, event, version, repetitions, last_sent_at)
+            VALUES (:uuid, :profileUuid, :resource, :objectUuid, :event, :version, 1, CURRENT_TIMESTAMP)
+            ON CONFLICT (notification_profile_uuid, resource, object_uuid, event)
+            DO UPDATE SET repetitions = pending_notification.repetitions + 1, last_sent_at = CURRENT_TIMESTAMP
+            """, nativeQuery = true)
+    void upsertSent(@Param("uuid") UUID uuid, @Param("profileUuid") UUID profileUuid, @Param("resource") String resource,
+                    @Param("objectUuid") UUID objectUuid, @Param("event") String event, @Param("version") int version);
 
 }

--- a/src/main/java/com/otilm/core/dao/repository/notifications/PendingNotificationRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/notifications/PendingNotificationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Repository
@@ -20,17 +21,19 @@ public interface PendingNotificationRepository extends SecurityFilterRepository<
      * Records a successful send atomically: the first send inserts the suppression row with one
      * repetition, every conflicting send increments the count and refreshes {@code last_sent_at}.
      * The pinned profile {@code version} is deliberately never updated on conflict -- it anchors
-     * monitoring-stream continuity. {@code last_sent_at} is set in SQL because
-     * {@code @UpdateTimestamp} does not apply to modifying queries.
+     * monitoring-stream continuity. {@code last_sent_at} is bound by the caller from the
+     * application clock: the frequency-eligibility check compares it against application time,
+     * so writing database time here would shift suppression windows by the clock skew.
      */
     @Modifying
     @Query(value = """
             INSERT INTO {h-schema}pending_notification (uuid, notification_profile_uuid, resource, object_uuid, event, version, repetitions, last_sent_at)
-            VALUES (:uuid, :profileUuid, :resource, :objectUuid, :event, :version, 1, CURRENT_TIMESTAMP)
+            VALUES (:uuid, :profileUuid, :resource, :objectUuid, :event, :version, 1, :lastSentAt)
             ON CONFLICT (notification_profile_uuid, resource, object_uuid, event)
-            DO UPDATE SET repetitions = pending_notification.repetitions + 1, last_sent_at = CURRENT_TIMESTAMP
+            DO UPDATE SET repetitions = pending_notification.repetitions + 1, last_sent_at = EXCLUDED.last_sent_at
             """, nativeQuery = true)
     void upsertSent(@Param("uuid") UUID uuid, @Param("profileUuid") UUID profileUuid, @Param("resource") String resource,
-                    @Param("objectUuid") UUID objectUuid, @Param("event") String event, @Param("version") int version);
+                    @Param("objectUuid") UUID objectUuid, @Param("event") String event, @Param("version") int version,
+                    @Param("lastSentAt") OffsetDateTime lastSentAt);
 
 }

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -33,11 +33,13 @@ import com.otilm.core.service.NotificationInternalService;
 import com.otilm.core.service.ResourceObjectAssociationService;
 import com.otilm.core.service.TriggerInternalService;
 import com.otilm.core.service.v2.ConnectorInternalService;
+import com.otilm.core.service.writer.PendingNotificationWriter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
@@ -46,7 +48,7 @@ import java.util.*;
 
 @Component
 @AllArgsConstructor
-@Transactional
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 public class NotificationListener implements MessageProcessor<NotificationMessage> {
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationListener.class);
@@ -68,6 +70,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
     private RoleManagementApiClient roleManagementApiClient;
     private ResourceObjectAssociationService resourceObjectAssociationService;
     private TransactionHandler transactionHandler;
+    private PendingNotificationWriter pendingNotificationWriter;
 
     private static final Map<ResourceEvent, String> eventToLegacyNotificationTypeMapping = new EnumMap<>(ResourceEvent.class);
 
@@ -151,8 +154,22 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         }
 
         if (pendingNotification != null && notificationSent) {
-            pendingNotification.setRepetitions(pendingNotification.getRepetitions() + 1);
-            pendingNotificationRepository.save(pendingNotification);
+            recordSuppressionState(notificationProfileUuid, message, pendingNotification.getVersion());
+        }
+    }
+
+    /**
+     * Records the successful send in the suppression row. A write failure is logged and swallowed:
+     * the connector already accepted this notification, so suppression state stays as-is and the
+     * next occurrence may send one extra notification -- rolling anything back or reporting a
+     * delivery failure would put local state behind a delivery that already happened.
+     */
+    private void recordSuppressionState(UUID notificationProfileUuid, NotificationMessage message, int pinnedVersion) {
+        try {
+            pendingNotificationWriter.recordSent(notificationProfileUuid, message.getResource(), message.getObjectUuid(), message.getEvent(), pinnedVersion);
+        } catch (RuntimeException e) {
+            logger.error("Notification for profile {} event {} on {} {} was sent but recording suppression state failed",
+                    notificationProfileUuid, message.getEvent(), message.getResource(), message.getObjectUuid(), e);
         }
     }
 
@@ -204,10 +221,11 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
     }
 
     /**
-     * Written in its own transaction: the caller's transaction may already be rollback-only from the failure being
-     * reported here, and this record is the only durable trace of why the trigger's notification did not go out.
-     * The trigger history row it references is committed well before this runs -- the notification message is
-     * dispatched from an {@code AFTER_COMMIT} listener on the transaction that created it.
+     * Written in its own transaction: the listener runs without an ambient one, and the two history
+     * writes must land atomically -- this record is the only durable trace of why the trigger's
+     * notification did not go out. The trigger history row it references is committed well before
+     * this runs -- the notification message is dispatched from an {@code AFTER_COMMIT} listener on
+     * the transaction that created it.
      */
     private void recordNotificationFailureOnTriggerHistory(String errorMessage, NotificationMessage message) {
         if (message.getTriggerHistoryUuid() == null) {
@@ -247,24 +265,6 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
                 && (notificationProfileVersion.getRepetitions() == null || pendingNotification.getRepetitions() < notificationProfileVersion.getRepetitions());
     }
 
-    /**
-     * Reads through collaborators that carry their own {@code @Transactional} are made in a transaction of their
-     * own. Joining this listener's transaction, anything unchecked they raise marks it rollback-only past the catch
-     * that handles it: the notification still goes out to the connector, and the commit then fails and rolls local
-     * state back behind a delivery that already happened.
-     */
-    private NameAndUuidDto ownerOf(Resource resource, UUID objectUuid) {
-        return transactionHandler.runInNewTransaction(() -> resourceObjectAssociationService.getOwner(resource, objectUuid));
-    }
-
-    private List<UUID> groupUuidsOf(Resource resource, UUID objectUuid) {
-        return transactionHandler.runInNewTransaction(() -> resourceObjectAssociationService.getGroupUuids(resource, objectUuid));
-    }
-
-    private List<ResponseAttribute> customAttributesOf(Resource resource, UUID objectUuid) {
-        return transactionHandler.runInNewTransaction(() -> attributeEngine.getObjectCustomAttributesContentForSystemContext(resource, objectUuid));
-    }
-
     private List<NotificationRecipient> getRecipients(RecipientType recipientType, List<UUID> recipientUuids, ResourceEvent event, Object data, Resource resource, UUID objectUuid) {
         if (recipientType == RecipientType.OBJECT) {
             return List.of(new NotificationRecipient(RecipientType.OBJECT, objectUuid));
@@ -275,7 +275,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         }
 
         if (recipientType == RecipientType.OWNER) {
-            NameAndUuidDto ownerInfo = ownerOf(resource, objectUuid);
+            NameAndUuidDto ownerInfo = resourceObjectAssociationService.getOwner(resource, objectUuid);
             if (ownerInfo == null) return List.of();
             return List.of(new NotificationRecipient(RecipientType.USER, UUID.fromString(ownerInfo.getUuid())));
         }
@@ -300,12 +300,12 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         switch (event) {
             case CERTIFICATE_STATUS_CHANGED, CERTIFICATE_ACTION_PERFORMED, CERTIFICATE_EXPIRING,
                  CERTIFICATE_NOT_COMPLIANT, CERTIFICATE_UPLOADED -> {
-                NameAndUuidDto ownerInfo = ownerOf(resource, objectUuid);
+                NameAndUuidDto ownerInfo = resourceObjectAssociationService.getOwner(resource, objectUuid);
                 if (ownerInfo != null) {
                     recipients.add(new NotificationRecipient(RecipientType.USER, UUID.fromString(ownerInfo.getUuid())));
                 }
 
-                for (UUID groupUuid : groupUuidsOf(resource, objectUuid)) {
+                for (UUID groupUuid : resourceObjectAssociationService.getGroupUuids(resource, objectUuid)) {
                     recipients.add(new NotificationRecipient(RecipientType.GROUP, groupUuid));
                 }
             }
@@ -337,7 +337,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
             }
             case CERTIFICATE_REGISTERED -> {
                 // Owner only by default (no groups) — a credential-bearing event; a profile can override.
-                NameAndUuidDto ownerInfo = ownerOf(resource, objectUuid);
+                NameAndUuidDto ownerInfo = resourceObjectAssociationService.getOwner(resource, objectUuid);
                 if (ownerInfo != null) {
                     recipients.add(new NotificationRecipient(RecipientType.USER, UUID.fromString(ownerInfo.getUuid())));
                 }
@@ -358,7 +358,9 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
      */
     private boolean sendExternalNotifications(UUID notificationInstanceUUID, List<NotificationRecipient> recipients, Object notificationData, ResourceEvent
             event, Resource resource) throws ConnectorException, ValidationException, NotFoundException {
-        NotificationInstanceReference notificationInstanceReference = notificationInstanceReferenceRepository.findByUuid(notificationInstanceUUID).orElseThrow(() -> new NotFoundException(NotificationInstanceReference.class, notificationInstanceUUID));
+        // Fetch-join the mapped attributes: the listener runs without an ambient transaction, so the
+        // entity is detached the moment the repository call returns and lazy loading would fail.
+        NotificationInstanceReference notificationInstanceReference = notificationInstanceReferenceRepository.findWithMappedAttributesByUuid(notificationInstanceUUID).orElseThrow(() -> new NotFoundException(NotificationInstanceReference.class, notificationInstanceUUID));
         if (notificationInstanceReference.getConnectorUuid() == null) {
             throw new ValidationException("Notification instance does not have assigned connector");
         }
@@ -389,7 +391,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
                         ? resource
                         : recipient.getRecipientType().getRecipientResource();
                 // Unauthenticated lookup is correct here, since the access to the custom attributes has been resolved when defining mapping attributes.
-                List<ResponseAttribute> recipientCustomAttributes = customAttributesOf(customAttributeResource, recipient.getRecipientUuid());
+                List<ResponseAttribute> recipientCustomAttributes = attributeEngine.getObjectCustomAttributesContentForSystemContext(customAttributeResource, recipient.getRecipientUuid());
                 // prepare mapped attributes
                 List<RequestAttribute> mappedAttributes = getMappedAttributes(notificationInstanceReference, mappingAttributes, recipientCustomAttributes);
                 if (recipient.getRecipientType() == RecipientType.OBJECT && mappedAttributes.isEmpty()) {
@@ -521,10 +523,9 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         int failed = 0;
         for (NotificationRecipient recipient : recipients) {
             try {
-                // Each recipient commits on its own. Anything unchecked raised while creating one would otherwise
-                // mark the shared transaction rollback-only past the caller's catch, discarding the notifications
-                // already created for the recipients before it.
-                if (transactionHandler.runInNewTransaction(() -> createInternalNotification(recipient, notificationData, resource, objectUuid)) != null) {
+                // Each recipient commits on its own: the listener runs without an ambient transaction, so
+                // every notification-service call opens and commits its own short transaction.
+                if (createInternalNotification(recipient, notificationData, resource, objectUuid) != null) {
                     ++notified;
                 }
             } catch (Exception e) {

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -159,10 +159,11 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
     }
 
     /**
-     * Records the successful send in the suppression row. A write failure is logged and swallowed:
-     * the connector already accepted this notification, so suppression state stays as-is and the
-     * next occurrence may send one extra notification -- rolling anything back or reporting a
-     * delivery failure would put local state behind a delivery that already happened.
+     * Records the successful delivery in the suppression row. A write failure is logged and
+     * swallowed: the notification was already delivered -- to the connector, internally, or both
+     * -- so suppression state stays as-is and the next occurrence may send one extra
+     * notification. Rolling anything back or reporting a delivery failure would put local state
+     * behind a delivery that already happened.
      */
     private void recordSuppressionState(UUID notificationProfileUuid, NotificationMessage message, int pinnedVersion) {
         try {

--- a/src/main/java/com/otilm/core/service/writer/PendingNotificationWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/PendingNotificationWriter.java
@@ -11,9 +11,10 @@ import java.util.UUID;
 
 /**
  * Writer half of the notification listener's orchestrator/writer pair. Records a successful
- * external send as an atomic upsert so concurrent notification consumers cannot create duplicate
- * suppression rows for one (profile, resource, object, event). REQUIRED propagation so it
- * composes: joins an ambient transaction when present, starts a short one otherwise.
+ * notification delivery -- external, internal, or both -- as an atomic upsert so concurrent
+ * notification consumers cannot create duplicate suppression rows for one (profile, resource,
+ * object, event). REQUIRED propagation so it composes: joins an ambient transaction when
+ * present, starts a short one otherwise.
  */
 @Service
 public class PendingNotificationWriter {

--- a/src/main/java/com/otilm/core/service/writer/PendingNotificationWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/PendingNotificationWriter.java
@@ -1,0 +1,33 @@
+package com.otilm.core.service.writer;
+
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.dao.repository.notifications.PendingNotificationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Writer half of the notification listener's orchestrator/writer pair. Records a successful
+ * external send as an atomic upsert so concurrent notification consumers cannot create duplicate
+ * suppression rows for one (profile, resource, object, event). REQUIRED propagation so it
+ * composes: joins an ambient transaction when present, starts a short one otherwise.
+ */
+@Service
+public class PendingNotificationWriter {
+
+    private final PendingNotificationRepository pendingNotificationRepository;
+
+    @Autowired
+    public PendingNotificationWriter(PendingNotificationRepository pendingNotificationRepository) {
+        this.pendingNotificationRepository = pendingNotificationRepository;
+    }
+
+    @Transactional
+    public void recordSent(UUID notificationProfileUuid, Resource resource, UUID objectUuid, ResourceEvent event, int pinnedVersion) {
+        pendingNotificationRepository.upsertSent(UUID.randomUUID(), notificationProfileUuid,
+                resource.name(), objectUuid, event.name(), pinnedVersion);
+    }
+}

--- a/src/main/java/com/otilm/core/service/writer/PendingNotificationWriter.java
+++ b/src/main/java/com/otilm/core/service/writer/PendingNotificationWriter.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 /**
@@ -28,7 +29,9 @@ public class PendingNotificationWriter {
 
     @Transactional
     public void recordSent(UUID notificationProfileUuid, Resource resource, UUID objectUuid, ResourceEvent event, int pinnedVersion) {
+        // Application clock, matching the frequency-eligibility comparison in the listener --
+        // one clock source for both the write and the read keeps suppression windows skew-free.
         pendingNotificationRepository.upsertSent(UUID.randomUUID(), notificationProfileUuid,
-                resource.name(), objectUuid, event.name(), pinnedVersion);
+                resource.name(), objectUuid, event.name(), pinnedVersion, OffsetDateTime.now());
     }
 }

--- a/src/main/resources/db/migration/V202608031000__pending_notification_unique_suppression_row.sql
+++ b/src/main/resources/db/migration/V202608031000__pending_notification_unique_suppression_row.sql
@@ -1,0 +1,19 @@
+-- Concurrent notification consumers (the queue runs multiple consumers) can create duplicate
+-- suppression rows through the read-then-insert flow. Collapse duplicates deterministically --
+-- keep the row with the greatest last_sent_at, then repetitions, then uuid -- and add the unique
+-- constraint the atomic upsert relies on. Legacy rows may carry a NULL event, so the duplicate
+-- match treats NULL as a value; new rows always carry an event (only monitoring events are tracked).
+LOCK TABLE "pending_notification" IN SHARE ROW EXCLUSIVE MODE;
+
+DELETE FROM "pending_notification" p
+USING "pending_notification" d
+WHERE p."notification_profile_uuid" = d."notification_profile_uuid"
+  AND p."resource" = d."resource"
+  AND p."object_uuid" = d."object_uuid"
+  AND p."event" IS NOT DISTINCT FROM d."event"
+  AND p."uuid" <> d."uuid"
+  AND (p."last_sent_at", p."repetitions", p."uuid") < (d."last_sent_at", d."repetitions", d."uuid");
+
+ALTER TABLE "pending_notification"
+    ADD CONSTRAINT "uq_pending_notification_suppression_row"
+    UNIQUE ("notification_profile_uuid", "resource", "object_uuid", "event");

--- a/src/test/java/com/otilm/core/integration/events/NotificationObjectRecipientITest.java
+++ b/src/test/java/com/otilm/core/integration/events/NotificationObjectRecipientITest.java
@@ -19,11 +19,13 @@ import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.dao.entity.Connector;
 import com.otilm.core.dao.entity.notifications.NotificationInstanceMappedAttributes;
 import com.otilm.core.dao.entity.notifications.NotificationInstanceReference;
+import com.otilm.core.dao.entity.notifications.PendingNotification;
 import com.otilm.core.dao.entity.workflows.Trigger;
 import com.otilm.core.dao.entity.workflows.TriggerHistory;
 import com.otilm.core.dao.repository.ConnectorRepository;
 import com.otilm.core.dao.repository.notifications.NotificationInstanceMappedAttributeRepository;
 import com.otilm.core.dao.repository.notifications.NotificationInstanceReferenceRepository;
+import com.otilm.core.dao.repository.notifications.PendingNotificationRepository;
 import com.otilm.core.dao.repository.workflows.TriggerHistoryRepository;
 import com.otilm.core.dao.repository.workflows.TriggerRepository;
 import com.otilm.core.messaging.jms.listeners.NotificationListener;
@@ -64,6 +66,7 @@ class NotificationObjectRecipientITest extends BaseSpringBootTest {
     @Autowired private ConnectorRepository connectorRepository;
     @Autowired private TriggerRepository triggerRepository;
     @Autowired private TriggerHistoryRepository triggerHistoryRepository;
+    @Autowired private PendingNotificationRepository pendingNotificationRepository;
 
     private WireMockServer mockServer;
     private CustomAttributeDefinitionDetailDto customAttr;
@@ -241,6 +244,84 @@ class NotificationObjectRecipientITest extends BaseSpringBootTest {
 
         mockServer.verify(1, WireMock.postRequestedFor(
                 WireMock.urlPathMatching("/v1/notificationProvider/notifications/[^/]+/notify")));
+    }
+
+    /**
+     * A NONE profile may persist its recipient UUIDs as an explicit empty list rather than null;
+     * both representations must deliver identically (empty recipients, request still sent).
+     */
+    @Test
+    void testNoneRecipient_withEmptyRecipientUuidList_connectorCalledWithoutRecipients() throws AlreadyExistException, NotFoundException {
+        NotificationInstanceReference webhookInstance = new NotificationInstanceReference();
+        webhookInstance.setName("testWebhookInstance-noneEmptyList");
+        webhookInstance.setKind("WEBHOOK");
+        webhookInstance.setConnectorUuid(connectorUuid);
+        webhookInstance.setNotificationInstanceUuid(UUID.randomUUID());
+        notificationInstanceReferenceRepository.save(webhookInstance);
+
+        NotificationProfileRequestDto profileRequest = new NotificationProfileRequestDto();
+        profileRequest.setName("noneEmptyListProfile");
+        profileRequest.setRecipientType(RecipientType.NONE);
+        profileRequest.setRecipientUuids(List.of());
+        profileRequest.setInternalNotification(false);
+        profileRequest.setNotificationInstanceUuid(webhookInstance.getUuid());
+        NotificationProfileDetailDto noneProfile = notificationProfileService.createNotificationProfile(profileRequest);
+
+        NotificationMessage message = new NotificationMessage(
+                ResourceEvent.CERTIFICATE_STATUS_CHANGED, Resource.CERTIFICATE,
+                UUID.randomUUID(),
+                List.of(UUID.fromString(noneProfile.getUuid())),
+                List.of(), null);
+
+        Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(message));
+
+        mockServer.verify(1, WireMock.postRequestedFor(
+                WireMock.urlPathMatching("/v1/notificationProvider/notifications/[^/]+/notify"))
+                .withRequestBody(WireMock.matchingJsonPath("$.recipients", WireMock.equalToJson("[]"))));
+    }
+
+    /**
+     * The repetition limit is enforced through the suppression-row upsert: sends below the limit
+     * each reach the connector and bump the counter, the send at the limit is suppressed.
+     */
+    @Test
+    void testMonitoringEvent_repetitionLimitEnforcedThroughUpsert() throws AlreadyExistException, NotFoundException {
+        NotificationInstanceReference webhookInstance = new NotificationInstanceReference();
+        webhookInstance.setName("testWebhookInstance-repetitions");
+        webhookInstance.setKind("WEBHOOK");
+        webhookInstance.setConnectorUuid(connectorUuid);
+        webhookInstance.setNotificationInstanceUuid(UUID.randomUUID());
+        notificationInstanceReferenceRepository.save(webhookInstance);
+
+        NotificationProfileRequestDto profileRequest = new NotificationProfileRequestDto();
+        profileRequest.setName("repetitionLimitProfile");
+        profileRequest.setRecipientType(RecipientType.NONE);
+        profileRequest.setInternalNotification(false);
+        profileRequest.setNotificationInstanceUuid(webhookInstance.getUuid());
+        profileRequest.setRepetitions(2);
+        NotificationProfileDetailDto limitedProfile = notificationProfileService.createNotificationProfile(profileRequest);
+
+        UUID certificateUuid = UUID.randomUUID();
+        NotificationMessage message = new NotificationMessage(
+                ResourceEvent.CERTIFICATE_EXPIRING, Resource.CERTIFICATE,
+                certificateUuid,
+                List.of(UUID.fromString(limitedProfile.getUuid())),
+                List.of(), null);
+
+        for (int occurrence = 0; occurrence < 3; occurrence++) {
+            Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(message));
+        }
+
+        // Two sends reach the connector, the third occurrence is suppressed by the counter.
+        mockServer.verify(2, WireMock.postRequestedFor(
+                WireMock.urlPathMatching("/v1/notificationProvider/notifications/[^/]+/notify")));
+
+        PendingNotification suppressionRow = pendingNotificationRepository
+                .findByNotificationProfileUuidAndResourceAndObjectUuidAndEvent(
+                        UUID.fromString(limitedProfile.getUuid()), Resource.CERTIFICATE, certificateUuid, ResourceEvent.CERTIFICATE_EXPIRING);
+        Assertions.assertNotNull(suppressionRow, "the suppression row must exist after the first send");
+        Assertions.assertEquals(2, suppressionRow.getRepetitions());
+        Assertions.assertEquals(1, suppressionRow.getVersion(), "the row pins the profile version current at the first send");
     }
 
     private NotificationProfileDetailDto webhookProfile(String name, RecipientType recipientType) throws AlreadyExistException, NotFoundException {

--- a/src/test/java/com/otilm/core/integration/migration/PendingNotificationUniqueMigrationITest.java
+++ b/src/test/java/com/otilm/core/integration/migration/PendingNotificationUniqueMigrationITest.java
@@ -1,0 +1,114 @@
+package com.otilm.core.integration.migration;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+
+import javax.sql.DataSource;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Verifies the data repair of {@code V202608031000__pending_notification_unique_suppression_row.sql}
+ * against seeded duplicate suppression rows. The regular test bootstrap generates the unique
+ * constraint from the entity annotation on an empty schema, so without this test the deduplication
+ * would never execute against data, including legacy rows with a NULL event.
+ */
+class PendingNotificationUniqueMigrationITest extends BaseMigrationTest {
+
+    private static final String MIGRATION_RESOURCE = "db/migration/V202608031000__pending_notification_unique_suppression_row.sql";
+
+    private static final String PROFILE = "aaaaaaaa-0000-0000-0000-000000000000";
+
+    @Autowired
+    DataSource dataSource;
+
+    @Test
+    void testMigration() throws Exception {
+        try (Connection connection = dataSource.getConnection()) {
+            seedPreMigrationState(connection);
+
+            String migrationSql = new ClassPathResource(MIGRATION_RESOURCE).getContentAsString(StandardCharsets.UTF_8);
+            // Flyway runs the migration in a single transaction; LOCK TABLE requires one, so mirror that here.
+            connection.setAutoCommit(false);
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(migrationSql);
+                connection.commit();
+            } catch (SQLException e) {
+                connection.rollback();
+                throw e;
+            } finally {
+                connection.setAutoCommit(true);
+            }
+
+            // Duplicated key (event present): the row with the greatest last_sent_at survives.
+            Assertions.assertEquals(List.of("e0000000-0000-0000-0000-000000000002"),
+                    rowsForObject(connection, "d0000000-0000-0000-0000-000000000001"));
+
+            // Duplicated key with equal last_sent_at and NULL event: greatest repetitions wins,
+            // proving NULL events are matched as duplicates rather than treated as distinct.
+            Assertions.assertEquals(List.of("e0000000-0000-0000-0000-000000000012"),
+                    rowsForObject(connection, "d0000000-0000-0000-0000-000000000002"));
+
+            // A key without duplicates is untouched.
+            Assertions.assertEquals(List.of("e0000000-0000-0000-0000-000000000021"),
+                    rowsForObject(connection, "d0000000-0000-0000-0000-000000000003"));
+
+            // The unique constraint is in place and rejects a duplicate suppression row.
+            try (Statement statement = connection.createStatement()) {
+                SQLException rejection = Assertions.assertThrows(SQLException.class, () -> statement.execute("""
+                        INSERT INTO pending_notification
+                            (uuid, notification_profile_uuid, version, resource, object_uuid, event, last_sent_at, repetitions)
+                        VALUES ('c0000000-0000-0000-0000-000000000001', '%s', 1, 'CERTIFICATE',
+                                'd0000000-0000-0000-0000-000000000001', 'CERTIFICATE_EXPIRING', now(), 0)
+                        """.formatted(PROFILE)));
+                Assertions.assertEquals("23505", rejection.getSQLState(),
+                        "Duplicate insert should fail with the unique-violation SQLSTATE, but was: " + rejection.getMessage());
+                Assertions.assertTrue(rejection.getMessage().contains("uq_pending_notification_suppression_row"),
+                        "Duplicate insert should be rejected by the unique constraint, but was: " + rejection.getMessage());
+            }
+        }
+    }
+
+    private void seedPreMigrationState(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            // The entity-generated schema already carries the constraint; drop it to seed pre-migration data.
+            statement.execute("ALTER TABLE pending_notification DROP CONSTRAINT uq_pending_notification_suppression_row");
+
+            statement.execute("""
+                    INSERT INTO notification_profile (uuid, name, version_lock, created_at)
+                    VALUES ('%s', 'ProfileWithDuplicates', 0, now())
+                    """.formatted(PROFILE));
+
+            statement.execute("""
+                    INSERT INTO pending_notification
+                        (uuid, notification_profile_uuid, version, resource, object_uuid, event, last_sent_at, repetitions)
+                    VALUES
+                        ('e0000000-0000-0000-0000-000000000001', '%1$s', 1, 'CERTIFICATE', 'd0000000-0000-0000-0000-000000000001', 'CERTIFICATE_EXPIRING', TIMESTAMP '2026-01-01 10:00:00', 4),
+                        ('e0000000-0000-0000-0000-000000000002', '%1$s', 1, 'CERTIFICATE', 'd0000000-0000-0000-0000-000000000001', 'CERTIFICATE_EXPIRING', TIMESTAMP '2026-01-02 12:00:00', 1),
+                        ('e0000000-0000-0000-0000-000000000003', '%1$s', 2, 'CERTIFICATE', 'd0000000-0000-0000-0000-000000000001', 'CERTIFICATE_EXPIRING', TIMESTAMP '2026-01-01 10:00:00', 9),
+                        ('e0000000-0000-0000-0000-000000000011', '%1$s', 1, 'CERTIFICATE', 'd0000000-0000-0000-0000-000000000002', NULL, TIMESTAMP '2026-01-01 10:00:00', 2),
+                        ('e0000000-0000-0000-0000-000000000012', '%1$s', 1, 'CERTIFICATE', 'd0000000-0000-0000-0000-000000000002', NULL, TIMESTAMP '2026-01-01 10:00:00', 7),
+                        ('e0000000-0000-0000-0000-000000000021', '%1$s', 1, 'CERTIFICATE', 'd0000000-0000-0000-0000-000000000003', 'CERTIFICATE_EXPIRING', TIMESTAMP '2026-01-01 10:00:00', 0)
+                    """.formatted(PROFILE));
+        }
+    }
+
+    private List<String> rowsForObject(Connection connection, String objectUuid) throws SQLException {
+        List<String> uuids = new ArrayList<>();
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(
+                     "SELECT uuid FROM pending_notification WHERE object_uuid = '%s' ORDER BY uuid".formatted(objectUuid))) {
+            while (resultSet.next()) {
+                uuids.add(resultSet.getString("uuid"));
+            }
+        }
+        return uuids;
+    }
+}

--- a/src/test/java/com/otilm/core/integration/service/writer/PendingNotificationConcurrentUpsertITest.java
+++ b/src/test/java/com/otilm/core/integration/service/writer/PendingNotificationConcurrentUpsertITest.java
@@ -1,0 +1,125 @@
+package com.otilm.core.integration.service.writer;
+
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.RecipientType;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.dao.entity.notifications.NotificationProfile;
+import com.otilm.core.dao.entity.notifications.NotificationProfileVersion;
+import com.otilm.core.dao.entity.notifications.PendingNotification;
+import com.otilm.core.dao.repository.notifications.NotificationProfileRepository;
+import com.otilm.core.dao.repository.notifications.NotificationProfileVersionRepository;
+import com.otilm.core.dao.repository.notifications.PendingNotificationRepository;
+import com.otilm.core.service.writer.PendingNotificationWriter;
+import com.otilm.core.util.BaseSpringBootTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Proves the suppression-row upsert is atomic: two consumers recording a send for the same
+ * (profile, resource, object, event) at the same time must converge on one row with an
+ * accurate repetition count, and the pinned profile version must never change on conflict.
+ * The pre-upsert read-then-insert flow produced duplicate rows in exactly this race.
+ */
+class PendingNotificationConcurrentUpsertITest extends BaseSpringBootTest {
+
+    private static final Resource RESOURCE = Resource.CERTIFICATE;
+    private static final ResourceEvent EVENT = ResourceEvent.CERTIFICATE_EXPIRING;
+
+    @Autowired
+    private PendingNotificationWriter pendingNotificationWriter;
+    @Autowired
+    private PendingNotificationRepository pendingNotificationRepository;
+    @Autowired
+    private NotificationProfileRepository notificationProfileRepository;
+    @Autowired
+    private NotificationProfileVersionRepository notificationProfileVersionRepository;
+
+    private UUID profileUuid;
+    private UUID objectUuid;
+
+    @BeforeEach
+    void seedProfile() {
+        NotificationProfile profile = new NotificationProfile();
+        profile.setName("concurrent-upsert-profile");
+        profile = notificationProfileRepository.save(profile);
+        profileUuid = profile.getUuid();
+
+        NotificationProfileVersion version = new NotificationProfileVersion();
+        version.setNotificationProfileUuid(profileUuid);
+        version.setVersion(1);
+        version.setRecipientType(RecipientType.NONE);
+        version.setInternalNotification(false);
+        version.setRepetitions(10);
+        notificationProfileVersionRepository.save(version);
+
+        objectUuid = UUID.randomUUID();
+    }
+
+    @Test
+    void concurrentRecordSentConvergesOnOneRow() throws Exception {
+        int workers = 2;
+        CountDownLatch ready = new CountDownLatch(workers);
+        CountDownLatch fire = new CountDownLatch(1);
+        ExecutorService pool = Executors.newFixedThreadPool(workers);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        try {
+            List<Future<?>> futures = List.of(
+                    pool.submit(raceWorker(ready, fire, failure)),
+                    pool.submit(raceWorker(ready, fire, failure)));
+
+            Assertions.assertTrue(ready.await(10, TimeUnit.SECONDS), "workers did not become ready in time");
+            fire.countDown();
+            for (Future<?> future : futures) {
+                future.get(20, TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+
+        Assertions.assertNull(failure.get(), () -> "worker failed: " + failure.get());
+
+        PendingNotification row = pendingNotificationRepository
+                .findByNotificationProfileUuidAndResourceAndObjectUuidAndEvent(profileUuid, RESOURCE, objectUuid, EVENT);
+        Assertions.assertNotNull(row, "exactly one suppression row should exist; a duplicate would make the finder throw");
+        Assertions.assertEquals(2, row.getRepetitions(), "both concurrent sends must be counted");
+        Assertions.assertEquals(1, row.getVersion());
+        Assertions.assertNotNull(row.getLastSentAt());
+
+        // A later send updates in place and never touches the pinned version.
+        pendingNotificationWriter.recordSent(profileUuid, RESOURCE, objectUuid, EVENT, 7);
+        PendingNotification updated = pendingNotificationRepository
+                .findByNotificationProfileUuidAndResourceAndObjectUuidAndEvent(profileUuid, RESOURCE, objectUuid, EVENT);
+        Assertions.assertEquals(3, updated.getRepetitions());
+        Assertions.assertEquals(1, updated.getVersion(), "the pinned version must survive conflicts");
+    }
+
+    private Runnable raceWorker(CountDownLatch ready, CountDownLatch fire, AtomicReference<Throwable> failure) {
+        // The security context does not propagate to pool threads; each worker re-injects it.
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        return () -> {
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            try {
+                ready.countDown();
+                fire.await(10, TimeUnit.SECONDS);
+                pendingNotificationWriter.recordSent(profileUuid, RESOURCE, objectUuid, EVENT, 1);
+            } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+            } finally {
+                SecurityContextHolder.clearContext();
+            }
+        };
+    }
+}

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/NotificationListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/NotificationListenerTest.java
@@ -2,10 +2,13 @@ package com.otilm.core.messaging.jms.listeners;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.otilm.api.interfaces.client.v1.NotificationInstanceSyncApiClient;
 import com.otilm.api.model.common.events.data.CertificateRegisteredEventData;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.dao.entity.notifications.NotificationInstanceReference;
+import com.otilm.core.dao.entity.notifications.NotificationProfileVersion;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.client.ConnectorApiFactory;
 import com.otilm.core.dao.repository.GroupRepository;
@@ -21,19 +24,27 @@ import com.otilm.core.service.NotificationInternalService;
 import com.otilm.core.service.ResourceObjectAssociationService;
 import com.otilm.core.service.TriggerInternalService;
 import com.otilm.core.service.v2.ConnectorInternalService;
+import com.otilm.core.service.writer.PendingNotificationWriter;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class NotificationListenerTest {
 
@@ -57,7 +68,8 @@ class NotificationListenerTest {
                 mock(ResourceObjectAssociationService.class),
                 // The real handler, invoked directly rather than through its proxy, runs the work without a
                 // transaction -- which is what this unencumbered unit context wants.
-                new TransactionHandler());
+                new TransactionHandler(),
+                mock(PendingNotificationWriter.class));
     }
 
     @Test
@@ -84,6 +96,75 @@ class NotificationListenerTest {
         assertTrue(text.getValue().contains("CN=device-7"), "the internal notification names the certificate");
         assertFalse((text.getValue() + detail.getValue()).contains("s3cret-challenge-value"),
                 "the credential must never be written into the persisted internal notification");
+    }
+
+    @Test
+    void connectorAcceptedSendSurvivesFailedSuppressionWrite() throws Exception {
+        // The connector accepted the notification; the suppression-state write then fails. The
+        // failure must be logged and swallowed: reporting it as a delivery failure (trigger
+        // history) would misstate a delivery that already happened, and letting it escape would
+        // trigger a redelivery and a duplicate send.
+        UUID profileUuid = UUID.randomUUID();
+        UUID instanceRefUuid = UUID.randomUUID();
+
+        NotificationProfileVersion version = new NotificationProfileVersion();
+        version.setNotificationProfileUuid(profileUuid);
+        version.setVersion(1);
+        version.setRecipientType(RecipientType.NONE);
+        version.setInternalNotification(false);
+        version.setRepetitions(5);
+        version.setNotificationInstanceRefUuid(instanceRefUuid);
+
+        NotificationInstanceReference instanceRef = new NotificationInstanceReference();
+        instanceRef.setKind("WEBHOOK");
+        instanceRef.setConnectorUuid(UUID.randomUUID());
+        instanceRef.setNotificationInstanceUuid(UUID.randomUUID());
+        instanceRef.setMappedAttributes(List.of());
+
+        NotificationProfileVersionRepository versionRepository = mock(NotificationProfileVersionRepository.class);
+        when(versionRepository.findTopByNotificationProfileUuidOrderByVersionDesc(profileUuid)).thenReturn(Optional.of(version));
+        NotificationInstanceReferenceRepository instanceRefRepository = mock(NotificationInstanceReferenceRepository.class);
+        when(instanceRefRepository.findWithMappedAttributesByUuid(instanceRefUuid)).thenReturn(Optional.of(instanceRef));
+
+        ConnectorInternalService connectorService = mock(ConnectorInternalService.class);
+        NotificationInstanceSyncApiClient apiClient = mock(NotificationInstanceSyncApiClient.class);
+        when(apiClient.listMappingAttributes(any(), any())).thenReturn(List.of());
+        ConnectorApiFactory connectorApiFactory = mock(ConnectorApiFactory.class);
+        when(connectorApiFactory.getNotificationInstanceApiClient(any())).thenReturn(apiClient);
+
+        PendingNotificationWriter failingWriter = mock(PendingNotificationWriter.class);
+        doThrow(new RuntimeException("suppression store unavailable")).when(failingWriter)
+                .recordSent(any(), any(), any(), any(), anyInt());
+        TriggerInternalService triggerService = mock(TriggerInternalService.class);
+
+        NotificationListener listener = new NotificationListener(
+                JsonMapper.builder().findAndAddModules().build(),
+                mock(AttributeEngine.class),
+                notificationService,
+                triggerService,
+                connectorApiFactory,
+                connectorService,
+                mock(PendingNotificationRepository.class),
+                versionRepository,
+                instanceRefRepository,
+                mock(GroupRepository.class),
+                mock(UserManagementApiClient.class),
+                mock(RoleManagementApiClient.class),
+                mock(ResourceObjectAssociationService.class),
+                new TransactionHandler(),
+                failingWriter);
+
+        NotificationMessage message = new NotificationMessage(
+                ResourceEvent.CERTIFICATE_EXPIRING, Resource.CERTIFICATE, UUID.randomUUID(),
+                List.of(profileUuid), List.of(), null,
+                UUID.randomUUID(), null);
+
+        assertDoesNotThrow(() -> listener.processMessage(message));
+
+        verify(apiClient).sendNotification(any(), any(), any());
+        verify(failingWriter).recordSent(eq(profileUuid), eq(Resource.CERTIFICATE), any(), eq(ResourceEvent.CERTIFICATE_EXPIRING), eq(1));
+        // The failed suppression write is not a delivery failure: trigger history stays untouched.
+        verifyNoInteractions(triggerService);
     }
 
     @Test


### PR DESCRIPTION
Closes #1860. Part of epic OmniTrustILM/ilm#301.

The listener carried a class-level `@Transactional`, so one transaction spanned the DB reads, the connector HTTP calls, and the post-send `PendingNotification` write: a read failure could roll local state back behind a delivery that already happened, and concurrent consumers (the queue runs three) could duplicate suppression rows through the read-then-insert flow.

- `NotificationListener` now runs with `NOT_SUPPORTED` propagation; reads go directly to the transactional collaborators, and `NotificationInstanceReference.mappedAttributes` is fetch-joined so detached traversal cannot hit lazy loading.
- The suppression write moves to a `PendingNotificationWriter` performing an atomic `INSERT … ON CONFLICT` upsert. The pinned profile version is never updated on conflict, preserving monitoring-stream continuity, and `last_sent_at` is set in SQL.
- Migration `V202608031000` deduplicates pre-existing rows (keeping the greatest `last_sent_at`, then `repetitions`, matching NULL events as duplicates) and adds the unique constraint on `(notification_profile_uuid, resource, object_uuid, event)`, also declared on the entity.
- A suppression-write failure after connector acceptance is logged and swallowed: the external delivery stands, trigger history is not marked failed, and the next occurrence may send one extra notification.
- Regression tests cover the concurrency race, the repetition-limit flow through the upsert, `NONE` profiles with both null and empty persisted recipient lists, and the post-acceptance failure policy.