### PR TITLE
Resolve OWNER and OBJECT recipients from the notification subject

### DIFF
--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -345,7 +345,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
      * channel carries raw attribute content with neither the enrichment protection filters nor a
      * category gate, and approval targets are polymorphic -- a secret's attribute content must
      * not become exportable as a side effect of recipient resolution. Non-whitelisted subjects
-     * keep today's behavior and resolve against the event object.
+     * resolve against the event object.
      */
     private static UUID objectRecipientUuid(NotificationMessage message, NotificationSubjectResolver.SubjectRef subject) {
         return OBJECT_RECIPIENT_SUBJECT_RESOURCES.contains(subject.resource()) ? subject.objectUuid() : message.getObjectUuid();

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -452,7 +452,8 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
             logger.debug("Processing recipient {} of type {}.", recipient.getRecipientUuid(), recipient.getRecipientType());
             try {
                 // construct recipient DTO
-                NotificationRecipientDto recipientDto = constructNotificationRecipientDto(recipient, notificationInstanceReference.getKind(), resource);
+                // The OBJECT recipient's label must name the resource its mapped attributes resolve from.
+                NotificationRecipientDto recipientDto = constructNotificationRecipientDto(recipient, notificationInstanceReference.getKind(), objectRecipientResource);
                 if (recipientDto == null) {
                     // this should happen only in case of recipient type NONE
                     ++skippedByDesign;

--- a/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
+++ b/src/main/java/com/otilm/core/messaging/jms/listeners/NotificationListener.java
@@ -36,6 +36,7 @@ import com.otilm.core.service.ResourceObjectAssociationService;
 import com.otilm.core.service.TriggerInternalService;
 import com.otilm.core.service.v2.ConnectorInternalService;
 import com.otilm.core.service.notifications.NotificationObjectDataService;
+import com.otilm.core.service.notifications.NotificationSubjectResolver;
 import com.otilm.core.service.writer.PendingNotificationWriter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
@@ -56,6 +57,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationListener.class);
     private static final String EMAIL_NOTIFICATION_PROVIDER_KIND = "EMAIL";
+    private static final Set<Resource> OBJECT_RECIPIENT_SUBJECT_RESOURCES = Set.of(Resource.CERTIFICATE);
 
     private ObjectMapper mapper;
     private AttributeEngine attributeEngine;
@@ -133,10 +135,12 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
             return;
         }
 
-        List<NotificationRecipient> recipients = getRecipients(notificationProfileVersion.getRecipientType(), notificationProfileVersion.getRecipientUuids(), message.getEvent(), message.getData(), message.getResource(), message.getObjectUuid());
+        EventData eventData = convertEventDataBestEffort(message);
+        NotificationSubjectResolver.SubjectRef subject = NotificationSubjectResolver.resolveSubject(message.getResource(), message.getObjectUuid(), eventData);
+        List<NotificationRecipient> recipients = getRecipients(notificationProfileVersion.getRecipientType(), notificationProfileVersion.getRecipientUuids(), message, subject);
 
         // send external notification
-        boolean notificationSent = sendExternalNotificationsForProfile(message, notificationProfileVersion, recipients);
+        boolean notificationSent = sendExternalNotificationsForProfile(message, notificationProfileVersion, recipients, subject, eventData);
 
         // send internal notification when not Default recipient type. Default internal notifications for events are sent in corresponding event handlers
         if (sendInternalNotifications) {
@@ -184,14 +188,15 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         }
     }
 
