### PR TITLE
Remove dead build/config settings ahead of Spring Boot 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,6 @@
         <testcontainers.version>1.21.4</testcontainers.version>
         <git-commit-id-maven.version>9.0.2</git-commit-id-maven.version>
         <java.version>21</java.version>
-        <!-- Temporary override for CVE-2026-41293 and CVE-2026-43512.
-          Remove after the parent com.otilm:dependencies upgrades to a Spring Boot release that ships Tomcat 10.1.55+
-          (expected with Spring Boot 3.5.15). Then delete this override. -->
-        <tomcat.version>10.1.55</tomcat.version>
 
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>ilm</sonar.organization>
@@ -327,21 +323,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <configuration>
-                    <packagingExcludes>
-                        **/META-INF/maven/**,
-                        **/WEB-INF/classes/*.p12,
-                        **/WEB-INF/classes/*.jks,
-                        **/WEB-INF/classes/application-*.properties
-                    </packagingExcludes>
-                    <archive>
-                        <addMavenDescriptor>false</addMavenDescriptor>
-                    </archive>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>@{argLine} -Dspring.test.context.cache.maxSize=128</argLine>
@@ -350,10 +331,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <executable>true</executable>
-                    <includeSystemScope>true</includeSystemScope>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.hibernate.orm.tooling</groupId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,11 +96,6 @@ provider:
           - PT5M
         max-attempts: 50
 
-hibernate:
-  types:
-    print:
-      banner: false
-
 info:
   app:
     name: ILM Core

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -46,11 +46,6 @@ cmp:
         timeout: 10
   verbose: true
 
-hibernate:
-  types:
-    print:
-      banner: false
-
 logging:
   level:
     org:


### PR DESCRIPTION
Five build/config settings configure nothing today and get in the way of the Spring Boot 4 upgrade. Remove them while still on Boot 3.5.

- tomcat.version=10.1.55 override: the parent com.otilm:dependencies is on Boot 3.5.16, which manages exactly Tomcat 10.1.55, so the effective version is unchanged. Left in place, the pin would silently hold Tomcat back once the parent moves on. Verified: tomcat-embed-core/-el/-websocket all still resolve to 10.1.55, so CVE-2026-41293 and CVE-2026-43512 stay fixed.
- maven-war-plugin block: the project declares no <packaging>, so it builds as a jar and the war plugin never runs.
- <executable>true</executable>: prepends a shell launch script to the jar. Spring Boot 4 removes the feature entirely. Nothing consumes it -- the container entrypoint runs "java -jar ./app.jar" and the Dockerfile only does "jar xf".
- <includeSystemScope>true</includeSystemScope>: there are no system-scope dependencies, so the flag is inert.
- hibernate.types.print.banner: the key belongs to hypersistence-utils, which is not a dependency here. Nothing reads it.
