### PR TITLE
Add notification profile event data categories with authorization gate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.otilm</groupId>
             <artifactId>interfaces</artifactId>
-            <version>2.19.0</version>
+            <version>2.20.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Spring  -->

--- a/src/main/java/com/otilm/core/dao/entity/notifications/NotificationProfile.java
+++ b/src/main/java/com/otilm/core/dao/entity/notifications/NotificationProfile.java
@@ -1,5 +1,6 @@
 package com.otilm.core.dao.entity.notifications;
 
+import com.otilm.api.model.core.notification.NotificationDataCategory;
 import com.otilm.core.dao.entity.UniquelyIdentified;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
@@ -8,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 import java.util.*;
@@ -33,6 +36,21 @@ public class NotificationProfile extends UniquelyIdentified {
     @Column(name = "created_at", nullable = false, updatable = false)
     @CreationTimestamp
     protected OffsetDateTime createdAt;
+
+    // Parent-level, not versioned: a data-exposure switch must apply at send time to every
+    // delivery, including monitoring streams pinned to older profile versions.
+    @Column(name = "event_data_categories")
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    private List<NotificationDataCategory> eventDataCategories = new ArrayList<>();
+
+    /**
+     * Never null: rows created before the column existed load as null, which means the same
+     * as an empty list -- no enrichment.
+     */
+    public List<NotificationDataCategory> getEventDataCategories() {
+        return eventDataCategories == null ? List.of() : eventDataCategories;
+    }
 
     @ToString.Exclude
     @JsonBackReference

--- a/src/main/java/com/otilm/core/dao/entity/notifications/NotificationProfileVersion.java
+++ b/src/main/java/com/otilm/core/dao/entity/notifications/NotificationProfileVersion.java
@@ -85,6 +85,7 @@ public class NotificationProfileVersion extends UniquelyIdentified {
         notificationProfileDto.setRecipientUuids(this.recipientUuids);
         notificationProfileDto.setNotificationInstanceUuid(this.notificationInstanceRefUuid);
         notificationProfileDto.setInternalNotification(this.internalNotification);
+        notificationProfileDto.setEventDataCategories(this.getNotificationProfile().getEventDataCategories());
 
         return notificationProfileDto;
     }
@@ -101,6 +102,7 @@ public class NotificationProfileVersion extends UniquelyIdentified {
         notificationProfileDetailDto.setInternalNotification(this.internalNotification);
         notificationProfileDetailDto.setFrequency(this.frequency);
         notificationProfileDetailDto.setRepetitions(this.repetitions);
+        notificationProfileDetailDto.setEventDataCategories(this.getNotificationProfile().getEventDataCategories());
 
         return notificationProfileDetailDto;
     }

--- a/src/main/java/com/otilm/core/service/impl/NotificationProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/NotificationProfileServiceImpl.java
@@ -6,6 +6,7 @@ import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.notification.*;
 import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.NotificationDataCategory;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.scheduler.PaginationRequestDto;
 import com.otilm.core.dao.entity.notifications.NotificationInstanceReference;
@@ -20,8 +21,11 @@ import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.security.authz.ExternalAuthorization;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.security.authz.SecurityFilter;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import com.otilm.core.service.NotificationProfileExternalService;
 import com.otilm.core.service.ResourceObjectAssociationService;
+import com.otilm.core.service.notifications.NotificationDataCategoryGate;
 import com.otilm.core.util.RequestValidatorHelper;
 import org.hibernate.exception.ConstraintViolationException;
 import org.slf4j.Logger;
@@ -36,8 +40,11 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -47,6 +54,8 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationProfileServiceImpl.class);
 
+    private EntityManager entityManager;
+
     private NotificationProfileServiceImpl self;
     private NotificationProfileRepository notificationProfileRepository;
     private NotificationProfileVersionRepository notificationProfileVersionRepository;
@@ -54,11 +63,17 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
 
     private ExecutionRepository executionRepository;
     private ResourceObjectAssociationService resourceObjectAssociationService;
+    private NotificationDataCategoryGate notificationDataCategoryGate;
 
     @Lazy
     @Autowired
     public void setSelf(NotificationProfileServiceImpl self) {
         this.self = self;
+    }
+
+    @PersistenceContext
+    public void setEntityManager(EntityManager entityManager) {
+        this.entityManager = entityManager;
     }
 
     @Autowired
@@ -84,6 +99,11 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
     @Autowired
     public void setResourceObjectAssociationService(ResourceObjectAssociationService resourceObjectAssociationService) {
         this.resourceObjectAssociationService = resourceObjectAssociationService;
+    }
+
+    @Autowired
+    public void setNotificationDataCategoryGate(NotificationDataCategoryGate notificationDataCategoryGate) {
+        this.notificationDataCategoryGate = notificationDataCategoryGate;
     }
 
     @Override