-    private boolean sendExternalNotificationsForProfile(NotificationMessage message, NotificationProfileVersion notificationProfileVersion, List<NotificationRecipient> recipients) {
+    private boolean sendExternalNotificationsForProfile(NotificationMessage message, NotificationProfileVersion notificationProfileVersion, List<NotificationRecipient> recipients,
+                                                        NotificationSubjectResolver.SubjectRef subject, EventData eventData) {
         boolean notificationSent = false;
         if (notificationProfileVersion.getNotificationInstanceRefUuid() != null) {
             UUID notificationInstanceUUID = notificationProfileVersion.getNotificationInstanceRefUuid();
             logger.debug("Sending notification message externally. Notification instance UUID: {}", notificationInstanceUUID);
-            NotificationEventObjectDataDto objectData = buildObjectData(message, notificationProfileVersion);
+            NotificationEventObjectDataDto objectData = buildObjectData(message, notificationProfileVersion, eventData);
             try {
-                if (!sendExternalNotifications(notificationInstanceUUID, recipients, message.getData(), message.getEvent(), message.getResource(), objectData)) {
+                if (!sendExternalNotifications(notificationInstanceUUID, recipients, message.getData(), message.getEvent(), message.getResource(), objectRecipientResource(message, subject), objectData)) {
                     // The connector still received the notification -- reported so a recipient that never resolves
                     // is visible, rather than the notification quietly reaching fewer people than configured.
                     handleNotificationErrorWithWarnLog("Notification profile %s in event %s could not prepare all of its recipients for delivery.".formatted(notificationProfileVersion.getNotificationProfile().getName(), message.getEvent()), message);
@@ -216,14 +221,14 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
      * best-effort: any failure yields a data-less send, never a suppressed one. The result
      * exists only in the outbound connector request; internal notifications never carry it.
      */
-    private NotificationEventObjectDataDto buildObjectData(NotificationMessage message, NotificationProfileVersion notificationProfileVersion) {
+    private NotificationEventObjectDataDto buildObjectData(NotificationMessage message, NotificationProfileVersion notificationProfileVersion, EventData eventData) {
         try {
             List<NotificationDataCategory> categories = notificationProfileVersion.getNotificationProfile().getEventDataCategories();
             if (categories.isEmpty()) {
                 return null;
             }
             return notificationObjectDataService.getObjectData(message.getEvent(), message.getResource(),
-                    message.getObjectUuid(), convertEventDataBestEffort(message), EnumSet.copyOf(categories));
+                    message.getObjectUuid(), eventData, EnumSet.copyOf(categories));
         } catch (Exception e) {
             logger.warn("Notification object data could not be built for profile version {} in event {}; sending without it",
                     notificationProfileVersion.getUuid(), message.getEvent(), e);
@@ -314,9 +319,9 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
                 && (notificationProfileVersion.getRepetitions() == null || pendingNotification.getRepetitions() < notificationProfileVersion.getRepetitions());
     }
 
-    private List<NotificationRecipient> getRecipients(RecipientType recipientType, List<UUID> recipientUuids, ResourceEvent event, Object data, Resource resource, UUID objectUuid) {
+    private List<NotificationRecipient> getRecipients(RecipientType recipientType, List<UUID> recipientUuids, NotificationMessage message, NotificationSubjectResolver.SubjectRef subject) {
         if (recipientType == RecipientType.OBJECT) {
-            return List.of(new NotificationRecipient(RecipientType.OBJECT, objectUuid));
+            return List.of(new NotificationRecipient(RecipientType.OBJECT, objectRecipientUuid(message, subject)));
         }
 
         if (recipientType != RecipientType.OWNER && recipientType != RecipientType.DEFAULT) {
@@ -324,12 +329,30 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
         }
 
         if (recipientType == RecipientType.OWNER) {
-            NameAndUuidDto ownerInfo = resourceObjectAssociationService.getOwner(resource, objectUuid);
+            // The subject's owner, not the event object's: for approval events this is the owner
+            // of the object awaiting approval -- the approval record itself has no owner.
+            NameAndUuidDto ownerInfo = resourceObjectAssociationService.getOwner(subject.resource(), subject.objectUuid());
             if (ownerInfo == null) return List.of();
             return List.of(new NotificationRecipient(RecipientType.USER, UUID.fromString(ownerInfo.getUuid())));
         }
 
-        return getDefaultRecipients(event, data, resource, objectUuid);
+        return getDefaultRecipients(message.getEvent(), message.getData(), message.getResource(), message.getObjectUuid());
+    }
+
+    /**
+     * The object an OBJECT recipient resolves its mapped attributes from. Subject redirection is
+     * whitelisted per resource, mirroring the content-exporter philosophy: the mapped-attribute
+     * channel carries raw attribute content with neither the enrichment protection filters nor a
+     * category gate, and approval targets are polymorphic -- a secret's attribute content must
+     * not become exportable as a side effect of recipient resolution. Non-whitelisted subjects
+     * keep today's behavior and resolve against the event object.
+     */
+    private static UUID objectRecipientUuid(NotificationMessage message, NotificationSubjectResolver.SubjectRef subject) {
+        return OBJECT_RECIPIENT_SUBJECT_RESOURCES.contains(subject.resource()) ? subject.objectUuid() : message.getObjectUuid();
+    }
+
+    private static Resource objectRecipientResource(NotificationMessage message, NotificationSubjectResolver.SubjectRef subject) {
+        return OBJECT_RECIPIENT_SUBJECT_RESOURCES.contains(subject.resource()) ? subject.resource() : message.getResource();
     }
 
     /**
@@ -406,7 +429,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
      * @return false when some named recipient could not be prepared, so the caller can report the gap.
      */
     private boolean sendExternalNotifications(UUID notificationInstanceUUID, List<NotificationRecipient> recipients, Object notificationData, ResourceEvent
-            event, Resource resource, NotificationEventObjectDataDto objectData) throws ConnectorException, ValidationException, NotFoundException {
+            event, Resource resource, Resource objectRecipientResource, NotificationEventObjectDataDto objectData) throws ConnectorException, ValidationException, NotFoundException {
         // Fetch-join the mapped attributes: the listener runs without an ambient transaction, so the
         // entity is detached the moment the repository call returns and lazy loading would fail.
         NotificationInstanceReference notificationInstanceReference = notificationInstanceReferenceRepository.findWithMappedAttributesByUuid(notificationInstanceUUID).orElseThrow(() -> new NotFoundException(NotificationInstanceReference.class, notificationInstanceUUID));
@@ -437,7 +460,7 @@ public class NotificationListener implements MessageProcessor<NotificationMessag
                 }
 
                 Resource customAttributeResource = recipient.getRecipientType() == RecipientType.OBJECT
-                        ? resource
+                        ? objectRecipientResource
                         : recipient.getRecipientType().getRecipientResource();
                 // Unauthenticated lookup is correct here, since the access to the custom attributes has been resolved when defining mapping attributes.
                 List<ResponseAttribute> recipientCustomAttributes = attributeEngine.getObjectCustomAttributesContentForSystemContext(customAttributeResource, recipient.getRecipientUuid());

--- a/src/test/java/com/otilm/core/integration/events/NotificationObjectRecipientITest.java
+++ b/src/test/java/com/otilm/core/integration/events/NotificationObjectRecipientITest.java
@@ -330,8 +330,8 @@ class NotificationObjectRecipientITest extends BaseSpringBootTest {
     /**
      * OWNER and OBJECT recipients resolve against the notification subject: for approval events
      * the approval's target object, for every other event the event object itself. OBJECT
-     * redirection is whitelisted to certificate subjects; other approval targets keep today's
-     * behavior (skipped with no attribute content resolved).
+     * redirection is whitelisted to certificate subjects; other approval targets are skipped
+     * because no attribute content is resolved for them.
      */
     @Test
     void testOwnerRecipient_approvalEvent_resolvesTargetOwnerExternally() throws AlreadyExistException, NotFoundException {
@@ -387,7 +387,7 @@ class NotificationObjectRecipientITest extends BaseSpringBootTest {
     }
 
     @Test
-    void testObjectRecipient_approvalEvent_nonWhitelistedTargetKeepsTodaysBehavior() throws AlreadyExistException, AttributeException, NotFoundException {
+    void testObjectRecipient_approvalEvent_nonWhitelistedTargetResolvesNoAttributeContent() throws AlreadyExistException, AttributeException, NotFoundException {
         // The secret target carries a mapped attribute value; a whitelist regression that starts
         // resolving mapped attributes from non-whitelisted subjects would put it on the wire.
         CustomAttributeCreateRequestDto secretAttrRequest = new CustomAttributeCreateRequestDto();

--- a/src/test/java/com/otilm/core/integration/events/NotificationObjectRecipientITest.java
+++ b/src/test/java/com/otilm/core/integration/events/NotificationObjectRecipientITest.java
@@ -387,15 +387,36 @@ class NotificationObjectRecipientITest extends BaseSpringBootTest {
     }
 
     @Test
-    void testObjectRecipient_approvalEvent_nonWhitelistedTargetKeepsTodaysBehavior() throws AlreadyExistException, NotFoundException {
-        NotificationProfileDetailDto secretTargetProfile = webhookProfile("approvalObjectSecretProfile", RecipientType.OBJECT);
+    void testObjectRecipient_approvalEvent_nonWhitelistedTargetKeepsTodaysBehavior() throws AlreadyExistException, AttributeException, NotFoundException {
+        // The secret target carries a mapped attribute value; a whitelist regression that starts
+        // resolving mapped attributes from non-whitelisted subjects would put it on the wire.
+        CustomAttributeCreateRequestDto secretAttrRequest = new CustomAttributeCreateRequestDto();
+        secretAttrRequest.setName("secretContact");
+        secretAttrRequest.setLabel("Secret Contact");
+        secretAttrRequest.setResources(List.of(Resource.SECRET));
+        secretAttrRequest.setContentType(AttributeContentType.STRING);
+        CustomAttributeDefinitionDetailDto secretAttr = attributeService.createCustomAttribute(secretAttrRequest);
+
+        UUID secretTargetUuid = UUID.randomUUID();
+        String secretMarker = "secret-target-contact@example.com";
+        attributeEngine.updateObjectCustomAttributeContent(Resource.SECRET, secretTargetUuid,
+                UUID.fromString(secretAttr.getUuid()), secretAttr.getName(),
+                List.of(new StringAttributeContentV3(secretMarker)));
+
+        NotificationInstanceMappedAttributes secretMapping = new NotificationInstanceMappedAttributes();
+        secretMapping.setAttributeDefinitionUuid(UUID.fromString(secretAttr.getUuid()));
+        secretMapping.setMappingAttributeUuid(UUID.fromString(MAPPING_ATTRIBUTE_UUID));
+        secretMapping.setNotificationInstanceRefUuid(notificationInstanceReferenceRepository.findAll().getFirst().getUuid());
+        notificationInstanceMappedAttributeRepository.save(secretMapping);
 
         Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(
-                approvalMessage(secretTargetProfile, Resource.SECRET, UUID.randomUUID())));
+                approvalMessage(profile, Resource.SECRET, secretTargetUuid)));
 
         String body = onlyNotifyBody();
         Assertions.assertTrue(body.contains("\"recipients\":[]"),
                 "a non-whitelisted target resolves no attribute content and the recipient is skipped: " + body);
+        Assertions.assertFalse(body.contains(secretMarker),
+                "the secret target's attribute content must never reach the wire through recipient resolution: " + body);
     }
 
     @Test

--- a/src/test/java/com/otilm/core/integration/events/NotificationObjectRecipientITest.java
+++ b/src/test/java/com/otilm/core/integration/events/NotificationObjectRecipientITest.java
@@ -10,6 +10,7 @@ import com.otilm.api.model.client.notification.NotificationProfileDetailDto;
 import com.otilm.api.model.client.notification.NotificationProfileRequestDto;
 import com.otilm.api.model.common.attribute.common.content.AttributeContentType;
 import com.otilm.api.model.common.attribute.v3.content.StringAttributeContentV3;
+import com.otilm.api.model.common.events.data.ApprovalEventData;
 import com.otilm.api.model.core.auth.Resource;
 import com.otilm.api.model.core.connector.ConnectorStatus;
 import com.otilm.api.model.core.notification.RecipientType;
@@ -17,14 +18,17 @@ import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.api.model.core.workflows.TriggerType;
 import com.otilm.core.attribute.engine.AttributeEngine;
 import com.otilm.core.dao.entity.Connector;
+import com.otilm.core.dao.entity.OwnerAssociation;
 import com.otilm.core.dao.entity.notifications.NotificationInstanceMappedAttributes;
 import com.otilm.core.dao.entity.notifications.NotificationInstanceReference;
 import com.otilm.core.dao.entity.notifications.PendingNotification;
 import com.otilm.core.dao.entity.workflows.Trigger;
 import com.otilm.core.dao.entity.workflows.TriggerHistory;
 import com.otilm.core.dao.repository.ConnectorRepository;
+import com.otilm.core.dao.repository.OwnerAssociationRepository;
 import com.otilm.core.dao.repository.notifications.NotificationInstanceMappedAttributeRepository;
 import com.otilm.core.dao.repository.notifications.NotificationInstanceReferenceRepository;
+import com.otilm.core.dao.repository.notifications.NotificationRepository;
 import com.otilm.core.dao.repository.notifications.PendingNotificationRepository;
 import com.otilm.core.dao.repository.workflows.TriggerHistoryRepository;
 import com.otilm.core.dao.repository.workflows.TriggerRepository;
@@ -36,6 +40,7 @@ import com.otilm.core.util.BaseSpringBootTest;
 import com.otilm.core.util.WireMockPorts;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,6 +68,8 @@ class NotificationObjectRecipientITest extends BaseSpringBootTest {
     @Autowired private TriggerRepository triggerRepository;
     @Autowired private TriggerHistoryRepository triggerHistoryRepository;
     @Autowired private PendingNotificationRepository pendingNotificationRepository;
+    @Autowired private OwnerAssociationRepository ownerAssociationRepository;
+    @Autowired private NotificationRepository notificationRepository;
 
     private WireMockServer mockServer;
     private CustomAttributeDefinitionDetailDto customAttr;
@@ -318,6 +325,145 @@ class NotificationObjectRecipientITest extends BaseSpringBootTest {
         Assertions.assertNotNull(suppressionRow, "the suppression row must exist after the first send");
         Assertions.assertEquals(2, suppressionRow.getRepetitions());
         Assertions.assertEquals(1, suppressionRow.getVersion(), "the row pins the profile version current at the first send");
+    }
+
+    /**
+     * OWNER and OBJECT recipients resolve against the notification subject: for approval events
+     * the approval's target object, for every other event the event object itself. OBJECT
+     * redirection is whitelisted to certificate subjects; other approval targets keep today's
+     * behavior (skipped with no attribute content resolved).
+     */
+    @Test
+    void testOwnerRecipient_approvalEvent_resolvesTargetOwnerExternally() throws AlreadyExistException, NotFoundException {
+        UUID certificateUuid = UUID.randomUUID();
+        UUID ownerUuid = ownerOf(certificateUuid);
+        WireMockServer authServer = authServerWithUserDetail(ownerUuid);
+        try {
+            NotificationProfileDetailDto ownerProfile = webhookProfile("approvalOwnerProfile", RecipientType.OWNER);
+
+            Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(
+                    approvalMessage(ownerProfile, Resource.CERTIFICATE, certificateUuid)));
+
+            String body = onlyNotifyBody();
+            Assertions.assertTrue(body.contains("cert.owner@example.com"),
+                    "the approval target's owner is the recipient: " + body);
+        } finally {
+            authServer.stop();
+        }
+    }
+
+    @Test
+    void testOwnerRecipient_approvalEvent_deliversInternallyToTargetOwner() throws AlreadyExistException, NotFoundException {
+        UUID certificateUuid = UUID.randomUUID();
+        ownerOf(certificateUuid);
+
+        NotificationProfileRequestDto request = new NotificationProfileRequestDto();
+        request.setName("approvalOwnerInternalProfile");
+        request.setRecipientType(RecipientType.OWNER);
+        request.setInternalNotification(true);
+        NotificationProfileDetailDto internalProfile = notificationProfileService.createNotificationProfile(request);
+
+        Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(
+                approvalMessage(internalProfile, Resource.CERTIFICATE, certificateUuid)));
+
+        Assertions.assertEquals(1, notificationRepository.findAll().size(),
+                "the target's owner receives an in-app notification for the approval event");
+    }
+
+    @Test
+    void testObjectRecipient_approvalEvent_certificateTargetResolvesMappedAttributes() throws AttributeException, NotFoundException {
+        UUID certificateUuid = UUID.randomUUID();
+        attributeEngine.updateObjectCustomAttributeContent(
+                Resource.CERTIFICATE, certificateUuid,
+                UUID.fromString(customAttr.getUuid()), customAttr.getName(),
+                List.of(new StringAttributeContentV3(CONTACT_VALUE)));
+
+        Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(
+                approvalMessage(profile, Resource.CERTIFICATE, certificateUuid)));
+
+        String body = onlyNotifyBody();
+        Assertions.assertTrue(body.contains(CONTACT_VALUE),
+                "mapped attributes resolve from the approval's certificate target: " + body);
+    }
+
+    @Test
+    void testObjectRecipient_approvalEvent_nonWhitelistedTargetKeepsTodaysBehavior() throws AlreadyExistException, NotFoundException {
+        NotificationProfileDetailDto secretTargetProfile = webhookProfile("approvalObjectSecretProfile", RecipientType.OBJECT);
+
+        Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(
+                approvalMessage(secretTargetProfile, Resource.SECRET, UUID.randomUUID())));
+
+        String body = onlyNotifyBody();
+        Assertions.assertTrue(body.contains("\"recipients\":[]"),
+                "a non-whitelisted target resolves no attribute content and the recipient is skipped: " + body);
+    }
+
+    @Test
+    void testOwnerRecipient_certificateEvent_behaviorUnchanged() throws AlreadyExistException, NotFoundException {
+        UUID certificateUuid = UUID.randomUUID();
+        UUID ownerUuid = ownerOf(certificateUuid);
+        WireMockServer authServer = authServerWithUserDetail(ownerUuid);
+        try {
+            NotificationProfileDetailDto ownerProfile = webhookProfile("certificateOwnerProfile", RecipientType.OWNER);
+
+            NotificationMessage message = new NotificationMessage(
+                    ResourceEvent.CERTIFICATE_STATUS_CHANGED, Resource.CERTIFICATE, certificateUuid,
+                    List.of(UUID.fromString(ownerProfile.getUuid())), List.of(), null);
+            Assertions.assertDoesNotThrow(() -> notificationListener.processMessage(message));
+
+            String body = onlyNotifyBody();
+            Assertions.assertTrue(body.contains("cert.owner@example.com"),
+                    "for ordinary events the subject is the event object, exactly as before: " + body);
+        } finally {
+            authServer.stop();
+        }
+    }
+
+    private UUID ownerOf(UUID certificateUuid) {
+        UUID ownerUuid = UUID.randomUUID();
+        OwnerAssociation association = new OwnerAssociation();
+        association.setResource(Resource.CERTIFICATE);
+        association.setObjectUuid(certificateUuid);
+        association.setOwnerUuid(ownerUuid);
+        association.setOwnerUsername("cert-owner");
+        ownerAssociationRepository.save(association);
+        return ownerUuid;
+    }
+
+    private WireMockServer authServerWithUserDetail(UUID userUuid) {
+        WireMockServer authServer = new WireMockServer(WireMockPorts.AUTH_SERVICE);
+        authServer.start();
+        authServer.stubFor(WireMock.get(WireMock.urlPathMatching("/auth/users/" + userUuid))
+                .willReturn(WireMock.okJson("""
+                        {
+                            "uuid": "%s",
+                            "username": "cert-owner",
+                            "email": "cert.owner@example.com",
+                            "enabled": true,
+                            "systemUser": false,
+                            "groups": []
+                        }
+                        """.formatted(userUuid))));
+        return authServer;
+    }
+
+    private NotificationMessage approvalMessage(NotificationProfileDetailDto notificationProfile, Resource targetResource, UUID targetUuid) {
+        ApprovalEventData approval = new ApprovalEventData();
+        approval.setApprovalUuid(UUID.randomUUID());
+        approval.setApprovalProfileName("prod-approvals");
+        approval.setResource(targetResource);
+        approval.setResourceAction("issue");
+        approval.setObjectUuid(targetUuid);
+        approval.setCreatorUsername("jane.operator");
+        return new NotificationMessage(ResourceEvent.APPROVAL_REQUESTED, Resource.APPROVAL,
+                UUID.randomUUID(), List.of(UUID.fromString(notificationProfile.getUuid())), List.of(), approval);
+    }
+
+    private String onlyNotifyBody() {
+        List<LoggedRequest> requests = mockServer.findAll(WireMock.postRequestedFor(
+                WireMock.urlPathMatching("/v1/notificationProvider/notifications/[^/]+/notify")));
+        Assertions.assertEquals(1, requests.size(), "exactly one notify call expected");
+        return requests.getFirst().getBodyAsString();
     }
 
     private NotificationProfileDetailDto webhookProfile(String name, RecipientType recipientType) throws AlreadyExistException, NotFoundException {


### PR DESCRIPTION
Closes #1861. Part of epic OmniTrustILM/ilm#301.

Unifies `OWNER` and `OBJECT` recipient resolution with the enrichment subject rule, so approval-event notifications resolve recipients from the approval's **target** object instead of the approval record (which has no owner and no custom attributes — both types silently resolved nothing):

- `OWNER` resolves the subject's owner for every resource. For approval events this notifies the owner of the object awaiting approval, externally and in-app; ordinary events keep their behavior (the subject is the event object itself).
- `OBJECT` resolves mapped attributes from the subject only for whitelisted certificate subjects, mirroring the content-exporter philosophy: the mapped-attribute channel carries raw attribute content with neither the enrichment protection filters nor a category gate, and polymorphic approval targets must not become exportable through recipient resolution. Non-whitelisted targets keep today's behavior (recipient skipped, no attribute content resolved).
- A malformed event payload falls back to the event object as the subject instead of failing the send.

Compatibility note for release notes: profiles combining approval events with `OWNER`/`OBJECT` previously produced empty-recipient requests, which recipient-less providers may act on; after this change such requests carry resolved recipients — for `OWNER` whenever the target has an owner, for `OBJECT` only with certificate targets.