### PR TITLE
Enrich external notifications with event subject object data

### DIFF
--- a/src/main/java/com/otilm/core/dao/repository/AttributeContent2ObjectRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/AttributeContent2ObjectRepository.java
@@ -18,6 +18,33 @@ import java.util.UUID;
 @Repository
 public interface AttributeContent2ObjectRepository extends SecurityFilterRepository<AttributeContent2Object, String> {
 
+    /**
+     * Per-attribute footprint of an object's stored attribute content, for the notification
+     * enrichment load guard: how many content rows each attribute definition contributes and the
+     * largest serialized row. Grouped by the definition's stable attribute UUID so oversized
+     * attributes can be excluded before their values are put on the wire.
+     */
+    @Query(value = """
+            SELECT ad.attribute_uuid AS attributeUuid, ad.type AS attributeType,
+                   count(*) AS rowCount, max(octet_length(aci.json::text)) AS maxBytes
+            FROM {h-schema}attribute_content_2_object aco
+            JOIN {h-schema}attribute_content_item aci ON aci.uuid = aco.attribute_content_item_uuid
+            JOIN {h-schema}attribute_definition ad ON ad.uuid = aci.attribute_definition_uuid
+            WHERE aco.object_type = :objectType AND aco.object_uuid = :objectUuid
+            GROUP BY ad.attribute_uuid, ad.type
+            """, nativeQuery = true)
+    List<AttributeContentFootprint> summarizeContentFootprint(@Param("objectType") String objectType, @Param("objectUuid") UUID objectUuid);
+
+    interface AttributeContentFootprint {
+        UUID getAttributeUuid();
+
+        String getAttributeType();
+
+        long getRowCount();
+
+        long getMaxBytes();
+    }
+
     // ── Deduplication check — version-aware and purpose-aware ───────────────
     /**
      * Locates the content mapping that would collide with a new (content item, object, version, purpose, source, connector) tuple,

--- a/src/main/java/com/otilm/core/dao/repository/AttributeDefinitionRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/AttributeDefinitionRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -19,6 +20,7 @@ public interface AttributeDefinitionRepository extends SecurityFilterRepository<
     Optional<AttributeDefinition> findByUuidAndType(UUID uuid, AttributeType type);
     Optional<AttributeDefinition> findByUuidAndTypeAndGlobalTrue(UUID uuid, AttributeType type);
     Optional<AttributeDefinition> findByAttributeUuid(UUID uuid);
+    List<AttributeDefinition> findByAttributeUuidIn(Collection<UUID> attributeUuids);
     List<AttributeDefinition> findByTypeAndConnectorUuidAndAttributeUuidInAndNameIn(AttributeType type, UUID connectorUuid, List<UUID> uuids, List<String> names);
     List<AttributeDefinition> findAllByTypeAndConnectorUuidAndName(AttributeType type, UUID connectorUuid, String attributeName);
     List<AttributeDefinition> findByTypeAndGlobal(AttributeType type, boolean global);

--- a/src/main/java/com/otilm/core/dao/repository/CertificateRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/CertificateRepository.java
@@ -43,6 +43,13 @@ public interface CertificateRepository extends SecurityFilterRepository<Certific
     @EntityGraph(attributePaths = {"certificateContent"})
     Optional<Certificate> findByUuid(UUID uuid);
 
+    /**
+     * Loads the certificate with its RA profile fetched eagerly, for callers that run without
+     * an ambient transaction and would otherwise hit the lazy association detached.
+     */
+    @EntityGraph(attributePaths = "raProfile")
+    Optional<Certificate> findWithRaProfileByUuid(UUID uuid);
+
     @EntityGraph(attributePaths = {"certificateContent", "raProfile"})
     List<Certificate> findAllWithAssociationsByUuidIn(List<UUID> uuids);
 

--- a/src/main/java/com/otilm/core/dao/repository/GroupRepository.java
+++ b/src/main/java/com/otilm/core/dao/repository/GroupRepository.java
@@ -3,6 +3,8 @@ package com.otilm.core.dao.repository;
 import com.otilm.core.dao.entity.Group;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +14,6 @@ public interface GroupRepository extends SecurityFilterRepository<Group, Long> {
     Optional<Group> findByName(String name);
 
     Optional<Group> findByUuid(UUID uuid);
+
+    List<Group> findByUuidIn(Collection<UUID> uuids);
 }

--- a/src/main/java/com/otilm/core/mapper/notifications/NotificationObjectDataMapper.java
+++ b/src/main/java/com/otilm/core/mapper/notifications/NotificationObjectDataMapper.java
@@ -1,0 +1,289 @@
+package com.otilm.core.mapper.notifications;
+
+import com.otilm.api.model.client.attribute.ResponseAttribute;
+import com.otilm.api.model.client.metadata.MetadataResponseDto;
+import com.otilm.api.model.client.metadata.ResponseMetadata;
+import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.common.attribute.common.AttributeContent;
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import com.otilm.api.model.connector.notification.NotificationAttributeDto;
+import com.otilm.api.model.connector.notification.NotificationEventObjectDataDto;
+import com.otilm.api.model.connector.notification.NotificationMetadataGroupDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+
+/**
+ * Pure mapping kernel between the attribute engine's response DTOs and the notification wire
+ * contract. Value extraction, secret filtering, duplicate-name policy, and payload bounding live
+ * here and nowhere else, so they are unit-testable without Spring and cannot drift between
+ * categories. The wire DTOs carry plain scalars and reference strings only -- attribute-engine
+ * content evolution never reaches notification templates.
+ */
+public final class NotificationObjectDataMapper {
+
+    /** Individual string values above this length are truncated; a certificate would be useless truncated, so content is exempt. */
+    static final int MAX_VALUE_LENGTH = 4096;
+    /** Cap on the serialized objectData contribution to the connector request. */
+    static final int MAX_TOTAL_BYTES = 131_072;
+    static final String TRUNCATION_SUFFIX = "...[truncated]";
+
+    private static final Logger logger = LoggerFactory.getLogger(NotificationObjectDataMapper.class);
+
+    // CREDENTIAL is the legacy predecessor of SECRET and is treated identically: not even its
+    // reference string is exported.
+    private static final Set<AttributeContentType> SECRET_BEARING_TYPES =
+            Set.of(AttributeContentType.SECRET, AttributeContentType.CREDENTIAL);
+
+    private static final Set<AttributeContentType> SCALAR_TYPES = Set.of(
+            AttributeContentType.STRING, AttributeContentType.TEXT, AttributeContentType.INTEGER,
+            AttributeContentType.FLOAT, AttributeContentType.BOOLEAN, AttributeContentType.DATE,
+            AttributeContentType.TIME, AttributeContentType.DATETIME);
+
+    private NotificationObjectDataMapper() {
+    }
+
+    /**
+     * Maps custom attributes to the name-keyed wire map. Custom attribute names are kept unique
+     * platform-wide by an application-level check, so a duplicate is a defect state: the first
+     * definition in attribute-UUID order wins deterministically and the rest are dropped with a
+     * warning. Attributes whose definition is excluded (protected or secret-bearing) or that
+     * yield no values are omitted.
+     */
+    public static Map<String, NotificationAttributeDto> mapCustomAttributes(List<ResponseAttribute> attributes,
+                                                                            Set<UUID> excludedDefinitions) {
+        if (attributes == null || attributes.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, NotificationAttributeDto> byName = new LinkedHashMap<>();
+        for (ResponseAttribute attribute : sortedByUuid(attributes, ResponseAttribute::getUuid)) {
+            toWireAttribute(attribute.getUuid(), attribute.getName(), attribute.getLabel(),
+                    attribute.getContentType(), attribute.getContent(), excludedDefinitions)
+                    .ifPresent(dto -> putFirstWins(byName, dto));
+        }
+        return byName;
+    }
+
+    private static void putFirstWins(Map<String, NotificationAttributeDto> byName, NotificationAttributeDto dto) {
+        if (byName.putIfAbsent(dto.getName(), dto) != null) {
+            logger.warn("Duplicate custom attribute name {} on the notification subject; keeping the first definition", dto.getName());
+        }
+    }
+
+    /**
+     * One admissible wire attribute, or empty when the definition is excluded (secret-bearing or
+     * protected) or its content yields no values.
+     */
+    private static Optional<NotificationAttributeDto> toWireAttribute(UUID uuid, String name, String label,
+                                                                      AttributeContentType contentType,
+                                                                      List<? extends AttributeContent> content,
+                                                                      Set<UUID> excludedDefinitions) {
+        if (isExcluded(contentType, uuid, excludedDefinitions)) {
+            return Optional.empty();
+        }
+        List<Object> values = extractValues(contentType, content);
+        if (values.isEmpty()) {
+            return Optional.empty();
+        }
+        NotificationAttributeDto dto = new NotificationAttributeDto();
+        dto.setName(name);
+        dto.setLabel(label);
+        dto.setContentType(contentType);
+        dto.setValues(values);
+        return Optional.of(dto);
+    }
+
+    /**
+     * Maps metadata preserving the engine's connector + source-object grouping. Within a group,
+     * same-named entries are merged in attribute-UUID order (a connector legitimately re-declares
+     * a metadata attribute over time): {@code values} is the deduplicated union, {@code
+     * sourceObjects} the union of contributors, label from the first sorted entry. A same-named
+     * entry that disagrees on content type is excluded with a warning instead of merged --
+     * fail-safe for templates that assume a type. The two aggregates are independent: values are
+     * never positionally paired with source objects.
+     */
+    public static List<NotificationMetadataGroupDto> mapMetadata(List<MetadataResponseDto> groups,
+                                                                 Set<UUID> excludedDefinitions) {
+        if (groups == null || groups.isEmpty()) {
+            return List.of();
+        }
+        List<NotificationMetadataGroupDto> result = new ArrayList<>();
+        for (MetadataResponseDto group : groups) {
+            Map<String, NotificationAttributeDto> attributes = mergeGroupItems(group, excludedDefinitions);
+            if (attributes.isEmpty()) {
+                continue;
+            }
+            NotificationMetadataGroupDto groupDto = new NotificationMetadataGroupDto();
+            groupDto.setConnectorName(group.getConnectorName());
+            groupDto.setSourceObjectType(group.getSourceObjectType());
+            groupDto.setAttributes(attributes);
+            result.add(groupDto);
+        }
+        return result;
+    }
+
+    private static Map<String, NotificationAttributeDto> mergeGroupItems(MetadataResponseDto group,
+                                                                         Set<UUID> excludedDefinitions) {
+        MetadataGroupAccumulator accumulator = new MetadataGroupAccumulator(group);
+        List<ResponseMetadata> items = group.getItems() == null ? List.of() : group.getItems();
+        for (ResponseMetadata item : sortedByUuid(items, ResponseMetadata::getUuid)) {
+            toWireAttribute(item.getUuid(), item.getName(), item.getLabel(),
+                    item.getContentType(), item.getContent(), excludedDefinitions)
+                    .ifPresent(dto -> accumulator.merge(dto, item.getSourceObjects()));
+        }
+        return accumulator.finish();
+    }
+
+    /**
+     * Accumulates one metadata group's same-named entries: values as a deduplicated union,
+     * source objects as a union keyed by UUID, label and content type fixed by the first entry
+     * in attribute-UUID order.
+     */
+    private static final class MetadataGroupAccumulator {
+
+        private final MetadataResponseDto group;
+        private final Map<String, NotificationAttributeDto> attributes = new LinkedHashMap<>();
+        private final Map<String, LinkedHashSet<Object>> valuesByName = new LinkedHashMap<>();
+        private final Map<String, LinkedHashMap<String, NameAndUuidDto>> sourcesByName = new LinkedHashMap<>();
+
+        private MetadataGroupAccumulator(MetadataResponseDto group) {
+            this.group = group;
+        }
+
+        private void merge(NotificationAttributeDto dto, List<NameAndUuidDto> sourceObjects) {
+            NotificationAttributeDto existing = attributes.get(dto.getName());
+            if (existing == null) {
+                attributes.put(dto.getName(), dto);
+                valuesByName.put(dto.getName(), new LinkedHashSet<>());
+                sourcesByName.put(dto.getName(), new LinkedHashMap<>());
+            } else if (existing.getContentType() != dto.getContentType()) {
+                logger.warn("Metadata attribute {} in group {}/{} re-declared with conflicting content type {}; excluding the conflicting definition",
+                        dto.getName(), group.getConnectorName(), group.getSourceObjectType(), dto.getContentType());
+                return;
+            }
+            valuesByName.get(dto.getName()).addAll(dto.getValues());
+            for (NameAndUuidDto source : sourceObjects == null ? List.<NameAndUuidDto>of() : sourceObjects) {
+                sourcesByName.get(dto.getName()).putIfAbsent(source.getUuid(), source);
+            }
+        }
+
+        private Map<String, NotificationAttributeDto> finish() {
+            for (Map.Entry<String, NotificationAttributeDto> entry : attributes.entrySet()) {
+                entry.getValue().setValues(new ArrayList<>(valuesByName.get(entry.getKey())));
+                LinkedHashMap<String, NameAndUuidDto> sources = sourcesByName.get(entry.getKey());
+                if (!sources.isEmpty()) {
+                    entry.getValue().setSourceObjects(new ArrayList<>(sources.values()));
+                }
+            }
+            return attributes;
+        }
+    }
+
+    /**
+     * Enforces the total serialized-size cap by dropping whole categories in deterministic order
+     * -- metadata, custom attributes, object content, associations -- until the payload fits.
+     * The size is measured with the caller's wire mapper so it matches what the connector
+     * request will actually carry.
+     */
+    public static void applyTotalCap(NotificationEventObjectDataDto objectData, ObjectMapper wireMapper) {
+        if (serializedSize(objectData, wireMapper) <= MAX_TOTAL_BYTES) {
+            return;
+        }
+        if (objectData.getMetadata() != null) {
+            objectData.setMetadata(null);
+            logger.warn("Notification object data exceeded {} bytes; dropped the metadata category", MAX_TOTAL_BYTES);
+            if (serializedSize(objectData, wireMapper) <= MAX_TOTAL_BYTES) {
+                return;
+            }
+        }
+        if (objectData.getCustomAttributes() != null) {
+            objectData.setCustomAttributes(null);
+            logger.warn("Notification object data exceeded {} bytes; dropped the custom attributes category", MAX_TOTAL_BYTES);
+            if (serializedSize(objectData, wireMapper) <= MAX_TOTAL_BYTES) {
+                return;
+            }
+        }
+        if (objectData.getContent() != null) {
+            objectData.setContent(null);
+            logger.warn("Notification object data exceeded {} bytes; dropped the object content category", MAX_TOTAL_BYTES);
+            if (serializedSize(objectData, wireMapper) <= MAX_TOTAL_BYTES) {
+                return;
+            }
+        }
+        if (objectData.getAssociations() != null) {
+            objectData.setAssociations(null);
+            logger.warn("Notification object data exceeded {} bytes; dropped the associations category", MAX_TOTAL_BYTES);
+        }
+    }
+
+    /**
+     * Extracts template-ready values: scalar content types contribute raw data, every other
+     * non-secret type contributes only its human-readable reference string, so nested internal
+     * structures (including secret-bearing shapes) structurally cannot reach the wire. String
+     * values are truncated at {@link #MAX_VALUE_LENGTH}.
+     */
+    private static List<Object> extractValues(AttributeContentType contentType, List<? extends AttributeContent> content) {
+        if (content == null || content.isEmpty()) {
+            return List.of();
+        }
+        List<Object> values = new ArrayList<>(content.size());
+        for (AttributeContent item : content) {
+            if (item == null) {
+                continue;
+            }
+            if (SCALAR_TYPES.contains(contentType)) {
+                Object data = item.getData();
+                if (data != null) {
+                    values.add(truncate(data));
+                }
+            } else {
+                String reference = item.getReference();
+                if (reference != null && !reference.isBlank()) {
+                    values.add(truncate(reference));
+                }
+            }
+        }
+        return values;
+    }
+
+    private static Object truncate(Object value) {
+        if (value instanceof String text && text.length() > MAX_VALUE_LENGTH) {
+            logger.warn("Notification attribute value of {} characters truncated to {}", text.length(), MAX_VALUE_LENGTH);
+            return text.substring(0, MAX_VALUE_LENGTH) + TRUNCATION_SUFFIX;
+        }
+        return value;
+    }
+
+    private static boolean isExcluded(AttributeContentType contentType, UUID definitionUuid, Set<UUID> excludedDefinitions) {
+        return contentType == null
+                || SECRET_BEARING_TYPES.contains(contentType)
+                || (excludedDefinitions != null && excludedDefinitions.contains(definitionUuid));
+    }
+
+    private static <T> List<T> sortedByUuid(List<T> items, Function<T, UUID> uuidAccessor) {
+        return items.stream()
+                .sorted(Comparator.comparing(uuidAccessor, Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
+    }
+
+    private static int serializedSize(NotificationEventObjectDataDto objectData, ObjectMapper wireMapper) {
+        try {
+            return wireMapper.writeValueAsBytes(objectData).length;
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException("Notification object data is not serializable", e);
+        }
+    }
+}

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -9,11 +9,13 @@ import com.otilm.api.model.client.notification.NotificationDto;
 import com.otilm.api.model.common.NameAndUuidDto;
 import com.otilm.api.model.common.attribute.common.DataAttribute;
 import com.otilm.api.model.common.events.data.*;
+import com.otilm.api.model.connector.notification.NotificationEventObjectDataDto;
 import com.otilm.api.model.connector.notification.NotificationProviderNotifyRequestDto;
 import com.otilm.api.model.connector.notification.NotificationRecipientDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.auth.RoleDetailDto;
 import com.otilm.api.model.core.auth.UserDetailDto;
+import com.otilm.api.model.core.notification.NotificationDataCategory;
 import com.otilm.api.model.core.notification.RecipientType;
 import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.core.attribute.engine.AttributeEngine;
@@ -33,6 +35,7 @@ import com.otilm.core.service.NotificationInternalService;
 import com.otilm.core.service.ResourceObjectAssociationService;
 import com.otilm.core.service.TriggerInternalService;
 import com.otilm.core.service.v2.ConnectorInternalService;
+import com.otilm.core.service.notifications.NotificationObjectDataService;
 import com.otilm.core.service.writer.PendingNotificationWriter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
@@ -71,6 +74,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
     private ResourceObjectAssociationService resourceObjectAssociationService;
     private TransactionHandler transactionHandler;
     private PendingNotificationWriter pendingNotificationWriter;
+    private NotificationObjectDataService notificationObjectDataService;
 
     private static final Map<ResourceEvent, String> eventToLegacyNotificationTypeMapping = new EnumMap<>(ResourceEvent.class);
 
@@ -110,20 +114,12 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
     }
 
     private void sendByNotificationProfile(UUID notificationProfileUuid, NotificationMessage message) throws NotFoundException {
-        NotificationProfileVersion notificationProfileVersion = null;
-        PendingNotification pendingNotification = null;
-        if (message.getEvent().isMonitoring()) {
-            pendingNotification = pendingNotificationRepository.findByNotificationProfileUuidAndResourceAndObjectUuidAndEvent(notificationProfileUuid, message.getResource(), message.getObjectUuid(), message.getEvent());
-            if (pendingNotification == null) {
-                notificationProfileVersion = notificationProfileVersionRepository.findTopByNotificationProfileUuidOrderByVersionDesc(notificationProfileUuid).orElseThrow(() -> new NotFoundException(NotificationProfile.class, notificationProfileUuid));
-                pendingNotification = getNewPendingNotification(message, notificationProfileVersion, pendingNotification);
-            } else {
-                notificationProfileVersion = notificationProfileVersionRepository.findByNotificationProfileUuidAndVersion(notificationProfileUuid, pendingNotification.getVersion()).orElseThrow(() -> new NotFoundException(NotificationProfile.class, notificationProfileUuid));
-            }
-        }
-
-        if (notificationProfileVersion == null) {
-            notificationProfileVersion = notificationProfileVersionRepository.findTopByNotificationProfileUuidOrderByVersionDesc(notificationProfileUuid).orElseThrow(() -> new NotFoundException(NotificationProfile.class, notificationProfileUuid));
+        PendingNotification pendingNotification = message.getEvent().isMonitoring()
+                ? pendingNotificationRepository.findByNotificationProfileUuidAndResourceAndObjectUuidAndEvent(notificationProfileUuid, message.getResource(), message.getObjectUuid(), message.getEvent())
+                : null;
+        NotificationProfileVersion notificationProfileVersion = resolveProfileVersion(notificationProfileUuid, pendingNotification);
+        if (pendingNotification == null) {
+            pendingNotification = getNewPendingNotification(message, notificationProfileVersion, null);
         }
 
         boolean sendInternalNotifications = notificationProfileVersion.isInternalNotification() && (notificationProfileVersion.getRecipientType() != RecipientType.DEFAULT || message.getEvent().isMonitoring());
@@ -159,6 +155,20 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
     }
 
     /**
+     * The profile version this send runs under: an existing suppression row pins the version
+     * that was current when its monitoring stream started (frequency and repetition accounting
+     * stay consistent across profile edits); everything else takes the latest version.
+     */
+    private NotificationProfileVersion resolveProfileVersion(UUID notificationProfileUuid, PendingNotification pendingNotification) throws NotFoundException {
+        if (pendingNotification != null) {
+            return notificationProfileVersionRepository.findByNotificationProfileUuidAndVersion(notificationProfileUuid, pendingNotification.getVersion())
+                    .orElseThrow(() -> new NotFoundException(NotificationProfile.class, notificationProfileUuid));
+        }
+        return notificationProfileVersionRepository.findTopByNotificationProfileUuidOrderByVersionDesc(notificationProfileUuid)
+                .orElseThrow(() -> new NotFoundException(NotificationProfile.class, notificationProfileUuid));
+    }
+
+    /**
      * Records the successful delivery in the suppression row. A write failure is logged and
      * swallowed: the notification was already delivered -- to the connector, internally, or both
      * -- so suppression state stays as-is and the next occurrence may send one extra
@@ -179,8 +189,9 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         if (notificationProfileVersion.getNotificationInstanceRefUuid() != null) {
             UUID notificationInstanceUUID = notificationProfileVersion.getNotificationInstanceRefUuid();
             logger.debug("Sending notification message externally. Notification instance UUID: {}", notificationInstanceUUID);
+            NotificationEventObjectDataDto objectData = buildObjectData(message, notificationProfileVersion);
             try {
-                if (!sendExternalNotifications(notificationInstanceUUID, recipients, message.getData(), message.getEvent(), message.getResource())) {
+                if (!sendExternalNotifications(notificationInstanceUUID, recipients, message.getData(), message.getEvent(), message.getResource(), objectData)) {
                     // The connector still received the notification -- reported so a recipient that never resolves
                     // is visible, rather than the notification quietly reaching fewer people than configured.
                     handleNotificationErrorWithWarnLog("Notification profile %s in event %s could not prepare all of its recipients for delivery.".formatted(notificationProfileVersion.getNotificationProfile().getName(), message.getEvent()), message);
@@ -196,6 +207,29 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
             }
         }
         return notificationSent;
+    }
+
+    /**
+     * Builds the enriched object data once per profile send, only when the parent profile has
+     * categories enabled -- the parent field is read so a category change applies immediately,
+     * including to monitoring streams pinned to older profile versions. Enrichment is
+     * best-effort: any failure yields a data-less send, never a suppressed one. The result
+     * exists only in the outbound connector request; internal notifications never carry it.
+     */
+    private NotificationEventObjectDataDto buildObjectData(NotificationMessage message, NotificationProfileVersion notificationProfileVersion) {
+        try {
+            List<NotificationDataCategory> categories = notificationProfileVersion.getNotificationProfile().getEventDataCategories();
+            if (categories.isEmpty()) {
+                return null;
+            }
+            EventData eventData = getEventData(message.getEvent(), message.getData());
+            return notificationObjectDataService.getObjectData(message.getEvent(), message.getResource(),
+                    message.getObjectUuid(), eventData, EnumSet.copyOf(categories));
+        } catch (Exception e) {
+            logger.warn("Notification object data could not be built for profile version {} in event {}; sending without it",
+                    notificationProfileVersion.getUuid(), message.getEvent(), e);
+            return null;
+        }
     }
 
     /**
@@ -358,7 +392,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
      * @return false when some named recipient could not be prepared, so the caller can report the gap.
      */
     private boolean sendExternalNotifications(UUID notificationInstanceUUID, List<NotificationRecipient> recipients, Object notificationData, ResourceEvent
-            event, Resource resource) throws ConnectorException, ValidationException, NotFoundException {
+            event, Resource resource, NotificationEventObjectDataDto objectData) throws ConnectorException, ValidationException, NotFoundException {
         // Fetch-join the mapped attributes: the listener runs without an ambient transaction, so the
         // entity is detached the moment the repository call returns and lazy loading would fail.
         NotificationInstanceReference notificationInstanceReference = notificationInstanceReferenceRepository.findWithMappedAttributesByUuid(notificationInstanceUUID).orElseThrow(() -> new NotFoundException(NotificationInstanceReference.class, notificationInstanceUUID));
@@ -412,6 +446,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         notificationProviderNotifyRequestDto.setEvent(event);
         notificationProviderNotifyRequestDto.setEventType(eventToLegacyNotificationTypeMapping.getOrDefault(event, "other")); // legacy
         notificationProviderNotifyRequestDto.setRecipients(recipientsDto);
+        notificationProviderNotifyRequestDto.setObjectData(objectData);
 
         try {
             connectorApiFactory.getNotificationInstanceApiClient(connector).sendNotification(connector, notificationInstanceReference.getNotificationInstanceUuid().toString(), notificationProviderNotifyRequestDto);

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -51,7 +51,7 @@ import java.util.*;
 
 @Component
 @AllArgsConstructor
-@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Transactional(propagation = Propagation.NOT_SUPPORTED, rollbackFor = Exception.class)
 public class NotificationListener implements MessageProcessor<NotificationMessage> {
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationListener.class);

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -222,12 +222,26 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
             if (categories.isEmpty()) {
                 return null;
             }
-            EventData eventData = getEventData(message.getEvent(), message.getData());
             return notificationObjectDataService.getObjectData(message.getEvent(), message.getResource(),
-                    message.getObjectUuid(), eventData, EnumSet.copyOf(categories));
+                    message.getObjectUuid(), convertEventDataBestEffort(message), EnumSet.copyOf(categories));
         } catch (Exception e) {
             logger.warn("Notification object data could not be built for profile version {} in event {}; sending without it",
                     notificationProfileVersion.getUuid(), message.getEvent(), e);
+            return null;
+        }
+    }
+
+    /**
+     * The typed event payload is needed only for subject resolution (approval events carry their
+     * target's coordinates in it); a malformed payload therefore falls back to the event object
+     * as the subject instead of disabling every enrichment category.
+     */
+    private EventData convertEventDataBestEffort(NotificationMessage message) {
+        try {
+            return getEventData(message.getEvent(), message.getData());
+        } catch (Exception e) {
+            logger.warn("Event data of {} for {} {} could not be converted; the enrichment subject falls back to the event object: {}",
+                    message.getEvent(), message.getResource(), message.getObjectUuid(), e.getMessage());
             return null;
         }
     }

--- a/src/main/java/com/otilm/core/service/notifications/AttributeProtectionExclusions.java
+++ b/src/main/java/com/otilm/core/service/notifications/AttributeProtectionExclusions.java
@@ -1,0 +1,95 @@
+package com.otilm.core.service.notifications;
+
+import com.otilm.api.model.common.attribute.common.BaseAttribute;
+import com.otilm.api.model.common.attribute.common.CustomAttribute;
+import com.otilm.api.model.common.attribute.common.MetadataAttribute;
+import com.otilm.api.model.common.attribute.common.content.data.ProtectionLevel;
+import com.otilm.core.dao.entity.AttributeDefinition;
+import com.otilm.core.dao.repository.AttributeDefinitionRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Resolves which attribute definitions must never contribute to notification object data,
+ * fail-closed. The attribute engine decrypts protected content before building its response
+ * DTOs, and the response carries no protection marker, so protection must be re-checked against
+ * the definitions. The entity's protection column under-reports for connector-declared metadata
+ * (declared protection is not copied onto the definition entity), so the stored definition
+ * document's declared properties are consulted as well; an attribute whose protection cannot be
+ * determined -- unresolvable definition, unreadable document, missing properties -- is excluded.
+ */
+@Component
+public class AttributeProtectionExclusions {
+
+    private static final Logger logger = LoggerFactory.getLogger(AttributeProtectionExclusions.class);
+
+    private final AttributeDefinitionRepository attributeDefinitionRepository;
+
+    @Autowired
+    public AttributeProtectionExclusions(AttributeDefinitionRepository attributeDefinitionRepository) {
+        this.attributeDefinitionRepository = attributeDefinitionRepository;
+    }
+
+    /**
+     * The subset of the given attribute UUIDs that must be excluded from notification object
+     * data because their definition declares protection or its protection is indeterminate.
+     */
+    public Set<UUID> excludedFrom(Collection<UUID> attributeUuids) {
+        if (attributeUuids == null || attributeUuids.isEmpty()) {
+            return Set.of();
+        }
+        Map<UUID, List<AttributeDefinition>> definitionsByAttributeUuid =
+                attributeDefinitionRepository.findByAttributeUuidIn(attributeUuids).stream()
+                        .collect(Collectors.groupingBy(AttributeDefinition::getAttributeUuid));
+
+        Set<UUID> excluded = new HashSet<>();
+        for (UUID attributeUuid : attributeUuids) {
+            List<AttributeDefinition> definitions = definitionsByAttributeUuid.get(attributeUuid);
+            if (definitions == null || definitions.isEmpty()) {
+                logger.warn("No definition found for attribute {}; excluding it from notification data", attributeUuid);
+                excluded.add(attributeUuid);
+                continue;
+            }
+            if (definitions.stream().anyMatch(this::isProtectedOrIndeterminate)) {
+                excluded.add(attributeUuid);
+            }
+        }
+        return excluded;
+    }
+
+    private boolean isProtectedOrIndeterminate(AttributeDefinition definition) {
+        if (definition.getProtectionLevel() != null && definition.getProtectionLevel() != ProtectionLevel.NONE) {
+            return true;
+        }
+        try {
+            return declaresProtection(definition.getDefinition());
+        } catch (RuntimeException e) {
+            logger.warn("Cannot determine declared protection of attribute definition {}; excluding it from notification data", definition.getUuid(), e);
+            return true;
+        }
+    }
+
+    private boolean declaresProtection(BaseAttribute document) {
+        if (document instanceof MetadataAttribute metadata) {
+            return metadata.getProperties() == null
+                    || metadata.getProperties().getProtectionLevel() != ProtectionLevel.NONE;
+        }
+        if (document instanceof CustomAttribute custom) {
+            return custom.getProperties() == null
+                    || custom.getProperties().getProtectionLevel() != ProtectionLevel.NONE;
+        }
+        // Definition kinds other than metadata and custom carry no declared protection relevant
+        // to this export path, so the entity column checked above remains authoritative.
+        return false;
+    }
+}

--- a/src/main/java/com/otilm/core/service/notifications/CertificateContentExporter.java
+++ b/src/main/java/com/otilm/core/service/notifications/CertificateContentExporter.java
@@ -1,0 +1,46 @@
+package com.otilm.core.service.notifications;
+
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.repository.CertificateRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Exports the certificate's stored Base64 DER -- public material by definition, no key material
+ * exists in the certificate content. Certificates in request or pre-registered states have no
+ * DER yet and yield no content.
+ */
+@Component
+public class CertificateContentExporter implements NotificationObjectContentExporter {
+
+    static final String FORMAT_X509_DER_BASE64 = "X509_DER_BASE64";
+
+    private final CertificateRepository certificateRepository;
+
+    @Autowired
+    public CertificateContentExporter(CertificateRepository certificateRepository) {
+        this.certificateRepository = certificateRepository;
+    }
+
+    @Override
+    public Resource resource() {
+        return Resource.CERTIFICATE;
+    }
+
+    @Override
+    public String format() {
+        return FORMAT_X509_DER_BASE64;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<String> export(UUID objectUuid) {
+        return certificateRepository.findByUuid(objectUuid)
+                .map(Certificate::getContentData);
+    }
+}

--- a/src/main/java/com/otilm/core/service/notifications/NotificationObjectContentExporter.java
+++ b/src/main/java/com/otilm/core/service/notifications/NotificationObjectContentExporter.java
@@ -1,0 +1,29 @@
+package com.otilm.core.service.notifications;
+
+import com.otilm.api.model.core.auth.Resource;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Exports a resource's canonical content representation for the notification OBJECT_CONTENT
+ * category. The set of registered exporters is the fail-closed whitelist: no resource's content
+ * is exportable unless an exporter is deliberately registered for it. A new exporter requires
+ * its own design covering what is exported (public material only), which permissions join the
+ * config-time gate in {@link NotificationDataCategoryGate}, and the activation policy for
+ * profiles that already have the category enabled.
+ */
+public interface NotificationObjectContentExporter {
+
+    /** The resource type this exporter serves. */
+    Resource resource();
+
+    /** Wire format identifier of the exported content, e.g. {@code X509_DER_BASE64}. */
+    String format();
+
+    /**
+     * The subject's content, or empty when the object does not exist or carries no content yet
+     * -- absence is best-effort, never an error.
+     */
+    Optional<String> export(UUID objectUuid);
+}

--- a/src/main/java/com/otilm/core/service/notifications/NotificationObjectContentExporter.java
+++ b/src/main/java/com/otilm/core/service/notifications/NotificationObjectContentExporter.java
@@ -8,14 +8,16 @@ import java.util.UUID;
 /**
  * Exports a resource's canonical content representation for the notification OBJECT_CONTENT
  * category. The set of registered exporters is the fail-closed whitelist: no resource's content
- * is exportable unless an exporter is deliberately registered for it. A new exporter requires
- * its own design covering what is exported (public material only), which permissions join the
- * config-time gate in {@link NotificationDataCategoryGate}, and the activation policy for
- * profiles that already have the category enabled.
+ * is exportable unless an exporter is deliberately registered for it. An implementation must
+ * export public material only (never key material, secrets, or protected content), must have
+ * its permission requirements added to {@link NotificationDataCategoryGate} so enabling the
+ * category is gated on them at configuration time, and must never activate silently for
+ * profiles that already have the category enabled -- their operators were not gated against
+ * the new exporter's permissions.
  */
 public interface NotificationObjectContentExporter {
 
-    /** The resource type this exporter serves. */
+    /** Resource key used to register this exporter; each resource may have only one exporter. */
     Resource resource();
 
     /** Wire format identifier of the exported content, e.g. {@code X509_DER_BASE64}. */

--- a/src/main/java/com/otilm/core/service/notifications/NotificationObjectDataService.java
+++ b/src/main/java/com/otilm/core/service/notifications/NotificationObjectDataService.java
@@ -13,6 +13,7 @@ import com.otilm.api.model.connector.notification.NotificationObjectContentDto;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.notification.NotificationDataCategory;
 import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.core.other.ResourceObjectDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
@@ -31,7 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -52,7 +53,7 @@ import java.util.stream.Stream;
  * expiry warning must never be suppressed because metadata failed to load. This service is
  * called once per profile send; the result exists only in the outbound connector request.
  */
-@Component
+@Service
 public class NotificationObjectDataService {
 
     /** Attributes whose largest stored content row exceeds this are excluded before the wire. */
@@ -116,17 +117,19 @@ public class NotificationObjectDataService {
 
         boolean loadsAttributeContent = categories.contains(NotificationDataCategory.CUSTOM_ATTRIBUTES)
                 || categories.contains(NotificationDataCategory.METADATA);
-        Set<UUID> oversizedAttributes = loadsAttributeContent ? guardExclusions(subject, event) : Set.of();
+        LoadGuard guard = loadsAttributeContent ? contentLoadGuard(subject, event) : LoadGuard.OPEN;
 
-        if (categories.contains(NotificationDataCategory.CUSTOM_ATTRIBUTES) && subject.resource().hasCustomAttributes()) {
+        if (categories.contains(NotificationDataCategory.CUSTOM_ATTRIBUTES) && subject.resource().hasCustomAttributes()
+                && allowsLoad(guard.skipCustomAttributes(), NotificationDataCategory.CUSTOM_ATTRIBUTES, subject)) {
             loadCategory(NotificationDataCategory.CUSTOM_ATTRIBUTES, subject, event, () -> {
-                Map<String, NotificationAttributeDto> customAttributes = loadCustomAttributes(subject, oversizedAttributes);
+                Map<String, NotificationAttributeDto> customAttributes = loadCustomAttributes(subject, guard.cappedAttributes());
                 objectData.setCustomAttributes(customAttributes.isEmpty() ? null : customAttributes);
             });
         }
-        if (categories.contains(NotificationDataCategory.METADATA)) {
+        if (categories.contains(NotificationDataCategory.METADATA)
+                && allowsLoad(guard.skipMetadata(), NotificationDataCategory.METADATA, subject)) {
             loadCategory(NotificationDataCategory.METADATA, subject, event, () -> {
-                List<NotificationMetadataGroupDto> metadata = loadMetadata(subject, oversizedAttributes);
+                List<NotificationMetadataGroupDto> metadata = loadMetadata(subject, guard.cappedAttributes());
                 objectData.setMetadata(metadata.isEmpty() ? null : metadata);
             });
         }
@@ -186,40 +189,65 @@ public class NotificationObjectDataService {
     }
 
     /**
-     * Attributes excluded by the load guard: any attribute whose largest stored content row
-     * exceeds the byte bound, and everything beyond the per-category attribute cap in
-     * attribute-UUID order. A failing guard excludes nothing -- the mapper's value truncation
-     * and total cap remain the backstop.
+     * Two-tier load guard over the subject's stored attribute content, evaluated with one cheap
+     * aggregate query before any engine load. An attribute row above the byte bound is a memory
+     * hazard -- the engine would deserialize and decrypt it whole -- so its category's engine
+     * load is skipped entirely rather than materializing the row and dropping it from the wire.
+     * Attribute counts beyond the per-category cap carry no per-row hazard: the load proceeds
+     * and the overflow (in attribute-UUID order) is excluded from the wire. A failing guard
+     * blocks nothing -- the mapper's value truncation and total cap remain the backstop.
      */
-    private Set<UUID> guardExclusions(SubjectRef subject, ResourceEvent event) {
-        Set<UUID> excluded = new HashSet<>();
+    private LoadGuard contentLoadGuard(SubjectRef subject, ResourceEvent event) {
+        Set<UUID> capped = new HashSet<>();
+        boolean skipCustom = false;
+        boolean skipMetadata = false;
         try {
             List<AttributeContentFootprint> footprints = attributeContent2ObjectRepository
                     .summarizeContentFootprint(subject.resource().name(), subject.objectUuid());
             Map<String, List<AttributeContentFootprint>> byType = footprints.stream()
                     .collect(Collectors.groupingBy(AttributeContentFootprint::getAttributeType));
-            for (Map.Entry<String, List<AttributeContentFootprint>> bucket : byType.entrySet()) {
-                int kept = 0;
-                List<AttributeContentFootprint> ordered = bucket.getValue().stream()
-                        .sorted(Comparator.comparing(AttributeContentFootprint::getAttributeUuid))
-                        .toList();
-                for (AttributeContentFootprint footprint : ordered) {
-                    if (footprint.getMaxBytes() > MAX_ROW_BYTES) {
-                        logger.warn("Attribute {} of {} {} carries a {}-byte content row; excluding it from notification data",
-                                footprint.getAttributeUuid(), subject.resource(), subject.objectUuid(), footprint.getMaxBytes());
-                        excluded.add(footprint.getAttributeUuid());
-                    } else if (++kept > MAX_ATTRIBUTES_PER_CATEGORY) {
-                        logger.warn("{} {} carries more than {} {} attributes; excluding attribute {} from notification data",
-                                subject.resource(), subject.objectUuid(), MAX_ATTRIBUTES_PER_CATEGORY, bucket.getKey(), footprint.getAttributeUuid());
-                        excluded.add(footprint.getAttributeUuid());
-                    }
-                }
-            }
+            skipCustom = guardBucket(byType.get(AttributeType.CUSTOM.name()), capped, subject);
+            skipMetadata = guardBucket(byType.get(AttributeType.META.name()), capped, subject);
         } catch (Exception e) {
             logger.warn("Content footprint guard failed for {} {} in event {}; relying on the mapper bounds only",
                     subject.resource(), subject.objectUuid(), event, e);
         }
-        return excluded;
+        return new LoadGuard(capped, skipCustom, skipMetadata);
+    }
+
+    private boolean guardBucket(List<AttributeContentFootprint> bucket, Set<UUID> capped, SubjectRef subject) {
+        if (bucket == null) {
+            return false;
+        }
+        boolean oversized = false;
+        int kept = 0;
+        for (AttributeContentFootprint footprint : bucket.stream()
+                .sorted(Comparator.comparing(AttributeContentFootprint::getAttributeUuid)).toList()) {
+            if (footprint.getMaxBytes() > MAX_ROW_BYTES) {
+                logger.warn("Attribute {} of {} {} carries a {}-byte content row",
+                        footprint.getAttributeUuid(), subject.resource(), subject.objectUuid(), footprint.getMaxBytes());
+                oversized = true;
+            } else if (++kept > MAX_ATTRIBUTES_PER_CATEGORY) {
+                logger.warn("{} {} carries more than {} attributes; excluding attribute {} from notification data",
+                        subject.resource(), subject.objectUuid(), MAX_ATTRIBUTES_PER_CATEGORY, footprint.getAttributeUuid());
+                capped.add(footprint.getAttributeUuid());
+            }
+        }
+        return oversized;
+    }
+
+    private boolean allowsLoad(boolean skip, NotificationDataCategory category, SubjectRef subject) {
+        if (skip) {
+            logger.warn("Notification data category {} skipped for {} {}: stored attribute content exceeds the per-row byte bound; sending without it",
+                    category, subject.resource(), subject.objectUuid());
+        }
+        return !skip;
+    }
+
+    /** Outcome of {@link #contentLoadGuard}: attributes excluded from the wire and categories whose engine load must not run. */
+    private record LoadGuard(Set<UUID> cappedAttributes, boolean skipCustomAttributes, boolean skipMetadata) {
+
+        static final LoadGuard OPEN = new LoadGuard(Set.of(), false, false);
     }
 
     private Map<String, NotificationAttributeDto> loadCustomAttributes(SubjectRef subject, Set<UUID> oversizedAttributes) {

--- a/src/main/java/com/otilm/core/service/notifications/NotificationObjectDataService.java
+++ b/src/main/java/com/otilm/core/service/notifications/NotificationObjectDataService.java
@@ -17,6 +17,7 @@ import com.otilm.api.model.core.other.ResourceObjectDto;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
 import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.entity.Group;
 import com.otilm.core.dao.repository.AttributeContent2ObjectRepository;
 import com.otilm.core.dao.repository.AttributeContent2ObjectRepository.AttributeContentFootprint;
 import com.otilm.core.dao.repository.CertificateRepository;
@@ -113,7 +114,9 @@ public class NotificationObjectDataService {
         NotificationEventObjectDataDto objectData = new NotificationEventObjectDataDto();
         objectData.setSubject(resolveSubjectReference(subject));
 
-        Set<UUID> oversizedAttributes = guardExclusions(subject, event);
+        boolean loadsAttributeContent = categories.contains(NotificationDataCategory.CUSTOM_ATTRIBUTES)
+                || categories.contains(NotificationDataCategory.METADATA);
+        Set<UUID> oversizedAttributes = loadsAttributeContent ? guardExclusions(subject, event) : Set.of();
 
         if (categories.contains(NotificationDataCategory.CUSTOM_ATTRIBUTES) && subject.resource().hasCustomAttributes()) {
             loadCategory(NotificationDataCategory.CUSTOM_ATTRIBUTES, subject, event, () -> {
@@ -138,8 +141,26 @@ public class NotificationObjectDataService {
                     loadContent(subject).ifPresent(objectData::setContent));
         }
 
-        NotificationObjectDataMapper.applyTotalCap(objectData, wireMapper);
+        applyTotalCapSafely(objectData, subject);
         return objectData;
+    }
+
+    /**
+     * The size cap serializes the payload, which can fail on a pathological value; the
+     * never-throws contract then degrades the payload to its subject reference rather than
+     * letting the failure reach the caller.
+     */
+    private void applyTotalCapSafely(NotificationEventObjectDataDto objectData, SubjectRef subject) {
+        try {
+            NotificationObjectDataMapper.applyTotalCap(objectData, wireMapper);
+        } catch (RuntimeException e) {
+            logger.warn("Notification object data for {} {} could not be size-capped; sending the subject reference only",
+                    subject.resource(), subject.objectUuid(), e);
+            objectData.setCustomAttributes(null);
+            objectData.setMetadata(null);
+            objectData.setAssociations(null);
+            objectData.setContent(null);
+        }
     }
 
     private void loadCategory(NotificationDataCategory category, SubjectRef subject, ResourceEvent event, Runnable loader) {
@@ -229,9 +250,11 @@ public class NotificationObjectDataService {
             }
         }
         if (subject.resource().hasGroups()) {
-            for (UUID groupUuid : resourceObjectAssociationService.getGroupUuids(subject.resource(), subject.objectUuid())) {
-                groupRepository.findByUuid(groupUuid).ifPresent(group ->
-                        associations.add(association(Resource.GROUP, group.getUuid().toString(), group.getName())));
+            List<UUID> groupUuids = resourceObjectAssociationService.getGroupUuids(subject.resource(), subject.objectUuid());
+            if (!groupUuids.isEmpty()) {
+                for (Group group : groupRepository.findByUuidIn(groupUuids)) {
+                    associations.add(association(Resource.GROUP, group.getUuid().toString(), group.getName()));
+                }
             }
         }
         if (subject.resource() == Resource.CERTIFICATE) {

--- a/src/main/java/com/otilm/core/service/notifications/NotificationObjectDataService.java
+++ b/src/main/java/com/otilm/core/service/notifications/NotificationObjectDataService.java
@@ -1,0 +1,279 @@
+package com.otilm.core.service.notifications;
+
+import com.otilm.api.model.client.attribute.ResponseAttribute;
+import com.otilm.api.model.client.metadata.MetadataResponseDto;
+import com.otilm.api.model.client.metadata.ResponseMetadata;
+import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.common.events.data.EventData;
+import com.otilm.api.model.connector.notification.NotificationAssociationDto;
+import com.otilm.api.model.connector.notification.NotificationAttributeDto;
+import com.otilm.api.model.connector.notification.NotificationEventObjectDataDto;
+import com.otilm.api.model.connector.notification.NotificationMetadataGroupDto;
+import com.otilm.api.model.connector.notification.NotificationObjectContentDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.NotificationDataCategory;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.api.model.core.other.ResourceObjectDto;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.attribute.engine.records.ObjectAttributeContentInfo;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.repository.AttributeContent2ObjectRepository;
+import com.otilm.core.dao.repository.AttributeContent2ObjectRepository.AttributeContentFootprint;
+import com.otilm.core.dao.repository.CertificateRepository;
+import com.otilm.core.dao.repository.GroupRepository;
+import com.otilm.core.mapper.notifications.NotificationObjectDataMapper;
+import com.otilm.core.service.ResourceInternalService;
+import com.otilm.core.service.ResourceObjectAssociationService;
+import com.otilm.core.service.notifications.NotificationSubjectResolver.SubjectRef;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Loads the object data a notification profile's enabled categories describe, at send time, in
+ * system context. Delivery is best-effort by contract: a category that fails to load, is not
+ * supported by the subject's resource, or is dropped by the size bounds is simply absent -- an
+ * expiry warning must never be suppressed because metadata failed to load. This service is
+ * called once per profile send; the result exists only in the outbound connector request.
+ */
+@Component
+public class NotificationObjectDataService {
+
+    /** Attributes whose largest stored content row exceeds this are excluded before the wire. */
+    static final int MAX_ROW_BYTES = 16_384;
+    /** At most this many attributes per category, kept in attribute-UUID order. */
+    static final int MAX_ATTRIBUTES_PER_CATEGORY = 100;
+
+    private static final Logger logger = LoggerFactory.getLogger(NotificationObjectDataService.class);
+
+    private final AttributeEngine attributeEngine;
+    private final AttributeProtectionExclusions attributeProtectionExclusions;
+    private final AttributeContent2ObjectRepository attributeContent2ObjectRepository;
+    private final ResourceObjectAssociationService resourceObjectAssociationService;
+    private final ResourceInternalService resourceInternalService;
+    private final GroupRepository groupRepository;
+    private final CertificateRepository certificateRepository;
+    private final Map<Resource, NotificationObjectContentExporter> contentExporters;
+    private final ObjectMapper wireMapper;
+
+    @Autowired
+    public NotificationObjectDataService(AttributeEngine attributeEngine,
+                                         AttributeProtectionExclusions attributeProtectionExclusions,
+                                         AttributeContent2ObjectRepository attributeContent2ObjectRepository,
+                                         ResourceObjectAssociationService resourceObjectAssociationService,
+                                         ResourceInternalService resourceInternalService,
+                                         GroupRepository groupRepository,
+                                         CertificateRepository certificateRepository,
+                                         List<NotificationObjectContentExporter> exporters,
+                                         @Qualifier("jacksonObjectMapper") ObjectMapper wireMapper) {
+        this.attributeEngine = attributeEngine;
+        this.attributeProtectionExclusions = attributeProtectionExclusions;
+        this.attributeContent2ObjectRepository = attributeContent2ObjectRepository;
+        this.resourceObjectAssociationService = resourceObjectAssociationService;
+        this.resourceInternalService = resourceInternalService;
+        this.groupRepository = groupRepository;
+        this.certificateRepository = certificateRepository;
+        this.contentExporters = exporters.stream()
+                .collect(Collectors.toUnmodifiableMap(NotificationObjectContentExporter::resource, Function.identity()));
+        this.wireMapper = wireMapper;
+    }
+
+    /**
+     * Never throws: every category loads independently and a failed one is logged with
+     * identifiers only and omitted. The subject reference is always present so template authors
+     * know whose data they are rendering -- for an unresolvable subject (e.g. a stale approval
+     * target) it keeps the resource and UUID with no name and every category stays empty.
+     *
+     * <p>Deliberately not transactional: every collaborator opens its own short transaction, so
+     * a runtime failure in one category rolls back only that collaborator's work. A shared
+     * transaction would be marked rollback-only by the first participating failure and its
+     * commit would then discard every category, breaking the independence this contract
+     * promises. Entities read here are therefore detached -- associations this service
+     * traverses must be fetched eagerly.
+     */
+    public NotificationEventObjectDataDto getObjectData(ResourceEvent event, Resource resource, UUID objectUuid,
+                                                        EventData eventData, Set<NotificationDataCategory> categories) {
+        SubjectRef subject = NotificationSubjectResolver.resolveSubject(resource, objectUuid, eventData);
+
+        NotificationEventObjectDataDto objectData = new NotificationEventObjectDataDto();
+        objectData.setSubject(resolveSubjectReference(subject));
+
+        Set<UUID> oversizedAttributes = guardExclusions(subject, event);
+
+        if (categories.contains(NotificationDataCategory.CUSTOM_ATTRIBUTES) && subject.resource().hasCustomAttributes()) {
+            loadCategory(NotificationDataCategory.CUSTOM_ATTRIBUTES, subject, event, () -> {
+                Map<String, NotificationAttributeDto> customAttributes = loadCustomAttributes(subject, oversizedAttributes);
+                objectData.setCustomAttributes(customAttributes.isEmpty() ? null : customAttributes);
+            });
+        }
+        if (categories.contains(NotificationDataCategory.METADATA)) {
+            loadCategory(NotificationDataCategory.METADATA, subject, event, () -> {
+                List<NotificationMetadataGroupDto> metadata = loadMetadata(subject, oversizedAttributes);
+                objectData.setMetadata(metadata.isEmpty() ? null : metadata);
+            });
+        }
+        if (categories.contains(NotificationDataCategory.ASSOCIATIONS)) {
+            loadCategory(NotificationDataCategory.ASSOCIATIONS, subject, event, () -> {
+                List<NotificationAssociationDto> associations = loadAssociations(subject);
+                objectData.setAssociations(associations.isEmpty() ? null : associations);
+            });
+        }
+        if (categories.contains(NotificationDataCategory.OBJECT_CONTENT)) {
+            loadCategory(NotificationDataCategory.OBJECT_CONTENT, subject, event, () ->
+                    loadContent(subject).ifPresent(objectData::setContent));
+        }
+
+        NotificationObjectDataMapper.applyTotalCap(objectData, wireMapper);
+        return objectData;
+    }
+
+    private void loadCategory(NotificationDataCategory category, SubjectRef subject, ResourceEvent event, Runnable loader) {
+        try {
+            loader.run();
+        } catch (Exception e) {
+            // Identifiers only -- attribute content must not reach the logs.
+            logger.warn("Notification data category {} could not be loaded for {} {} in event {}; sending without it",
+                    category, subject.resource(), subject.objectUuid(), event, e);
+        }
+    }
+
+    private NotificationAssociationDto resolveSubjectReference(SubjectRef subject) {
+        NotificationAssociationDto reference = association(subject.resource(), subject.objectUuid().toString(), null);
+        try {
+            ResourceObjectDto resourceObject = resourceInternalService.getResourceObjectInternal(subject.resource(), subject.objectUuid());
+            reference.setName(resourceObject.getName());
+        } catch (Exception e) {
+            logger.warn("Notification subject {} {} could not be resolved; sending the reference without a name: {}",
+                    subject.resource(), subject.objectUuid(), e.getMessage());
+        }
+        return reference;
+    }
+
+    /**
+     * Attributes excluded by the load guard: any attribute whose largest stored content row
+     * exceeds the byte bound, and everything beyond the per-category attribute cap in
+     * attribute-UUID order. A failing guard excludes nothing -- the mapper's value truncation
+     * and total cap remain the backstop.
+     */
+    private Set<UUID> guardExclusions(SubjectRef subject, ResourceEvent event) {
+        Set<UUID> excluded = new HashSet<>();
+        try {
+            List<AttributeContentFootprint> footprints = attributeContent2ObjectRepository
+                    .summarizeContentFootprint(subject.resource().name(), subject.objectUuid());
+            Map<String, List<AttributeContentFootprint>> byType = footprints.stream()
+                    .collect(Collectors.groupingBy(AttributeContentFootprint::getAttributeType));
+            for (Map.Entry<String, List<AttributeContentFootprint>> bucket : byType.entrySet()) {
+                int kept = 0;
+                List<AttributeContentFootprint> ordered = bucket.getValue().stream()
+                        .sorted(Comparator.comparing(AttributeContentFootprint::getAttributeUuid))
+                        .toList();
+                for (AttributeContentFootprint footprint : ordered) {
+                    if (footprint.getMaxBytes() > MAX_ROW_BYTES) {
+                        logger.warn("Attribute {} of {} {} carries a {}-byte content row; excluding it from notification data",
+                                footprint.getAttributeUuid(), subject.resource(), subject.objectUuid(), footprint.getMaxBytes());
+                        excluded.add(footprint.getAttributeUuid());
+                    } else if (++kept > MAX_ATTRIBUTES_PER_CATEGORY) {
+                        logger.warn("{} {} carries more than {} {} attributes; excluding attribute {} from notification data",
+                                subject.resource(), subject.objectUuid(), MAX_ATTRIBUTES_PER_CATEGORY, bucket.getKey(), footprint.getAttributeUuid());
+                        excluded.add(footprint.getAttributeUuid());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Content footprint guard failed for {} {} in event {}; relying on the mapper bounds only",
+                    subject.resource(), subject.objectUuid(), event, e);
+        }
+        return excluded;
+    }
+
+    private Map<String, NotificationAttributeDto> loadCustomAttributes(SubjectRef subject, Set<UUID> oversizedAttributes) {
+        List<ResponseAttribute> attributes = attributeEngine
+                .getObjectCustomAttributesContentForSystemContext(subject.resource(), subject.objectUuid());
+        Set<UUID> excluded = merge(oversizedAttributes,
+                attributeProtectionExclusions.excludedFrom(attributes.stream().map(ResponseAttribute::getUuid).toList()));
+        return NotificationObjectDataMapper.mapCustomAttributes(attributes, excluded);
+    }
+
+    private List<NotificationMetadataGroupDto> loadMetadata(SubjectRef subject, Set<UUID> oversizedAttributes) {
+        List<MetadataResponseDto> metadata = attributeEngine.getMappedMetadataContent(
+                ObjectAttributeContentInfo.builder(subject.resource(), subject.objectUuid()).build());
+        List<UUID> attributeUuids = metadata.stream()
+                .flatMap(group -> group.getItems() == null ? Stream.<UUID>empty()
+                        : group.getItems().stream().map(ResponseMetadata::getUuid))
+                .toList();
+        Set<UUID> excluded = merge(oversizedAttributes, attributeProtectionExclusions.excludedFrom(attributeUuids));
+        return NotificationObjectDataMapper.mapMetadata(metadata, excluded);
+    }
+
+    private List<NotificationAssociationDto> loadAssociations(SubjectRef subject) {
+        List<NotificationAssociationDto> associations = new ArrayList<>();
+        if (subject.resource().hasOwner()) {
+            NameAndUuidDto owner = resourceObjectAssociationService.getOwner(subject.resource(), subject.objectUuid());
+            if (owner != null) {
+                associations.add(association(Resource.USER, owner.getUuid(), owner.getName()));
+            }
+        }
+        if (subject.resource().hasGroups()) {
+            for (UUID groupUuid : resourceObjectAssociationService.getGroupUuids(subject.resource(), subject.objectUuid())) {
+                groupRepository.findByUuid(groupUuid).ifPresent(group ->
+                        associations.add(association(Resource.GROUP, group.getUuid().toString(), group.getName())));
+            }
+        }
+        if (subject.resource() == Resource.CERTIFICATE) {
+            // The RA profile is a certificate-specific relation not covered by the generic flags;
+            // fetched eagerly because the entity is detached once the repository call returns.
+            certificateRepository.findWithRaProfileByUuid(subject.objectUuid())
+                    .map(Certificate::getRaProfile)
+                    .ifPresent(raProfile -> associations.add(
+                            association(Resource.RA_PROFILE, raProfile.getUuid().toString(), raProfile.getName())));
+        }
+        return associations;
+    }
+
+    private Optional<NotificationObjectContentDto> loadContent(SubjectRef subject) {
+        NotificationObjectContentExporter exporter = contentExporters.get(subject.resource());
+        if (exporter == null) {
+            // A resource without a registered exporter has no exportable content, just as a
+            // subject without groups yields no group associations.
+            return Optional.empty();
+        }
+        return exporter.export(subject.objectUuid()).map(data -> {
+            NotificationObjectContentDto content = new NotificationObjectContentDto();
+            content.setFormat(exporter.format());
+            content.setData(data);
+            return content;
+        });
+    }
+
+    private static NotificationAssociationDto association(Resource resource, String uuid, String name) {
+        NotificationAssociationDto dto = new NotificationAssociationDto();
+        dto.setResource(resource);
+        dto.setUuid(uuid);
+        dto.setName(name);
+        return dto;
+    }
+
+    private static Set<UUID> merge(Set<UUID> first, Set<UUID> second) {
+        if (second.isEmpty()) {
+            return first;
+        }
+        Set<UUID> merged = new HashSet<>(first);
+        merged.addAll(second);
+        return merged;
+    }
+}

--- a/src/main/java/com/otilm/core/service/notifications/NotificationSubjectResolver.java
+++ b/src/main/java/com/otilm/core/service/notifications/NotificationSubjectResolver.java
@@ -1,0 +1,30 @@
+package com.otilm.core.service.notifications;
+
+import com.otilm.api.model.common.events.data.ApprovalEventData;
+import com.otilm.api.model.common.events.data.EventData;
+import com.otilm.api.model.core.auth.Resource;
+
+import java.util.UUID;
+
+/**
+ * Resolves which object a notification's enrichment and subject-scoped recipients describe.
+ * Approval events reference a target object in their payload; the approval record itself
+ * carries no attributes, owner, or groups, so the target is the meaningful subject. Every
+ * other event's subject is the event object itself.
+ */
+public final class NotificationSubjectResolver {
+
+    public record SubjectRef(Resource resource, UUID objectUuid) {
+    }
+
+    private NotificationSubjectResolver() {
+    }
+
+    public static SubjectRef resolveSubject(Resource resource, UUID objectUuid, EventData eventData) {
+        if (eventData instanceof ApprovalEventData approval
+                && approval.getResource() != null && approval.getObjectUuid() != null) {
+            return new SubjectRef(approval.getResource(), approval.getObjectUuid());
+        }
+        return new SubjectRef(resource, objectUuid);
+    }
+}

--- a/src/test/java/com/otilm/core/integration/events/NotificationObjectDataEnrichmentITest.java
+++ b/src/test/java/com/otilm/core/integration/events/NotificationObjectDataEnrichmentITest.java
@@ -1,0 +1,256 @@
+package com.otilm.core.integration.events;
+
+import com.otilm.api.exception.AlreadyExistException;
+import com.otilm.api.exception.AttributeException;
+import com.otilm.api.exception.NotFoundException;
+import com.otilm.api.model.client.attribute.custom.CustomAttributeCreateRequestDto;
+import com.otilm.api.model.client.attribute.custom.CustomAttributeDefinitionDetailDto;
+import com.otilm.api.model.client.connector.v2.ConnectorVersion;
+import com.otilm.api.model.client.notification.NotificationProfileDetailDto;
+import com.otilm.api.model.client.notification.NotificationProfileRequestDto;
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import com.otilm.api.model.common.attribute.common.content.data.ProtectionLevel;
+import com.otilm.api.model.common.attribute.v3.content.StringAttributeContentV3;
+import com.otilm.api.model.common.events.data.ApprovalEventData;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.connector.ConnectorStatus;
+import com.otilm.api.model.core.notification.NotificationDataCategory;
+import com.otilm.api.model.core.notification.RecipientType;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.dao.entity.AttributeDefinition;
+import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.entity.notifications.NotificationInstanceReference;
+import com.otilm.core.dao.entity.notifications.NotificationProfile;
+import com.otilm.core.dao.repository.AttributeDefinitionRepository;
+import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.dao.repository.notifications.NotificationInstanceReferenceRepository;
+import com.otilm.core.dao.repository.notifications.NotificationProfileRepository;
+import com.otilm.core.messaging.jms.listeners.NotificationListener;
+import com.otilm.core.messaging.model.NotificationMessage;
+import com.otilm.core.service.AttributeExternalService;
+import com.otilm.core.service.NotificationProfileExternalService;
+import com.otilm.core.util.BaseSpringBootTest;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.UUID;
+
+class NotificationObjectDataEnrichmentITest extends BaseSpringBootTest {
+
+    private static final String NOTIFY_PATH = "/v1/notificationProvider/notifications/[^/]+/notify";
+    private static final String DEPARTMENT_VALUE = "E-Commerce";
+    private static final String PROTECTED_VALUE = "protected-marker-value";
+
+    @Autowired private NotificationListener notificationListener;
+    @Autowired private NotificationProfileExternalService notificationProfileService;
+    @Autowired private NotificationProfileRepository notificationProfileRepository;
+    @Autowired private NotificationInstanceReferenceRepository notificationInstanceReferenceRepository;
+    @Autowired private AttributeExternalService attributeService;
+    @Autowired private AttributeEngine attributeEngine;
+    @Autowired private AttributeDefinitionRepository attributeDefinitionRepository;
+    @Autowired private ConnectorRepository connectorRepository;
+
+    private WireMockServer mockServer;
+    private NotificationInstanceReference instance;
+    private CustomAttributeDefinitionDetailDto departmentAttr;
+
+    @BeforeEach
+    void setUp() throws AlreadyExistException, AttributeException {
+        mockServer = new WireMockServer(0);
+        mockServer.start();
+        WireMock.configureFor("localhost", mockServer.port());
+        mockServer.stubFor(WireMock.get(WireMock.urlPathMatching("/v1/notificationProvider/[^/]+/attributes/mapping"))
+                .willReturn(WireMock.okJson("[]")));
+        mockServer.stubFor(WireMock.post(WireMock.urlPathMatching(NOTIFY_PATH)).willReturn(WireMock.ok()));
+
+        Connector connector = new Connector();
+        connector.setName("enrichmentConnector");
+        connector.setUrl("http://localhost:" + mockServer.port());
+        connector.setVersion(ConnectorVersion.V1);
+        connector.setStatus(ConnectorStatus.CONNECTED);
+        connector = connectorRepository.save(connector);
+
+        instance = new NotificationInstanceReference();
+        instance.setName("enrichmentInstance");
+        instance.setKind("WEBHOOK");
+        instance.setConnectorUuid(connector.getUuid());
+        instance.setNotificationInstanceUuid(UUID.randomUUID());
+        notificationInstanceReferenceRepository.save(instance);
+
+        CustomAttributeCreateRequestDto attrRequest = new CustomAttributeCreateRequestDto();
+        attrRequest.setName("department");
+        attrRequest.setLabel("Department");
+        attrRequest.setResources(List.of(Resource.CERTIFICATE));
+        attrRequest.setContentType(AttributeContentType.STRING);
+        departmentAttr = attributeService.createCustomAttribute(attrRequest);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockServer.stop();
+    }
+
+    @Test
+    void enrichedSendCarriesSubjectAndCustomAttributes() throws Exception {
+        UUID certificateUuid = certificateWithDepartment();
+        NotificationProfileDetailDto profile = profile("enrichedProfile",
+                List.of(NotificationDataCategory.CUSTOM_ATTRIBUTES, NotificationDataCategory.ASSOCIATIONS));
+
+        process(message(ResourceEvent.CERTIFICATE_STATUS_CHANGED, Resource.CERTIFICATE, certificateUuid, profile));
+
+        String body = onlyRequestBody();
+        Assertions.assertTrue(body.contains("\"objectData\""), body);
+        Assertions.assertTrue(body.contains("\"uuid\":\"%s\"".formatted(certificateUuid)), "the subject names the certificate: " + body);
+        Assertions.assertTrue(body.contains("\"department\""), "custom attributes are keyed by name: " + body);
+        Assertions.assertTrue(body.contains(DEPARTMENT_VALUE), body);
+    }
+
+    @Test
+    void withoutCategoriesThePayloadCarriesNoObjectData() throws Exception {
+        UUID certificateUuid = certificateWithDepartment();
+        NotificationProfileDetailDto profile = profile("plainProfile", null);
+
+        process(message(ResourceEvent.CERTIFICATE_STATUS_CHANGED, Resource.CERTIFICATE, certificateUuid, profile));
+
+        String body = onlyRequestBody();
+        Assertions.assertFalse(body.contains("objectData"), "categories-off sends stay byte-identical to today: " + body);
+        Assertions.assertFalse(body.contains(DEPARTMENT_VALUE), body);
+    }
+
+    @Test
+    void protectedAttributeContentNeverReachesTheWire() throws Exception {
+        UUID certificateUuid = certificateWithDepartment();
+
+        CustomAttributeCreateRequestDto protectedRequest = new CustomAttributeCreateRequestDto();
+        protectedRequest.setName("internalTicket");
+        protectedRequest.setLabel("Internal Ticket");
+        protectedRequest.setResources(List.of(Resource.CERTIFICATE));
+        protectedRequest.setContentType(AttributeContentType.STRING);
+        CustomAttributeDefinitionDetailDto protectedAttr = attributeService.createCustomAttribute(protectedRequest);
+        attributeEngine.updateObjectCustomAttributeContent(Resource.CERTIFICATE, certificateUuid,
+                UUID.fromString(protectedAttr.getUuid()), protectedAttr.getName(),
+                List.of(new StringAttributeContentV3(PROTECTED_VALUE)));
+        // The protection column is what the fail-closed filter consults; declare it protected.
+        AttributeDefinition definition = attributeDefinitionRepository.findByUuid(UUID.fromString(protectedAttr.getUuid())).orElseThrow();
+        definition.setProtectionLevel(ProtectionLevel.ENCRYPTED);
+        attributeDefinitionRepository.save(definition);
+
+        NotificationProfileDetailDto profile = profile("protectionProfile", List.of(NotificationDataCategory.CUSTOM_ATTRIBUTES));
+        process(message(ResourceEvent.CERTIFICATE_STATUS_CHANGED, Resource.CERTIFICATE, certificateUuid, profile));
+
+        String body = onlyRequestBody();
+        Assertions.assertTrue(body.contains(DEPARTMENT_VALUE), "unprotected attributes still flow: " + body);
+        Assertions.assertFalse(body.contains(PROTECTED_VALUE), "protected content must never reach the wire: " + body);
+        Assertions.assertFalse(body.contains("internalTicket"), body);
+    }
+
+    @Test
+    void approvalEventsDescribeTheTargetObject() throws Exception {
+        UUID certificateUuid = certificateWithDepartment();
+        UUID approvalUuid = UUID.randomUUID();
+        NotificationProfileDetailDto profile = profile("approvalProfile", List.of(NotificationDataCategory.CUSTOM_ATTRIBUTES));
+
+        ApprovalEventData approval = new ApprovalEventData();
+        approval.setApprovalUuid(approvalUuid);
+        approval.setResource(Resource.CERTIFICATE);
+        approval.setObjectUuid(certificateUuid);
+        NotificationMessage message = new NotificationMessage(ResourceEvent.APPROVAL_REQUESTED, Resource.APPROVAL,
+                approvalUuid, List.of(UUID.fromString(profile.getUuid())), List.of(), approval);
+
+        process(message);
+
+        String body = onlyRequestBody();
+        Assertions.assertTrue(body.contains("\"uuid\":\"%s\"".formatted(certificateUuid)),
+                "the subject is the approval's target, not the approval record: " + body);
+        Assertions.assertTrue(body.contains(DEPARTMENT_VALUE), "the target's attributes are rendered: " + body);
+    }
+
+    @Test
+    void staleApprovalTargetStillDelivers() throws Exception {
+        UUID approvalUuid = UUID.randomUUID();
+        UUID deletedTargetUuid = UUID.randomUUID();
+        NotificationProfileDetailDto profile = profile("staleTargetProfile", List.of(NotificationDataCategory.CUSTOM_ATTRIBUTES));
+
+        ApprovalEventData approval = new ApprovalEventData();
+        approval.setApprovalUuid(approvalUuid);
+        approval.setResource(Resource.CERTIFICATE);
+        approval.setObjectUuid(deletedTargetUuid);
+        NotificationMessage message = new NotificationMessage(ResourceEvent.APPROVAL_REQUESTED, Resource.APPROVAL,
+                approvalUuid, List.of(UUID.fromString(profile.getUuid())), List.of(), approval);
+
+        process(message);
+
+        String body = onlyRequestBody();
+        Assertions.assertTrue(body.contains("\"uuid\":\"%s\"".formatted(deletedTargetUuid)),
+                "the subject keeps the target reference even when unresolvable: " + body);
+    }
+
+    @Test
+    void categoryChangeAppliesToPinnedMonitoringStream() throws Exception {
+        UUID certificateUuid = certificateWithDepartment();
+        NotificationProfileRequestDto request = new NotificationProfileRequestDto();
+        request.setName("pinnedStreamProfile");
+        request.setRecipientType(RecipientType.NONE);
+        request.setInternalNotification(false);
+        request.setNotificationInstanceUuid(instance.getUuid());
+        request.setRepetitions(5);
+        NotificationProfileDetailDto profile = notificationProfileService.createNotificationProfile(request);
+
+        NotificationMessage message = message(ResourceEvent.CERTIFICATE_EXPIRING, Resource.CERTIFICATE, certificateUuid, profile);
+
+        // First send pins the profile version in the suppression row; no categories yet.
+        process(message);
+        // Enabling categories on the parent must affect the already-pinned stream.
+        NotificationProfile parent = notificationProfileRepository.findById(UUID.fromString(profile.getUuid())).orElseThrow();
+        parent.setEventDataCategories(List.of(NotificationDataCategory.CUSTOM_ATTRIBUTES));
+        notificationProfileRepository.save(parent);
+        process(message);
+
+        List<LoggedRequest> requests = mockServer.findAll(WireMock.postRequestedFor(WireMock.urlPathMatching(NOTIFY_PATH)));
+        Assertions.assertEquals(2, requests.size());
+        Assertions.assertFalse(requests.get(0).getBodyAsString().contains("objectData"));
+        Assertions.assertTrue(requests.get(1).getBodyAsString().contains(DEPARTMENT_VALUE),
+                "the pinned stream picks up the parent-level category change: " + requests.get(1).getBodyAsString());
+    }
+
+    private UUID certificateWithDepartment() throws AttributeException, NotFoundException {
+        UUID certificateUuid = UUID.randomUUID();
+        attributeEngine.updateObjectCustomAttributeContent(Resource.CERTIFICATE, certificateUuid,
+                UUID.fromString(departmentAttr.getUuid()), departmentAttr.getName(),
+                List.of(new StringAttributeContentV3(DEPARTMENT_VALUE)));
+        return certificateUuid;
+    }
+
+    private NotificationProfileDetailDto profile(String name, List<NotificationDataCategory> categories) throws AlreadyExistException, NotFoundException {
+        NotificationProfileRequestDto request = new NotificationProfileRequestDto();
+        request.setName(name);
+        request.setRecipientType(RecipientType.NONE);
+        request.setInternalNotification(false);
+        request.setNotificationInstanceUuid(instance.getUuid());
+        request.setEventDataCategories(categories);
+        return notificationProfileService.createNotificationProfile(request);
+    }
+
+    private NotificationMessage message(ResourceEvent event, Resource resource, UUID objectUuid, NotificationProfileDetailDto profile) {
+        return new NotificationMessage(event, resource, objectUuid,
+                List.of(UUID.fromString(profile.getUuid())), List.of(), null);
+    }
+
+    private void process(NotificationMessage message) {
+        Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(message));
+    }
+
+    private String onlyRequestBody() {
+        List<LoggedRequest> requests = mockServer.findAll(WireMock.postRequestedFor(WireMock.urlPathMatching(NOTIFY_PATH)));
+        Assertions.assertEquals(1, requests.size(), "exactly one notify call expected");
+        return requests.getFirst().getBodyAsString();
+    }
+}

--- a/src/test/java/com/otilm/core/mapper/notifications/NotificationObjectDataMapperTest.java
+++ b/src/test/java/com/otilm/core/mapper/notifications/NotificationObjectDataMapperTest.java
@@ -1,0 +1,298 @@
+package com.otilm.core.mapper.notifications;
+
+import com.otilm.api.model.client.attribute.ResponseAttributeV2;
+import com.otilm.api.model.client.attribute.ResponseAttributeV3;
+import com.otilm.api.model.client.metadata.MetadataResponseDto;
+import com.otilm.api.model.client.metadata.ResponseMetadata;
+import com.otilm.api.model.client.metadata.ResponseMetadataV3;
+import com.otilm.api.model.common.NameAndUuidDto;
+import com.otilm.api.model.common.attribute.common.AttributeType;
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import com.otilm.api.model.common.attribute.v2.content.BaseAttributeContentV2;
+import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
+import com.otilm.api.model.connector.notification.NotificationAssociationDto;
+import com.otilm.api.model.connector.notification.NotificationAttributeDto;
+import com.otilm.api.model.connector.notification.NotificationEventObjectDataDto;
+import com.otilm.api.model.connector.notification.NotificationMetadataGroupDto;
+import com.otilm.api.model.connector.notification.NotificationObjectContentDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NotificationObjectDataMapperTest {
+
+    private static final UUID UUID_1 = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID UUID_2 = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final UUID UUID_3 = UUID.fromString("00000000-0000-0000-0000-000000000003");
+
+    // --- custom attributes ---
+
+    @Test
+    void scalarTypesContributeRawData() {
+        Map<String, NotificationAttributeDto> mapped = NotificationObjectDataMapper.mapCustomAttributes(List.of(
+                custom(UUID_1, "department", AttributeContentType.STRING, content("E-Commerce")),
+                custom(UUID_2, "port", AttributeContentType.INTEGER, content(443)),
+                custom(UUID_3, "active", AttributeContentType.BOOLEAN, content(Boolean.TRUE))), Set.of());
+
+        assertEquals(List.of("E-Commerce"), mapped.get("department").getValues());
+        assertEquals(List.of(443), mapped.get("port").getValues());
+        assertEquals(List.of(Boolean.TRUE), mapped.get("active").getValues());
+        assertEquals("Label department", mapped.get("department").getLabel());
+        assertEquals(AttributeContentType.STRING, mapped.get("department").getContentType());
+    }
+
+    @Test
+    void secretBearingTypesAreUnconditionallyExcluded() {
+        Map<String, NotificationAttributeDto> mapped = NotificationObjectDataMapper.mapCustomAttributes(List.of(
+                custom(UUID_1, "apiKey", AttributeContentType.SECRET, content("s3cret")),
+                custom(UUID_2, "creds", AttributeContentType.CREDENTIAL, content("token")),
+                custom(UUID_3, "plain", AttributeContentType.STRING, content("visible"))), Set.of());
+
+        assertEquals(Set.of("plain"), mapped.keySet());
+    }
+
+    @Test
+    void excludedDefinitionsAreFilteredOut() {
+        Map<String, NotificationAttributeDto> mapped = NotificationObjectDataMapper.mapCustomAttributes(List.of(
+                custom(UUID_1, "protected", AttributeContentType.STRING, content("decrypted-secret")),
+                custom(UUID_2, "plain", AttributeContentType.STRING, content("visible"))), Set.of(UUID_1));
+
+        assertEquals(Set.of("plain"), mapped.keySet());
+    }
+
+    @Test
+    void complexTypesContributeReferenceOnlyAndReferencelessEntriesAreOmitted() {
+        BaseAttributeContentV3<Serializable> withReference = new BaseAttributeContentV3<>("P1 - 24x7 pager", (Serializable) Map.of("nested", "structure"));
+        BaseAttributeContentV3<Serializable> withoutReference = new BaseAttributeContentV3<>(null, (Serializable) Map.of("other", "structure"));
+        BaseAttributeContentV3<Serializable> blankReference = new BaseAttributeContentV3<>("  ", (Serializable) Map.of("third", "structure"));
+
+        Map<String, NotificationAttributeDto> mapped = NotificationObjectDataMapper.mapCustomAttributes(List.of(
+                customWithContent(UUID_1, "escalation", AttributeContentType.OBJECT, List.of(withReference, withoutReference, blankReference)),
+                customWithContent(UUID_2, "emptyObject", AttributeContentType.OBJECT, List.of(withoutReference))), Set.of());
+
+        assertEquals(List.of("P1 - 24x7 pager"), mapped.get("escalation").getValues());
+        assertFalse(mapped.containsKey("emptyObject"), "an attribute with no extractable values is omitted");
+    }
+
+    @Test
+    void duplicateCustomNameFirstWinsInUuidOrder() {
+        Map<String, NotificationAttributeDto> mapped = NotificationObjectDataMapper.mapCustomAttributes(List.of(
+                custom(UUID_2, "department", AttributeContentType.STRING, content("second")),
+                custom(UUID_1, "department", AttributeContentType.STRING, content("first"))), Set.of());
+
+        assertEquals(List.of("first"), mapped.get("department").getValues(),
+                "the definition with the lowest attribute UUID wins deterministically");
+    }
+
+    @Test
+    void v2ContentExtractsLikeV3() {
+        BaseAttributeContentV2<String> v2Content = new BaseAttributeContentV2<>();
+        v2Content.setData("legacy-value");
+        ResponseAttributeV2 attribute = new ResponseAttributeV2();
+        attribute.setUuid(UUID_1);
+        attribute.setName("legacy");
+        attribute.setLabel("Legacy");
+        attribute.setType(AttributeType.CUSTOM);
+        attribute.setContentType(AttributeContentType.STRING);
+        attribute.setContent(List.of(v2Content));
+
+        Map<String, NotificationAttributeDto> mapped = NotificationObjectDataMapper.mapCustomAttributes(List.of(attribute), Set.of());
+
+        assertEquals(List.of("legacy-value"), mapped.get("legacy").getValues());
+    }
+
+    @Test
+    void longStringValuesAreTruncatedWithSuffix() {
+        String longValue = "x".repeat(NotificationObjectDataMapper.MAX_VALUE_LENGTH + 100);
+        Map<String, NotificationAttributeDto> mapped = NotificationObjectDataMapper.mapCustomAttributes(List.of(
+                custom(UUID_1, "big", AttributeContentType.TEXT, content(longValue)),
+                custom(UUID_2, "number", AttributeContentType.INTEGER, content(42))), Set.of());
+
+        String truncated = (String) mapped.get("big").getValues().getFirst();
+        assertEquals(NotificationObjectDataMapper.MAX_VALUE_LENGTH + NotificationObjectDataMapper.TRUNCATION_SUFFIX.length(), truncated.length());
+        assertTrue(truncated.endsWith(NotificationObjectDataMapper.TRUNCATION_SUFFIX));
+        assertEquals(42, mapped.get("number").getValues().getFirst(), "non-string scalars are never truncated");
+    }
+
+    @Test
+    void nullAndEmptyInputsYieldEmptyOutputs() {
+        assertTrue(NotificationObjectDataMapper.mapCustomAttributes(null, Set.of()).isEmpty());
+        assertTrue(NotificationObjectDataMapper.mapCustomAttributes(List.of(), Set.of()).isEmpty());
+        assertTrue(NotificationObjectDataMapper.mapMetadata(null, Set.of()).isEmpty());
+        assertTrue(NotificationObjectDataMapper.mapMetadata(List.of(), Set.of()).isEmpty());
+    }
+
+    // --- metadata ---
+
+    @Test
+    void metadataKeepsConnectorAndSourceTypeGrouping() {
+        MetadataResponseDto discoveryGroup = group("Network-Discovery", Resource.DISCOVERY,
+                meta(UUID_1, "discoverySource", AttributeContentType.STRING, List.of(content("10.20.30.0/24")),
+                        List.of(source(UUID_2, "weekly-sweep"))));
+        MetadataResponseDto authorityGroup = group("ACME-Server", Resource.AUTHORITY,
+                meta(UUID_3, "discoverySource", AttributeContentType.STRING, List.of(content("acme-directory")),
+                        List.of(source(UUID_1, "acme-prod-ca"))));
+
+        List<NotificationMetadataGroupDto> mapped = NotificationObjectDataMapper.mapMetadata(
+                List.of(discoveryGroup, authorityGroup), Set.of());
+
+        assertEquals(2, mapped.size());
+        assertEquals("Network-Discovery", mapped.get(0).getConnectorName());
+        assertEquals(Resource.DISCOVERY, mapped.get(0).getSourceObjectType());
+        assertEquals(List.of("10.20.30.0/24"), mapped.get(0).getAttributes().get("discoverySource").getValues());
+        assertEquals("ACME-Server", mapped.get(1).getConnectorName());
+        assertEquals(List.of("acme-directory"), mapped.get(1).getAttributes().get("discoverySource").getValues());
+    }
+
+    @Test
+    void sameNameMetadataInOneGroupMergesValuesAndSources() {
+        // The same connector re-declared the attribute over time: two definition UUIDs, one name.
+        MetadataResponseDto group = group("Network-Discovery", Resource.DISCOVERY,
+                meta(UUID_2, "port", AttributeContentType.INTEGER, List.of(content(443), content(8443)),
+                        List.of(source(UUID_1, "sweep-a"))),
+                meta(UUID_1, "port", AttributeContentType.INTEGER, List.of(content(443)),
+                        List.of(source(UUID_3, "sweep-b"))));
+
+        List<NotificationMetadataGroupDto> mapped = NotificationObjectDataMapper.mapMetadata(List.of(group), Set.of());
+
+        NotificationAttributeDto merged = mapped.getFirst().getAttributes().get("port");
+        assertEquals(List.of(443, 8443), merged.getValues(), "values are the deduplicated union in attribute-UUID order");
+        assertEquals(2, merged.getSourceObjects().size(), "source objects are the union of contributors");
+        assertEquals("sweep-b", merged.getSourceObjects().getFirst().getName(),
+                "the lower attribute UUID contributes first");
+    }
+
+    @Test
+    void conflictingContentTypeRedeclarationIsExcluded() {
+        MetadataResponseDto group = group("Network-Discovery", Resource.DISCOVERY,
+                meta(UUID_1, "port", AttributeContentType.INTEGER, List.of(content(443)), List.of()),
+                meta(UUID_2, "port", AttributeContentType.STRING, List.of(content("https")), List.of()));
+
+        List<NotificationMetadataGroupDto> mapped = NotificationObjectDataMapper.mapMetadata(List.of(group), Set.of());
+
+        NotificationAttributeDto merged = mapped.getFirst().getAttributes().get("port");
+        assertEquals(AttributeContentType.INTEGER, merged.getContentType());
+        assertEquals(List.of(443), merged.getValues(), "the conflicting re-declaration contributes nothing");
+    }
+
+    @Test
+    void metadataGroupWithOnlyExcludedItemsIsOmitted() {
+        MetadataResponseDto group = group("Vault", Resource.CREDENTIAL,
+                meta(UUID_1, "apiKey", AttributeContentType.SECRET, List.of(content("s3cret")), List.of()));
+
+        assertTrue(NotificationObjectDataMapper.mapMetadata(List.of(group), Set.of()).isEmpty());
+    }
+
+    // --- total cap ---
+
+    @Test
+    void totalCapDropsCategoriesInDeterministicOrder() {
+        ObjectMapper wireMapper = new ObjectMapper();
+        NotificationEventObjectDataDto objectData = boundedFixture(200_000, 200_000, 200_000);
+
+        NotificationObjectDataMapper.applyTotalCap(objectData, wireMapper);
+
+        assertNull(objectData.getMetadata(), "metadata drops first");
+        assertNull(objectData.getCustomAttributes(), "custom attributes drop second");
+        assertNull(objectData.getContent(), "object content drops third");
+        assertNotNull(objectData.getAssociations(), "associations survive when the rest sufficed");
+        assertNotNull(objectData.getSubject(), "the subject is never dropped");
+    }
+
+    @Test
+    void totalCapKeepsEverythingThatFits() {
+        ObjectMapper wireMapper = new ObjectMapper();
+        NotificationEventObjectDataDto objectData = boundedFixture(100, 100, 100);
+
+        NotificationObjectDataMapper.applyTotalCap(objectData, wireMapper);
+
+        assertNotNull(objectData.getMetadata());
+        assertNotNull(objectData.getCustomAttributes());
+        assertNotNull(objectData.getContent());
+        assertNotNull(objectData.getAssociations());
+    }
+
+    // --- fixtures ---
+
+    private static BaseAttributeContentV3<?> content(Serializable data) {
+        return new BaseAttributeContentV3<>(null, data);
+    }
+
+    private static ResponseAttributeV3 custom(UUID uuid, String name, AttributeContentType contentType, BaseAttributeContentV3<?> content) {
+        return customWithContent(uuid, name, contentType, List.of(content));
+    }
+
+    private static ResponseAttributeV3 customWithContent(UUID uuid, String name, AttributeContentType contentType, List<BaseAttributeContentV3<?>> content) {
+        ResponseAttributeV3 attribute = new ResponseAttributeV3();
+        attribute.setUuid(uuid);
+        attribute.setName(name);
+        attribute.setLabel("Label " + name);
+        attribute.setType(AttributeType.CUSTOM);
+        attribute.setContentType(contentType);
+        attribute.setContent(content);
+        return attribute;
+    }
+
+    private static ResponseMetadataV3 meta(UUID uuid, String name, AttributeContentType contentType,
+                                           List<BaseAttributeContentV3<?>> content, List<NameAndUuidDto> sources) {
+        return new ResponseMetadataV3(sources, uuid, name, "Label " + name, AttributeType.META, contentType, content);
+    }
+
+    private static MetadataResponseDto group(String connectorName, Resource sourceType, ResponseMetadata... items) {
+        MetadataResponseDto group = new MetadataResponseDto();
+        group.setConnectorName(connectorName);
+        group.setSourceObjectType(sourceType);
+        group.setItems(List.of(items));
+        return group;
+    }
+
+    private static NameAndUuidDto source(UUID uuid, String name) {
+        return new NameAndUuidDto(uuid.toString(), name);
+    }
+
+    private static NotificationEventObjectDataDto boundedFixture(int metadataBytes, int customBytes, int contentBytes) {
+        NotificationEventObjectDataDto objectData = new NotificationEventObjectDataDto();
+
+        NotificationAssociationDto subject = new NotificationAssociationDto();
+        subject.setResource(Resource.CERTIFICATE);
+        subject.setUuid(UUID_1.toString());
+        subject.setName("shop.acme.example");
+        objectData.setSubject(subject);
+        objectData.setAssociations(List.of(subject));
+
+        NotificationAttributeDto customAttribute = new NotificationAttributeDto();
+        customAttribute.setName("big");
+        customAttribute.setContentType(AttributeContentType.TEXT);
+        customAttribute.setValues(List.of("c".repeat(customBytes)));
+        objectData.setCustomAttributes(Map.of("big", customAttribute));
+
+        NotificationAttributeDto metadataAttribute = new NotificationAttributeDto();
+        metadataAttribute.setName("bulk");
+        metadataAttribute.setContentType(AttributeContentType.TEXT);
+        metadataAttribute.setValues(List.of("m".repeat(metadataBytes)));
+        NotificationMetadataGroupDto metadataGroup = new NotificationMetadataGroupDto();
+        metadataGroup.setConnectorName("Bulk-Connector");
+        metadataGroup.setSourceObjectType(Resource.DISCOVERY);
+        metadataGroup.setAttributes(Map.of("bulk", metadataAttribute));
+        objectData.setMetadata(List.of(metadataGroup));
+
+        NotificationObjectContentDto content = new NotificationObjectContentDto();
+        content.setFormat("X509_DER_BASE64");
+        content.setData("d".repeat(contentBytes));
+        objectData.setContent(content);
+
+        return objectData;
+    }
+}

--- a/src/test/java/com/otilm/core/messaging/jms/listeners/NotificationListenerTest.java
+++ b/src/test/java/com/otilm/core/messaging/jms/listeners/NotificationListenerTest.java
@@ -24,6 +24,7 @@ import com.otilm.core.service.NotificationInternalService;
 import com.otilm.core.service.ResourceObjectAssociationService;
 import com.otilm.core.service.TriggerInternalService;
 import com.otilm.core.service.v2.ConnectorInternalService;
+import com.otilm.core.service.notifications.NotificationObjectDataService;
 import com.otilm.core.service.writer.PendingNotificationWriter;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -69,7 +70,8 @@ class NotificationListenerTest {
                 // The real handler, invoked directly rather than through its proxy, runs the work without a
                 // transaction -- which is what this unencumbered unit context wants.
                 new TransactionHandler(),
-                mock(PendingNotificationWriter.class));
+                mock(PendingNotificationWriter.class),
+                mock(NotificationObjectDataService.class));
     }
 
     @Test
@@ -152,7 +154,8 @@ class NotificationListenerTest {
                 mock(RoleManagementApiClient.class),
                 mock(ResourceObjectAssociationService.class),
                 new TransactionHandler(),
-                failingWriter);
+                failingWriter,
+                mock(NotificationObjectDataService.class));
 
         NotificationMessage message = new NotificationMessage(
                 ResourceEvent.CERTIFICATE_EXPIRING, Resource.CERTIFICATE, UUID.randomUUID(),

--- a/src/test/java/com/otilm/core/service/notifications/AttributeProtectionExclusionsTest.java
+++ b/src/test/java/com/otilm/core/service/notifications/AttributeProtectionExclusionsTest.java
@@ -1,0 +1,115 @@
+package com.otilm.core.service.notifications;
+
+import com.otilm.api.model.common.attribute.common.content.data.ProtectionLevel;
+import com.otilm.api.model.common.attribute.common.properties.MetadataAttributeProperties;
+import com.otilm.api.model.common.attribute.v3.MetadataAttributeV3;
+import com.otilm.core.dao.entity.AttributeDefinition;
+import com.otilm.core.dao.repository.AttributeDefinitionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AttributeProtectionExclusionsTest {
+
+    private static final UUID PLAIN = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID PROTECTED_COLUMN = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final UUID PROTECTED_DECLARED = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    private static final UUID MISSING = UUID.fromString("00000000-0000-0000-0000-000000000004");
+    private static final UUID UNREADABLE = UUID.fromString("00000000-0000-0000-0000-000000000005");
+    private static final UUID NO_PROPERTIES = UUID.fromString("00000000-0000-0000-0000-000000000006");
+
+    @Mock
+    private AttributeDefinitionRepository repository;
+
+    private AttributeProtectionExclusions exclusions() {
+        return new AttributeProtectionExclusions(repository);
+    }
+
+    @Test
+    void plainDefinitionsAreNotExcluded() {
+        when(repository.findByAttributeUuidIn(anyCollection()))
+                .thenReturn(List.of(definition(PLAIN, ProtectionLevel.NONE, declaredMetadata(ProtectionLevel.NONE))));
+
+        assertTrue(exclusions().excludedFrom(List.of(PLAIN)).isEmpty());
+    }
+
+    @Test
+    void entityColumnProtectionExcludes() {
+        when(repository.findByAttributeUuidIn(anyCollection()))
+                .thenReturn(List.of(definition(PROTECTED_COLUMN, ProtectionLevel.ENCRYPTED, declaredMetadata(ProtectionLevel.NONE))));
+
+        assertEquals(Set.of(PROTECTED_COLUMN), exclusions().excludedFrom(List.of(PROTECTED_COLUMN)));
+    }
+
+    @Test
+    void declaredMetadataProtectionExcludesEvenWhenTheColumnIsEmpty() {
+        // The definition builder never copies declared metadata protection onto the entity
+        // column, so the column alone under-reports -- the declared properties are authoritative.
+        when(repository.findByAttributeUuidIn(anyCollection()))
+                .thenReturn(List.of(definition(PROTECTED_DECLARED, null, declaredMetadata(ProtectionLevel.ENCRYPTED))));
+
+        assertEquals(Set.of(PROTECTED_DECLARED), exclusions().excludedFrom(List.of(PROTECTED_DECLARED)));
+    }
+
+    @Test
+    void unresolvableDefinitionIsExcludedFailClosed() {
+        when(repository.findByAttributeUuidIn(anyCollection())).thenReturn(List.of());
+
+        assertEquals(Set.of(MISSING), exclusions().excludedFrom(List.of(MISSING)));
+    }
+
+    @Test
+    void unreadableDefinitionDocumentIsExcludedFailClosed() {
+        AttributeDefinition definition = mock(AttributeDefinition.class);
+        when(definition.getAttributeUuid()).thenReturn(UNREADABLE);
+        when(definition.getProtectionLevel()).thenReturn(null);
+        when(definition.getDefinition()).thenThrow(new IllegalStateException("corrupt document"));
+        when(repository.findByAttributeUuidIn(anyCollection())).thenReturn(List.of(definition));
+
+        assertEquals(Set.of(UNREADABLE), exclusions().excludedFrom(List.of(UNREADABLE)));
+    }
+
+    @Test
+    void metadataWithoutDeclaredPropertiesIsExcludedFailClosed() {
+        MetadataAttributeV3 document = new MetadataAttributeV3();
+        document.setProperties(null);
+        when(repository.findByAttributeUuidIn(anyCollection()))
+                .thenReturn(List.of(definition(NO_PROPERTIES, null, document)));
+
+        assertEquals(Set.of(NO_PROPERTIES), exclusions().excludedFrom(List.of(NO_PROPERTIES)));
+    }
+
+    @Test
+    void emptyInputYieldsEmptyOutput() {
+        assertTrue(exclusions().excludedFrom(null).isEmpty());
+        assertTrue(exclusions().excludedFrom(List.of()).isEmpty());
+    }
+
+    private static AttributeDefinition definition(UUID attributeUuid, ProtectionLevel columnLevel, MetadataAttributeV3 document) {
+        AttributeDefinition definition = new AttributeDefinition();
+        definition.setAttributeUuid(attributeUuid);
+        definition.setProtectionLevel(columnLevel);
+        definition.setDefinition(document);
+        return definition;
+    }
+
+    private static MetadataAttributeV3 declaredMetadata(ProtectionLevel level) {
+        MetadataAttributeProperties properties = new MetadataAttributeProperties();
+        properties.setProtectionLevel(level);
+        MetadataAttributeV3 document = new MetadataAttributeV3();
+        document.setProperties(properties);
+        return document;
+    }
+}

--- a/src/test/java/com/otilm/core/service/notifications/CertificateContentExporterTest.java
+++ b/src/test/java/com/otilm/core/service/notifications/CertificateContentExporterTest.java
@@ -1,0 +1,63 @@
+package com.otilm.core.service.notifications;
+
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.core.dao.entity.Certificate;
+import com.otilm.core.dao.repository.CertificateRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CertificateContentExporterTest {
+
+    @Mock
+    private CertificateRepository certificateRepository;
+
+    private CertificateContentExporter exporter() {
+        return new CertificateContentExporter(certificateRepository);
+    }
+
+    @Test
+    void exportsStoredBase64DerForIssuedCertificate() {
+        UUID certificateUuid = UUID.randomUUID();
+        Certificate certificate = mock(Certificate.class);
+        when(certificate.getContentData()).thenReturn("MIIBbase64der");
+        when(certificateRepository.findByUuid(certificateUuid)).thenReturn(Optional.of(certificate));
+
+        assertEquals(Optional.of("MIIBbase64der"), exporter().export(certificateUuid));
+    }
+
+    @Test
+    void certificateWithoutStoredContentYieldsNothing() {
+        // Request and pre-registered states have no DER yet; absence is best-effort, not an error.
+        UUID certificateUuid = UUID.randomUUID();
+        Certificate certificate = mock(Certificate.class);
+        when(certificate.getContentData()).thenReturn(null);
+        when(certificateRepository.findByUuid(certificateUuid)).thenReturn(Optional.of(certificate));
+
+        assertTrue(exporter().export(certificateUuid).isEmpty());
+    }
+
+    @Test
+    void missingCertificateYieldsNothing() {
+        UUID certificateUuid = UUID.randomUUID();
+        when(certificateRepository.findByUuid(certificateUuid)).thenReturn(Optional.empty());
+
+        assertTrue(exporter().export(certificateUuid).isEmpty());
+    }
+
+    @Test
+    void declaresCertificateResourceAndDerFormat() {
+        assertEquals(Resource.CERTIFICATE, exporter().resource());
+        assertEquals("X509_DER_BASE64", exporter().format());
+    }
+}

--- a/src/test/java/com/otilm/core/service/notifications/NotificationObjectDataServiceTest.java
+++ b/src/test/java/com/otilm/core/service/notifications/NotificationObjectDataServiceTest.java
@@ -1,5 +1,6 @@
 package com.otilm.core.service.notifications;
 
+import com.otilm.api.exception.NotFoundException;
 import com.otilm.api.model.client.attribute.ResponseAttributeV3;
 import com.otilm.api.model.common.attribute.common.AttributeType;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
@@ -138,7 +139,7 @@ class NotificationObjectDataServiceTest {
         approval.setResource(Resource.CERTIFICATE);
         approval.setObjectUuid(deletedTargetUuid);
         when(resourceInternalService.getResourceObjectInternal(any(), any()))
-                .thenThrow(new com.otilm.api.exception.NotFoundException("Certificate", deletedTargetUuid.toString()));
+                .thenThrow(new NotFoundException("Certificate", deletedTargetUuid.toString()));
 
         NotificationEventObjectDataDto objectData = assertDoesNotThrow(() -> service.getObjectData(
                 ResourceEvent.APPROVAL_REQUESTED, Resource.APPROVAL, approvalUuid, approval, ALL_CATEGORIES));
@@ -164,33 +165,77 @@ class NotificationObjectDataServiceTest {
     }
 
     @Test
-    void protectionAndGuardExclusionsReachTheMapper() {
+    void protectionExclusionsReachTheMapper() {
         UUID certificateUuid = UUID.randomUUID();
         UUID protectedUuid = UUID.fromString("00000000-0000-0000-0000-00000000000a");
-        UUID oversizedUuid = UUID.fromString("00000000-0000-0000-0000-00000000000b");
         UUID plainUuid = UUID.fromString("00000000-0000-0000-0000-00000000000c");
 
         when(attributeEngine.getObjectCustomAttributesContentForSystemContext(Resource.CERTIFICATE, certificateUuid))
                 .thenReturn(List.of(
                         attribute(protectedUuid, "protected", "hidden"),
-                        attribute(oversizedUuid, "oversized", "huge"),
                         attribute(plainUuid, "plain", "visible")));
         when(attributeProtectionExclusions.excludedFrom(anyCollection())).thenReturn(Set.of(protectedUuid));
-
-        AttributeContent2ObjectRepository.AttributeContentFootprint footprint =
-                mock(AttributeContent2ObjectRepository.AttributeContentFootprint.class);
-        when(footprint.getAttributeUuid()).thenReturn(oversizedUuid);
-        when(footprint.getAttributeType()).thenReturn("CUSTOM");
-        when(footprint.getMaxBytes()).thenReturn((long) NotificationObjectDataService.MAX_ROW_BYTES + 1);
-        when(attributeContent2ObjectRepository.summarizeContentFootprint(Resource.CERTIFICATE.name(), certificateUuid))
-                .thenReturn(List.of(footprint));
 
         NotificationEventObjectDataDto objectData = service.getObjectData(
                 ResourceEvent.CERTIFICATE_EXPIRING, Resource.CERTIFICATE, certificateUuid, null,
                 Set.of(NotificationDataCategory.CUSTOM_ATTRIBUTES));
 
         assertEquals(Set.of("plain"), objectData.getCustomAttributes().keySet(),
-                "protected and oversized attributes never reach the wire");
+                "protected attributes never reach the wire");
+    }
+
+    @Test
+    void oversizedStoredContentSkipsTheCategoryLoadEntirely() {
+        UUID certificateUuid = UUID.randomUUID();
+        AttributeContent2ObjectRepository.AttributeContentFootprint oversized = footprint(
+                UUID.fromString("00000000-0000-0000-0000-00000000000b"), "CUSTOM",
+                NotificationObjectDataService.MAX_ROW_BYTES + 1);
+        when(attributeContent2ObjectRepository.summarizeContentFootprint(Resource.CERTIFICATE.name(), certificateUuid))
+                .thenReturn(List.of(oversized));
+
+        NotificationEventObjectDataDto objectData = service.getObjectData(
+                ResourceEvent.CERTIFICATE_EXPIRING, Resource.CERTIFICATE, certificateUuid, null,
+                Set.of(NotificationDataCategory.CUSTOM_ATTRIBUTES, NotificationDataCategory.METADATA));
+
+        assertNull(objectData.getCustomAttributes(), "an oversized row skips the category load");
+        // The engine must never materialize (and decrypt) the oversized row.
+        verify(attributeEngine, never()).getObjectCustomAttributesContentForSystemContext(any(), any());
+        // The metadata bucket carried no oversized row; its load proceeds.
+        verify(attributeEngine).getMappedMetadataContent(any());
+    }
+
+    @Test
+    void attributesBeyondTheCategoryCapAreExcludedFromTheWire() {
+        UUID certificateUuid = UUID.randomUUID();
+        List<AttributeContent2ObjectRepository.AttributeContentFootprint> footprints = new java.util.ArrayList<>();
+        for (int i = 1; i <= NotificationObjectDataService.MAX_ATTRIBUTES_PER_CATEGORY + 1; i++) {
+            footprints.add(footprint(UUID.fromString("00000000-0000-0000-0000-%012d".formatted(i)), "CUSTOM", 10));
+        }
+        when(attributeContent2ObjectRepository.summarizeContentFootprint(Resource.CERTIFICATE.name(), certificateUuid))
+                .thenReturn(footprints);
+
+        UUID firstUuid = UUID.fromString("00000000-0000-0000-0000-%012d".formatted(1));
+        UUID overflowUuid = UUID.fromString("00000000-0000-0000-0000-%012d".formatted(NotificationObjectDataService.MAX_ATTRIBUTES_PER_CATEGORY + 1));
+        when(attributeEngine.getObjectCustomAttributesContentForSystemContext(Resource.CERTIFICATE, certificateUuid))
+                .thenReturn(List.of(
+                        attribute(firstUuid, "first", "kept"),
+                        attribute(overflowUuid, "overflow", "dropped")));
+
+        NotificationEventObjectDataDto objectData = service.getObjectData(
+                ResourceEvent.CERTIFICATE_EXPIRING, Resource.CERTIFICATE, certificateUuid, null,
+                Set.of(NotificationDataCategory.CUSTOM_ATTRIBUTES));
+
+        assertEquals(Set.of("first"), objectData.getCustomAttributes().keySet(),
+                "the attribute beyond the cap loads but never reaches the wire");
+    }
+
+    private static AttributeContent2ObjectRepository.AttributeContentFootprint footprint(UUID attributeUuid, String type, long maxBytes) {
+        AttributeContent2ObjectRepository.AttributeContentFootprint footprint =
+                mock(AttributeContent2ObjectRepository.AttributeContentFootprint.class);
+        when(footprint.getAttributeUuid()).thenReturn(attributeUuid);
+        when(footprint.getAttributeType()).thenReturn(type);
+        when(footprint.getMaxBytes()).thenReturn(maxBytes);
+        return footprint;
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/notifications/NotificationObjectDataServiceTest.java
+++ b/src/test/java/com/otilm/core/service/notifications/NotificationObjectDataServiceTest.java
@@ -1,0 +1,221 @@
+package com.otilm.core.service.notifications;
+
+import com.otilm.api.model.client.attribute.ResponseAttributeV3;
+import com.otilm.api.model.common.attribute.common.AttributeType;
+import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
+import com.otilm.api.model.common.attribute.v3.content.BaseAttributeContentV3;
+import com.otilm.api.model.common.events.data.ApprovalEventData;
+import com.otilm.api.model.connector.notification.NotificationEventObjectDataDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.notification.NotificationDataCategory;
+import com.otilm.api.model.core.other.ResourceEvent;
+import com.otilm.api.model.core.other.ResourceObjectDto;
+import com.otilm.core.attribute.engine.AttributeEngine;
+import com.otilm.core.dao.repository.AttributeContent2ObjectRepository;
+import com.otilm.core.dao.repository.CertificateRepository;
+import com.otilm.core.dao.repository.GroupRepository;
+import com.otilm.core.service.ResourceInternalService;
+import com.otilm.core.service.ResourceObjectAssociationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class NotificationObjectDataServiceTest {
+
+    private static final Set<NotificationDataCategory> ALL_CATEGORIES = Set.of(NotificationDataCategory.values());
+
+    @Mock
+    private AttributeEngine attributeEngine;
+    @Mock
+    private AttributeProtectionExclusions attributeProtectionExclusions;
+    @Mock
+    private AttributeContent2ObjectRepository attributeContent2ObjectRepository;
+    @Mock
+    private ResourceObjectAssociationService resourceObjectAssociationService;
+    @Mock
+    private ResourceInternalService resourceInternalService;
+    @Mock
+    private GroupRepository groupRepository;
+    @Mock
+    private CertificateRepository certificateRepository;
+    @Mock
+    private NotificationObjectContentExporter certificateExporter;
+
+    private NotificationObjectDataService service;
+
+    @BeforeEach
+    void setUp() {
+        when(certificateExporter.resource()).thenReturn(Resource.CERTIFICATE);
+        when(certificateExporter.format()).thenReturn("X509_DER_BASE64");
+        when(attributeProtectionExclusions.excludedFrom(anyCollection())).thenReturn(Set.of());
+        when(attributeContent2ObjectRepository.summarizeContentFootprint(any(), any())).thenReturn(List.of());
+        when(attributeEngine.getObjectCustomAttributesContentForSystemContext(any(), any())).thenReturn(List.of());
+        when(attributeEngine.getMappedMetadataContent(any())).thenReturn(List.of());
+        when(resourceObjectAssociationService.getGroupUuids(any(), any())).thenReturn(List.of());
+        when(certificateRepository.findByUuid(any(UUID.class))).thenReturn(Optional.empty());
+        when(certificateExporter.export(any())).thenReturn(Optional.empty());
+
+        service = new NotificationObjectDataService(attributeEngine, attributeProtectionExclusions,
+                attributeContent2ObjectRepository, resourceObjectAssociationService, resourceInternalService,
+                groupRepository, certificateRepository, List.of(certificateExporter), new ObjectMapper());
+    }
+
+    @Test
+    void categoriesFailIndependently() throws Exception {
+        UUID certificateUuid = UUID.randomUUID();
+        when(attributeEngine.getObjectCustomAttributesContentForSystemContext(any(), any()))
+                .thenThrow(new IllegalStateException("attribute store down"));
+        when(resourceInternalService.getResourceObjectInternal(Resource.CERTIFICATE, certificateUuid))
+                .thenReturn(new ResourceObjectDto(Resource.CERTIFICATE, certificateUuid, "shop.acme.example"));
+        when(certificateExporter.export(certificateUuid)).thenReturn(Optional.of("MIIBder"));
+
+        NotificationEventObjectDataDto objectData = assertDoesNotThrow(() -> service.getObjectData(
+                ResourceEvent.CERTIFICATE_EXPIRING, Resource.CERTIFICATE, certificateUuid, null, ALL_CATEGORIES));
+
+        assertNull(objectData.getCustomAttributes(), "the failed category is absent");
+        assertNotNull(objectData.getContent(), "other categories still load");
+        assertEquals("MIIBder", objectData.getContent().getData());
+        assertEquals("shop.acme.example", objectData.getSubject().getName());
+    }
+
+    @Test
+    void capabilityFlagsGateTheLoaders() {
+        UUID discoveryUuid = UUID.randomUUID();
+
+        NotificationEventObjectDataDto objectData = service.getObjectData(
+                ResourceEvent.DISCOVERY_FINISHED, Resource.DISCOVERY, discoveryUuid, null, ALL_CATEGORIES);
+
+        // DISCOVERY declares neither owner nor groups; the association loaders are never consulted.
+        verify(resourceObjectAssociationService, never()).getOwner(any(), any());
+        verify(resourceObjectAssociationService, never()).getGroupUuids(any(), any());
+        assertNull(objectData.getAssociations());
+        assertNull(objectData.getContent(), "no exporter is registered for discoveries");
+    }
+
+    @Test
+    void subjectWithoutCapabilitiesYieldsSubjectOnly() {
+        UUID jobUuid = UUID.randomUUID();
+
+        NotificationEventObjectDataDto objectData = service.getObjectData(
+                ResourceEvent.SCHEDULED_JOB_FINISHED, Resource.SCHEDULED_JOB, jobUuid, null, ALL_CATEGORIES);
+
+        verify(attributeEngine, never()).getObjectCustomAttributesContentForSystemContext(any(), any());
+        assertNotNull(objectData.getSubject());
+        assertEquals(jobUuid.toString(), objectData.getSubject().getUuid());
+        assertNull(objectData.getCustomAttributes());
+        assertNull(objectData.getAssociations());
+        assertNull(objectData.getContent());
+    }
+
+    @Test
+    void staleSubjectKeepsReferenceWithoutNameAndEmptyCategories() throws Exception {
+        UUID approvalUuid = UUID.randomUUID();
+        UUID deletedTargetUuid = UUID.randomUUID();
+        ApprovalEventData approval = new ApprovalEventData();
+        approval.setResource(Resource.CERTIFICATE);
+        approval.setObjectUuid(deletedTargetUuid);
+        when(resourceInternalService.getResourceObjectInternal(any(), any()))
+                .thenThrow(new com.otilm.api.exception.NotFoundException("Certificate", deletedTargetUuid.toString()));
+
+        NotificationEventObjectDataDto objectData = assertDoesNotThrow(() -> service.getObjectData(
+                ResourceEvent.APPROVAL_REQUESTED, Resource.APPROVAL, approvalUuid, approval, ALL_CATEGORIES));
+
+        assertEquals(Resource.CERTIFICATE, objectData.getSubject().getResource());
+        assertEquals(deletedTargetUuid.toString(), objectData.getSubject().getUuid());
+        assertNull(objectData.getSubject().getName(), "an unresolvable subject keeps resource and UUID only");
+    }
+
+    @Test
+    void approvalEventsLoadTheTargetObjectsData() {
+        UUID approvalUuid = UUID.randomUUID();
+        UUID targetCertificateUuid = UUID.randomUUID();
+        ApprovalEventData approval = new ApprovalEventData();
+        approval.setResource(Resource.CERTIFICATE);
+        approval.setObjectUuid(targetCertificateUuid);
+
+        service.getObjectData(ResourceEvent.APPROVAL_REQUESTED, Resource.APPROVAL, approvalUuid, approval, ALL_CATEGORIES);
+
+        verify(attributeEngine).getObjectCustomAttributesContentForSystemContext(Resource.CERTIFICATE, targetCertificateUuid);
+        verify(certificateExporter).export(targetCertificateUuid);
+        verify(attributeEngine, never()).getObjectCustomAttributesContentForSystemContext(Resource.APPROVAL, approvalUuid);
+    }
+
+    @Test
+    void protectionAndGuardExclusionsReachTheMapper() {
+        UUID certificateUuid = UUID.randomUUID();
+        UUID protectedUuid = UUID.fromString("00000000-0000-0000-0000-00000000000a");
+        UUID oversizedUuid = UUID.fromString("00000000-0000-0000-0000-00000000000b");
+        UUID plainUuid = UUID.fromString("00000000-0000-0000-0000-00000000000c");
+
+        when(attributeEngine.getObjectCustomAttributesContentForSystemContext(Resource.CERTIFICATE, certificateUuid))
+                .thenReturn(List.of(
+                        attribute(protectedUuid, "protected", "hidden"),
+                        attribute(oversizedUuid, "oversized", "huge"),
+                        attribute(plainUuid, "plain", "visible")));
+        when(attributeProtectionExclusions.excludedFrom(anyCollection())).thenReturn(Set.of(protectedUuid));
+
+        AttributeContent2ObjectRepository.AttributeContentFootprint footprint =
+                mock(AttributeContent2ObjectRepository.AttributeContentFootprint.class);
+        when(footprint.getAttributeUuid()).thenReturn(oversizedUuid);
+        when(footprint.getAttributeType()).thenReturn("CUSTOM");
+        when(footprint.getMaxBytes()).thenReturn((long) NotificationObjectDataService.MAX_ROW_BYTES + 1);
+        when(attributeContent2ObjectRepository.summarizeContentFootprint(Resource.CERTIFICATE.name(), certificateUuid))
+                .thenReturn(List.of(footprint));
+
+        NotificationEventObjectDataDto objectData = service.getObjectData(
+                ResourceEvent.CERTIFICATE_EXPIRING, Resource.CERTIFICATE, certificateUuid, null,
+                Set.of(NotificationDataCategory.CUSTOM_ATTRIBUTES));
+
+        assertEquals(Set.of("plain"), objectData.getCustomAttributes().keySet(),
+                "protected and oversized attributes never reach the wire");
+    }
+
+    @Test
+    void emptyCategorySetYieldsSubjectOnly() {
+        UUID certificateUuid = UUID.randomUUID();
+
+        NotificationEventObjectDataDto objectData = service.getObjectData(
+                ResourceEvent.CERTIFICATE_EXPIRING, Resource.CERTIFICATE, certificateUuid, null, Set.of());
+
+        assertNotNull(objectData.getSubject());
+        assertNull(objectData.getCustomAttributes());
+        assertNull(objectData.getMetadata());
+        assertNull(objectData.getAssociations());
+        assertNull(objectData.getContent());
+        verify(attributeEngine, never()).getObjectCustomAttributesContentForSystemContext(any(), any());
+    }
+
+    private static ResponseAttributeV3 attribute(UUID uuid, String name, String value) {
+        ResponseAttributeV3 attribute = new ResponseAttributeV3();
+        attribute.setUuid(uuid);
+        attribute.setName(name);
+        attribute.setLabel("Label " + name);
+        attribute.setType(AttributeType.CUSTOM);
+        attribute.setContentType(AttributeContentType.STRING);
+        attribute.setContent(List.of(new BaseAttributeContentV3<>(null, value)));
+        return attribute;
+    }
+}

--- a/src/test/java/com/otilm/core/service/notifications/NotificationObjectDataServiceTest.java
+++ b/src/test/java/com/otilm/core/service/notifications/NotificationObjectDataServiceTest.java
@@ -75,7 +75,7 @@ class NotificationObjectDataServiceTest {
         when(attributeEngine.getObjectCustomAttributesContentForSystemContext(any(), any())).thenReturn(List.of());
         when(attributeEngine.getMappedMetadataContent(any())).thenReturn(List.of());
         when(resourceObjectAssociationService.getGroupUuids(any(), any())).thenReturn(List.of());
-        when(certificateRepository.findByUuid(any(UUID.class))).thenReturn(Optional.empty());
+        when(certificateRepository.findWithRaProfileByUuid(any(UUID.class))).thenReturn(Optional.empty());
         when(certificateExporter.export(any())).thenReturn(Optional.empty());
 
         service = new NotificationObjectDataService(attributeEngine, attributeProtectionExclusions,
@@ -191,6 +191,25 @@ class NotificationObjectDataServiceTest {
 
         assertEquals(Set.of("plain"), objectData.getCustomAttributes().keySet(),
                 "protected and oversized attributes never reach the wire");
+    }
+
+    @Test
+    void associationsIncludeTheCertificatesRaProfile() {
+        UUID certificateUuid = UUID.randomUUID();
+        com.otilm.core.dao.entity.RaProfile raProfile = mock(com.otilm.core.dao.entity.RaProfile.class);
+        when(raProfile.getUuid()).thenReturn(UUID.randomUUID());
+        when(raProfile.getName()).thenReturn("acme-web-servers");
+        com.otilm.core.dao.entity.Certificate certificate = mock(com.otilm.core.dao.entity.Certificate.class);
+        when(certificate.getRaProfile()).thenReturn(raProfile);
+        when(certificateRepository.findWithRaProfileByUuid(certificateUuid)).thenReturn(Optional.of(certificate));
+
+        NotificationEventObjectDataDto objectData = service.getObjectData(
+                ResourceEvent.CERTIFICATE_EXPIRING, Resource.CERTIFICATE, certificateUuid, null,
+                Set.of(NotificationDataCategory.ASSOCIATIONS));
+
+        assertNotNull(objectData.getAssociations());
+        assertEquals(Resource.RA_PROFILE, objectData.getAssociations().getFirst().getResource());
+        assertEquals("acme-web-servers", objectData.getAssociations().getFirst().getName());
     }
 
     @Test

--- a/src/test/java/com/otilm/core/service/notifications/NotificationSubjectResolverTest.java
+++ b/src/test/java/com/otilm/core/service/notifications/NotificationSubjectResolverTest.java
@@ -1,0 +1,66 @@
+package com.otilm.core.service.notifications;
+
+import com.otilm.api.model.common.events.data.ApprovalEventData;
+import com.otilm.api.model.common.events.data.CertificateExpiringEventData;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.core.service.notifications.NotificationSubjectResolver.SubjectRef;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NotificationSubjectResolverTest {
+
+    @Test
+    void ordinaryEventsResolveToTheEventObject() {
+        UUID certificateUuid = UUID.randomUUID();
+
+        SubjectRef subject = NotificationSubjectResolver.resolveSubject(
+                Resource.CERTIFICATE, certificateUuid, new CertificateExpiringEventData());
+
+        assertEquals(new SubjectRef(Resource.CERTIFICATE, certificateUuid), subject);
+    }
+
+    @Test
+    void approvalEventsResolveToTheApprovalTarget() {
+        UUID approvalUuid = UUID.randomUUID();
+        UUID targetUuid = UUID.randomUUID();
+        ApprovalEventData approval = new ApprovalEventData();
+        approval.setResource(Resource.CERTIFICATE);
+        approval.setObjectUuid(targetUuid);
+
+        SubjectRef subject = NotificationSubjectResolver.resolveSubject(
+                Resource.APPROVAL, approvalUuid, approval);
+
+        assertEquals(new SubjectRef(Resource.CERTIFICATE, targetUuid), subject);
+    }
+
+    @Test
+    void approvalWithoutTargetCoordinatesFallsBackToTheEventObject() {
+        UUID approvalUuid = UUID.randomUUID();
+        ApprovalEventData approval = new ApprovalEventData();
+        approval.setResource(null);
+        approval.setObjectUuid(UUID.randomUUID());
+
+        SubjectRef subject = NotificationSubjectResolver.resolveSubject(
+                Resource.APPROVAL, approvalUuid, approval);
+
+        assertEquals(new SubjectRef(Resource.APPROVAL, approvalUuid), subject);
+
+        approval.setResource(Resource.CERTIFICATE);
+        approval.setObjectUuid(null);
+        subject = NotificationSubjectResolver.resolveSubject(Resource.APPROVAL, approvalUuid, approval);
+
+        assertEquals(new SubjectRef(Resource.APPROVAL, approvalUuid), subject);
+    }
+
+    @Test
+    void nullEventDataResolvesToTheEventObject() {
+        UUID objectUuid = UUID.randomUUID();
+
+        SubjectRef subject = NotificationSubjectResolver.resolveSubject(Resource.DISCOVERY, objectUuid, null);
+
+        assertEquals(new SubjectRef(Resource.DISCOVERY, objectUuid), subject);
+    }
+}


### PR DESCRIPTION
Closes #1832. Part of epic OmniTrustILM/ilm#301. Depends on OmniTrustILM/interfaces#809.

Adds send-time enrichment of external notifications with the event subject's object data, per the categories enabled on the notification profile:

- Approval events describe the approval's **target** object; every other event its own object. An unresolvable target keeps its reference with empty categories and delivery proceeds.
- Category loaders are driven by the resource capability flags and fail independently; the service runs without an ambient transaction, and any enrichment failure yields a data-less send, never a suppressed one.
- Custom attributes and metadata pass a fail-closed protection filter consulting both the definition entity's protection column and the declared definition document; `SECRET` and `CREDENTIAL` content types are always excluded; object content flows only through the exporter registry (v1: certificate Base64 DER).
- Payloads are bounded: oversized attribute rows and per-category attribute counts are guarded at load, long string values truncate, and the serialized total caps with the drop order metadata → custom attributes → content → associations.
- The wire carries plain scalars and reference strings only: name-keyed custom attributes with first-wins duplicate resolution, metadata merged per connector group with deduplicated value and source-object unions.
- The listener builds the payload once per profile send from the **parent** profile's categories, so category edits apply immediately, including to monitoring streams pinned to older profile versions. Internal notifications never carry object data.