@@ -135,15 +155,35 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
 
     @Override
     @ExternalAuthorization(resource = Resource.NOTIFICATION_PROFILE, action = ResourceAction.CREATE)
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public NotificationProfileDetailDto createNotificationProfile(NotificationProfileRequestDto requestDto) throws AlreadyExistException, NotFoundException {
+        validateNotificationInstanceExists(requestDto.getNotificationInstanceUuid());
+        // The gate calls the authorization service over HTTP and must not hold a DB connection,
+        // so it runs here while the writes happen in the self-proxied transactional method below.
+        if (requestDto.getEventDataCategories() != null) {
+            requestDto.setEventDataCategories(normalizeEventDataCategories(requestDto.getEventDataCategories()));
+        }
+        Set<NotificationDataCategory> gatedCategories = gatedCategoriesRequiringAuthorization(
+                List.of(), null, requestDto.getEventDataCategories(), requestDto.getNotificationInstanceUuid());
+        if (!gatedCategories.isEmpty()) {
+            notificationDataCategoryGate.assertCanEnable(gatedCategories);
+        }
+
+        return self.persistNewProfile(requestDto);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    NotificationProfileDetailDto persistNewProfile(NotificationProfileRequestDto requestDto) throws AlreadyExistException, NotFoundException {
         if (notificationProfileRepository.findByName(requestDto.getName()).isPresent()) {
             throw new AlreadyExistException("Notification profile with name " + requestDto.getName() + " already exists.");
         }
-        validateNotificationInstanceExists(requestDto.getNotificationInstanceUuid());
 
         NotificationProfile notificationProfile = new NotificationProfile();
         notificationProfile.setName(requestDto.getName());
         notificationProfile.setDescription(requestDto.getDescription());
+        if (requestDto.getEventDataCategories() != null) {
+            notificationProfile.setEventDataCategories(requestDto.getEventDataCategories());
+        }
         notificationProfile = notificationProfileRepository.save(notificationProfile);
 
         NotificationProfileVersion notificationProfileVersion = new NotificationProfileVersion();
@@ -171,17 +211,48 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
         // can call the auth service over HTTP and must not hold a DB connection or the profile row lock.
         List<NameAndUuidDto> recipients = resolveRecipients(updateRequestDto.getRecipientType(), updateRequestDto.getRecipientUuids());
 
+        // The category gate also calls the authorization service over HTTP, so it is evaluated here
+        // against an unlocked read while persistEditedVersion re-asserts the decision under the row lock.
+        if (updateRequestDto.getEventDataCategories() != null) {
+            updateRequestDto.setEventDataCategories(normalizeEventDataCategories(updateRequestDto.getEventDataCategories()));
+        }
+        NotificationProfile currentProfile = notificationProfileRepository.findById(uuid.getValue()).orElseThrow(() -> new NotFoundException(NotificationProfile.class, uuid));
+        NotificationProfileVersion currentVersion = notificationProfileVersionRepository.findTopByNotificationProfileUuidOrderByVersionDesc(uuid.getValue()).orElseThrow(() -> new NotFoundException(NotificationProfileVersion.class, uuid));
+        Set<NotificationDataCategory> authorizedGatedCategories = gatedCategoriesRequiringAuthorization(
+                currentProfile.getEventDataCategories(), currentVersion.getNotificationInstanceRefUuid(),
+                updateRequestDto.getEventDataCategories(), updateRequestDto.getNotificationInstanceUuid());
+        if (!authorizedGatedCategories.isEmpty()) {
+            notificationDataCategoryGate.assertCanEnable(authorizedGatedCategories);
+        }
+
         // The transaction boundary comes from the self-proxied call; invoking persistEditedVersion directly
         // on `this` would skip the @Transactional advice and reintroduce the version race.
-        return self.persistEditedVersion(uuid, updateRequestDto, recipients);
+        return self.persistEditedVersion(uuid, updateRequestDto, recipients, authorizedGatedCategories);
     }
 
     @Transactional(rollbackFor = Exception.class)
-    NotificationProfileDetailDto persistEditedVersion(SecuredUUID uuid, NotificationProfileUpdateRequestDto updateRequestDto, List<NameAndUuidDto> recipients) throws NotFoundException {
+    NotificationProfileDetailDto persistEditedVersion(SecuredUUID uuid, NotificationProfileUpdateRequestDto updateRequestDto, List<NameAndUuidDto> recipients, Set<NotificationDataCategory> authorizedGatedCategories) throws NotFoundException {
         // The row lock serializes concurrent edits; without it, both could read the same latest version and
         // insert duplicate version numbers.
         NotificationProfile notificationProfile = notificationProfileRepository.findAndLockByUuid(uuid.getValue()).orElseThrow(() -> new NotFoundException(NotificationProfile.class, uuid));
+        // Under open-session-in-view the orchestrator's unlocked read is already in this persistence
+        // context, so the locking finder can return that stale managed instance; refresh re-reads the
+        // now-locked row so every check below sees post-lock state.
+        entityManager.refresh(notificationProfile);
         NotificationProfileVersion currentVersion = notificationProfileVersionRepository.findTopByNotificationProfileUuidOrderByVersionDesc(uuid.getValue()).orElseThrow(() -> new NotFoundException(NotificationProfileVersion.class, uuid));
+        entityManager.refresh(currentVersion);
+
+        // The gate ran outside this transaction against an unlocked read. If a concurrent edit changed
+        // the gate-relevant state in between, the pre-lock authorization no longer covers this request:
+        // fail closed with a retry rather than calling the authorization service under the row lock.
+        Set<NotificationDataCategory> gatedCategoriesUnderLock = gatedCategoriesRequiringAuthorization(
+                notificationProfile.getEventDataCategories(), currentVersion.getNotificationInstanceRefUuid(),
+                updateRequestDto.getEventDataCategories(), updateRequestDto.getNotificationInstanceUuid());
+        if (!authorizedGatedCategories.containsAll(gatedCategoriesUnderLock)) {
+            throw new ValidationException("Notification profile %s was concurrently modified. Retry the edit.".formatted(notificationProfile.getName()));
+        }
+
+        applyEventDataCategories(notificationProfile, updateRequestDto);
 
         // Description lives on the profile, not on the version — persist it even when no new version is created
         if (!Objects.equals(notificationProfile.getDescription(), updateRequestDto.getDescription())) {
@@ -217,6 +288,55 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
         }
 
         return notificationProfileVersion.mapToDetailDto(recipients);
+    }
+
+    /**
+     * Normalizes a requested category list to its canonical form: rejects null elements with an
+     * actionable error, removes duplicates, and orders by enum declaration so stored values and
+     * equality checks are representation-independent. Callers keep an absent (null) field as-is --
+     * it means "keep the current value" on update and never reaches this method.
+     */
+    private static List<NotificationDataCategory> normalizeEventDataCategories(List<NotificationDataCategory> categories) {
+        // Immutable lists reject null probes, so the null scan must not use contains(null).
+        if (categories.stream().anyMatch(Objects::isNull)) {
+            throw new ValidationException("Event data categories must not contain null entries");
+        }
+        return categories.isEmpty() ? List.of() : List.copyOf(EnumSet.copyOf(categories));
+    }
+
+    /**
+     * The gated categories a request must be authorized for, or an empty set when no gate applies.
+     * The gate fires when the resulting state has a gated category enabled and the request either
+     * adds a gated category or moves the profile to another notification instance -- swapping the
+     * destination must not become an ungated route for data an operator was never allowed to
+     * export. Absent (null) requested categories keep the current value (presence-aware update).
+     */
+    private static Set<NotificationDataCategory> gatedCategoriesRequiringAuthorization(
+            List<NotificationDataCategory> currentCategories, UUID currentDestination,
+            List<NotificationDataCategory> requestedCategories, UUID requestedDestination) {
+        List<NotificationDataCategory> resultingCategories = requestedCategories != null ? requestedCategories : currentCategories;
+
+        Set<NotificationDataCategory> resultingGated = resultingCategories.stream()
+                .filter(NotificationDataCategoryGate::isGated)
+                .collect(Collectors.toSet());
+        boolean addsGatedCategory = !new HashSet<>(currentCategories).containsAll(resultingGated);
+        boolean destinationChanges = !Objects.equals(currentDestination, requestedDestination);
+        return !resultingGated.isEmpty() && (addsGatedCategory || destinationChanges) ? resultingGated : Set.of();
+    }
+
+    /**
+     * Applies the parent-level {@code eventDataCategories} update with presence-aware semantics:
+     * an absent (null) field keeps the current value so older API clients cannot silently clear
+     * it, an empty list disables enrichment. Category edits update the parent in place (through
+     * its optimistic lock) and never create a profile version. Authorization happened in the
+     * orchestrator, outside this transaction.
+     */
+    private void applyEventDataCategories(NotificationProfile notificationProfile, NotificationProfileUpdateRequestDto updateRequestDto) {
+        List<NotificationDataCategory> requestedCategories = updateRequestDto.getEventDataCategories();
+        if (requestedCategories != null && !Objects.equals(notificationProfile.getEventDataCategories(), requestedCategories)) {
+            notificationProfile.setEventDataCategories(requestedCategories);
+            notificationProfileRepository.save(notificationProfile);
+        }
     }
 
     /**

--- a/src/main/java/com/otilm/core/service/impl/NotificationProfileServiceImpl.java
+++ b/src/main/java/com/otilm/core/service/impl/NotificationProfileServiceImpl.java
@@ -155,7 +155,7 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
 
     @Override
     @ExternalAuthorization(resource = Resource.NOTIFICATION_PROFILE, action = ResourceAction.CREATE)
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @Transactional(propagation = Propagation.NOT_SUPPORTED, rollbackFor = Exception.class)
     public NotificationProfileDetailDto createNotificationProfile(NotificationProfileRequestDto requestDto) throws AlreadyExistException, NotFoundException {
         validateNotificationInstanceExists(requestDto.getNotificationInstanceUuid());
         // The gate calls the authorization service over HTTP and must not hold a DB connection,
@@ -204,7 +204,7 @@ public class NotificationProfileServiceImpl implements NotificationProfileExtern
 
     @Override
     @ExternalAuthorization(resource = Resource.NOTIFICATION_PROFILE, action = ResourceAction.UPDATE)
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @Transactional(propagation = Propagation.NOT_SUPPORTED, rollbackFor = Exception.class)
     public NotificationProfileDetailDto editNotificationProfile(SecuredUUID uuid, NotificationProfileUpdateRequestDto updateRequestDto) throws NotFoundException {
         validateNotificationInstanceExists(updateRequestDto.getNotificationInstanceUuid());
         // Resolve recipient info from the request before opening the write transaction: recipient lookup

--- a/src/main/java/com/otilm/core/service/notifications/NotificationDataCategoryGate.java
+++ b/src/main/java/com/otilm/core/service/notifications/NotificationDataCategoryGate.java
@@ -21,6 +21,17 @@ import java.util.Map;
  * any object-level restriction at configuration time. OBJECT_CONTENT lists the certificate
  * content exporter's requirements; registering another content exporter requires extending this
  * map as part of that exporter's own design, never silently.
+ *
+ * <p>Trust boundary: the gate fires on the two edges that change the export decision itself --
+ * enabling a gated category (what data leaves) and moving the profile to another notification
+ * instance while a gated category stays enabled (where it leaves to). Recipient edits and
+ * notification-instance configuration updates deliberately do not re-fire it: recipients only
+ * choose who the provider addresses (holders of NOTIFICATION_PROFILE UPDATE already direct all
+ * notification content, including the event payload, to any recipients), and administering an
+ * instance's connector configuration is governed by the instance's own update authority, which
+ * already controls where every notification through that instance -- enriched or not -- is
+ * delivered. The gate is point-in-time: permissions lost later do not retroactively disable
+ * existing profiles.
  */
 @Component
 @AllArgsConstructor

--- a/src/main/java/com/otilm/core/service/notifications/NotificationDataCategoryGate.java
+++ b/src/main/java/com/otilm/core/service/notifications/NotificationDataCategoryGate.java
@@ -1,0 +1,65 @@
+package com.otilm.core.service.notifications;
+
+import com.otilm.api.exception.ValidationError;
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.NotificationDataCategory;
+import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.security.authz.SecurityResourceFilter;
+import com.otilm.core.util.AuthHelper;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Config-time authorization gate for notification data categories. Enabling a gated category
+ * routes object data to the profile's connector at send time, when loads run in system context
+ * with no user to authorize -- so the configuring user must hold the listed permissions without
+ * any object-level restriction at configuration time. OBJECT_CONTENT lists the certificate
+ * content exporter's requirements; registering another content exporter requires extending this
+ * map as part of that exporter's own design, never silently.
+ */
+@Component
+@AllArgsConstructor
+public class NotificationDataCategoryGate {
+
+    private record RequiredPermission(Resource resource, ResourceAction action) {
+
+        String describe() {
+            return resource.name() + " " + action.name();
+        }
+    }
+
+    private static final Map<NotificationDataCategory, List<RequiredPermission>> GATED_CATEGORIES = Map.of(
+            NotificationDataCategory.CUSTOM_ATTRIBUTES, List.of(
+                    new RequiredPermission(Resource.ATTRIBUTE, ResourceAction.MEMBERS)),
+            NotificationDataCategory.OBJECT_CONTENT, List.of(
+                    new RequiredPermission(Resource.CERTIFICATE, ResourceAction.DETAIL),
+                    new RequiredPermission(Resource.RA_PROFILE, ResourceAction.MEMBERS)));
+
+    private final AuthHelper authHelper;
+
+    public static boolean isGated(NotificationDataCategory category) {
+        return GATED_CATEGORIES.containsKey(category);
+    }
+
+    /**
+     * Refuses with an actionable message unless the current user holds every permission the
+     * given categories require without allow-list or deny-list restriction.
+     */
+    public void assertCanEnable(Collection<NotificationDataCategory> categories) {
+        for (NotificationDataCategory category : categories) {
+            for (RequiredPermission required : GATED_CATEGORIES.getOrDefault(category, List.of())) {
+                SecurityResourceFilter filter = authHelper.loadObjectPermissions(required.resource(), required.action());
+                if (filter.areOnlySpecificObjectsAllowed() || !filter.getForbiddenObjects().isEmpty()) {
+                    throw new ValidationException(ValidationError.create(
+                            "Enabling notification data category {} requires unrestricted {} access",
+                            category.getLabel(), required.describe()));
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/db/migration/V202608031100__notification_profile_event_data_categories.sql
+++ b/src/main/resources/db/migration/V202608031100__notification_profile_event_data_categories.sql
@@ -1,0 +1,4 @@
+-- Opt-in notification data categories on the parent profile. Null or empty means no
+-- enrichment, so existing profiles keep today's behavior without a backfill.
+ALTER TABLE "notification_profile"
+    ADD COLUMN "event_data_categories" TEXT[];

--- a/src/test/java/com/otilm/core/integration/service/NotificationProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/NotificationProfileServiceITest.java
@@ -3,6 +3,7 @@ package com.otilm.core.integration.service;
 import com.otilm.api.exception.AlreadyExistException;
 import com.otilm.api.exception.AttributeException;
 import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.attribute.RequestAttributeV2;
 import com.otilm.api.model.client.attribute.RequestAttributeV3;
 import com.otilm.api.model.client.attribute.custom.CustomAttributeCreateRequestDto;
@@ -20,6 +21,7 @@ import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.certificate.group.GroupDto;
 import com.otilm.api.model.core.certificate.group.GroupRequestDto;
 import com.otilm.api.model.core.connector.ConnectorStatus;
+import com.otilm.api.model.core.notification.NotificationDataCategory;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.api.model.core.scheduler.PaginationRequestDto;
@@ -198,6 +200,161 @@ class NotificationProfileServiceITest extends BaseSpringBootTest {
         Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(notificationMessage));
 
         mockServer.stop();
+    }
+
+    @Test
+    void testEventDataCategories_createPersistsAndExposesThem() throws NotFoundException, AlreadyExistException {
+        NotificationProfileRequestDto requestDto = new NotificationProfileRequestDto();
+        requestDto.setName("EnrichedProfile");
+        requestDto.setRecipientType(RecipientType.OWNER);
+        requestDto.setInternalNotification(true);
+        requestDto.setEventDataCategories(List.of(NotificationDataCategory.METADATA, NotificationDataCategory.ASSOCIATIONS));
+
+        NotificationProfileDetailDto created = notificationProfileService.createNotificationProfile(requestDto);
+        Assertions.assertEquals(List.of(NotificationDataCategory.METADATA, NotificationDataCategory.ASSOCIATIONS), created.getEventDataCategories());
+
+        NotificationProfileDetailDto reloaded = notificationProfileService.getNotificationProfile(SecuredUUID.fromString(created.getUuid()), null);
+        Assertions.assertEquals(List.of(NotificationDataCategory.METADATA, NotificationDataCategory.ASSOCIATIONS), reloaded.getEventDataCategories());
+
+        // A profile created without the field stays enrichment-free.
+        Assertions.assertTrue(originalNotificationProfile.getEventDataCategories() == null
+                        || originalNotificationProfile.getEventDataCategories().isEmpty(),
+                "profiles created without the field must not enable enrichment");
+    }
+
+    @Test
+    void testEventDataCategories_presenceAwareUpdate() throws NotFoundException {
+        SecuredUUID profileUuid = SecuredUUID.fromString(originalNotificationProfile.getUuid());
+        NotificationProfileUpdateRequestDto sameVersionFields = new NotificationProfileUpdateRequestDto();
+        sameVersionFields.setRecipientType(RecipientType.OWNER);
+        sameVersionFields.setInternalNotification(true);
+
+        // Populated list sets the value; a category-only edit creates no new version.
+        sameVersionFields.setEventDataCategories(List.of(NotificationDataCategory.METADATA));
+        NotificationProfileDetailDto updated = notificationProfileService.editNotificationProfile(profileUuid, sameVersionFields);
+        Assertions.assertEquals(List.of(NotificationDataCategory.METADATA), updated.getEventDataCategories());
+        Assertions.assertEquals(originalNotificationProfile.getVersion(), updated.getVersion(),
+                "a category-only edit must not create a new profile version");
+
+        // Absent field keeps the current value: an older API client cannot silently clear it.
+        sameVersionFields.setEventDataCategories(null);
+        updated = notificationProfileService.editNotificationProfile(profileUuid, sameVersionFields);
+        Assertions.assertEquals(List.of(NotificationDataCategory.METADATA), updated.getEventDataCategories(),
+                "an update without the field must preserve the stored categories");
+
+        // Empty list disables enrichment.
+        sameVersionFields.setEventDataCategories(List.of());
+        updated = notificationProfileService.editNotificationProfile(profileUuid, sameVersionFields);
+        Assertions.assertTrue(updated.getEventDataCategories().isEmpty(), "an empty list must clear the categories");
+    }
+
+    @Test
+    void testEventDataCategories_nullEntriesRejectedAndDuplicatesCanonicalized() throws NotFoundException, AlreadyExistException {
+        NotificationProfileRequestDto requestDto = new NotificationProfileRequestDto();
+        requestDto.setName("NormalizedProfile");
+        requestDto.setRecipientType(RecipientType.OWNER);
+        requestDto.setInternalNotification(true);
+
+        // A null entry is a client error, not a server error.
+        List<NotificationDataCategory> withNull = new ArrayList<>();
+        withNull.add(NotificationDataCategory.METADATA);
+        withNull.add(null);
+        requestDto.setEventDataCategories(withNull);
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
+                () -> notificationProfileService.createNotificationProfile(requestDto));
+        Assertions.assertTrue(ex.getMessage().contains("null"), ex.getMessage());
+
+        // Duplicates collapse and the stored order is canonical (enum declaration order).
+        requestDto.setEventDataCategories(List.of(
+                NotificationDataCategory.ASSOCIATIONS, NotificationDataCategory.METADATA, NotificationDataCategory.METADATA));
+        NotificationProfileDetailDto created = notificationProfileService.createNotificationProfile(requestDto);
+        Assertions.assertEquals(List.of(NotificationDataCategory.METADATA, NotificationDataCategory.ASSOCIATIONS),
+                created.getEventDataCategories());
+    }
+
+    @Test
+    void testEventDataCategories_gateRefusesRestrictedAttributeAccess() {
+        restrictObjectAccess(Resource.ATTRIBUTE, com.otilm.core.model.auth.ResourceAction.MEMBERS);
+
+        NotificationProfileRequestDto requestDto = new NotificationProfileRequestDto();
+        requestDto.setName("GatedProfile");
+        requestDto.setRecipientType(RecipientType.OWNER);
+        requestDto.setInternalNotification(true);
+        requestDto.setEventDataCategories(List.of(NotificationDataCategory.CUSTOM_ATTRIBUTES));
+
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
+                () -> notificationProfileService.createNotificationProfile(requestDto));
+        Assertions.assertTrue(ex.getMessage().contains("ATTRIBUTE") && ex.getMessage().contains("MEMBERS"), ex.getMessage());
+
+        // The ungated categories remain available to the same restricted user.
+        requestDto.setEventDataCategories(List.of(NotificationDataCategory.METADATA, NotificationDataCategory.ASSOCIATIONS));
+        Assertions.assertDoesNotThrow(() -> notificationProfileService.createNotificationProfile(requestDto));
+    }
+
+    @Test
+    void testEventDataCategories_objectContentGateChecksBothPermissions() {
+        NotificationProfileRequestDto requestDto = new NotificationProfileRequestDto();
+        requestDto.setName("ContentGatedProfile");
+        requestDto.setRecipientType(RecipientType.OWNER);
+        requestDto.setInternalNotification(true);
+        requestDto.setEventDataCategories(List.of(NotificationDataCategory.OBJECT_CONTENT));
+
+        restrictObjectAccess(Resource.CERTIFICATE, com.otilm.core.model.auth.ResourceAction.DETAIL);
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
+                () -> notificationProfileService.createNotificationProfile(requestDto));
+        Assertions.assertTrue(ex.getMessage().contains("CERTIFICATE") && ex.getMessage().contains("DETAIL"), ex.getMessage());
+
+        // Reset to allow-all, then restrict only the RA profile membership side.
+        mockSuccessfulCheckObjectAccess();
+        restrictObjectAccess(Resource.RA_PROFILE, com.otilm.core.model.auth.ResourceAction.MEMBERS);
+        ex = Assertions.assertThrows(ValidationException.class,
+                () -> notificationProfileService.createNotificationProfile(requestDto));
+        Assertions.assertTrue(ex.getMessage().contains("RA_PROFILE") && ex.getMessage().contains("MEMBERS"), ex.getMessage());
+    }
+
+    @Test
+    void testEventDataCategories_destinationChangeRegates() throws NotFoundException, AlreadyExistException {
+        NotificationInstanceReference firstInstance = new NotificationInstanceReference();
+        firstInstance.setName("gateInstanceFirst");
+        firstInstance.setKind("WEBHOOK");
+        firstInstance.setNotificationInstanceUuid(UUID.randomUUID());
+        notificationInstanceReferenceRepository.save(firstInstance);
+        NotificationInstanceReference secondInstance = new NotificationInstanceReference();
+        secondInstance.setName("gateInstanceSecond");
+        secondInstance.setKind("WEBHOOK");
+        secondInstance.setNotificationInstanceUuid(UUID.randomUUID());
+        notificationInstanceReferenceRepository.save(secondInstance);
+
+        // An unrestricted user enables a gated category against the first instance.
+        NotificationProfileRequestDto requestDto = new NotificationProfileRequestDto();
+        requestDto.setName("RegateProfile");
+        requestDto.setRecipientType(RecipientType.NONE);
+        requestDto.setInternalNotification(false);
+        requestDto.setNotificationInstanceUuid(firstInstance.getUuid());
+        requestDto.setEventDataCategories(List.of(NotificationDataCategory.CUSTOM_ATTRIBUTES));
+        NotificationProfileDetailDto created = notificationProfileService.createNotificationProfile(requestDto);
+
+        // The user then loses unrestricted attribute access.
+        restrictObjectAccess(Resource.ATTRIBUTE, com.otilm.core.model.auth.ResourceAction.MEMBERS);
+
+        // Edits that touch neither the categories nor the destination stay available.
+        NotificationProfileUpdateRequestDto updateDto = new NotificationProfileUpdateRequestDto();
+        updateDto.setDescription("still allowed");
+        updateDto.setRecipientType(RecipientType.NONE);
+        updateDto.setInternalNotification(false);
+        updateDto.setNotificationInstanceUuid(firstInstance.getUuid());
+        SecuredUUID profileUuid = SecuredUUID.fromString(created.getUuid());
+        Assertions.assertDoesNotThrow(() -> notificationProfileService.editNotificationProfile(profileUuid, updateDto));
+
+        // Swapping the destination while the gated category stays enabled re-fires the gate.
+        updateDto.setNotificationInstanceUuid(secondInstance.getUuid());
+        ValidationException ex = Assertions.assertThrows(ValidationException.class,
+                () -> notificationProfileService.editNotificationProfile(profileUuid, updateDto));
+        Assertions.assertTrue(ex.getMessage().contains("ATTRIBUTE") && ex.getMessage().contains("MEMBERS"), ex.getMessage());
+
+        // Disabling the gated category makes the destination swap legal again.
+        updateDto.setEventDataCategories(List.of());
+        Assertions.assertDoesNotThrow(() -> notificationProfileService.editNotificationProfile(profileUuid, updateDto));
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/service/NotificationProfileServiceITest.java
+++ b/src/test/java/com/otilm/core/integration/service/NotificationProfileServiceITest.java
@@ -35,6 +35,7 @@ import com.otilm.core.dao.repository.notifications.NotificationInstanceReference
 import com.otilm.core.dao.repository.notifications.NotificationProfileRepository;
 import com.otilm.core.dao.repository.notifications.NotificationProfileVersionRepository;
 import com.otilm.core.messaging.jms.listeners.NotificationListener;
+import com.otilm.core.model.auth.ResourceAction;
 import com.otilm.core.messaging.model.NotificationMessage;
 import com.otilm.core.security.authz.SecuredUUID;
 import com.otilm.core.service.AttributeExternalService;
@@ -274,7 +275,7 @@ class NotificationProfileServiceITest extends BaseSpringBootTest {
 
     @Test
     void testEventDataCategories_gateRefusesRestrictedAttributeAccess() {
-        restrictObjectAccess(Resource.ATTRIBUTE, com.otilm.core.model.auth.ResourceAction.MEMBERS);
+        restrictObjectAccess(Resource.ATTRIBUTE, ResourceAction.MEMBERS);
 
         NotificationProfileRequestDto requestDto = new NotificationProfileRequestDto();
         requestDto.setName("GatedProfile");
@@ -299,17 +300,55 @@ class NotificationProfileServiceITest extends BaseSpringBootTest {
         requestDto.setInternalNotification(true);
         requestDto.setEventDataCategories(List.of(NotificationDataCategory.OBJECT_CONTENT));
 
-        restrictObjectAccess(Resource.CERTIFICATE, com.otilm.core.model.auth.ResourceAction.DETAIL);
+        restrictObjectAccess(Resource.CERTIFICATE, ResourceAction.DETAIL);
         ValidationException ex = Assertions.assertThrows(ValidationException.class,
                 () -> notificationProfileService.createNotificationProfile(requestDto));
         Assertions.assertTrue(ex.getMessage().contains("CERTIFICATE") && ex.getMessage().contains("DETAIL"), ex.getMessage());
 
         // Reset to allow-all, then restrict only the RA profile membership side.
         mockSuccessfulCheckObjectAccess();
-        restrictObjectAccess(Resource.RA_PROFILE, com.otilm.core.model.auth.ResourceAction.MEMBERS);
+        restrictObjectAccess(Resource.RA_PROFILE, ResourceAction.MEMBERS);
         ex = Assertions.assertThrows(ValidationException.class,
                 () -> notificationProfileService.createNotificationProfile(requestDto));
         Assertions.assertTrue(ex.getMessage().contains("RA_PROFILE") && ex.getMessage().contains("MEMBERS"), ex.getMessage());
+    }
+
+    /**
+     * Pins the trust boundary: recipient edits do not re-fire the category gate. Recipients only
+     * choose who the provider addresses; NOTIFICATION_PROFILE UPDATE holders already direct all
+     * notification content to any recipients, so a recipient change on a profile with a gated
+     * category enabled stays available to a user who has since lost the gated permission.
+     */
+    @Test
+    void testEventDataCategories_recipientChangesDoNotRegate() throws NotFoundException, AlreadyExistException {
+        NotificationInstanceReference instance = new NotificationInstanceReference();
+        instance.setName("recipientEditInstance");
+        instance.setKind("WEBHOOK");
+        instance.setNotificationInstanceUuid(UUID.randomUUID());
+        notificationInstanceReferenceRepository.save(instance);
+
+        NotificationProfileRequestDto requestDto = new NotificationProfileRequestDto();
+        requestDto.setName("RecipientEditProfile");
+        requestDto.setRecipientType(RecipientType.NONE);
+        requestDto.setInternalNotification(false);
+        requestDto.setNotificationInstanceUuid(instance.getUuid());
+        requestDto.setEventDataCategories(List.of(NotificationDataCategory.CUSTOM_ATTRIBUTES));
+        NotificationProfileDetailDto created = notificationProfileService.createNotificationProfile(requestDto);
+
+        // The user loses unrestricted attribute access after enabling the gated category.
+        restrictObjectAccess(Resource.ATTRIBUTE, ResourceAction.MEMBERS);
+
+        // Recipient routing changes; categories and destination stay untouched.
+        NotificationProfileUpdateRequestDto updateDto = new NotificationProfileUpdateRequestDto();
+        updateDto.setRecipientType(RecipientType.DEFAULT);
+        updateDto.setInternalNotification(false);
+        updateDto.setNotificationInstanceUuid(instance.getUuid());
+        NotificationProfileDetailDto updated = notificationProfileService.editNotificationProfile(
+                SecuredUUID.fromString(created.getUuid()), updateDto);
+
+        Assertions.assertEquals(RecipientType.DEFAULT, updated.getRecipientType());
+        Assertions.assertEquals(List.of(NotificationDataCategory.CUSTOM_ATTRIBUTES), updated.getEventDataCategories(),
+                "the gated category stays enabled; only its addition or a destination change re-fires the gate");
     }
 
     @Test
@@ -335,7 +374,7 @@ class NotificationProfileServiceITest extends BaseSpringBootTest {
         NotificationProfileDetailDto created = notificationProfileService.createNotificationProfile(requestDto);
 
         // The user then loses unrestricted attribute access.
-        restrictObjectAccess(Resource.ATTRIBUTE, com.otilm.core.model.auth.ResourceAction.MEMBERS);
+        restrictObjectAccess(Resource.ATTRIBUTE, ResourceAction.MEMBERS);
 
         // Edits that touch neither the categories nor the destination stay available.
         NotificationProfileUpdateRequestDto updateDto = new NotificationProfileUpdateRequestDto();

--- a/src/test/java/com/otilm/core/service/impl/NotificationProfileServiceImplPersistEditTest.java
+++ b/src/test/java/com/otilm/core/service/impl/NotificationProfileServiceImplPersistEditTest.java
@@ -2,24 +2,29 @@ package com.otilm.core.service.impl;
 
 import com.otilm.api.exception.ValidationException;
 import com.otilm.api.model.client.notification.NotificationProfileUpdateRequestDto;
+import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.core.notification.NotificationDataCategory;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.core.dao.entity.notifications.NotificationProfile;
 import com.otilm.core.dao.entity.notifications.NotificationProfileVersion;
 import com.otilm.core.dao.repository.notifications.NotificationProfileRepository;
 import com.otilm.core.dao.repository.notifications.NotificationProfileVersionRepository;
 import com.otilm.core.security.authz.SecuredUUID;
+import jakarta.persistence.EntityManager;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -43,12 +48,16 @@ class NotificationProfileServiceImplPersistEditTest {
 
     private SecuredUUID profileUuid;
     private NotificationProfileUpdateRequestDto updateRequest;
+    private final List<NameAndUuidDto> noRecipients = List.of();
+    private final Set<NotificationDataCategory> noGatedCategories = Set.of();
 
     @BeforeEach
     void setUp() {
         service = new NotificationProfileServiceImpl();
         service.setNotificationProfileRepository(notificationProfileRepository);
         service.setNotificationProfileVersionRepository(notificationProfileVersionRepository);
+        // The under-lock refresh is a no-op here: the mocked repositories return detached fixtures.
+        service.setEntityManager(Mockito.mock(EntityManager.class));
 
         profileUuid = SecuredUUID.fromUUID(UUID.randomUUID());
 
@@ -76,7 +85,7 @@ class NotificationProfileServiceImplPersistEditTest {
                 .thenThrow(integrityViolation(NotificationProfileVersion.UNIQUE_VERSION_CONSTRAINT));
 
         ValidationException e = Assertions.assertThrows(ValidationException.class,
-                () -> service.persistEditedVersion(profileUuid, updateRequest, List.of()));
+                () -> service.persistEditedVersion(profileUuid, updateRequest, noRecipients, noGatedCategories));
         Assertions.assertTrue(e.getMessage().contains("concurrently modified"),
                 "Message should tell the client to retry, but was: " + e.getMessage());
     }
@@ -87,7 +96,7 @@ class NotificationProfileServiceImplPersistEditTest {
         when(notificationProfileVersionRepository.saveAndFlush(any())).thenThrow(foreignKeyViolation);
 
         DataIntegrityViolationException e = Assertions.assertThrows(DataIntegrityViolationException.class,
-                () -> service.persistEditedVersion(profileUuid, updateRequest, List.of()));
+                () -> service.persistEditedVersion(profileUuid, updateRequest, noRecipients, noGatedCategories));
         Assertions.assertSame(foreignKeyViolation, e, "Non-duplicate integrity violations must surface unchanged");
     }
 
@@ -97,7 +106,7 @@ class NotificationProfileServiceImplPersistEditTest {
         when(notificationProfileVersionRepository.saveAndFlush(any())).thenThrow(anonymousViolation);
 
         DataIntegrityViolationException e = Assertions.assertThrows(DataIntegrityViolationException.class,
-                () -> service.persistEditedVersion(profileUuid, updateRequest, List.of()));
+                () -> service.persistEditedVersion(profileUuid, updateRequest, noRecipients, noGatedCategories));
         Assertions.assertSame(anonymousViolation, e);
     }
 

--- a/src/test/java/com/otilm/core/service/impl/NotificationProfileServiceImplPersistEditTest.java
+++ b/src/test/java/com/otilm/core/service/impl/NotificationProfileServiceImplPersistEditTest.java
@@ -28,6 +28,9 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -57,7 +60,7 @@ class NotificationProfileServiceImplPersistEditTest {
         service.setNotificationProfileRepository(notificationProfileRepository);
         service.setNotificationProfileVersionRepository(notificationProfileVersionRepository);
         // The under-lock refresh is a no-op here: the mocked repositories return detached fixtures.
-        service.setEntityManager(Mockito.mock(EntityManager.class));
+        service.setEntityManager(mock(EntityManager.class));
 
         profileUuid = SecuredUUID.fromUUID(UUID.randomUUID());
 
@@ -108,6 +111,36 @@ class NotificationProfileServiceImplPersistEditTest {
         DataIntegrityViolationException e = Assertions.assertThrows(DataIntegrityViolationException.class,
                 () -> service.persistEditedVersion(profileUuid, updateRequest, noRecipients, noGatedCategories));
         Assertions.assertSame(anonymousViolation, e);
+    }
+
+    /**
+     * The gate runs outside the write transaction against an unlocked read; when a concurrent
+     * edit changes gate-relevant state in between, the under-lock re-check must fail closed
+     * with the retry error before anything is persisted -- never call the authorization
+     * service under the row lock.
+     */
+    @Test
+    void lockedStateDemandingUnauthorizedGatingFailsClosedBeforePersisting() {
+        NotificationProfile lockedProfile = new NotificationProfile();
+        lockedProfile.uuid = profileUuid.getValue();
+        lockedProfile.setName("TestProfile");
+        // A concurrent edit enabled a gated category after the unlocked pre-check ran.
+        lockedProfile.setEventDataCategories(List.of(NotificationDataCategory.CUSTOM_ATTRIBUTES));
+        when(notificationProfileRepository.findAndLockByUuid(profileUuid.getValue())).thenReturn(Optional.of(lockedProfile));
+
+        // The request swaps the destination, so the locked state demands gating for
+        // CUSTOM_ATTRIBUTES -- which the pre-lock check (empty authorized set) never covered.
+        NotificationProfileUpdateRequestDto destinationSwap = new NotificationProfileUpdateRequestDto();
+        destinationSwap.setRecipientType(RecipientType.OWNER);
+        destinationSwap.setInternalNotification(true);
+        destinationSwap.setNotificationInstanceUuid(UUID.randomUUID());
+
+        ValidationException e = Assertions.assertThrows(ValidationException.class,
+                () -> service.persistEditedVersion(profileUuid, destinationSwap, noRecipients, noGatedCategories));
+        Assertions.assertTrue(e.getMessage().contains("concurrently modified"),
+                "Message should tell the client to retry, but was: " + e.getMessage());
+        verify(notificationProfileRepository, never()).save(any());
+        verify(notificationProfileVersionRepository, never()).saveAndFlush(any());
     }
 
     private static DataIntegrityViolationException integrityViolation(String constraintName) {

--- a/src/test/java/com/otilm/core/service/impl/NotificationProfileServiceImplPersistEditTest.java
+++ b/src/test/java/com/otilm/core/service/impl/NotificationProfileServiceImplPersistEditTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 

--- a/src/test/java/com/otilm/core/service/notifications/NotificationDataCategoryGateTest.java
+++ b/src/test/java/com/otilm/core/service/notifications/NotificationDataCategoryGateTest.java
@@ -1,0 +1,103 @@
+package com.otilm.core.service.notifications;
+
+import com.otilm.api.exception.ValidationException;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.NotificationDataCategory;
+import com.otilm.core.model.auth.ResourceAction;
+import com.otilm.core.security.authz.SecurityResourceFilter;
+import com.otilm.core.util.AuthHelper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationDataCategoryGateTest {
+
+    private static final SecurityResourceFilter UNRESTRICTED = new SecurityResourceFilter(List.of(), List.of(), false);
+    private static final SecurityResourceFilter ALLOW_LISTED = new SecurityResourceFilter(List.of(UUID.randomUUID().toString()), List.of(), true);
+    private static final SecurityResourceFilter DENY_LISTED = new SecurityResourceFilter(List.of(), List.of(UUID.randomUUID().toString()), false);
+
+    @Mock
+    private AuthHelper authHelper;
+
+    private NotificationDataCategoryGate gate() {
+        return new NotificationDataCategoryGate(authHelper);
+    }
+
+    @Test
+    void unrestrictedUserEnablesEverything() {
+        when(authHelper.loadObjectPermissions(any(), any())).thenReturn(UNRESTRICTED);
+        assertDoesNotThrow(() -> gate().assertCanEnable(List.of(NotificationDataCategory.values())));
+    }
+
+    @Test
+    void allowListRestrictedAttributeMembersRefusesCustomAttributes() {
+        when(authHelper.loadObjectPermissions(Resource.ATTRIBUTE, ResourceAction.MEMBERS)).thenReturn(ALLOW_LISTED);
+
+        NotificationDataCategoryGate gate = gate();
+        List<NotificationDataCategory> categories = List.of(NotificationDataCategory.CUSTOM_ATTRIBUTES);
+        ValidationException ex = assertThrows(ValidationException.class, () -> gate.assertCanEnable(categories));
+        assertTrue(ex.getMessage().contains("ATTRIBUTE"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("MEMBERS"), ex.getMessage());
+    }
+
+    @Test
+    void denyListRestrictionAlsoRefuses() {
+        when(authHelper.loadObjectPermissions(Resource.ATTRIBUTE, ResourceAction.MEMBERS)).thenReturn(DENY_LISTED);
+
+        NotificationDataCategoryGate gate = gate();
+        List<NotificationDataCategory> categories = List.of(NotificationDataCategory.CUSTOM_ATTRIBUTES);
+        assertThrows(ValidationException.class, () -> gate.assertCanEnable(categories));
+    }
+
+    @Test
+    void objectContentRequiresCertificateDetail() {
+        when(authHelper.loadObjectPermissions(Resource.CERTIFICATE, ResourceAction.DETAIL)).thenReturn(ALLOW_LISTED);
+
+        NotificationDataCategoryGate gate = gate();
+        List<NotificationDataCategory> categories = List.of(NotificationDataCategory.OBJECT_CONTENT);
+        ValidationException ex = assertThrows(ValidationException.class, () -> gate.assertCanEnable(categories));
+        assertTrue(ex.getMessage().contains("CERTIFICATE"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("DETAIL"), ex.getMessage());
+    }
+
+    @Test
+    void objectContentRequiresRaProfileMembers() {
+        when(authHelper.loadObjectPermissions(Resource.CERTIFICATE, ResourceAction.DETAIL)).thenReturn(UNRESTRICTED);
+        when(authHelper.loadObjectPermissions(Resource.RA_PROFILE, ResourceAction.MEMBERS)).thenReturn(ALLOW_LISTED);
+
+        NotificationDataCategoryGate gate = gate();
+        List<NotificationDataCategory> categories = List.of(NotificationDataCategory.OBJECT_CONTENT);
+        ValidationException ex = assertThrows(ValidationException.class, () -> gate.assertCanEnable(categories));
+        assertTrue(ex.getMessage().contains("RA_PROFILE"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("MEMBERS"), ex.getMessage());
+    }
+
+    @Test
+    void ungatedCategoriesNeverConsultPermissions() {
+        assertDoesNotThrow(() -> gate().assertCanEnable(
+                List.of(NotificationDataCategory.METADATA, NotificationDataCategory.ASSOCIATIONS)));
+        verify(authHelper, never()).loadObjectPermissions(any(), any());
+    }
+
+    @Test
+    void gatedMarkerMatchesTheGateMap() {
+        assertTrue(NotificationDataCategoryGate.isGated(NotificationDataCategory.CUSTOM_ATTRIBUTES));
+        assertTrue(NotificationDataCategoryGate.isGated(NotificationDataCategory.OBJECT_CONTENT));
+        assertFalse(NotificationDataCategoryGate.isGated(NotificationDataCategory.METADATA));
+        assertFalse(NotificationDataCategoryGate.isGated(NotificationDataCategory.ASSOCIATIONS));
+    }
+}

--- a/src/test/java/com/otilm/core/util/BaseSpringBootTest.java
+++ b/src/test/java/com/otilm/core/util/BaseSpringBootTest.java
@@ -123,6 +123,26 @@ public class BaseSpringBootTest {
         ).thenReturn(denied);
     }
 
+    /**
+     * Restricts object-level access for one (resource, action) pair to an allow-list, so
+     * {@code AuthHelper.loadObjectPermissions} reports the user as restricted. Everything else
+     * keeps the default allow-all stub.
+     */
+    protected void restrictObjectAccess(Resource resource, ResourceAction action) {
+        OpaObjectAccessResult restricted = new OpaObjectAccessResult();
+        restricted.setActionAllowedForGroupOfObjects(false);
+        restricted.setAllowedObjects(List.of(UUID.randomUUID().toString()));
+        restricted.setForbiddenObjects(List.of());
+        Mockito.when(opaClient.checkObjectAccess(
+                Mockito.any(),
+                Mockito.argThat(req -> req != null
+                        && req.getProperties() != null
+                        && resource.getCode().equals(req.getProperties().get("name"))
+                        && action.getCode().equals(req.getProperties().get("action"))),
+                Mockito.any(), Mockito.any())
+        ).thenReturn(restricted);
+    }
+
     protected void allowResourceAccess(Resource resource, ResourceAction action) {
         OpaResourceAccessResult allowed = new OpaResourceAccessResult();
         allowed.setAuthorized(true);

--- a/src/test/java/com/otilm/core/util/BaseSpringBootTest.java
+++ b/src/test/java/com/otilm/core/util/BaseSpringBootTest.java
@@ -27,6 +27,8 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.TestExecutionListeners.MergeMode;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import static org.mockito.Mockito.when;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -94,7 +96,7 @@ public class BaseSpringBootTest {
         accessAllowed.setAuthorized(true);
         accessAllowed.setAllow(List.of());
 
-        Mockito.when(
+        when(
                 opaClient.checkResourceAccess(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())
         ).thenReturn(accessAllowed);
     }
@@ -105,7 +107,7 @@ public class BaseSpringBootTest {
         objectAccessAllowed.setAllowedObjects(List.of());
         objectAccessAllowed.setForbiddenObjects(List.of());
 
-        Mockito.when(
+        when(
                 opaClient.checkObjectAccess(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())
         ).thenReturn(objectAccessAllowed);
     }
@@ -113,7 +115,7 @@ public class BaseSpringBootTest {
     protected void denyResourceAccess(Resource resource, ResourceAction action) {
         OpaResourceAccessResult denied = new OpaResourceAccessResult();
         denied.setAuthorized(false);
-        Mockito.when(opaClient.checkResourceAccess(
+        when(opaClient.checkResourceAccess(
                 Mockito.any(),
                 Mockito.argThat(req -> req != null
                         && req.getProperties() != null
@@ -133,7 +135,7 @@ public class BaseSpringBootTest {
         restricted.setActionAllowedForGroupOfObjects(false);
         restricted.setAllowedObjects(List.of(UUID.randomUUID().toString()));
         restricted.setForbiddenObjects(List.of());
-        Mockito.when(opaClient.checkObjectAccess(
+        when(opaClient.checkObjectAccess(
                 Mockito.any(),
                 Mockito.argThat(req -> req != null
                         && req.getProperties() != null
@@ -147,7 +149,7 @@ public class BaseSpringBootTest {
         OpaResourceAccessResult allowed = new OpaResourceAccessResult();
         allowed.setAuthorized(true);
         allowed.setAllow(List.of());
-        Mockito.when(opaClient.checkResourceAccess(
+        when(opaClient.checkResourceAccess(
                 Mockito.any(),
                 Mockito.argThat(req -> req != null
                         && req.getProperties() != null


### PR DESCRIPTION
Closes #1859. Part of epic OmniTrustILM/ilm#301. Depends on OmniTrustILM/interfaces#805 publishing `2.20.0-SNAPSHOT` — CI cannot resolve the dependency until that merges.

Adds the opt-in `eventDataCategories` configuration to notification profiles:

- Nullable `event_data_categories` text array on the parent `notification_profile` table (migration `V202608031100`); null or empty means no enrichment, so existing profiles behave identically. Parent-level, not versioned: the current value applies at send time, including to monitoring streams pinned to older profile versions.
- Presence-aware updates: an absent field keeps the current value so older API clients cannot silently clear it, an empty list disables enrichment, and category-only edits update the parent in place without creating a profile version. Requested lists are normalized: null entries are a validation error, duplicates collapse, storage order is canonical.
- Config-time authorization gate: enabling `CUSTOM_ATTRIBUTES` requires unrestricted ATTRIBUTE MEMBERS access; `OBJECT_CONTENT` requires the certificate content exporter's unrestricted CERTIFICATE DETAIL and RA_PROFILE MEMBERS access. The gate also re-fires when the profile's notification instance changes while a gated category stays enabled, so a destination swap cannot become an ungated export route.
- The gate calls the authorization service outside any transaction against an unlocked read; the locked write refreshes the entities and re-asserts the decision, failing closed with a retry error when gate-relevant state changed concurrently.
- Bumps the interfaces dependency to `2.20.0-SNAPSHOT`.